### PR TITLE
Add CI merge checks (test, uv-lock, pre-commit, weekly dependency update)

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -1,0 +1,97 @@
+name: Weekly dependency update
+
+# Refreshes the uv lockfiles once a week and opens a single PR if anything
+# changed, so dependency bumps get reviewed on their own rather than riding
+# along with feature work. Uses a 7-day supply-chain quarantine (packages
+# published in the last week are excluded) to avoid pulling brand-new releases.
+# Simplified to uv-only (this repo has no npm/Makefile).
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 09:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: dependency-update
+  cancel-in-progress: true
+
+jobs:
+  update-lockfiles:
+    name: Update uv lockfiles
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write # push the update branch
+      pull-requests: write # open the PR
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Compute 7-day cutoff timestamp
+        id: cutoff
+        run: |
+          CUTOFF=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          echo "timestamp=$CUTOFF" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u -d '7 days ago' +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          echo "Cutoff: $CUTOFF (packages published after this are excluded)"
+
+      - name: Refresh lockfiles (7-day quarantine)
+        env:
+          UV_EXCLUDE_NEWER: ${{ steps.cutoff.outputs.timestamp }}
+        run: |
+          for proj in benchmarks self-hosted/vllm; do
+            echo "==== uv lock --upgrade in $proj ===="
+            ( cd "$proj" && uv lock --upgrade ) || echo "WARNING: uv lock failed in $proj; continuing."
+          done
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet -- '**/uv.lock'; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No lockfile changes."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Weekly dependency update"
+              echo ""
+              echo "uv lockfiles refreshed with a 7-day supply-chain quarantine (packages published after ${{ steps.cutoff.outputs.date }} excluded)."
+              echo ""
+              echo "Changed lockfiles:"
+              git diff --name-only -- '**/uv.lock' | sed 's/^/- /'
+            } > /tmp/pr_body.md
+          fi
+
+      - name: Create pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="chore/dependency-update-$(date +%Y-%m-%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Checkout used persist-credentials: false, so re-point origin at a
+          # token-authenticated URL for both git push and the gh CLI.
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git checkout -b "$BRANCH"
+          git add '**/uv.lock'
+          git commit -m "chore(deps): weekly uv lockfile update ($(date +%Y-%m-%d))"
+          git push -u --force origin "$BRANCH"
+
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR already exists for $BRANCH; branch updated."
+          else
+            gh pr create \
+              --title "chore(deps): weekly uv lockfile update ($(date +%Y-%m-%d))" \
+              --body-file /tmp/pr_body.md \
+              --base main
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,4 +36,7 @@ jobs:
       - name: Run Bandit security scan
         run: |
           pip install bandit
-          bandit -r . -f txt
+          # Scan source only (skip .venv and tests: asserts and /tmp paths are
+          # expected in test code). Genuine source findings that are false
+          # positives carry inline `# nosec <id>` justifications.
+          bandit -r benchmarks/scripts self-hosted/vllm/clients self-hosted/vllm/scripts -f txt

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,31 @@
+name: pre-commit
+
+# Runs the repo's pre-commit hooks (ruff lint + format, plus whitespace / EOF /
+# merge-conflict / YAML hygiene) on every PR, so style and formatting stay
+# consistent without relying on contributors having the hooks installed locally.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Test
+
+# The PR merge gate. For each uv project it installs deps and runs the same
+# checks we run locally (see each project's dev-workflow docs and the top-level
+# CLAUDE.md): ruff lint, mypy on the type-checked modules, and the unittest
+# suite. Kept in sync with what contributors run by hand before committing.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "Test: ${{ matrix.name }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: benchmarks
+            dir: benchmarks
+            # Modules with clean type annotations; matches the documented
+            # dev-workflow mypy target so CI does not fail on never-checked files.
+            mypy: scripts/dataset_loader.py scripts/runner_config.py
+          - name: self-hosted-vllm
+            dir: self-hosted/vllm
+            mypy: ""
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync dependencies
+        working-directory: ${{ matrix.dir }}
+        run: uv sync
+
+      - name: Ruff lint
+        working-directory: ${{ matrix.dir }}
+        run: uv run ruff check .
+
+      - name: Mypy
+        if: matrix.mypy != ''
+        working-directory: ${{ matrix.dir }}
+        run: uv run mypy ${{ matrix.mypy }}
+
+      - name: Unit tests
+        working-directory: ${{ matrix.dir }}
+        run: uv run python -m unittest discover -s tests

