### PR TITLE
swe skill: write artifacts to an absolute path (fix cwd-doubling)

### DIFF
--- a/.claude/skills/swe/SKILL.md
+++ b/.claude/skills/swe/SKILL.md
@@ -187,6 +187,16 @@ This quick review takes 5-10 minutes and helps you ask better clarifying questio
 
 All artifacts live under a top-level `benchmarks/` directory. Within it, every run gets its own `{model-name}/{repo-name}/{problem-name}/` subfolder. Grouping by model first keeps each model's full set of results together, while still letting multiple models be compared on the same `{repo-name}/{problem-name}` across sibling model folders.
 
+> **CRITICAL - write to the ABSOLUTE artifact path, never the bare relative string.** The `benchmarks/swe-benchmark-data/...` paths shown throughout this skill are written relative to the repository root for readability. Your working directory is often already inside `benchmarks/` (the harness runs there), so if you pass a bare relative path like `benchmarks/swe-benchmark-data/{model}/...` to Write/Edit it resolves against the cwd and doubles to `benchmarks/benchmarks/swe-benchmark-data/...` -- the files land in the wrong place, the run scores 0/4 artifacts despite "File created successfully", and the work is lost. Always resolve the repo root and build one absolute artifact directory up front, then write every artifact under it:
+>
+> ```bash
+> REPO_ROOT="$(git rev-parse --show-toplevel)"
+> ART_DIR="$REPO_ROOT/benchmarks/swe-benchmark-data/{model-name}/{repo-name}/{problem-name}"
+> mkdir -p "$ART_DIR"
+> ```
+>
+> Every `Write`/`Edit` in Steps 4-8 must use an **absolute** `file_path` of the form `$ART_DIR/github-issue.md` (i.e. the fully-expanded `/.../benchmarks/swe-benchmark-data/{model}/{repo}/{problem}/github-issue.md`), not a path beginning with `benchmarks/`. After writing each file, confirm it exists at the absolute path (e.g. `test -f "$ART_DIR/github-issue.md"`).
+
 The target repository's source code is **not** stored here. It is cloned locally at a specific tag by each contributor following the instructions in `benchmarks/swe-benchmark-data/README.md`, into a `repo/` subdirectory, or into a temporary clone (e.g. under `/tmp`, as the harness does). The `repo/` checkout is gitignored so it is never committed.
 
 ### Folder Structure
@@ -670,12 +680,14 @@ After producing the four artifacts, present a clear summary to the user. **Do no
 
 ### Documents Created
 
+Locations below are shown relative to the repo root; write them to the **absolute** `$ART_DIR/<file>` path from Step 3 (never a bare `benchmarks/...` path -- see the Step 3 warning).
+
 | Document | Location | Description |
 |----------|----------|-------------|
-| GitHub Issue | `benchmarks/swe-benchmark-data/{model}/{repo}/{problem}/github-issue.md` | Issue specification |
-| Low-Level Design | `benchmarks/swe-benchmark-data/{model}/{repo}/{problem}/lld.md` | Technical design |
-| Expert Review | `benchmarks/swe-benchmark-data/{model}/{repo}/{problem}/review.md` | Multi-persona review |
-| Testing Plan | `benchmarks/swe-benchmark-data/{model}/{repo}/{problem}/testing.md` | All test categories |
+| GitHub Issue | `$ART_DIR/github-issue.md` | Issue specification |
+| Low-Level Design | `$ART_DIR/lld.md` | Technical design |
+| Expert Review | `$ART_DIR/review.md` | Multi-persona review |
+| Testing Plan | `$ART_DIR/testing.md` | All test categories |
 
 ### Review Verdicts
 

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -796,6 +796,12 @@ def _run_claude(cmd: list[str], env: dict[str, str], timeout: int) -> dict[str, 
         proc = subprocess.run(  # nosec B603 - hardcoded 'claude', list args, no shell
             cmd,
             env=env,
+            # Run from the repo root so the /swe skill's artifact paths (written
+            # relative to the repo root, e.g. benchmarks/swe-benchmark-data/...)
+            # resolve correctly. Without this, cwd is wherever the harness was
+            # invoked (typically benchmarks/), and a model that writes a relative
+            # path doubles it to benchmarks/benchmarks/... and the run scores 0/4.
+            cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -942,6 +948,10 @@ def _run_claude_streaming(
     proc = subprocess.Popen(  # nosec B603 - hardcoded 'claude', list args, no shell
         cmd,
         env=env,
+        # Run from the repo root so the /swe skill's relative artifact paths
+        # resolve correctly (see the note in _run_claude); otherwise a model that
+        # writes a relative path doubles it to benchmarks/benchmarks/...
+        cwd=str(REPO_ROOT),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,


### PR DESCRIPTION
## Problem

Benchmarking Gemma-4-31B, every artifact Write "succeeded" but the run scored 0/4 -- the files landed in `benchmarks/benchmarks/swe-benchmark-data/...` (doubled `benchmarks/`). Cause: the `/swe` skill shows artifact paths as bare `benchmarks/swe-benchmark-data/...` strings, and the harness runs with cwd already inside `benchmarks/`, so a relative Write path doubles. Other models happened to emit absolute paths; gemma took the relative string literally.

## Fix

Make the skill build one **absolute** artifact directory up front and write everything under it:

```bash
REPO_ROOT="$(git rev-parse --show-toplevel)"
ART_DIR="$REPO_ROOT/benchmarks/swe-benchmark-data/{model}/{repo}/{problem}"
mkdir -p "$ART_DIR"
```

- Prominent **CRITICAL** warning in Step 3 explaining the cwd-doubling trap and that a bare `benchmarks/...` path silently misfiles the artifacts.
- Every Write/Edit in Steps 4-8 must use an absolute `$ART_DIR/<file>` path, with a post-write `test -f` existence check.
- Documents-created table updated to the `$ART_DIR/` form.

Applies to every model, not just gemma. Docs-only (skill instructions).