### PR TITLE
Gate the benchmark on a >=200K context window

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -27,7 +27,7 @@ Collect these three, in order. Do not guess -- ask if any is missing.
 ## Workflow
 
 1. **Gather the three inputs** -- provider, model, dataset. Confirm them back to the user.
-2. **Bring up / confirm the backing service** for the chosen path. For **vllm**: check the HF token, then (re)start the vLLM server on the requested model -- stopping any other model first -- using the model guide's serve command at its largest context window, and start the DuckDB collector. For litellm/bedrock: confirm the proxy/credentials.
+2. **Bring up / confirm the backing service** for the chosen path. For **vllm**: check the HF token, then (re)start the vLLM server on the requested model -- stopping any other model first -- using the model guide's serve command at its largest context window; **require the served window to be at least 200K or STOP** (a smaller window is unsuited to agentic coding and fails on turn 1); then start the DuckDB collector. For litellm/bedrock: confirm the proxy/credentials.
 3. **Dry-run the pre-flight** so the user sees what will happen before anything runs.
 4. **Run the orchestrator**, streaming its output, and tell the user what to tail.
 5. **Wrap up and report**: (vllm) stop the collector and archive its DuckDB snapshot tagged with model/scope/timestamp; write a `RUN-SUMMARY.md` (results table + notes) into the run's `{model-slug}/{scope}/` folder; then report where the results landed.
@@ -106,7 +106,24 @@ TOOL_PARSER="<parser from the guide>" \
 
 If there is no guide for `{model}` under `self-hosted/vllm/models/`, tell the user and ask for the HF repo id, tool-call parser, and desired context window rather than guessing.
 
