### PR TITLE
Judge: score missing-artifact folders 0 instead of erroring out

### DIFF
--- a/benchmarks/scripts/codex_judge.py
+++ b/benchmarks/scripts/codex_judge.py
@@ -60,9 +60,12 @@ from judge_common import (  # noqa: E402
     EvaluationResult,
     JudgeError,
     atomic_write_json,
+    identify_folder,
+    missing_artifacts,
     optional_file,
     parse_and_validate_result,
     render_judge_prompt,
+    zero_score_result,
 )
 
 logging.basicConfig(
@@ -491,6 +494,39 @@ def evaluate_artifact_folder_with_codex(
     eval_path = artifact_dir / "eval.json"
     if eval_path.exists() and not overwrite:
         raise JudgeError(f"eval.json exists and overwrite is disabled: {eval_path}")
+
+    # A folder missing (or with empty) required artifacts is a genuine model
+    # failure, not a judging error: score it 0 and record why, instead of
+    # cloning the repo and calling codex only to fail. This keeps the failed
+    # task in the results with an explicit MODEL FAILURE verdict.
+    missing = missing_artifacts(artifact_dir)
+    if missing:
+        task_id, candidate_id = identify_folder(artifact_dir)
+        logger.warning(
+            "%s: missing artifact(s) %s -- scoring 0 (model failure)",
+            artifact_dir,
+            ", ".join(missing),
+        )
+        result = zero_score_result(
+            task_id=task_id, candidate_id=candidate_id, missing=missing
+        )
+        result["judge"] = {
+            "model": model or "codex-config-default",
+            "provider": "codex-exec",
+            "repo_grounded": False,
+            "scored_zero_missing_artifacts": missing,
+            "evaluated_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+        }
+        if write_outputs:
+            atomic_write_json(eval_path, result)
+            metrics_path = artifact_dir / "metrics.json"
+            if metrics_path.exists():
+                existing = json.loads(metrics_path.read_text(encoding="utf-8"))
+                existing["evaluation"] = result
+                atomic_write_json(metrics_path, existing)
+        return result
 
     prompt, task_id, candidate_id, metrics = render_judge_prompt(
         artifact_dir,

--- a/benchmarks/scripts/judge_common.py
+++ b/benchmarks/scripts/judge_common.py
@@ -102,6 +102,102 @@ class EvaluationResult(BaseModel):
         return self
 
 
+def missing_artifacts(folder: str | Path) -> list[str]:
+    """Return the required artifact filenames that are missing or empty.
+
+    A required artifact that does not exist -- or exists but is blank -- is a
+    genuine candidate (model) failure: the run did not produce that design
+    document. This lets the judge score such a folder 0 rather than erroring out
+    and dropping it from the results.
+
+    Args:
+        folder: The artifact directory.
+
+    Returns:
+        The missing/empty artifact filenames (e.g. ``["github-issue.md"]``),
+        empty if all four are present and non-empty.
+    """
+    artifact_dir = Path(folder).expanduser().resolve()
+    missing: list[str] = []
+    for filename in ARTIFACT_FILES.values():
+        path = artifact_dir / filename
+        try:
+            if not path.read_text(encoding="utf-8").strip():
+                missing.append(filename)
+        except (FileNotFoundError, OSError):
+            missing.append(filename)
+    return missing
+
+
+def zero_score_result(
+    *, task_id: str, candidate_id: str, missing: list[str]
+) -> dict[str, Any]:
+    """Build a valid zero-score evaluation for a folder missing artifacts.
+
+    The result is schema-shaped exactly like a judged one (all criteria 0, all
+    totals 0, ``task_score`` 0.0) so downstream tooling treats it uniformly, but
+    the verdict names the missing artifacts as the reason -- a genuine model
+    failure, not a judging error.
+
+    Args:
+        task_id: The task identifier for the ``task`` field.
+        candidate_id: The candidate (model) identifier for the ``model`` field.
+        missing: The missing/empty artifact filenames to name in the verdict.
+
+    Returns:
+        A validated, JSON-ready evaluation dict with ``task_score`` 0.0.
+    """
+    zero_artifact = {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run.",
+    }
+    verdict = (
+        "MODEL FAILURE: the candidate run did not produce the required "
+        f"artifact(s): {', '.join(missing)}. Scored 0."
+    )
+    result = EvaluationResult.model_validate(
+        {
+            "task": task_id,
+            "model": candidate_id,
+            "scores": {
+                "github_issue": dict(zero_artifact),
+                "lld": dict(zero_artifact),
+                "review": dict(zero_artifact),
+                "testing": dict(zero_artifact),
+            },
+            "task_score": 0.0,
+            "verdict": verdict,
+        }
+    )
+    return result.model_dump(mode="json")
+
+
+def identify_folder(folder: str | Path) -> tuple[str, str]:
+    """Resolve (task_id, candidate_id) for a folder the way the judge does.
+
+    Mirrors the identifier resolution in :func:`render_judge_prompt`: prefer
+    ``metrics.json`` fields, else the ``<model>/<repo>/<task>`` folder layout.
+
+    Args:
+        folder: The artifact directory.
+
+    Returns:
+        A tuple of (task id, candidate id).
+    """
+    artifact_dir = Path(folder).expanduser().resolve()
+    metrics_path = artifact_dir / "metrics.json"
+    metadata = (
+        _load_json_object(metrics_path, "metrics.json") if metrics_path.exists() else {}
+    )
+    task_id = metadata.get("task") or artifact_dir.name
+    candidate_id = metadata.get("model") or artifact_dir.parent.parent.name
+    return str(task_id), str(candidate_id)
+
+
 def read_text(path: Path, label: str) -> str:
     """Read a non-empty UTF-8 text file, raising JudgeError on any problem.
 

--- a/benchmarks/scripts/llm_as_judge.py
+++ b/benchmarks/scripts/llm_as_judge.py
@@ -11,6 +11,7 @@ shared with the agentic ``codex_judge.py`` backend via ``judge_common.py``.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -24,9 +25,12 @@ from judge_common import (
     EvaluationResult,
     JudgeError,
     atomic_write_json,
+    identify_folder,
+    missing_artifacts,
     optional_file,
     parse_and_validate_result,
     render_judge_prompt,
+    zero_score_result,
 )
 
 logging.basicConfig(
@@ -119,6 +123,38 @@ def evaluate_artifact_folder(
     eval_path = artifact_dir / "eval.json"
     if eval_path.exists() and not overwrite:
         raise JudgeError(f"eval.json exists and overwrite is disabled: {eval_path}")
+
+    # Missing/empty required artifacts are a model failure, not a judging error:
+    # score 0 with an explicit verdict instead of erroring out (parity with the
+    # codex judge).
+    missing = missing_artifacts(artifact_dir)
+    if missing:
+        task_id, candidate_id = identify_folder(artifact_dir)
+        logger.warning(
+            "%s: missing artifact(s) %s -- scoring 0 (model failure)",
+            artifact_dir,
+            ", ".join(missing),
+        )
+        result = zero_score_result(
+            task_id=task_id, candidate_id=candidate_id, missing=missing
+        )
+        result["judge"] = {
+            "model": model,
+            "provider": "bedrock-mantle",
+            "repo_grounded": False,
+            "scored_zero_missing_artifacts": missing,
+            "evaluated_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+        }
+        if write_outputs:
+            atomic_write_json(eval_path, result)
+            metrics_path = artifact_dir / "metrics.json"
+            if metrics_path.exists():
+                existing = json.loads(metrics_path.read_text(encoding="utf-8"))
+                existing["evaluation"] = result
+                atomic_write_json(metrics_path, existing)
+        return result
 
     prompt, task_id, candidate_id, metrics = render_judge_prompt(
         artifact_dir,

--- a/benchmarks/tests/test_codex_judge.py
+++ b/benchmarks/tests/test_codex_judge.py
@@ -186,6 +186,29 @@ class EvaluateWithCodexTest(unittest.TestCase):
         self.assertEqual(metrics["evaluation"], result)
         self.assertEqual(metrics["input_tokens"], 99)
 
+    def test_missing_artifact_scores_zero_without_running_codex(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            folder = _artifact_folder(Path(temp_dir))
+            # Simulate a model failure: one required artifact was never written.
+            (folder / "github-issue.md").unlink()
+            with mock.patch.object(codex_judge, "_run_codex") as run_codex:
+                with mock.patch.object(codex_judge, "clone_repo_at_ref") as clone_fn:
+                    result = codex_judge.evaluate_artifact_folder_with_codex(folder)
+            run_codex.assert_not_called()
+            clone_fn.assert_not_called()
+            self.assertEqual(result["task_score"], 0.0)
+            self.assertIn("MODEL FAILURE", result["verdict"])
+            self.assertIn("github-issue.md", result["verdict"])
+            self.assertEqual(
+                result["judge"]["scored_zero_missing_artifacts"], ["github-issue.md"]
+            )
+            self.assertFalse(result["judge"]["repo_grounded"])
+            # eval.json written and mirrored into metrics.json.
+            eval_data = json.loads((folder / "eval.json").read_text(encoding="utf-8"))
+            self.assertEqual(eval_data["task_score"], 0.0)
+            metrics = json.loads((folder / "metrics.json").read_text(encoding="utf-8"))
+            self.assertEqual(metrics["evaluation"]["task_score"], 0.0)
+
     def test_missing_metrics_fails_before_running_codex(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             folder = _artifact_folder(Path(temp_dir), with_metrics=False)


### PR DESCRIPTION
## Problem

When benchmarking qwen3-coder-30b on mcp-gateway-registry, the `ssrf-hardening-outbound-url-validation` task produced **zero artifacts** -- the model misread the design task as an implementation task, spent all 61 turns editing repo source files, hit the max-turns cap, and never wrote any of the four required design documents. This happened on both attempts, so it is a reproducible model failure.

The judge's response was to raise `JudgeError("missing github-issue.md")` and **drop the folder from the results**. So a genuine model failure silently disappeared from the scores (`batch complete: N scored, 1 failed`) instead of counting against the model. That understates how the model actually performed.

## Change

Treat missing/empty required artifacts as what they are -- a model failure, scored 0:

- New shared helpers in `judge_common.py`: `missing_artifacts()` (which required files are absent/empty), `zero_score_result()` (a schema-valid evaluation with all criteria 0, `task_score` 0.0, and a `MODEL FAILURE: ... did not produce the required artifact(s): ...` verdict), and `identify_folder()` (task/candidate id resolution).
- Both judge backends (`codex_judge.py` and `llm_as_judge.py`) short-circuit **before** the clone/model call when artifacts are missing: they write the zero-score `eval.json`, add a `scored_zero_missing_artifacts` marker to the judge block, and mirror it into `metrics.json` like any other score. Still gated by `--no-overwrite`.
- Test: a folder missing one artifact scores 0 without cloning or calling the model.

Net effect: failed tasks stay in the results with an explicit, auditable 0 instead of vanishing. The two backends behave identically (parity preserved).

## Validation

- 31 judge unit tests pass (+1); `ruff` + `ruff format` clean; `bandit -r scripts/` 0 issues.
- Verified end-to-end: re-judging the qwen3-coder-30b run now scores all 5 tasks (was 3 scored / 2 failed), with ssrf recorded as `task_score: 0.0` and a MODEL FAILURE verdict.
- Security gate (Cipher `security-check`): APPROVED -- fixed artifact names, no injection/leakage, never overwrites an existing eval.json; a net integrity improvement.