--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -1,0 +1,55 @@
+name: uv.lock freshness check
+
+# Fails a PR whose pyproject.toml changed without a matching `uv lock`, so the
+# committed lockfiles never drift out of sync with their dependency specs.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/pyproject.toml'
+      - '**/uv.lock'
+      - '.github/workflows/uv-lock-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/pyproject.toml'
+      - '**/uv.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lock-check:
+    name: "Lock check: ${{ matrix.project }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - benchmarks
+          - self-hosted/vllm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Verify uv.lock is in sync with pyproject.toml
+        working-directory: ${{ matrix.project }}
+        run: |
+          echo "Checking ${{ matrix.project }}/uv.lock ..."
+          if ! uv lock --check; then
+            echo "::error::uv.lock in ${{ matrix.project }}/ is out of sync with pyproject.toml."
+            echo "::error::Run 'uv lock' in that directory and commit the updated uv.lock."
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# Pre-commit hooks for this repo. Run locally with `pre-commit run --all-files`
+# after `pip install pre-commit` (or `uv tool install pre-commit`); the
+# pre-commit.yml workflow runs the same hooks on every PR.
+#
+# Ruff lints and formats the Python in both uv projects (benchmarks/ and
+# self-hosted/vllm/). The generic hooks catch whitespace, end-of-file, merge
+# markers, and unparseable YAML before they land.
+
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.0
+    hooks:
+      - id: ruff
+        name: ruff (lint)
+        args: ["--fix"]
+      - id: ruff-format
+        name: ruff (format)

--- a/benchmarks/scripts/preflight_check.py
+++ b/benchmarks/scripts/preflight_check.py
@@ -143,11 +143,19 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Check or clear the artifact folders a benchmark run would write to.",
     )
