### PR TITLE
Calibrate auto-compaction, deterministic task clones, and auto run-summaries

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -30,7 +30,7 @@ Collect these three, in order. Do not guess -- ask if any is missing.
 2. **Bring up / confirm the backing service** for the chosen path. For **vllm**: check the HF token, then (re)start the vLLM server on the requested model -- stopping any other model first -- using the model guide's serve command at its largest context window, and start the DuckDB collector. For litellm/bedrock: confirm the proxy/credentials.
 3. **Dry-run the pre-flight** so the user sees what will happen before anything runs.
 4. **Run the orchestrator**, streaming its output, and tell the user what to tail.
-5. **Wrap up and report**: (vllm) stop the collector and archive its DuckDB snapshot tagged with model/scope/timestamp, then report where the results landed.
+5. **Wrap up and report**: (vllm) stop the collector and archive its DuckDB snapshot tagged with model/scope/timestamp; write a `RUN-SUMMARY.md` (results table + notes) into the run's `{model-slug}/{scope}/` folder; then report where the results landed.
 
 Keep the user informed at every step: before each long-running command, print it verbatim and give the tail/status command to watch it.
 
@@ -167,7 +167,7 @@ If the run is long, remind the user they can run only the harness now and score 
 cd benchmarks/scripts && uv run python codex_judge.py --recursive --no-overwrite --folder ../swe-benchmark-data/{model-slug}
 ```
 
-## Step 5 - Wrap up (stop the collector, archive the DuckDB snapshot) and report
+## Step 5 - Wrap up (stop the collector, archive the DuckDB snapshot, write the run summary) and report
 
 **5a. (vllm path) Stop the DuckDB metrics collector** now that the run is done, so it stops appending to the live database:
 
@@ -193,8 +193,62 @@ cd self-hosted/vllm && uv run python -m clients.build_dashboard \
   --output benchmark-output/dashboard_{model-slug}_{scope}_{timestamp}.html
 ```
 
-**5c. Report** where the results are and what they contain:
+**5c. Write a run summary** to `benchmarks/swe-benchmark-data/{model-slug}/{scope}/RUN-SUMMARY.md` (one per model+dataset run, alongside the per-task folders) so the outcome is captured on disk, not just in the chat. Do this on **every** path (bedrock/litellm/vllm), after scoring. Gather the numbers from the artifacts rather than retyping them -- read each task's `metrics.json` (`metrics_that_matter`: `num_turns`, `input_tokens`, `output_tokens`, `latency_seconds`) and `eval.json` (`task_score`):
 
