### PR TITLE
Document p5en.48xlarge (8x H200) vLLM CUDA fixes

### DIFF
--- a/.claude/skills/vllm-setup/SKILL.md
+++ b/.claude/skills/vllm-setup/SKILL.md
@@ -15,6 +15,8 @@ Use this skill to bring up a vLLM inference server for an open-weight coding mod
 
 All the underlying logic lives in [`self-hosted/vllm/scripts/`](../../../self-hosted/vllm/scripts/): `vllm-install.sh`, `vllm-serve.sh`, `vllm-verify.sh`, `opencode-setup.sh`. This skill orchestrates them, reports each step, confirms inference works, and optionally sets up opencode. The full architecture and the *why* behind every dependency is documented in [`self-hosted/vllm/README.md`](../../../self-hosted/vllm/README.md) — read it if the user asks what is being installed or why a step exists. Every script also takes `--help`.
 
+> **Running on a p5en.48xlarge (8x H200 / NVSwitch)?** The scripts were verified on the reference g6e.12xlarge (4x L40S). An 8-GPU NVSwitch box needs extra one-time fixes the reference node never hits — NVIDIA driver alignment + reboot, putting the venv/weights on the large NVMe (the root disk is tiny), and two CUDA-JIT fixes at serve time (`ninja` on PATH, and unversioned `libcudart.so`/`libcuda.so` for FlashInfer's mnnvl allreduce link step). All of them, with copy-pasteable commands and a symptom→fix table, are in [`p5en-h200-cuda-fixes.md`](p5en-h200-cuda-fixes.md). Read it before Step 3/4 on that hardware; skip it entirely on the 4x L40S reference node.
+
 ## Workflow
 
 1. **Confirm the node** — verify a GPU + capture specs; abort if not on a GPU box
@@ -84,6 +86,7 @@ MODEL="<chosen>" SERVED_NAME="<chosen>" ./vllm-serve.sh
 ```
 
 - Note the reference-node fixes the serve script applies automatically: `VLLM_USE_FLASHINFER_SAMPLER=0` (native sampler — avoids FlashInfer's runtime nvcc requirement against a `/usr/local/cuda` that does not exist on the DLAMI) and a `CUDA_HOME` fallback pointing at `/opt/pytorch/cuda`.
+- **On a p5en.48xlarge (8x H200 / NVSwitch):** the serve script's automatic fixes are not enough — export the PATH and CUDA-link environment from [`p5en-h200-cuda-fixes.md`](p5en-h200-cuda-fixes.md) *before* running `vllm-serve.sh`, or startup fails at KV-cache init (`No such file or directory: 'ninja'`) and again after graph capture (`ld: cannot find -lcudart`). That file has the exact exports and a symptom→fix table.
 - The script tees the full server log to `self-hosted/vllm/logs/vllm-serve.log` (gitignored) and polls until ready. First serve of a model downloads the weights (~57 GB for 30B) — this can take several minutes. Reassure the user; tail the log if they want to watch: `tail -f self-hosted/vllm/logs/vllm-serve.log`.
 - If the process exits early, read the tail of that log for the root cause.
 

--- a/.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md
+++ b/.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md
@@ -1,0 +1,221 @@
+# Serving on a p5en.48xlarge (8x H200) - extra CUDA fixes
+
+> Companion note to [SKILL.md](SKILL.md). The vLLM scripts and the model guides under [`self-hosted/vllm/`](../../../self-hosted/vllm/) were verified on the **reference node**: g6e.12xlarge (4x L40S). On a **p5en.48xlarge (8x H200 141GB, NVSwitch)** several additional issues surface that the reference node never hits, because 8-GPU tensor parallelism over NVSwitch activates code paths (DeepGemm JIT, FlashInfer mnnvl allreduce) that JIT-compile CUDA at server startup. This file records every extra change needed there. If you are on the reference 4x L40S node you do **not** need any of this; if you are on a p5en (or any 8x H200 / NVSwitch box), you do.
+
+All paths below assume the venv and caches live on the large ephemeral NVMe (`/opt/dlami/nvme`) rather than the small root disk - see "Disk layout" first.
+
+## 0. Driver alignment (prerequisite, one-time)
+
+The DLAMI shipped a **mismatched NVIDIA driver**: the loaded kernel module was `595.71.05` while the userspace libraries had been upgraded (likely by unattended-upgrades) to `610.43.02`, so `nvidia-smi` failed with `Failed to initialize NVML: Driver/library version mismatch`. `nvidia-fabricmanager` (mandatory on an NVSwitch box) was apt-held at 595.
+
+Fix - align the whole stack to 610.43.02 and reboot:
+
+```bash
+sudo apt-get install -y --allow-change-held-packages \
+  nvidia-dkms-610=610.43.02-0ubuntu0.24.04.1 \
+  nvidia-fabricmanager=610.43.02-1ubuntu1 \
+  nvidia-utils-610=610.43.02-0ubuntu0.24.04.1
+sudo apt-mark hold nvidia-fabricmanager   # re-pin FM (preserve the original hold intent)
+sudo reboot                                # required: unload 595, load the freshly built 610 module
+```
+
+After reboot, verify before doing anything else:
+
+```bash
+nvidia-smi --query-gpu=index,name,driver_version --format=csv   # expect 8x H200 @ 610.43.02
+systemctl is-active nvidia-fabricmanager                        # expect: active
+nvidia-smi -q | grep -A2 Fabric                                 # expect: State: Completed / Status: Success
+```
+
+The NVLink fabric State must be `Completed` - tensor parallelism across 8 GPUs depends on it.
+
+## Disk layout: put the venv, caches, and weights on the NVMe
+
+On this node the root disk `/` is tiny (~29 GB). The vLLM venv (torch + CUDA wheels, several GB) and especially the model weights (Kimi-K2.7-Code is ~555 GB on disk) must not go there. Use the 27 TB ephemeral NVMe at `/opt/dlami/nvme`:
+
+```bash
+mkdir -p /opt/dlami/nvme/{vllm-env,uv-cache,hf-cache,tmp,cuda-link}
+export VLLM_ENV=/opt/dlami/nvme/vllm-env      # vllm-install.sh + vllm-serve.sh both honor this
+export UV_CACHE_DIR=/opt/dlami/nvme/uv-cache
+export TMPDIR=/opt/dlami/nvme/tmp
+# HF_HOME auto-defaults to /opt/dlami/nvme/hf-cache in vllm-serve.sh when the volume exists.
+```
+
+`/opt/dlami/nvme` is **ephemeral** - wiped on instance stop/terminate. Weights re-download after a stop; that is the right trade for a serving box.
+
+## The CUDA startup fixes (the core of this note)
+
+On 8x H200 + NVSwitch, vLLM JIT-compiles CUDA at startup in two places that the reference node never triggers. Both fail out of the box; both are fixed purely with environment variables passed to `vllm-serve.sh`.
+
+### Fix 1 - `ninja` must be on PATH (DeepGemm + FlashInfer JIT)
+
+DeepGemm and FlashInfer shell out to the **`ninja` executable** by name to build CUDA kernels. `vllm-install.sh` pip-installs the `ninja` package into the venv (`$VLLM_ENV/bin/ninja`), but `vllm-serve.sh` invokes vLLM by absolute path without activating the venv, so `bin/` is not on the subprocess PATH. Symptom:
+
+```
+RuntimeError: Worker failed with error '[Errno 2] No such file or directory: 'ninja''
+```
+
+(occurs at KV-cache init, after weight loading). Fix - put the venv bin (and the CUDA toolkit bin, for `nvcc`) on PATH:
+
+```bash
+export CUDA_HOME=/opt/pytorch/cuda                 # the DLAMI's real toolkit (has nvcc); /usr/local/cuda does NOT exist
+export PATH="$VLLM_ENV/bin:$CUDA_HOME/bin:$PATH"
+```
+
+### Fix 2 - CUDA libs must be linkable (`-lcudart` / `-lcuda`)
+
+Once `ninja` runs, FlashInfer's **mnnvl allreduce** kernel (`trtllm_mnnvl_comm`, auto-selected on an NVSwitch box) JIT-compiles and fails at the **link** step:
+
+```
+/usr/bin/ld: cannot find -lcudart: No such file or directory
+/usr/bin/ld: cannot find -lcuda:   No such file or directory
+collect2: error: ld returned 1 exit status
+RuntimeError: Ninja build failed. ... Engine core initialization failed.
+```
+
+(occurs late, after CUDA graph capture). The linker wants **unversioned** `libcudart.so` / `libcuda.so`, but this node only has versioned files:
+- `libcudart.so.13` inside the venv at `nvidia/cu13/lib/`
+- `libcuda.so.1 -> libcuda.so.610.43.02` in `/usr/lib/x86_64-linux-gnu/` (driver)
+
+Fix - create a link dir of unversioned symlinks and expose it via `LIBRARY_PATH` (link time) and `LD_LIBRARY_PATH` (runtime):
+
+```bash
+LINKDIR=/opt/dlami/nvme/cuda-link
+VENV_CU13="$VLLM_ENV/lib/python3.12/site-packages/nvidia/cu13/lib"
+mkdir -p "$LINKDIR"
+ln -sf "$VENV_CU13/libcudart.so.13"            "$LINKDIR/libcudart.so"
+ln -sf /usr/lib/x86_64-linux-gnu/libcuda.so.1  "$LINKDIR/libcuda.so"
+
+export LIBRARY_PATH="$LINKDIR:$VENV_CU13:/usr/lib/x86_64-linux-gnu:${LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="$LINKDIR:$VENV_CU13:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+```
+
+Verify the link resolves before launching (fast sanity check):
+
+```bash
+echo 'int main(){return 0;}' > /tmp/t.c
+gcc /tmp/t.c -L"$LINKDIR" -lcudart -lcuda -o /tmp/t.out && echo "LINK OK"
+```
+
+> Alternative: set `VLLM_FLASHINFER_ALLREDUCE_BACKEND` away from `mnnvl`, or otherwise disable the FlashInfer fused allreduce, so it never JIT-compiles. vLLM falls back to the CUSTOM/PYNCCL allreduce backends (already available). Fix 2 above keeps the optimized allreduce path instead of dropping it; prefer it unless you want to skip the JIT entirely.
+
+### Fix 3 - FP8 models (GLM-5.2) also need `libnvrtc.so`, in `$CUDA_HOME/lib64`
+
+Kimi-K2.7-Code needs only Fix 1 + Fix 2. **GLM-5.2-FP8 needs one more.** Its FP8 path JIT-compiles an extra FlashInfer kernel, `fp8_blockscale_gemm_90` (a CUTLASS/DeepGemm blockscale GEMM), that links against **NVRTC** (NVIDIA Runtime Compilation) in addition to cudart/cuda. Symptom (late, after CUDA graph capture, same shape as Fix 2 but a different lib):
+
+```
+/usr/bin/ld: cannot find -lnvrtc: No such file or directory
+collect2: error: ld returned 1 exit status
+RuntimeError: Ninja build failed ... fp8_blockscale_gemm_90.so ... Engine core initialization failed.
+```
+
+Two things make this distinct from Fix 2:
+
+1. **A different missing lib - `libnvrtc`.** Only `libnvrtc.so.13` exists (in the venv's `nvidia/cu13/lib`); the linker wants unversioned `libnvrtc.so`.
+2. **FlashInfer's link command hardcodes its `-L` search dirs to `$CUDA_HOME/lib64` and `$CUDA_HOME/lib64/stubs`** (visible in the failing `c++ ... -shared -L/opt/pytorch/cuda/lib64 -L/opt/pytorch/cuda/lib64/stubs -lcudart -lcuda -lnvrtc ...` line). On the DLAMI, `/opt/pytorch/cuda` has a `lib` dir but **no `lib64`** - so even `-lcudart`/`-lcuda` are only found via `LIBRARY_PATH` from Fix 2, and `-lnvrtc` is not found at all. The robust fix is to create `$CUDA_HOME/lib64` (+ `stubs`) and populate it with the unversioned symlinks the build command expects.
+
+Fix - add `libnvrtc.so` to the Fix-2 link dir AND materialize the symlinks in `$CUDA_HOME/lib64` where FlashInfer actually looks:
+
+```bash
+LINKDIR=/opt/dlami/nvme/cuda-link
+VENV_CU13="$VLLM_ENV/lib/python3.12/site-packages/nvidia/cu13/lib"
+
+# (a) extend the Fix-2 link dir with nvrtc
+ln -sf "$VENV_CU13/libnvrtc.so.13" "$LINKDIR/libnvrtc.so"
+
+# (b) create + populate $CUDA_HOME/lib64 and its stubs (the dirs FlashInfer's -L points at).
+#     /opt/pytorch/cuda has only lib/, no lib64 - so we make it. $CUDA_HOME/lib is writable
+#     without sudo on the DLAMI; if lib64 is not, prefix these with sudo.
+mkdir -p "$CUDA_HOME/lib64/stubs"
+ln -sf "$VENV_CU13/libcudart.so.13"            "$CUDA_HOME/lib64/libcudart.so"
+ln -sf "$VENV_CU13/libnvrtc.so.13"             "$CUDA_HOME/lib64/libnvrtc.so"
+ln -sf /usr/lib/x86_64-linux-gnu/libcuda.so.1  "$CUDA_HOME/lib64/libcuda.so"
+ln -sf /usr/lib/x86_64-linux-gnu/libcuda.so.1  "$CUDA_HOME/lib64/stubs/libcuda.so"
+
+# then add lib64 + stubs to LIBRARY_PATH (belt and suspenders):
+export LIBRARY_PATH="$LINKDIR:$CUDA_HOME/lib64:$CUDA_HOME/lib64/stubs:$VENV_CU13:/usr/lib/x86_64-linux-gnu:${LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="$LINKDIR:$CUDA_HOME/lib64:$VENV_CU13:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+```
+
+Verify all three resolve before launching:
+
+```bash
+echo 'int main(){return 0;}' > /tmp/t.c
+gcc /tmp/t.c -L"$LINKDIR" -lcudart -lcuda -lnvrtc -o /tmp/t.out && echo "LINK OK"
+```
+
+If a prior boot already failed on this, clear the stale JIT cache so it rebuilds cleanly: `rm -rf ~/.cache/flashinfer/*/*/cached_ops/fp8_blockscale_gemm_90`.
+
+GLM-5.2 verified serving with this: `zai-org/GLM-5.2-FP8`, TP=8, `MAX_MODEL_LEN=300000` (passes the >=200K gate), `GPU_MEM_UTIL=0.95`, `glm47` tool+reasoning parsers. Runtime: GPU KV cache ~413,000 tokens, max concurrency 1.38x at 300K.
+
+Note the pre-existing DLAMI fixes the serve script already applies automatically and that you should NOT undo: `VLLM_USE_FLASHINFER_SAMPLER=0` (native sampler, no runtime nvcc) and the `CUDA_HOME` fallback to `/opt/pytorch/cuda`.
+
+## Putting it together - the full p5en launch
+
+`vllm-serve.sh` inherits the caller's environment, so export everything above first, then run it with the model guide's parameters ([kimi-k2.7-code.md](../../../self-hosted/vllm/models/kimi-k2.7-code.md), TP=8):
+
+```bash
+cd self-hosted/vllm/scripts
+
+export VLLM_ENV=/opt/dlami/nvme/vllm-env
+export CUDA_HOME=/opt/pytorch/cuda
+export TMPDIR=/opt/dlami/nvme/tmp
+export PATH="$VLLM_ENV/bin:$CUDA_HOME/bin:$PATH"                        # Fix 1
+
+LINKDIR=/opt/dlami/nvme/cuda-link                                       # Fix 2 + Fix 3
+VENV_CU13="$VLLM_ENV/lib/python3.12/site-packages/nvidia/cu13/lib"
+mkdir -p "$LINKDIR"
+ln -sf "$VENV_CU13/libcudart.so.13"           "$LINKDIR/libcudart.so"
+ln -sf /usr/lib/x86_64-linux-gnu/libcuda.so.1 "$LINKDIR/libcuda.so"
+ln -sf "$VENV_CU13/libnvrtc.so.13"            "$LINKDIR/libnvrtc.so"    # Fix 3 (FP8 models)
+
+# Fix 3: FlashInfer's FP8 kernel link cmd hardcodes -L$CUDA_HOME/lib64[/stubs], which
+# does not exist on the DLAMI (only $CUDA_HOME/lib). Create + populate it.
+mkdir -p "$CUDA_HOME/lib64/stubs"
+ln -sf "$VENV_CU13/libcudart.so.13"           "$CUDA_HOME/lib64/libcudart.so"
+ln -sf "$VENV_CU13/libnvrtc.so.13"            "$CUDA_HOME/lib64/libnvrtc.so"
+ln -sf /usr/lib/x86_64-linux-gnu/libcuda.so.1 "$CUDA_HOME/lib64/libcuda.so"
+ln -sf /usr/lib/x86_64-linux-gnu/libcuda.so.1 "$CUDA_HOME/lib64/stubs/libcuda.so"
+
+export LIBRARY_PATH="$LINKDIR:$CUDA_HOME/lib64:$CUDA_HOME/lib64/stubs:$VENV_CU13:/usr/lib/x86_64-linux-gnu:${LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="$LINKDIR:$CUDA_HOME/lib64:$VENV_CU13:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+
+# --- Kimi-K2.7-Code (needs Fix 1 + Fix 2; Fix 3 is harmless to leave in) ---
+MODEL="moonshotai/Kimi-K2.7-Code" \
+SERVED_NAME="kimi-k2.7-code" \
+TP=8 PORT=8000 MAX_MODEL_LEN=131072 GPU_MEM_UTIL=0.90 \
+TOOL_PARSER="kimi_k2" REASONING_PARSER="kimi_k2" \
+EXTRA_ARGS="--trust-remote-code" \
+  ./vllm-serve.sh
+
+# --- OR GLM-5.2-FP8 (needs Fix 1 + Fix 2 + Fix 3; passes the >=200K gate at 300K) ---
+MODEL="zai-org/GLM-5.2-FP8" \
+SERVED_NAME="glm-5.2" \
+TP=8 PORT=8000 MAX_MODEL_LEN=300000 GPU_MEM_UTIL=0.95 \
+TOOL_PARSER="glm47" REASONING_PARSER="glm47" \
+EXTRA_ARGS="--trust-remote-code" \
+  ./vllm-serve.sh
+```
+
+## Startup timing and what "healthy" looks like
+
+First boot: ~10-15 min weight download (~555 GB at ~1 GB/s with an HF token) + ~4 min weight load (64 shards) + torch.compile + CUDA graph capture (51 graphs). Subsequent boots skip the download. Healthy-boot signposts in `self-hosted/vllm/logs/vllm-serve.log`:
+
+- `Using CompressedTensorsWNA16MarlinMoEMethod` / `MARLIN WNA16 MoE backend` (correct quantization)
+- `Using FLASH_ATTN_MLA attention backend` (correct for the DeepSeek-V3/MLA arch)
+- `Loading safetensors checkpoint shards: 100%`
+- `Capturing CUDA graphs ... 51/51`
+- `GPU KV cache size: ~740,000 tokens` / `Maximum concurrency for 131072 tokens per request: ~5.6x`
+- `Server ready at http://127.0.0.1:8000/v1`
+
+## Quick failure -> fix reference
+
+| Symptom in the log | Cause | Fix |
+|---|---|---|
+| `NVML: Driver/library version mismatch` | kernel module vs userspace driver skew | Section 0 (align to 610 + reboot) |
+| `No space left` during download, or root disk fills | weights/venv on the small root disk | Disk layout (use `/opt/dlami/nvme`) |
+| `No such file or directory: 'ninja'` | ninja binary not on subprocess PATH | Fix 1 (PATH) |
+| `ld: cannot find -lcudart / -lcuda` -> `Ninja build failed` -> `Engine core initialization failed` | FlashInfer mnnvl allreduce can't link CUDA | Fix 2 (cuda-link + LIBRARY_PATH) |
+| `ld: cannot find -lnvrtc` -> `Ninja build failed` on `fp8_blockscale_gemm_90` -> `Engine core initialization failed` | FP8 model (GLM-5.2) FlashInfer kernel needs NVRTC, and FlashInfer's `-L` points at a non-existent `$CUDA_HOME/lib64` | Fix 3 (libnvrtc.so + populate `$CUDA_HOME/lib64`) |
+
+**Model -> which fixes:** Kimi-K2.7-Code = Fix 1 + Fix 2. GLM-5.2-FP8 = Fix 1 + Fix 2 + Fix 3. Applying all three is harmless for any model, so the combined launch block above is a safe default on this node.

--- a/self-hosted/vllm/models/glm-5.2.md
+++ b/self-hosted/vllm/models/glm-5.2.md
@@ -20,6 +20,8 @@
 
 GLM-5.2-FP8 on 8×H200 (p5en.48xlarge). The model requires `--trust-remote-code` and benefits from setting `CUDA_HOME` explicitly for DeepGemm kernel JIT compilation.
 
+> **Verified on this repo's p5en.48xlarge node (2026-07):** the "Serve it" block below is correct as-is, but the DLAMI here has **no `/usr/local/cuda`** (nvcc lives at `/opt/pytorch/cuda`), and GLM-5.2's FP8 path JIT-compiles a FlashInfer kernel that needs `ninja` on PATH plus **three** unversioned CUDA libs (`libcudart.so`, `libcuda.so`, **`libnvrtc.so`**) in `$CUDA_HOME/lib64`. Export the environment from [`.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md`](../../../.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md) (Fixes 1+2+3) **before** running the command below, or the server fails at engine init with `cannot find -lnvrtc`. The CUDA_HOME/libcudart tips in "Tuning notes" below assume a different DLAMI layout (`/usr/local/cuda`) and do not apply to this node.
+
 ```bash
 MODEL="zai-org/GLM-5.2-FP8" \
 SERVED_NAME="glm-5.2" \
@@ -93,8 +95,8 @@ Uses the `glm47` parser. Tool calls are returned as structured `tool_use` blocks
 
 ## Tuning notes
 
-- **DeepGemm JIT:** GLM-5.2 uses DeepGemm kernels that require `nvcc` at runtime. Ensure `CUDA_HOME` points to a valid CUDA installation with `bin/nvcc`. On the Ubuntu 24.04 DLAMI, this is `/usr/local/cuda`.
-- **libcudart:** FlashInfer JIT also needs `libcudart.so` in the linker path. If you hit `cannot find -lcudart`, run: `sudo ln -sf /usr/local/cuda/lib64/libcudart.so /usr/lib/x86_64-linux-gnu/libcudart.so`
+- **DeepGemm JIT:** GLM-5.2 uses DeepGemm kernels that require `nvcc` at runtime. Ensure `CUDA_HOME` points to a valid CUDA installation with `bin/nvcc`. On some Ubuntu 24.04 DLAMIs this is `/usr/local/cuda`; **on this repo's p5en node it is `/opt/pytorch/cuda` (there is no `/usr/local/cuda`)** — see the p5en fixes doc linked above.
+- **libcudart / libcuda / libnvrtc:** FlashInfer's FP8-kernel JIT links against all three, and needs unversioned `.so` names on a path its build command searches (`$CUDA_HOME/lib64` + `stubs`). If you hit `cannot find -lcudart`, `-lcuda`, or `-lnvrtc`, do **not** just symlink libcudart into `/usr/lib` — follow Fixes 2+3 in [`p5en-h200-cuda-fixes.md`](../../../.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md), which create all three symlinks in the right place. (`-lnvrtc` in particular is GLM-5.2/FP8-specific; Kimi does not hit it.)
 - **Download speed:** The FP8 model is ~750 GB (282 safetensor files). Without `HF_TOKEN`, downloads are rate-limited. Set a token for faster downloads.
 - **Startup time:** First boot takes ~15–20 minutes (download + weight loading + torch.compile + CUDA graph capture). Subsequent boots (weights cached) take ~5–8 minutes.
 - **Prefix caching:** Enabled by default. Very effective for `/swe` and `/implement` benchmarks where the system prompt + skill instructions are constant across turns.


### PR DESCRIPTION
## Summary

Serving open-weight coding models with vLLM on a **p5en.48xlarge (8x H200, NVSwitch)** needs several fixes the repo's 4x L40S reference node never encounters. 8-GPU tensor parallelism over NVSwitch activates CUDA-JIT code paths (DeepGemm, FlashInfer mnnvl allreduce, FP8 blockscale GEMM) at server startup, each of which fails out of the box on the Deep Learning AMI. This PR documents every fix, verified while bringing up Kimi-K2.7-Code and GLM-5.2-FP8 on such a node.

## Changes

- **New:** `.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md` - companion note to the vllm-setup skill:
  - Driver alignment (595 kernel vs 610 userspace mismatch) + reboot
  - Putting the venv/caches/weights on the large ephemeral NVMe (the root disk is ~29 GB)
  - **Fix 1:** `ninja` on PATH so DeepGemm/FlashInfer JIT can find the binary
  - **Fix 2:** unversioned `libcudart.so`/`libcuda.so` for FlashInfer's mnnvl allreduce link step
  - **Fix 3:** `libnvrtc.so` plus a populated `$CUDA_HOME/lib64` for GLM-5.2's FP8 kernel (`fp8_blockscale_gemm_90`)
  - A symptom -> fix table and a per-model fix matrix (Kimi = 1+2; GLM-5.2 = 1+2+3)
- **Updated:** `.claude/skills/vllm-setup/SKILL.md` - references the new note from the intro and the serve step, with an "if running on a p5en you need these" callout.
- **Updated:** `self-hosted/vllm/models/glm-5.2.md` - corrects the CUDA_HOME/libcudart tuning notes, which assumed a `/usr/local/cuda` layout that does not exist on this DLAMI (nvcc is at `/opt/pytorch/cuda`) and omitted the `libnvrtc` requirement.

## Notes

Documentation only - no code or configuration changes, no secrets. The serve parameters in the model guides were already correct; only the CUDA environment guidance needed correcting for this hardware.