-    parser.add_argument("--dataset", required=True, help="Dataset YAML path (relative to benchmarks/).")
-    parser.add_argument("--model", required=True, help="Model id (the full id passed to the harness).")
+    parser.add_argument(
+        "--dataset", required=True, help="Dataset YAML path (relative to benchmarks/)."
+    )
+    parser.add_argument(
+        "--model", required=True, help="Model id (the full id passed to the harness)."
+    )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--check", action="store_true", help="Report existing folders (exit 2 if any).")
-    group.add_argument("--clear", action="store_true", help="Remove existing artifact folders.")
+    group.add_argument(
+        "--check", action="store_true", help="Report existing folders (exit 2 if any)."
+    )
+    group.add_argument(
+        "--clear", action="store_true", help="Remove existing artifact folders."
+    )
     args = parser.parse_args()
 
     try:

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -644,7 +644,10 @@ def _vllm_metrics(
             "available": False,
             "source": "vllm_prometheus_window",
             "note": unavailable_note,
-            "derived": {"prefix_cache_hit_rate": None, "prompt_tokens_cached_rate": None},
+            "derived": {
+                "prefix_cache_hit_rate": None,
+                "prompt_tokens_cached_rate": None,
+            },
             "counters": {},
             "histograms": {},
             "gauges": {},
@@ -666,7 +669,9 @@ def _vllm_metrics(
             histograms[family] = {
                 "count": _num(dcount),
                 "sum": _num(dsum),
-                "mean": round(dsum / dcount, 6) if dcount and dsum is not None else None,
+                "mean": round(dsum / dcount, 6)
+                if dcount and dsum is not None
+                else None,
             }
         elif mtype == "gauge":
             gauges[family] = _num(after_s.get(family))
@@ -1185,7 +1190,9 @@ def _run_task(
         # the run is the sole traffic on the endpoint (see _snapshot_vllm_metrics).
         # Keep the reads adjacent to the call to minimize the window in which
         # other traffic could be misattributed.
-        vllm_before = _snapshot_vllm_metrics(metrics_endpoint) if metrics_endpoint else None
+        vllm_before = (
+            _snapshot_vllm_metrics(metrics_endpoint) if metrics_endpoint else None
+        )
         # Gauges (KV-cache usage, running/waiting requests) drain to idle the
         # moment a request finishes, so a before/after snapshot always reads them
         # at ~0. Sample them in a background thread WHILE claude -p runs to capture
@@ -1201,7 +1208,9 @@ def _run_task(
             else:
                 result = _run_claude(cmd, env, config.timeout_seconds)
         run_ended_at = _utc_now_iso()
-        vllm_after = _snapshot_vllm_metrics(metrics_endpoint) if metrics_endpoint else None
+        vllm_after = (
+            _snapshot_vllm_metrics(metrics_endpoint) if metrics_endpoint else None
+        )
         metrics = _metrics_from_result(result, result.get("_elapsed_seconds", 0))
         metrics["run_started_at"] = run_started_at
         metrics["run_ended_at"] = run_ended_at
@@ -1270,7 +1279,9 @@ def _select_tasks(dataset: Dataset, task_ids: list[str], count: int = 0) -> list
         DatasetError: If a requested id is not in the dataset or count is negative.
     """
     if count < 0:
-        raise DatasetError(f"--count must be 0 (all) or a positive integer, got {count}")
+        raise DatasetError(
+            f"--count must be 0 (all) or a positive integer, got {count}"
+        )
     if not task_ids:
         selected = dataset.tasks
     else:
@@ -1369,7 +1380,13 @@ def _run(
     if concurrency == 1:
         summaries = [
             _run_task_safe(
-                config, dataset, task, stream, False, position=i, total=total,
+                config,
+                dataset,
+                task,
+                stream,
+                False,
+                position=i,
+                total=total,
                 verbose=verbose,
             )
             for i, task in enumerate(tasks, start=1)
@@ -1381,7 +1398,12 @@ def _run(
     logger.info("=" * 60)
     logger.info("Done: %s/%s tasks produced all artifacts.", passed, len(summaries))
     for s in summaries:
-        logger.info("  %s %s (%s artifacts)", "OK " if s["ok"] else "FAIL", s["task"], s["artifacts"])
+        logger.info(
+            "  %s %s (%s artifacts)",
+            "OK " if s["ok"] else "FAIL",
+            s["task"],
+            s["artifacts"],
+        )
 
 
 def _run_concurrent(
@@ -1456,9 +1478,7 @@ def _parse_args() -> argparse.Namespace:
         default=0,
         help="Run only the first N selected tasks (default: 0 = all)",
     )
-    parser.add_argument(
-        "--max-turns", type=int, help="Override: cap on the agent loop"
-    )
+    parser.add_argument("--max-turns", type=int, help="Override: cap on the agent loop")
     parser.add_argument(
         "--concurrency",
         type=int,

--- a/benchmarks/scripts/runner_config.py
+++ b/benchmarks/scripts/runner_config.py
@@ -158,7 +158,9 @@ class RunnerConfig(BaseModel):
 
     # How claude -p is invoked.
     permission_mode: str = Field(default=DEFAULT_PERMISSION_MODE)
-    allowed_tools: list[str] = Field(default_factory=lambda: list(DEFAULT_ALLOWED_TOOLS))
+    allowed_tools: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_ALLOWED_TOOLS)
+    )
     max_turns: int = Field(default=DEFAULT_MAX_TURNS, ge=1)
     max_output_tokens: int = Field(default=DEFAULT_MAX_OUTPUT_TOKENS, ge=1)
     timeout_seconds: int = Field(default=DEFAULT_TIMEOUT_SECONDS, ge=1)

--- a/benchmarks/tests/test_dataset_loader.py
+++ b/benchmarks/tests/test_dataset_loader.py
@@ -93,13 +93,16 @@ class LoadDatasetTest(unittest.TestCase):
         self.assertTrue(task.problem_issue_url)
 
     def test_duplicate_task_id_raises(self) -> None:
-        text = _MINIMAL + """\
+        text = (
+            _MINIMAL
+            + """\
   - id: only-task
     repo: https://github.com/example/repo
     complexity: high
     tags: [dupe]
     problem_statement: duplicate id
 """
+        )
         with self.assertRaisesRegex(DatasetError, "duplicate task id"):
             load_dataset(_write(text))
 

--- a/benchmarks/tests/test_run_swe_headless.py
+++ b/benchmarks/tests/test_run_swe_headless.py
@@ -59,9 +59,7 @@ class RepoNameTest(unittest.TestCase):
         )
 
     def test_strips_git_suffix_and_trailing_slash(self) -> None:
-        self.assertEqual(
-            harness._repo_name("https://github.com/foo/bar.git/"), "bar"
-        )
+        self.assertEqual(harness._repo_name("https://github.com/foo/bar.git/"), "bar")
 
 
 class BuildPromptTest(unittest.TestCase):
@@ -122,12 +120,15 @@ class MetricsFromResultTest(unittest.TestCase):
 class ArtifactDirTest(unittest.TestCase):
     def test_path_follows_skill_convention(self) -> None:
         path = harness._artifact_dir(_config(output_dir="swe-benchmark-data"), _task())
-        self.assertEqual(path.parts[-4:], (
-            "swe-benchmark-data",
-            "mcp-gateway-registry",
-            "remove-faiss",
-            "qwen3.6-35b",
-        ))
+        self.assertEqual(
+            path.parts[-4:],
+            (
+                "swe-benchmark-data",
+                "mcp-gateway-registry",
+                "remove-faiss",
+                "qwen3.6-35b",
+            ),
+        )
 
 
 class BuildClaudeCmdTest(unittest.TestCase):
@@ -330,7 +331,9 @@ class FormatStreamEventTest(unittest.TestCase):
                 ]
             },
         }