-**2d. Start the DuckDB metrics collector** so a GPU time series is captured for the whole run (it is stopped and the snapshot archived in Step 5):
+**2d. Context-window gate -- REQUIRE at least 200K, or STOP.** Agentic coding tasks on real repositories routinely need 100K-250K input tokens in a single request (the `/swe` skill prompt alone is ~12K, and reading repo files pushes far higher). A context window below **200000** is not suited for these tasks: the model overflows the window on turn 1 (before auto-compaction can help, since the first prompt already does not fit) and every task fails. This is a node/VRAM limitation, not a model-quality signal.
+
+After the server reports ready, read the window it actually booted with and hard-stop if it is under 200000:
+
+```bash
+WINDOW="$(curl -s -m 5 http://127.0.0.1:8000/v1/models \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin).get("data",[]); print(next((m.get("max_model_len") for m in d if m.get("max_model_len")), 0))' 2>/dev/null || echo 0)"
+echo "served context window: $WINDOW"
+if [ "$WINDOW" -lt 200000 ]; then echo "WINDOW TOO SMALL -- STOP"; fi
+```
+
+If it prints `WINDOW TOO SMALL -- STOP`, **do not run the benchmark.** Stop here and tell the user the model cannot be served at a usable window on this node, e.g.:
+
+> `{model}` booted at a {WINDOW}-token context window on this node, but agentic coding tasks need at least 200K. A window this small overflows on the first prompt and every task fails, so I am not starting the run. This is a VRAM limitation of the current machine, not the model. Options: benchmark a model that fits a >=200K window on this node (e.g. `qwen3.6-35b` or `qwen3-coder-30b`), or serve `{model}` on a larger-VRAM node (see its model guide for the required instance) where a 200K-256K window fits.
+
+Stop the collector if it was already started, leave the notes for the user, and do not proceed to Step 3. (This gate is why Step 2c picks the *largest* window the guide endorses -- if even that is under 200K, the model is not benchmarkable here.)
+
+**2e. Start the DuckDB metrics collector** so a GPU time series is captured for the whole run (it is stopped and the snapshot archived in Step 5):
 
 ```bash
 cd self-hosted/vllm/scripts && ./vllm-metrics.sh start && ./vllm-metrics.sh status

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -37,6 +37,14 @@ set -euo pipefail
 #   ./scripts/run-e2e-benchmark.sh vllm qwen3.6-35b dataset/mcp-gateway-registry.yaml
 #   ./scripts/run-e2e-benchmark.sh --provider vllm --model qwen3.6-35b \
 #       --dataset dataset/hello-world.yaml --count 1 --yes
+#
+# Optional flags:
+#   --count N              run only the first N tasks (0 = all, default)
+#   --max-output-tokens N  override the per-response output cap for this run
+#                          (e.g. 4096 on a small-window model so the prompt has
+#                          usable input room; usable input ~= window - this)
+#   --skip-judge           run the harness only; score later
+#   --yes                  clear pre-existing artifact folders without asking
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -49,6 +57,7 @@ PROVIDER=""
 MODEL=""
 DATASET=""
 COUNT="0"                 # 0 = all tasks
+MAX_OUTPUT_TOKENS=""      # empty = use the config value
 ENDPOINT=""               # derived from provider unless overridden
 AWS_REGION_ARG="${AWS_REGION:-us-east-1}"
 ASSUME_YES=0
@@ -79,6 +88,7 @@ while [[ $# -gt 0 ]]; do
         --model)    MODEL="${2:?--model needs a value}"; shift 2 ;;
         --dataset)  DATASET="${2:?--dataset needs a value}"; shift 2 ;;
         --count)    COUNT="${2:?--count needs a value}"; shift 2 ;;
+        --max-output-tokens) MAX_OUTPUT_TOKENS="${2:?--max-output-tokens needs a value}"; shift 2 ;;
         --endpoint) ENDPOINT="${2:?--endpoint needs a value}"; shift 2 ;;
         --aws-region) AWS_REGION_ARG="${2:?--aws-region needs a value}"; shift 2 ;;
         --config)   CONFIG="${2:?--config needs a value}"; shift 2 ;;
@@ -269,6 +279,7 @@ BENCH_ARGS=(--config "$CONFIG" --provider "$HARNESS_PROVIDER" --model "$MODEL" -
 [[ "$PROVIDER" == "bedrock" ]] && BENCH_ARGS+=(--aws-region "$AWS_REGION_ARG")
 # On the vllm path, calibrate auto-compaction to the live server's window.
 [[ -n "${VLLM_CONTEXT_WINDOW:-}" ]] && BENCH_ARGS+=(--context-window "$VLLM_CONTEXT_WINDOW")
+[[ -n "$MAX_OUTPUT_TOKENS" ]] && BENCH_ARGS+=(--max-output-tokens "$MAX_OUTPUT_TOKENS")
 
 SLUG="$(uv run python -c "import sys; sys.path.insert(0,'scripts'); from runner_config import model_to_slug; print(model_to_slug('$MODEL'))")"
 info "Command:"

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -1537,6 +1537,13 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--max-turns", type=int, help="Override: cap on the agent loop")
     parser.add_argument(
+        "--max-output-tokens",
+        type=int,
+        help="Override: per-response output-token cap (CLAUDE_CODE_MAX_OUTPUT_TOKENS). "
+        "Lower it on a small-window model so the prompt has usable input room "
+        "(usable input ~= context_window - max_output_tokens).",
+    )
+    parser.add_argument(
         "--context-window",
         type=int,
         help="Override: the model's true context window in tokens. Calibrates "
@@ -1576,6 +1583,7 @@ def main() -> None:
         "aws_region": args.aws_region,
         "dataset": args.dataset,
         "max_turns": args.max_turns,
+        "max_output_tokens": args.max_output_tokens,
         "context_window": args.context_window,
         "concurrency": args.concurrency,
     }

--- a/benchmarks/tests/test_runner_config.py
+++ b/benchmarks/tests/test_runner_config.py
@@ -82,6 +82,14 @@ class LoadRunnerConfigTest(unittest.TestCase):
         self.assertEqual(config.max_turns, 10)
         self.assertEqual(config.tasks, ["a", "b"])
 
+    def test_max_output_tokens_override(self) -> None:
+        # Lowered on the CLI for a small-window model so the prompt has input
+        # room; None must not clobber the config/default value.
+        config = load_runner_config(_write(_MINIMAL), {"max_output_tokens": 4096})
+        self.assertEqual(config.max_output_tokens, 4096)
+        default = load_runner_config(_write(_MINIMAL), {"max_output_tokens": None})
+        self.assertEqual(default.max_output_tokens, 16000)
+
     def test_none_overrides_are_ignored(self) -> None:
         config = load_runner_config(_write(_MINIMAL), {"model": None, "endpoint": None})
         self.assertEqual(config.model, "test-model")

--- a/self-hosted/vllm/models/qwen3-coder-next.md
+++ b/self-hosted/vllm/models/qwen3-coder-next.md
@@ -12,6 +12,9 @@
 | **Tool-call parser** | `qwen3_coder` |
 | **Native context** | **262144 (256K)** — but VRAM caps you *far* below this (see below) |
 | **Role** | largest model that fits the node — top-tier quality, low concurrency |
+| **For agentic coding (>=200K window)** | needs a **g6e.48xlarge** (8xL40S, 384 GB) or larger — a g6e.12xlarge (4xL40S) only fits ~16K, which is unusable for repo-scale tasks |
+
+> **Hardware requirement for benchmarking / agentic coding.** On a **g6e.12xlarge (4xL40S, 184 GB)** this model fits only a ~16384-token window (the ~160 GB of weights leave ~1 GB for KV cache). That is far too small for agentic coding: the `/swe` prompt alone is ~12K tokens, so the very first request overflows the window and every task fails on turn 1 (auto-compaction cannot help — the first message already does not fit). To serve a **200K or 256K** window this model needs a larger-VRAM node — a **g6e.48xlarge (8xL40S, 384 GB)** or bigger — where the weights leave enough room for a repo-scale KV cache. The 16384 config below is only useful for short-prompt smoke tests, **not** the SWE benchmark. For agentic coding on a 4xL40S node, use the 256K-native [Qwen3.6-35B-A3B](qwen3.6-35b-a3b.md) or [Qwen3-Coder-30B](qwen3-coder-30b.md) instead.
 
 ## Serve it
 
@@ -79,6 +82,20 @@ Despite only 3B active parameters per token (fast, MoE economics), this model's 
 ### Disk: ~160 GB of weights won't fit on the root disk
 
 Separate from VRAM: the **download** is ~160 GB, and the DLAMI root disk is only ~193 GB — nowhere near enough once anything else (e.g. the 30B, at ~57 GB) is also cached. A naive run fills the root disk and the download stalls with `Not enough free disk space`. `vllm-serve.sh` handles this by defaulting `HF_HOME` to the DLAMI's large local-NVMe scratch (`/opt/dlami/nvme/hf-cache`, 3.5 TB here) when it exists — the boot log prints `Weights cache: <dir> (<free>)` so you can confirm before the download starts. **Caveat:** that NVMe scratch is **ephemeral** — wiped on instance stop/terminate — so the 160 GB re-downloads after any stop. If you need the cache to survive a stop, set `HF_HOME` to a path on a persistent EBS volume with ≥200 GB free instead.
+
+## Benchmarking
+
+**The SWE benchmark requires a >=200K context window** (agentic coding tasks routinely need 100K-250K input tokens per request), so this model can only be benchmarked on a **g6e.48xlarge (8xL40S) or larger** where a 200K-256K window fits. The `/benchmark` skill enforces this: it reads the served `max_model_len` after boot and refuses to run if it is under 200000. On such a node, serve at a large window (e.g. `MAX_MODEL_LEN=200000`) and run:
+
+```bash
+cd benchmarks
+./scripts/run-e2e-benchmark.sh --provider vllm --model qwen3-coder-next \
+  --dataset dataset/mcp-gateway-registry.yaml --yes
+```
+
+**Do not attempt the benchmark on a g6e.12xlarge (4xL40S).** There the model is VRAM-bound to a ~16384 window; the `/swe` prompt alone (~12K tokens) plus the output reserve overflows it, so every task fails on turn 1. This was confirmed empirically: on a 4xL40S at 16384 with `--max-output-tokens 4096`, task 1 failed 0/4 with `maximum context length is 16384 tokens ... prompt contains at least 12289 input tokens`. Auto-compaction cannot rescue it because the first message already does not fit. For agentic coding on a 4xL40S node, benchmark the 256K-native [Qwen3.6-35B-A3B](qwen3.6-35b-a3b.md) or [Qwen3-Coder-30B](qwen3-coder-30b.md) instead.
+
+The `--max-output-tokens` flag (added to both the harness and the orchestrator) lets you lower the per-response output cap on the CLI without editing `runner.yaml` -- useful for short-window smoke tests, but it does not make this model benchmarkable on a small-VRAM node.
 
 ## Tuning notes
 


### PR DESCRIPTION
## Problem

Attempting to benchmark `qwen3-coder-next` (79.6B MoE, ~160 GB weights) on a g6e.12xlarge (4xL40S) exposed a gap: the model is VRAM-bound to a 16384-token context window on that node, and the harness ran it anyway. Every task failed on turn 1:

```
API Error: 500 This model's maximum context length is 16384 tokens. However, you
requested 4096 output tokens and your prompt contains at least 12289 input tokens,
for a total of at least 16385 tokens.
```

The `/swe` prompt alone is ~12K tokens, so the first request overflows the window before the agent reads a single file. Auto-compaction cannot help -- it shrinks history between turns, but the first message already does not fit. Agentic coding on real repos needs 100K-250K input tokens per request; anything under ~200K is not viable.

## Change

- **Benchmark skill gate (Step 2d):** after the vLLM server boots, read the served `max_model_len` and **STOP the run if it is under 200000**, telling the user to benchmark a model that fits (e.g. `qwen3.6-35b`, `qwen3-coder-30b`) or serve on a larger-VRAM node. Prevents wasting hours on a guaranteed-fail run.
- **`--max-output-tokens` CLI flag:** added to both the harness (`run-swe-headless.py`) and the orchestrator (`run-e2e-benchmark.sh`), threaded through the same override path as `--max-turns`. Lets you lower the per-response output cap for a short-window smoke test without editing `runner.yaml`.
- **qwen3-coder-next model guide:** documents that a >=200K window (for agentic coding) requires a **g6e.48xlarge (8xL40S) or larger**; a g6e.12xlarge only fits ~16K and is not benchmarkable. Points to the 256K-native 35B/30B models for the 4xL40S node.
- **Test:** covers the `--max-output-tokens` override (present and None-ignored).

## Validation

- 103 unit tests pass (+1); `ruff` + `ruff format` clean; `bash -n` clean; `bandit -r scripts/` 0 issues.
- Security gate (Cipher `security-check`): APPROVED, no findings.
- Empirically confirmed: the gate math (12,289-token prompt vs 16,384 window) is exactly the observed turn-1 failure.