+```bash
+cd benchmarks/swe-benchmark-data/{model-slug}/{scope}
+python3 - <<'PY'
+import json, os
+rows=[]
+for t in sorted(os.listdir('.')):
+    if not os.path.isdir(t):
+        continue
+    m=json.load(open(f'{t}/metrics.json')).get('metrics_that_matter',{})
+    e=json.load(open(f'{t}/eval.json'))
+    rows.append((t, m.get('num_turns'), m.get('input_tokens'),
+                 m.get('output_tokens'), m.get('latency_seconds'), e.get('task_score')))
+for r in sorted(rows, key=lambda r: -(r[5] or 0)):
+    print(r)
+PY
+```
+
+Then write `RUN-SUMMARY.md` with this structure (fill the front-matter from the run's actual inputs; sort the table by judge score, highest first):
+
+```markdown
+# Benchmark run summary: {model} on {scope}
+
+- Provider: {provider}
+- Model: {model}
+- Dataset: {dataset} ({N} tasks, ref {ref})
+- Served context window: {window if vllm/litellm, else n/a}; auto-compaction at {floor(window*0.9)}
+- Run date: {UTC date}
+
+{one-line headline: how many tasks succeeded (K/N with 4/4 artifacts), and whether any retries/crashes/compaction events occurred}
+
+## Results
+
+| Task | Turns | Input tokens | Output tokens | Latency (s) | Judge score |
+|---|---|---|---|---|---|
+| ... one row per task, sorted by judge score desc ... |
+
+Token counts are cumulative across all turns of a task, not a single request. The judge is calibrated so a median artifact lands around 60-70.
+
+## Notes
+
+- {anything notable: did compaction fire? were there failures and why? server/window changes made mid-run?}
+- Each task is a fresh `claude -p` process: independent context, per-task window, no cross-task carryover.
+
+## Artifacts
+
+- Per-task results under `benchmarks/swe-benchmark-data/{model-slug}/{scope}/<task>/` (four design artifacts + `metrics.json` + `eval.json`).
+- {if vllm: GPU time series snapshot path from 5b}
+```
+
+If a task failed (fewer than 4/4 artifacts, or `is_error`), say so in the headline and note the cause from its `metrics.json` (`error`/`api_error_status`). Do not present a partial run as a clean sweep.
+
+**5d. Report** where the results are and what they contain:
+
+- Point the user at the `RUN-SUMMARY.md` you just wrote first.
 - Each `benchmarks/swe-benchmark-data/{model-slug}/<repo>/<task>/` holds the four artifacts, `metrics.json` (cost + any vLLM server metrics), and `eval.json` (quality scores).
 - The same task run by another model lands under a sibling top-level `{model-slug}/` folder, directly comparable.
 - Suggest inspecting one result:

--- a/.gitignore
+++ b/.gitignore
@@ -27,12 +27,14 @@ benchmarks/swe-benchmark-data/
 # stays local so it can never be committed by accident.
 benchmarks/swe-benchmark-data/mcp-gateway-registry/
 **/benchmarks/swe-benchmark-data/mcp-gateway-registry/
-# Per-task target-repo clones. The harness clones into <clone_dir>/swe-<task-id>/
-# (clone_dir defaults to /tmp, outside the repo) and deletes them after each
-# task; this ignore is a backstop for a config that points clone_dir inside the
-# repo, so a leftover clone from a killed run can never be committed.
-swe-*/
-**/swe-*/
+# Per-task target-repo clones. The harness clones into
+# <clone_dir>/swe-clone-<task-id>/ (clone_dir defaults to /tmp, outside the
+# repo) and deletes them after each task; this ignore is a backstop for a config
+# that points clone_dir inside the repo, so a leftover clone from a killed run
+# can never be committed. The swe-clone- prefix is specific so this never
+# matches the swe-benchmark-data output dir.
+swe-clone-*/
+**/swe-clone-*/
 __pycache__/
 *.pyc
 credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ benchmarks/swe-benchmark-data/
 # stays local so it can never be committed by accident.
 benchmarks/swe-benchmark-data/mcp-gateway-registry/
 **/benchmarks/swe-benchmark-data/mcp-gateway-registry/
+# Per-task target-repo clones. The harness clones into <clone_dir>/swe-<task-id>/
+# (clone_dir defaults to /tmp, outside the repo) and deletes them after each
+# task; this ignore is a backstop for a config that points clone_dir inside the
+# repo, so a leftover clone from a killed run can never be committed.
+swe-*/
+**/swe-*/
 __pycache__/
 *.pyc
 credentials.json

--- a/benchmarks/config/runner.example.yaml
+++ b/benchmarks/config/runner.example.yaml
@@ -65,6 +65,22 @@
 #                           narrow: read the repo, write the four artifacts.
 #   max_turns         int   Cap on the agent loop (claude --max-turns).
 #   max_output_tokens int   Per-response output-token cap for the model.
+#   context_window    int   The model's true context window, in tokens. Claude
+#                           Code cannot detect the window of a custom model on a
+#                           custom base URL, so without this it never triggers
+#                           auto-compaction and the conversation grows until the
+#                           endpoint rejects the request (500 "maximum context
+#                           length is N tokens"), which the client then retries
+#                           forever. Set this to the served window (for vLLM, the
+#                           MAX_MODEL_LEN you booted with) to calibrate
+#                           auto-compaction (CLAUDE_CODE_AUTO_COMPACT_WINDOW).
+#                           0 (default) leaves it unset -- correct for known
+#                           Claude models / Bedrock, whose window is built in.
+#                           The orchestrator (run-e2e-benchmark.sh) passes the
+#                           live vLLM window automatically on the vllm path.
+#   auto_compact_fraction float  Fraction of context_window at which to compact
+#                           (default 0.9), leaving headroom above the output
+#                           reserve. Only applies when context_window > 0.
 #   timeout_seconds   int   Wall-clock timeout for a single task's claude -p run.
 #   settings_file     str   Optional claude --settings JSON (e.g. the vLLM
 #                           config that pins ANTHROPIC_BASE_URL). Optional.
@@ -133,6 +149,14 @@ allowed_tools:
   - Task
 max_turns: 60
 max_output_tokens: 16000
+
+# Model context window, in tokens, used to calibrate Claude Code's
+# auto-compaction for custom models it cannot introspect. 0 = leave unset (right
+# for known Claude models / Bedrock). On the vllm path the orchestrator passes
+# the live server's MAX_MODEL_LEN via --context-window, which overrides this.
+context_window: 0
+auto_compact_fraction: 0.9
+
 timeout_seconds: 1800
 
 # Point claude -p at the local vLLM server's Claude Code settings. Relative to

--- a/benchmarks/docs/harness-reference.md
+++ b/benchmarks/docs/harness-reference.md
@@ -163,7 +163,9 @@ CLI flags always win, so you can still pin `model`/`dataset` in the file if you 
 | `permission_mode` | str | `acceptEdits` | `claude -p` permission mode. `bypassPermissions` is intentionally rejected. |
 | `allowed_tools` | list | read + write set | Tools `claude -p` may use without prompting. |
 | `max_turns` | int | `60` | Cap on the agent loop (`claude --max-turns`). |
-| `max_output_tokens` | int | `16000` | Per-response output-token cap. |
+| `max_output_tokens` | int | `16000` | Per-response output-token cap (`CLAUDE_CODE_MAX_OUTPUT_TOKENS`). |
+| `context_window` | int | `0` | The model's true context window, in tokens, used to calibrate Claude Code's auto-compaction (`CLAUDE_CODE_AUTO_COMPACT_WINDOW`). `0` leaves it unset. See [Context window and auto-compaction](#context-window-and-auto-compaction). |
+| `auto_compact_fraction` | float | `0.9` | Fraction of `context_window` at which auto-compaction fires. Only used when `context_window > 0`. |
 | `timeout_seconds` | int | `1800` | Wall-clock timeout for a single task's run. |
 | `settings_file` | str | none | Optional `claude --settings` JSON (e.g. the vLLM Claude Code config). |
 
@@ -191,6 +193,30 @@ It runs `claude -p` with `--permission-mode acceptEdits` and a narrow `--allowed
 However `provider` is set, the harness always passes `claude --settings`, and this matters: a Claude Code settings object's `env` block takes precedence over process environment variables, including any in your global `~/.claude/settings.json`. Passing `--settings` is what reliably wins over that global file and pins routing to whatever the config asked for. Exactly what the harness puts in that settings object differs per path and is documented in each path guide.
 
 When `claude -p` returns an error, the harness records the error message and `api_error_status` in `metrics.json` and logs them, so a failed run is diagnosable without re-running it by hand.
+
+### Context window and auto-compaction
+
+Claude Code compacts its own conversation as it nears the context limit, but it can only do this if it knows the model's context window. For a **known Claude model or Amazon Bedrock** it has the window built in. For a **custom model served over a custom `ANTHROPIC_BASE_URL`** (the `endpoint` provider -- a vLLM server or the LiteLLM proxy) it **cannot detect the window**, so on a long agentic task the conversation grows unbounded until the endpoint rejects the request:
+
+```
+API Error: 500 This model's maximum context length is 262144 tokens. However, you
+requested 16000 output tokens and your prompt contains at least 246145 input tokens,
+for a total of at least 262145 tokens.
+```
+
+Claude Code treats that 500 as a transient server error and retries it forever, so the task never finishes. Note the arithmetic: the failing total is `input + max_output_tokens`, because Claude Code reserves the full output budget on top of the prompt.
+
+The fix is to tell Claude Code the true window via **`context_window`**, which the harness maps to the `CLAUDE_CODE_AUTO_COMPACT_WINDOW` environment variable (set both in the process env and in the `--settings` `env` block, since the latter takes precedence). The harness compacts at `floor(context_window * auto_compact_fraction)` -- `0.9` by default -- so there is headroom above the `max_output_tokens` reserve. With `context_window: 262144` that triggers compaction at `235929` tokens, well before the hard limit.
+
+Three ways to set it, in precedence order (CLI wins):
+
+- **Orchestrator, vllm path (automatic):** [run-e2e-benchmark.sh](../scripts/run-e2e-benchmark.sh) reads the live server's `max_model_len` from `/v1/models` and passes it as `--context-window`, so a vLLM run is calibrated to whatever window the server actually booted with -- no manual step.
+- **CLI:** `--context-window 262144` on `run-swe-headless.py`.
+- **Config:** `context_window: 262144` in `runner.yaml`.
+
+Leave it `0` for Anthropic-on-Bedrock and for any known Claude model: their windows are already known to Claude Code, and a `0` value leaves `CLAUDE_CODE_AUTO_COMPACT_WINDOW` unset. On the LiteLLM path, set it to the window of the underlying open-weight model. `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is clamped by Claude Code to the model's real window, so an over-large value cannot push it past what the endpoint supports.
+
+`/compact` is an interactive-only command and does **not** work in headless `-p` mode, and there is no tool a model can call to compact its own context -- auto-compaction calibrated by `context_window` is the only mechanism available to a headless run.
 
 ### Common invocations
 

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -231,10 +231,11 @@ ok "No blocking artifact folders."
 
 ok "Pre-flight complete."
 
-# The harness clones each task's repo into <clone_dir>/swe-<task-id>/ and removes
-# it in its own finally block after each task. Register a trap as a backstop so a
-# killed or crashed run does not leave clones behind: it removes exactly this
-# dataset's task dirs (never a broad swe-* glob, which would hit swe-judge-repos).
+# The harness clones each task's repo into <clone_dir>/swe-clone-<task-id>/ and
+# removes it in its own finally block after each task. Register a trap as a
+# backstop so a killed or crashed run does not leave clones behind: it removes
+# exactly this dataset's task dirs (never a broad glob, which would hit
+# swe-judge-repos or the swe-benchmark-data output dir).
 CLONE_DIRS="$(uv run python -c "import sys; sys.path.insert(0,'scripts')
 from dataset_loader import load_dataset
 from runner_config import load_runner_config
@@ -244,7 +245,7 @@ m=importlib.util.module_from_spec(s); s.loader.exec_module(m)
 cfg=load_runner_config('$CONFIG', {'model':'$MODEL','dataset':'$DATASET'})
 d=load_dataset('$DATASET_PATH')
 for t in d.tasks:
-    print(f'{cfg.clone_dir}/swe-{m._safe_task_slug(t.id)}')" 2>/dev/null || true)"
+    print(f'{cfg.clone_dir}/swe-clone-{m._safe_task_slug(t.id)}')" 2>/dev/null || true)"
 
 _cleanup_clones() {
     [[ -z "$CLONE_DIRS" ]] && return 0

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -251,6 +251,11 @@ _cleanup_clones() {
     while IFS= read -r dir; do
         [[ -n "$dir" && -d "$dir" ]] && rm -rf -- "$dir"
     done <<< "$CLONE_DIRS"
+    # Always succeed: this is a best-effort backstop on EXIT, and its return
+    # value becomes the script's exit code. The harness already removes each
+    # clone after its task, so the -d test above is normally false (nothing to
+    # remove) -- without this, that falsy test would report a spurious failure.
+    return 0
 }
 trap _cleanup_clones EXIT
 

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -231,6 +231,29 @@ ok "No blocking artifact folders."
 
 ok "Pre-flight complete."
 
+# The harness clones each task's repo into <clone_dir>/swe-<task-id>/ and removes
+# it in its own finally block after each task. Register a trap as a backstop so a
+# killed or crashed run does not leave clones behind: it removes exactly this
+# dataset's task dirs (never a broad swe-* glob, which would hit swe-judge-repos).
+CLONE_DIRS="$(uv run python -c "import sys; sys.path.insert(0,'scripts')
+from dataset_loader import load_dataset
+from runner_config import load_runner_config
+import importlib.util
+s=importlib.util.spec_from_file_location('h','scripts/run-swe-headless.py')
+m=importlib.util.module_from_spec(s); s.loader.exec_module(m)
+cfg=load_runner_config('$CONFIG', {'model':'$MODEL','dataset':'$DATASET'})
+d=load_dataset('$DATASET_PATH')
+for t in d.tasks:
+    print(f'{cfg.clone_dir}/swe-{m._safe_task_slug(t.id)}')" 2>/dev/null || true)"
+
+_cleanup_clones() {
+    [[ -z "$CLONE_DIRS" ]] && return 0
+    while IFS= read -r dir; do
+        [[ -n "$dir" && -d "$dir" ]] && rm -rf -- "$dir"
+    done <<< "$CLONE_DIRS"
+}
+trap _cleanup_clones EXIT
+
 # =============================================================================
 step "Step 1 - Run the SWE benchmark"
 # =============================================================================

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -183,6 +183,20 @@ case "$PROVIDER" in
         else
             ok "vLLM serving '$MODEL' at $ENDPOINT"
         fi
+        # Read the live server's context window (max_model_len) so we can
+        # calibrate Claude Code's auto-compaction to it. Claude Code cannot
+        # detect a custom model's window; without this the conversation grows
+        # until vLLM rejects the request (500) and the client retries forever.
+        VLLM_CONTEXT_WINDOW="$(curl -s -m 5 "$ENDPOINT/v1/models" 2>/dev/null \
+            | uv run python -c 'import sys,json
+d=json.load(sys.stdin).get("data",[])
+w=next((m.get("max_model_len") for m in d if m.get("max_model_len")), None)
+print(w if w else "")' 2>/dev/null || true)"
+        if [[ -n "$VLLM_CONTEXT_WINDOW" ]]; then
+            ok "vLLM context window (max_model_len): $VLLM_CONTEXT_WINDOW -- auto-compaction will be calibrated to it"
+        else
+            warn "Could not read vLLM max_model_len from /v1/models; falling back to the config's context_window. Long tasks may overflow the window."
+        fi
         # The DuckDB metrics collector is optional but recommended on this path.
         if uv run --project "$VLLM_DIR" python -c 'import sys' >/dev/null 2>&1; then :; fi
         if pgrep -f "collect_metrics" >/dev/null 2>&1; then
@@ -220,10 +234,12 @@ ok "Pre-flight complete."
 # =============================================================================
 step "Step 1 - Run the SWE benchmark"
 # =============================================================================
-BENCH_ARGS=(--config "$CONFIG" --provider "$HARNESS_PROVIDER" --model "$MODEL" --dataset "$DATASET" --stream)
+BENCH_ARGS=(--config "$CONFIG" --provider "$HARNESS_PROVIDER" --model "$MODEL" --dataset "$DATASET" --stream --verbose)
 [[ "$COUNT" != "0" ]] && BENCH_ARGS+=(--count "$COUNT")
 [[ "$HARNESS_PROVIDER" == "endpoint" ]] && BENCH_ARGS+=(--endpoint "$ENDPOINT")
 [[ "$PROVIDER" == "bedrock" ]] && BENCH_ARGS+=(--aws-region "$AWS_REGION_ARG")
+# On the vllm path, calibrate auto-compaction to the live server's window.
+[[ -n "${VLLM_CONTEXT_WINDOW:-}" ]] && BENCH_ARGS+=(--context-window "$VLLM_CONTEXT_WINDOW")
 
 SLUG="$(uv run python -c "import sys; sys.path.insert(0,'scripts'); from runner_config import model_to_slug; print(model_to_slug('$MODEL'))")"
 info "Command:"

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -124,13 +124,15 @@ def _safe_task_slug(task_id: str) -> str:
 def _clone_repo(task: Task, ref: str, clone_dir: str, log_prefix: str = "") -> Path:
     """Clone a task's repo at a ref into a temp dir named after the task.
 
-    The checkout lands at ``<clone_dir>/swe-<task-id>/<repo-name>`` so the /swe
-    skill, which derives {repo-name} from the clone path's basename, gets the
-    right name -- and the parent is a stable, transcribable name (the task id)
-    rather than a random mktemp suffix, which agents were mis-copying character
-    by character and burning turns on. The task-id parent is unique per task
-    (ids are unique within a dataset), so serial and concurrent runs do not
-    collide. A leftover directory from a previously killed run is removed first.
+    The checkout lands at ``<clone_dir>/swe-clone-<task-id>/<repo-name>`` so the
+    /swe skill, which derives {repo-name} from the clone path's basename, gets
+    the right name -- and the parent is a stable, transcribable name (the task
+    id) rather than a random mktemp suffix, which agents were mis-copying
+    character by character and burning turns on. The task-id parent is unique
+    per task (ids are unique within a dataset), so serial and concurrent runs do
+    not collide. The ``swe-clone-`` prefix is distinct from the ``swe-benchmark-
+    data`` output dir so a gitignore glob can target clones precisely. A leftover
+    directory from a previously killed run is removed first.
 
     Args:
         task: The task whose repo to clone.
@@ -146,7 +148,7 @@ def _clone_repo(task: Task, ref: str, clone_dir: str, log_prefix: str = "") -> P
         RuntimeError: If the clone command fails or times out.
     """
     name = _repo_name(task.repo)
-    parent = Path(clone_dir) / f"swe-{_safe_task_slug(task.id)}"
+    parent = Path(clone_dir) / f"swe-clone-{_safe_task_slug(task.id)}"
     # Clear any leftover clone from a prior killed run so the fresh clone into a
     # deterministic path does not fail on a non-empty destination.
     shutil.rmtree(parent, ignore_errors=True)
@@ -1352,7 +1354,7 @@ def _dry_run(config: RunnerConfig, dataset: Dataset, tasks: list[Task]) -> None:
         ref = dataset.resolved_ref(task)
         placeholder = (
             Path(config.clone_dir)
-            / f"swe-{_safe_task_slug(task.id)}"
+            / f"swe-clone-{_safe_task_slug(task.id)}"
             / _repo_name(task.repo)
         )
         prompt = _build_prompt(task, placeholder, ref, config.model_slug)

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -28,10 +28,10 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess  # nosec B404 - used with list args, no shell, hardcoded command
 import sys
-import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -96,11 +96,41 @@ def _repo_name(repo_url: str) -> str:
     return repo_url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
 
 
-def _clone_repo(task: Task, ref: str, clone_dir: str, log_prefix: str = "") -> Path:
-    """Clone a task's repo at a ref into a temp dir named after the repo.
+def _safe_task_slug(task_id: str) -> str:
+    """Return a filesystem-safe slug for a task id, for use in a clone path.
 
-    The checkout lands at ``<clone_dir>/<mktemp>/<repo-name>`` so the /swe skill,
-    which derives {repo-name} from the clone path's basename, gets the right name.
+    The task id lands in a directory name, so anything that is not a plain
+    path-segment character is replaced with ``-``. This both keeps the path the
+    agent must reproduce simple and blocks path-traversal (``/`` and ``.`` runs
+    cannot escape the parent). Task ids are already kebab-case slugs in practice,
+    so this is a defensive no-op for well-formed input.
+
+    Args:
+        task_id: The dataset task id.
+
+    Returns:
+        A slug containing only ``[A-Za-z0-9._-]``, with leading dots/dashes and
+        empty results collapsed to ``task``.
+
+    Raises:
+        ValueError: If task_id is empty.
+    """
+    if not task_id:
+        raise ValueError("task id must not be empty")
+    slug = re.sub(r"[^A-Za-z0-9._-]", "-", task_id).lstrip(".-")
+    return slug or "task"
+
+
+def _clone_repo(task: Task, ref: str, clone_dir: str, log_prefix: str = "") -> Path:
+    """Clone a task's repo at a ref into a temp dir named after the task.
+
+    The checkout lands at ``<clone_dir>/swe-<task-id>/<repo-name>`` so the /swe
+    skill, which derives {repo-name} from the clone path's basename, gets the
+    right name -- and the parent is a stable, transcribable name (the task id)
+    rather than a random mktemp suffix, which agents were mis-copying character
+    by character and burning turns on. The task-id parent is unique per task
+    (ids are unique within a dataset), so serial and concurrent runs do not
+    collide. A leftover directory from a previously killed run is removed first.
 
     Args:
         task: The task whose repo to clone.
@@ -116,7 +146,11 @@ def _clone_repo(task: Task, ref: str, clone_dir: str, log_prefix: str = "") -> P
         RuntimeError: If the clone command fails or times out.
     """
     name = _repo_name(task.repo)
-    parent = Path(tempfile.mkdtemp(prefix="swe-", dir=clone_dir))
+    parent = Path(clone_dir) / f"swe-{_safe_task_slug(task.id)}"
+    # Clear any leftover clone from a prior killed run so the fresh clone into a
+    # deterministic path does not fail on a non-empty destination.
+    shutil.rmtree(parent, ignore_errors=True)
+    parent.mkdir(parents=True, exist_ok=True)
     dest = parent / name
     prefix = f"{log_prefix} " if log_prefix else ""
     logger.info("  %sCloning %s @ %s into %s", prefix, task.repo, ref, dest)
@@ -1316,7 +1350,11 @@ def _dry_run(config: RunnerConfig, dataset: Dataset, tasks: list[Task]) -> None:
     """Print the prompt and command for each task without executing anything."""
     for task in tasks:
         ref = dataset.resolved_ref(task)
-        placeholder = Path(config.clone_dir) / "<tmp>" / _repo_name(task.repo)
+        placeholder = (
+            Path(config.clone_dir)
+            / f"swe-{_safe_task_slug(task.id)}"
+            / _repo_name(task.repo)
+        )
         prompt = _build_prompt(task, placeholder, ref, config.model_slug)
         cmd = _build_claude_cmd(config, prompt, clone_path=placeholder)
         print(f"\n=== {task.id} [{task.complexity}] ref={ref} ===")

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -198,6 +198,12 @@ def _build_env(config: RunnerConfig) -> dict[str, str]:
     env["DISABLE_NON_ESSENTIAL_MODEL_CALLS"] = "1"
     env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = str(config.max_output_tokens)
     env["CLAUDE_CODE_SUBAGENT_MODEL"] = config.model
+    # Calibrate auto-compaction to the model's true window when known. Claude
+    # Code cannot detect the window of a custom model on a custom base URL, so
+    # without this it never compacts and the request eventually overflows the
+    # endpoint's context limit (a 500 the client then retries forever).
+    if config.auto_compact_window is not None:
+        env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(config.auto_compact_window)
     if config.is_bedrock:
         env["CLAUDE_CODE_USE_BEDROCK"] = "1"
         region = config.resolved_region()
@@ -247,19 +253,30 @@ def _build_settings_arg(config: RunnerConfig) -> str:
         region = config.resolved_region()
         if region:
             env["AWS_REGION"] = region
+        # The settings env block overrides the process env, so mirror the
+        # auto-compaction window here too when it is set.
+        if config.auto_compact_window is not None:
+            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(config.auto_compact_window)
         return json.dumps({"env": env})
+    endpoint_env = {
+        "CLAUDE_CODE_USE_BEDROCK": "0",
+        "ANTHROPIC_BASE_URL": config.endpoint,
+        "ANTHROPIC_API_KEY": config.api_key,
+        "DISABLE_NON_ESSENTIAL_MODEL_CALLS": "1",
+        "CLAUDE_CODE_MAX_OUTPUT_TOKENS": str(config.max_output_tokens),
+        "CLAUDE_CODE_SUBAGENT_MODEL": config.model,
+    }
+    # The settings env block overrides the process env, so mirror the
+    # auto-compaction window here too when it is set.
+    if config.auto_compact_window is not None:
+        endpoint_env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(
+            config.auto_compact_window
+        )
     settings = {
         # Claude Code requires a token source even against a local endpoint that
         # ignores the value; without it the run fails with "Not logged in".
         "apiKeyHelper": f"echo {config.api_key}",
-        "env": {
-            "CLAUDE_CODE_USE_BEDROCK": "0",
-            "ANTHROPIC_BASE_URL": config.endpoint,
-            "ANTHROPIC_API_KEY": config.api_key,
-            "DISABLE_NON_ESSENTIAL_MODEL_CALLS": "1",
-            "CLAUDE_CODE_MAX_OUTPUT_TOKENS": str(config.max_output_tokens),
-            "CLAUDE_CODE_SUBAGENT_MODEL": config.model,
-        },
+        "env": endpoint_env,
     }
     return json.dumps(settings)
 
@@ -1480,6 +1497,13 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--max-turns", type=int, help="Override: cap on the agent loop")
     parser.add_argument(
+        "--context-window",
+        type=int,
+        help="Override: the model's true context window in tokens. Calibrates "
+        "auto-compaction (CLAUDE_CODE_AUTO_COMPACT_WINDOW) for custom models "
+        "whose window Claude Code cannot detect. 0 leaves it unset.",
+    )
+    parser.add_argument(
         "--concurrency",
         type=int,
         help="Override: how many tasks to run at once (default 1 = serial). "
@@ -1512,6 +1536,7 @@ def main() -> None:
         "aws_region": args.aws_region,
         "dataset": args.dataset,
         "max_turns": args.max_turns,
+        "context_window": args.context_window,
         "concurrency": args.concurrency,
     }
     if args.tasks:

--- a/benchmarks/scripts/runner_config.py
+++ b/benchmarks/scripts/runner_config.py
@@ -52,6 +52,20 @@ VALID_PERMISSION_MODES = {"default", "acceptEdits", "plan"}
 DEFAULT_MAX_TURNS = 60
 DEFAULT_MAX_OUTPUT_TOKENS = 16000
 DEFAULT_TIMEOUT_SECONDS = 1800
+# The model's true context window, in tokens. Claude Code cannot learn the
+# window of a custom model served over a custom base URL, so it never triggers
+# auto-compaction and the conversation grows until the endpoint rejects the
+# request (HTTP 500 "maximum context length is N tokens"), which the client
+# then retries forever. Setting CLAUDE_CODE_AUTO_COMPACT_WINDOW to the true
+# window lets auto-compaction fire before the request overflows. 0 means "leave
+# unset" -- for a known Claude model or Bedrock, Claude Code already knows the
+# window, so no override is needed.
+DEFAULT_CONTEXT_WINDOW = 0
+# Fraction of the context window at which to run auto-compaction. Kept below 1.0
+# so there is headroom for the output-token reserve (max_output_tokens) and
+# per-request overhead: at 0.9 of a 262144 window the compact target is 235929,
+# leaving ~26k tokens on top of the 16k output reserve.
+DEFAULT_AUTO_COMPACT_FRACTION = 0.9
 
 # Where claude -p sends requests. "endpoint" routes through an OpenAI/Anthropic-
 # compatible base URL (a local vLLM server, a gateway, the Anthropic API);
@@ -164,6 +178,18 @@ class RunnerConfig(BaseModel):
     max_turns: int = Field(default=DEFAULT_MAX_TURNS, ge=1)
     max_output_tokens: int = Field(default=DEFAULT_MAX_OUTPUT_TOKENS, ge=1)
     timeout_seconds: int = Field(default=DEFAULT_TIMEOUT_SECONDS, ge=1)
+    context_window: int = Field(
+        default=DEFAULT_CONTEXT_WINDOW,
+        ge=0,
+        description="Model's true context window in tokens; calibrates "
+        "auto-compaction for custom models. 0 leaves it unset.",
+    )
+    auto_compact_fraction: float = Field(
+        default=DEFAULT_AUTO_COMPACT_FRACTION,
+        gt=0.0,
+        le=1.0,
+        description="Fraction of context_window at which auto-compaction fires.",
+    )
     settings_file: str | None = Field(
         default=None,
         description="Optional claude --settings JSON file (e.g. the vLLM config).",
@@ -173,6 +199,23 @@ class RunnerConfig(BaseModel):
     def is_bedrock(self) -> bool:
         """True when claude -p should route natively to Amazon Bedrock."""
         return self.provider == PROVIDER_BEDROCK
+
+    @property
+    def auto_compact_window(self) -> int | None:
+        """Token budget for CLAUDE_CODE_AUTO_COMPACT_WINDOW, or None if unset.
+
+        Computed as ``floor(context_window * auto_compact_fraction)`` so
+        auto-compaction fires with headroom below the model's true window. When
+        ``context_window`` is 0 (the default) this returns None and the harness
+        leaves the env var unset -- Claude Code already knows the window for a
+        known Claude model or Bedrock, so no override is needed there.
+
+        Returns:
+            The compact-trigger token budget, or None when no window is set.
+        """
+        if self.context_window <= 0:
+            return None
+        return int(self.context_window * self.auto_compact_fraction)
 
     @property
     def model_slug(self) -> str:
@@ -336,6 +379,15 @@ def _summarize(config: RunnerConfig) -> None:
     logger.info("  concurrency: %s", config.concurrency)
     logger.info("  permission_mode: %s", config.permission_mode)
     logger.info("  max_turns: %s", config.max_turns)
+    if config.auto_compact_window is not None:
+        logger.info(
+            "  context_window: %s (auto-compact at %s, fraction %s)",
+            config.context_window,
+            config.auto_compact_window,
+            config.auto_compact_fraction,
+        )
+    else:
+        logger.info("  context_window: (unset -- relying on Claude Code's default)")
     logger.info("  allowed_tools: %s", ", ".join(config.allowed_tools))
 
 

--- a/benchmarks/tests/test_run_swe_headless.py
+++ b/benchmarks/tests/test_run_swe_headless.py
@@ -188,6 +188,32 @@ class BuildSettingsArgTest(unittest.TestCase):
         )
         self.assertTrue(arg.endswith("self-hosted/vllm/config/claude-code.json"))
 
+    def test_auto_compact_window_set_in_settings_env(self) -> None:
+        import json
+
+        arg = harness._build_settings_arg(_config(context_window=262144))
+        settings = json.loads(arg)
+        # 0.9 * 262144 = 235929: the settings env block must carry the window so
+        # it wins over the process env, which Claude Code otherwise overrides.
+        self.assertEqual(settings["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"], "235929")
+
+    def test_auto_compact_window_absent_when_unset(self) -> None:
+        import json
+
+        arg = harness._build_settings_arg(_config())
+        settings = json.loads(arg)
+        self.assertNotIn("CLAUDE_CODE_AUTO_COMPACT_WINDOW", settings["env"])
+
+
+class BuildEnvTest(unittest.TestCase):
+    def test_auto_compact_window_set_in_process_env(self) -> None:
+        env = harness._build_env(_config(context_window=262144))
+        self.assertEqual(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"], "235929")
+
+    def test_auto_compact_window_absent_when_unset(self) -> None:
+        env = harness._build_env(_config())
+        self.assertNotIn("CLAUDE_CODE_AUTO_COMPACT_WINDOW", env)
+
 
 def _dataset(n: int) -> Dataset:
     """Build a dataset with n tasks (ids task-0..task-{n-1})."""

--- a/benchmarks/tests/test_run_swe_headless.py
+++ b/benchmarks/tests/test_run_swe_headless.py
@@ -62,6 +62,29 @@ class RepoNameTest(unittest.TestCase):
         self.assertEqual(harness._repo_name("https://github.com/foo/bar.git/"), "bar")
 
 
+class SafeTaskSlugTest(unittest.TestCase):
+    def test_kebab_case_id_unchanged(self) -> None:
+        # Well-formed dataset ids pass through untouched -- this is the common
+        # case and what makes the clone path transcribable by the agent.
+        self.assertEqual(harness._safe_task_slug("remove-faiss"), "remove-faiss")
+
+    def test_dots_and_underscores_preserved(self) -> None:
+        self.assertEqual(harness._safe_task_slug("Foo_Bar.1"), "Foo_Bar.1")
+
+    def test_slashes_replaced(self) -> None:
+        self.assertEqual(harness._safe_task_slug("a/b"), "a-b")
+
+    def test_path_traversal_neutralized(self) -> None:
+        # Leading dots/dashes are stripped so a crafted id cannot escape the
+        # clone parent (e.g. "../etc" must not become a traversal).
+        self.assertEqual(harness._safe_task_slug("../etc"), "etc")
+        self.assertEqual(harness._safe_task_slug(".."), "task")
+
+    def test_empty_id_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            harness._safe_task_slug("")
+
+
 class BuildPromptTest(unittest.TestCase):
     def test_prompt_has_all_swe_keys(self) -> None:
         prompt = harness._build_prompt(

--- a/benchmarks/tests/test_runner_config.py
+++ b/benchmarks/tests/test_runner_config.py
@@ -210,5 +210,40 @@ class ModelSlugTest(unittest.TestCase):
         self.assertEqual(config.model_slug, "claude-opus-4-8")
 
 
+class AutoCompactWindowTest(unittest.TestCase):
+    def test_unset_by_default(self) -> None:
+        config = load_runner_config(_write(_MINIMAL))
+        self.assertEqual(config.context_window, 0)
+        self.assertIsNone(config.auto_compact_window)
+
+    def test_computed_from_window_and_fraction(self) -> None:
+        config = load_runner_config(_write(_MINIMAL), {"context_window": 262144})
+        self.assertEqual(config.auto_compact_fraction, 0.9)
+        self.assertEqual(config.auto_compact_window, 235929)
+
+    def test_custom_fraction_applied(self) -> None:
+        text = _MINIMAL + "context_window: 100000\nauto_compact_fraction: 0.8\n"
+        config = load_runner_config(_write(text))
+        self.assertEqual(config.auto_compact_window, 80000)
+
+    def test_cli_context_window_override_wins(self) -> None:
+        text = _MINIMAL + "context_window: 131072\n"
+        config = load_runner_config(_write(text), {"context_window": 262144})
+        self.assertEqual(config.auto_compact_window, 235929)
+
+    def test_zero_window_leaves_it_unset(self) -> None:
+        config = load_runner_config(_write(_MINIMAL), {"context_window": 0})
+        self.assertIsNone(config.auto_compact_window)
+
+    def test_negative_window_rejected(self) -> None:
+        with self.assertRaises(RunnerConfigError):
+            load_runner_config(_write(_MINIMAL), {"context_window": -1})
+
+    def test_fraction_above_one_rejected(self) -> None:
+        text = _MINIMAL + "context_window: 100000\nauto_compact_fraction: 1.5\n"
+        with self.assertRaises(RunnerConfigError):
+            load_runner_config(_write(text))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/self-hosted/vllm/models/qwen3.6-35b-a3b.md
+++ b/self-hosted/vllm/models/qwen3.6-35b-a3b.md
@@ -60,6 +60,17 @@ export DO_NOT_TRACK=1
 ```
 
 > **Why 200000 and not the full 256K?** `MAX_MODEL_LEN` is a hard ceiling you set — it does not auto-expand to native. 200K stays just under the 256K native window (so no rope scaling) while leaving a little KV-cache headroom; the full 256K would consume so much KV cache it may not boot at useful concurrency. If you hit OOM or see `Maximum concurrency ... 1x` at boot, lower it (e.g. `131072` or `65536`). See the long-context tuning note below.
+>
+> **Single-request benchmarking — use the full 262144.** The 200K default and the "may not boot at useful concurrency" caution above are written for multi-tenant serving, where every concurrent request needs its own KV-cache slice. The benchmark harness runs at `concurrency: 1` (see `benchmarks/config/runner.yaml`), so only one request is ever in flight and that caution does not apply — serve the full native window instead:
+>
+> ```bash
+> MODEL="Qwen/Qwen3.6-35B-A3B" SERVED_NAME="qwen3.6-35b" TP=4 PORT=8000 \
+>   MAX_MODEL_LEN=262144 GPU_MEM_UTIL=0.90 TOOL_PARSER="qwen3_coder" ./vllm-serve.sh
+> ```
+>
+> Measured on 4xL40S at boot: **GPU KV cache 2.15M tokens, max concurrency 8.21x** — no OOM, no `1x` warning. This matters because a real SWE task can exceed 200K in a single request: Claude Code reserves `max_output_tokens` (16000) on top of the prompt, so a 184,001-token prompt hits `184001 + 16000 = 200001`, one token over a 200K window. 262144 gives ~46K more input headroom at zero cost here.
+>
+> Serving the full window is only half the fix — the harness must also tell Claude Code the window so it auto-compacts *before* overflowing it, otherwise the conversation still grows into the ceiling (now 262145) and the client retries the resulting 500 forever. The orchestrator does this automatically on the vllm path (it reads the live `max_model_len` and passes `--context-window`); see [Context window and auto-compaction](../../../benchmarks/docs/harness-reference.md#context-window-and-auto-compaction).
 
 ## How it compares
 


### PR DESCRIPTION
## Summary

A set of fixes to the SWE benchmark harness, found and validated while running `qwen3.6-35b` on `mcp-gateway-registry` end to end. Five commits, each independently reviewed:

### 1. Calibrate Claude Code auto-compaction to the model's context window

Long headless `/swe` tasks against a custom endpoint (self-hosted vLLM or the LiteLLM proxy) failed in a retry loop:

```
API Error: 500 This model's maximum context length is 262144 tokens. However, you
requested 16000 output tokens and your prompt contains at least 246145 input tokens,
for a total of at least 262145 tokens.
```

Claude Code compacts as it nears the context limit, but only if it knows the model's window -- and it cannot detect the window of a custom model on a custom `ANTHROPIC_BASE_URL`, so auto-compaction never fired and the conversation grew until the server rejected it (a 500 the client then retries forever). The failing total is `input + max_output_tokens` (the output budget is reserved on top of the prompt).

Fix: wire the true window into `CLAUDE_CODE_AUTO_COMPACT_WINDOW` so compaction runs before overflow.
- `runner_config`: `context_window` (default 0 = unset) and `auto_compact_fraction` (default 0.9) fields + an `auto_compact_window` property (`floor(window * fraction)`).
- `run-swe-headless`: set the env var in both the process env and the `--settings` env block (the latter takes precedence); `--context-window` CLI override.
- `run-e2e-benchmark.sh`: on the vllm path, read the live server's `max_model_len` from `/v1/models` and pass it as `--context-window`, so a run is always calibrated to the booted window. Also make `--stream --verbose` the harness default.
- Docs: new "Context window and auto-compaction" section in the harness reference; config templates; qwen3.6-35b guide note.

Leaving `context_window` at 0 keeps Bedrock and known Claude models on Claude Code's built-in detection.

### 2. Deterministic `swe-clone-<task-id>` clone path

The harness cloned into `tempfile.mkdtemp(prefix="swe-")`, producing a random parent like `/tmp/swe-0xddi_2w/`. Agents could not reliably reproduce that random suffix in tool calls -- they mistranscribed it repeatedly and burned turns and context recovering, polluting the benchmark. Clone into `<clone_dir>/swe-clone-<task-id>/<repo-name>` instead: a stable, transcribable, per-task-unique name. Adds `_safe_task_slug` (allowlist `[A-Za-z0-9._-]`, strip leading dots/dashes) so the id is filesystem-safe and cannot traverse out of `clone_dir`.

### 3. Fix spurious exit 1 from the clone-cleanup trap

The cleanup EXIT trap's last statement was a `[[ -d "$dir" ]] && rm -rf` test; since the harness already removes each clone, that test is normally false and its non-zero status became the script's exit code -- so a fully successful run still exited 1. Return 0 explicitly.

### 4. Auto-write a RUN-SUMMARY.md

The benchmark skill now writes a `RUN-SUMMARY.md` into the run's `{model-slug}/{scope}/` folder after scoring: a results table (turns, tokens, latency, judge score) plus notes, gathered from the artifacts. Instructed not to present a partial/failed run as a clean sweep.

### 5. Tighten the clone gitignore glob

The `swe-*/` backstop rule also matched the `swe-benchmark-data` output dir (benign but imprecise). The `swe-clone-` prefix lets the ignore be `swe-clone-*/`, which cannot collide.

## Validation

- 102 unit tests pass (`unittest`), +16 new (auto-compact window, `_safe_task_slug`, env/settings wiring).
- `ruff check` + `ruff format` clean; `bash -n` clean; `bandit -r scripts/` 0 issues; `mypy` 0 new errors.
- Security gate (Cipher `security-check`): APPROVED, no findings.
- End-to-end proof: full 5-task `qwen3.6-35b` run on `mcp-gateway-registry` -- all 5 OK (4/4 artifacts), 0 retries, 0 crashes, judge scored 5/5.