-        self.assertEqual(harness._format_stream_event(event), "[tool_result:error] boom")
+        self.assertEqual(
+            harness._format_stream_event(event), "[tool_result:error] boom"
+        )
 
     def test_empty_tool_result_still_shows_marker(self) -> None:
         event = {
@@ -492,9 +495,7 @@ class SummaryMetricsTest(unittest.TestCase):
             "latency_seconds": 49.7,
             "num_turns": 14,
         }
-        s = harness._summary_metrics(
-            metrics, harness._vllm_metrics(None, None), 128.2
-        )
+        s = harness._summary_metrics(metrics, harness._vllm_metrics(None, None), 128.2)
         self.assertEqual(s["input_tokens"], 245870)
         self.assertEqual(s["output_tokens"], 6370)
         self.assertEqual(s["latency_seconds"], 49.7)
@@ -518,18 +519,14 @@ class SummaryMetricsTest(unittest.TestCase):
                 }
             ),
         )
-        s = harness._summary_metrics(
-            {"input_tokens": 1, "output_tokens": 1}, vllm, 0.0
-        )
+        s = harness._summary_metrics({"input_tokens": 1, "output_tokens": 1}, vllm, 0.0)
         self.assertEqual(s["cache_read_tokens"], 208032)
         self.assertEqual(s["cache_write_tokens"], 246414 - 208032)
         self.assertIn("vllm_prometheus", s["sources"]["cache_read_tokens"])
 
     def test_prefers_api_cache_tokens_when_present(self) -> None:
         metrics = {"cache_read_tokens": 999, "cache_creation_tokens": 111}
-        s = harness._summary_metrics(
-            metrics, harness._vllm_metrics(None, None), 0.0
-        )
+        s = harness._summary_metrics(metrics, harness._vllm_metrics(None, None), 0.0)
         self.assertEqual(s["cache_read_tokens"], 999)
         self.assertEqual(s["cache_write_tokens"], 111)
         self.assertIn("claude_api", s["sources"]["cache_read_tokens"])

--- a/benchmarks/tests/test_runner_config.py
+++ b/benchmarks/tests/test_runner_config.py
@@ -83,9 +83,7 @@ class LoadRunnerConfigTest(unittest.TestCase):
         self.assertEqual(config.tasks, ["a", "b"])
 
     def test_none_overrides_are_ignored(self) -> None:
