### PR TITLE
Preflight both claude and codex CLIs; state Bedrock-wiring expectation

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -146,7 +146,19 @@ aws sts get-caller-identity
 
 ## Step 3 - Pre-flight (see what will happen first)
 
-Show the user which artifact folders already exist for this model+dataset (a pre-existing folder makes the headless `/swe` run stall on its overwrite prompt). This is a read-only check:
+**3a. Both coding-agent CLIs must be installed, and both are expected to be wired to Amazon Bedrock.** The harness runs `claude -p` to produce the artifacts, and the judge runs `codex exec` to score them. Confirm both are on PATH:
+
+```bash
+command -v claude && command -v codex || echo "MISSING a required CLI"
+```
+
+If `claude` is missing, stop -- the harness cannot run. If `codex` is missing, the run can still proceed with `--skip-judge` (score later once codex is installed). The orchestrator re-checks both and fails loudly.
+
+State this expectation to the user **loudly**, because the skill does not configure it: both CLIs must already be authenticated against **Amazon Bedrock** on this machine. The codex judge *always* calls Bedrock for its scoring model; on `--provider bedrock`, `claude` calls Bedrock too (on the litellm/vllm paths `claude` is pointed at the proxy/local server instead, but the judge still uses Bedrock). If either CLI is unconfigured or pointed elsewhere, the run or the scoring will fail.
+
+> Heads-up: this benchmark assumes `claude` and `codex` on this machine are already wired to Amazon Bedrock (credentials/region). The judge always calls Bedrock; on the bedrock path claude does too. I do not configure them -- if either is pointed elsewhere, the run or scoring will fail.
+
+**3b.** Show the user which artifact folders already exist for this model+dataset (a pre-existing folder makes the headless `/swe` run stall on its overwrite prompt). This is a read-only check:
 
 ```bash
 cd benchmarks

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -149,9 +149,29 @@ if [[ ! -f "$CONFIG" ]]; then
 fi
 ok "runner config: $CONFIG"
 
-# claude CLI must be available (the harness shells out to it).
+# The two coding-agent CLIs this benchmark drives must be installed:
+#   - claude : the harness runs 'claude -p' to produce the artifacts (always).
+#   - codex  : the judge runs 'codex exec' to score them (unless --skip-judge).
+# Check both here, up front, so a missing codex fails fast instead of after the
+# entire (long) harness run has already completed.
 command -v claude >/dev/null 2>&1 || die "claude CLI not found on PATH (the harness runs 'claude -p'). Install Claude Code."
 ok "claude CLI found: $(command -v claude)"
+if [[ "$SKIP_JUDGE" -eq 1 ]]; then
+    command -v codex >/dev/null 2>&1 && ok "codex CLI found: $(command -v codex)" \
+        || warn "codex CLI not found, but --skip-judge is set, so scoring is skipped."
+else
+    command -v codex >/dev/null 2>&1 || die "codex CLI not found on PATH (the judge runs 'codex exec'). Install codex, or re-run with --skip-judge."
+    ok "codex CLI found: $(command -v codex)"
+fi
+
+# LOUD EXPECTATION: both CLIs must be wired to Amazon Bedrock. The harness points
+# claude at the model under test (Bedrock, the LiteLLM proxy, or local vLLM), but
+# the codex JUDGE always calls Amazon Bedrock for its scoring model, and on the
+# bedrock path claude does too. This benchmark assumes both 'claude' and 'codex'
+# are already configured to reach Amazon Bedrock (credentials/region/base URL) on
+# THIS machine. It does not configure them for you -- if either is pointed
+# elsewhere or unauthenticated, the run or the scoring will fail.
+warn "EXPECTATION: 'claude' and 'codex' on this machine are assumed to be wired to Amazon Bedrock (the judge always calls Bedrock; on --provider bedrock, claude does too). This script does not configure them."
 
 # Per-path readiness.
 case "$PROVIDER" in


### PR DESCRIPTION
## Problem

The orchestrator checked for the `codex` CLI only at judge time (Step 2), so if codex was missing the run failed *after* the entire (long) harness phase had already completed -- wasting the whole run. It also never stated that the coding-agent CLIs are expected to be authenticated against Amazon Bedrock, which is a common cause of confusing run/scoring failures.

## Change

- **Preflight both CLIs up front:** `claude` (always required -- the harness runs `claude -p`) and `codex` (required unless `--skip-judge` -- the judge runs `codex exec`). A missing codex now fails fast in pre-flight, or downgrades to a warning when `--skip-judge` is set.
- **Loud Bedrock-wiring expectation:** both the script and the benchmark skill now state plainly that `claude` and `codex` are assumed to be wired to Amazon Bedrock on the machine. The codex judge *always* calls Bedrock for its scoring model; on `--provider bedrock`, `claude` does too. The script does not configure them -- if either is pointed elsewhere or unauthenticated, the run or scoring fails.

## Validation

- `bash -n` clean; verified both CLIs resolve on this host; confirmed the `--skip-judge` branch warns rather than dies on missing codex.
- Security gate (Cipher `security-check`): APPROVED -- presence-only checks, prints CLI paths and a static notice, no credential material logged.