### PR TITLE
Rename README title to Agentic Coding Harness and Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Code Multi-Model
+# Agentic Coding Harness and Benchmarks
 
 [![License: MIT-0](https://img.shields.io/badge/License-MIT--0-yellow.svg)](LICENSE)
 [![Bedrock](https://img.shields.io/badge/Amazon-Bedrock-blue)](https://docs.aws.amazon.com/bedrock/latest/userguide/models-endpoint-availability.html)


### PR DESCRIPTION
The README H1 was `Claude Code Multi-Model`, which did not match the repository name (`agentic-coding-harness-benchmarks`). Rename it to **Agentic Coding Harness and Benchmarks** so the title reflects what the repo is.

Docs-only, one-line change.