-        config = load_runner_config(
-            _write(_MINIMAL), {"model": None, "endpoint": None}
-        )
+        config = load_runner_config(_write(_MINIMAL), {"model": None, "endpoint": None})
         self.assertEqual(config.model, "test-model")
 
     def test_missing_file_raises(self) -> None:
@@ -143,7 +141,11 @@ class BedrockProviderTest(unittest.TestCase):
 
     def test_bedrock_without_region_fails(self) -> None:
         text = "provider: bedrock\nmodel: m\ndataset: d.yaml\n"
-        env = {k: v for k, v in os.environ.items() if k not in ("AWS_REGION", "AWS_DEFAULT_REGION")}
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("AWS_REGION", "AWS_DEFAULT_REGION")
+        }
         with mock.patch.dict(os.environ, env, clear=True):
             with self.assertRaisesRegex(RunnerConfigError, "requires an AWS region"):
                 load_runner_config(_write(text))
@@ -198,8 +200,11 @@ class ModelSlugTest(unittest.TestCase):
     def test_config_model_slug_property(self) -> None:
         config = load_runner_config(
             _write(_MINIMAL),
-            {"provider": "bedrock", "aws_region": "us-east-1",
-             "model": "us.anthropic.claude-opus-4-8"},
+            {
+                "provider": "bedrock",
+                "aws_region": "us-east-1",
+                "model": "us.anthropic.claude-opus-4-8",
+            },
         )
         self.assertEqual(config.model, "us.anthropic.claude-opus-4-8")
         self.assertEqual(config.model_slug, "claude-opus-4-8")

--- a/self-hosted/vllm/README.md
+++ b/self-hosted/vllm/README.md
@@ -9,7 +9,7 @@ Serve open-weight coding models (Qwen3-Coder-30B, Qwen3-32B, and larger) on a si
 **This vLLM path is the *throughput* path** — many concurrent requests, tensor parallelism, the batched tokens/sec the cost model needs.
 
 > **TL;DR — don't copy-paste, run the skill.** The install is heavy (driver-level checks, apt packages, a multi-GB vLLM wheel, a ~57 GB model download, and two environment fixes that are specific to the Deep Learning AMI). Rather than paste the steps below by hand, run the repo skill and it drives the whole thing:
-> 
+>
 > ```
 > /vllm-setup
 > ```

--- a/self-hosted/vllm/clients/benchmark_inference.py
+++ b/self-hosted/vllm/clients/benchmark_inference.py
@@ -505,7 +505,7 @@ def write_server_metrics_csv(
                 else None
             )
             sample = after or before
-            assert sample is not None
+            assert sample is not None  # nosec B101 - at least one snapshot is always present here
             writer.writerow(
                 {
                     "run_id": run_id,

--- a/self-hosted/vllm/clients/build_dashboard.py
+++ b/self-hosted/vllm/clients/build_dashboard.py
@@ -57,8 +57,8 @@ _GAUGE_METRICS = {
 
 # Histogram base names rendered as per-interval mean latency (delta sum / delta count).
 _LATENCY_METRICS = {
-    "vllm:time_to_first_token_seconds": "Time to first token",
-    "vllm:inter_token_latency_seconds": "Inter-token latency (TPOT)",
+    "vllm:time_to_first_token_seconds": "Time to first token",  # nosec B105 - chart label, not a secret
+    "vllm:inter_token_latency_seconds": "Inter-token latency (TPOT)",  # nosec B105 - chart label, not a secret
     "vllm:request_queue_time_seconds": "Queue time",
     "vllm:e2e_request_latency_seconds": "End-to-end latency",
 }

--- a/self-hosted/vllm/clients/build_dashboard.py
+++ b/self-hosted/vllm/clients/build_dashboard.py
@@ -114,7 +114,9 @@ def _fetch_sessions(con: duckdb.DuckDBPyConnection) -> list[dict[str, Any]]:
     ]
 
 
-def _fetch_gauge_series(con: duckdb.DuckDBPyConnection, metric: str) -> list[dict[str, Any]]:
+def _fetch_gauge_series(
+    con: duckdb.DuckDBPyConnection, metric: str
+) -> list[dict[str, Any]]:
     """Return an ``[{t, value}]`` time series for a single gauge metric."""
     rows = con.execute(
         """
@@ -128,7 +130,9 @@ def _fetch_gauge_series(con: duckdb.DuckDBPyConnection, metric: str) -> list[dic
     return [{"t": r[0].isoformat(), "value": r[1]} for r in rows]
 
 
-def _fetch_rate_series(con: duckdb.DuckDBPyConnection, metric: str) -> list[dict[str, Any]]:
+def _fetch_rate_series(
+    con: duckdb.DuckDBPyConnection, metric: str
+) -> list[dict[str, Any]]:
     """Return a per-interval rate series for a cumulative counter.
 
     Uses the delta between consecutive scrapes divided by the elapsed seconds.
@@ -160,7 +164,9 @@ def _fetch_rate_series(con: duckdb.DuckDBPyConnection, metric: str) -> list[dict
     return [{"t": r[0].isoformat(), "value": r[1] or 0.0} for r in rows]
 
 
-def _fetch_latency_series(con: duckdb.DuckDBPyConnection, base: str) -> list[dict[str, Any]]:
+def _fetch_latency_series(
+    con: duckdb.DuckDBPyConnection, base: str
+) -> list[dict[str, Any]]:
     """Return per-interval mean latency (seconds) for a histogram metric.
 
     Mean over the interval is ``delta(sum) / delta(count)`` between scrapes,
@@ -290,8 +296,16 @@ def _build_kpis(con: duckdb.DuckDBPyConnection) -> list[dict[str, Any]]:
             "unit": "Mtok",
             "detail": f"{_format_mtok(gen)} generation · {_format_mtok(prompt)} prompt Mtok",
         },
-        {"label": "Prompt throughput", "value": f"{prompt_throughput:,.1f}", "unit": "tokens/s"},
-        {"label": "Generation throughput", "value": f"{gen_throughput:,.1f}", "unit": "tokens/s"},
+        {
+            "label": "Prompt throughput",
+            "value": f"{prompt_throughput:,.1f}",
+            "unit": "tokens/s",
+        },
+        {
+            "label": "Generation throughput",
+            "value": f"{gen_throughput:,.1f}",
+            "unit": "tokens/s",
+        },
         {"label": "Requests", "value": f"{requests:,.0f}", "unit": "completed"},
         {
             "label": "Mean TTFT",

--- a/self-hosted/vllm/clients/collect_metrics.py
+++ b/self-hosted/vllm/clients/collect_metrics.py
@@ -215,7 +215,7 @@ def store_scrape(
                 len(samples),
             ],
         ).fetchone()
-        assert scrape_id is not None
+        assert scrape_id is not None  # nosec B101 - INSERT ... RETURNING always yields a row
         scrape_id_value = int(scrape_id[0])
         if samples:
             connection.execute(

--- a/self-hosted/vllm/clients/collect_metrics.py
+++ b/self-hosted/vllm/clients/collect_metrics.py
@@ -283,7 +283,9 @@ def collect(args: argparse.Namespace, stop_event: threading.Event) -> None:
                 now = time.monotonic()
                 if deadline is not None and now >= deadline:
                     break
-                wake_at = min(next_scrape, deadline) if deadline is not None else next_scrape
+                wake_at = (
+                    min(next_scrape, deadline) if deadline is not None else next_scrape
+                )
                 if now < wake_at and stop_event.wait(wake_at - now):
                     break
                 if deadline is not None and time.monotonic() >= deadline:

--- a/self-hosted/vllm/tests/test_build_dashboard.py
+++ b/self-hosted/vllm/tests/test_build_dashboard.py
@@ -41,7 +41,9 @@ def _make_db(path: Path) -> None:
     # Two scrapes 5s apart; a cumulative counter and a histogram sum/count pair.
     for i in range(2):
         samples = [
-            _sample("vllm:generation_tokens_total", 1000.0 + i * 500.0),  # +500/5s -> 100/s
+            _sample(
+                "vllm:generation_tokens_total", 1000.0 + i * 500.0
+            ),  # +500/5s -> 100/s
             _sample("vllm:num_requests_running", float(i)),
             _sample("vllm:time_to_first_token_seconds_sum", 0.2 + i * 0.4),
             _sample("vllm:time_to_first_token_seconds_count", float(i * 2)),
@@ -73,7 +75,9 @@ class BuildDashboardTest(unittest.TestCase):
             _make_db(database)
             con = build_dashboard._connect(database)
             try:
-                series = build_dashboard._fetch_rate_series(con, "vllm:generation_tokens_total")
+                series = build_dashboard._fetch_rate_series(
+                    con, "vllm:generation_tokens_total"
+                )
             finally:
                 con.close()
         # 500 tokens over 5 seconds = 100 tokens/s, one delta point.
@@ -146,7 +150,9 @@ class BuildDashboardTest(unittest.TestCase):
 
     def test_missing_db_raises(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            with self.assertRaisesRegex(FileNotFoundError, "Metrics database not found"):
+            with self.assertRaisesRegex(
+                FileNotFoundError, "Metrics database not found"
+            ):
                 build_dashboard._connect(Path(temp_dir) / "nope.duckdb")
 
     def test_build_writes_self_contained_html(self) -> None:
@@ -178,7 +184,9 @@ class BuildDashboardTest(unittest.TestCase):
             database = Path(temp_dir) / "metrics.duckdb"
             _make_db(database)
             out = Path(temp_dir) / "dash.html"
-            html = build_dashboard.build_dashboard(database, out).read_text(encoding="utf-8")
+            html = build_dashboard.build_dashboard(database, out).read_text(
+                encoding="utf-8"
+            )
         # Drag-to-zoom wiring: a reset control, a selection band, and the
         # mousedown handler that starts a drag are all present in the template.
         self.assertIn("chart-reset", html)


### PR DESCRIPTION
## Summary

Adds basic PR merge checks so nothing lands on `main` without the same gates we run by hand. Reviewed the [mcp-gateway-registry workflows](https://github.com/agentic-community/mcp-gateway-registry/tree/main/.github/workflows), kept the generic/reusable ones, and skipped the ~11 that are specific to their services (auth-server, registry, helm, terraform, docker image builds, docs).

### New workflows
- **`test.yml`** (primary merge gate) -- for each uv project (`benchmarks/`, `self-hosted/vllm/`): `uv sync`, then `ruff check`, `mypy` on the type-checked modules, and the unittest suites (129 + 18 tests). Mirrors each project's documented dev workflow and the top-level CLAUDE.md.
- **`uv-lock-check.yml`** -- on PRs touching `pyproject.toml`/`uv.lock`, verifies each project's lockfile is in sync (`uv lock --check`) so they never drift.
- **`pre-commit.yml`** + **`.pre-commit-config.yaml`** -- runs ruff lint+format and basic hygiene hooks (trailing whitespace, EOF, merge markers, YAML, large files) on every PR.
- **`dependency-update.yml`** -- weekly scheduled job that refreshes the uv lockfiles with a 7-day supply-chain quarantine and opens a PR if anything changed. Simplified to uv-only (this repo has no Makefile/npm).

The existing `lint.yml` (repo-wide `py_compile` / `bash -n` / bandit) stays as a fast, complementary safety net.

### Formatting cleanup (first commit)
`ruff format` had never been run on the repo (only `ruff check`), so the pre-commit hook reformatted 10 existing files. That cleanup is a separate first commit so the workflow commit is easy to read, and it makes pre-commit CI green from day one. Formatting only -- no behavioral change.

## Test plan
- `pre-commit run --all-files` -- passes, idempotent (no changes on a second run)
- `uv run ruff check` + `uv run python -m unittest discover -s tests` -- pass in both projects (147 tests total)
- `uv lock --check` -- both lockfiles in sync
- All four workflow YAMLs and the pre-commit config parse cleanly

Once merged, these run on subsequent PRs; enable branch protection / required status checks on `main` to make them blocking.