### PR TITLE
Add --timeout-seconds override for slow models

### DIFF
--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -43,6 +43,9 @@ set -euo pipefail
 #   --max-output-tokens N  override the per-response output cap for this run
 #                          (e.g. 4096 on a small-window model so the prompt has
 #                          usable input room; usable input ~= window - this)
+#   --timeout-seconds N    override the per-task wall-clock timeout (raise it for
+#                          a slow/dense model that produces artifacts but does not
+#                          return before the default cutoff)
 #   --skip-judge           run the harness only; score later
 #   --yes                  clear pre-existing artifact folders without asking
 # ---------------------------------------------------------------------------
@@ -58,6 +61,7 @@ MODEL=""
 DATASET=""
 COUNT="0"                 # 0 = all tasks
 MAX_OUTPUT_TOKENS=""      # empty = use the config value
+TIMEOUT_SECONDS=""        # empty = use the config value
 ENDPOINT=""               # derived from provider unless overridden
 AWS_REGION_ARG="${AWS_REGION:-us-east-1}"
 ASSUME_YES=0
@@ -89,6 +93,7 @@ while [[ $# -gt 0 ]]; do
         --dataset)  DATASET="${2:?--dataset needs a value}"; shift 2 ;;
         --count)    COUNT="${2:?--count needs a value}"; shift 2 ;;
         --max-output-tokens) MAX_OUTPUT_TOKENS="${2:?--max-output-tokens needs a value}"; shift 2 ;;
+        --timeout-seconds) TIMEOUT_SECONDS="${2:?--timeout-seconds needs a value}"; shift 2 ;;
         --endpoint) ENDPOINT="${2:?--endpoint needs a value}"; shift 2 ;;
         --aws-region) AWS_REGION_ARG="${2:?--aws-region needs a value}"; shift 2 ;;
         --config)   CONFIG="${2:?--config needs a value}"; shift 2 ;;
@@ -300,6 +305,7 @@ BENCH_ARGS=(--config "$CONFIG" --provider "$HARNESS_PROVIDER" --model "$MODEL" -
 # On the vllm path, calibrate auto-compaction to the live server's window.
 [[ -n "${VLLM_CONTEXT_WINDOW:-}" ]] && BENCH_ARGS+=(--context-window "$VLLM_CONTEXT_WINDOW")
 [[ -n "$MAX_OUTPUT_TOKENS" ]] && BENCH_ARGS+=(--max-output-tokens "$MAX_OUTPUT_TOKENS")
+[[ -n "$TIMEOUT_SECONDS" ]] && BENCH_ARGS+=(--timeout-seconds "$TIMEOUT_SECONDS")
 
 SLUG="$(uv run python -c "import sys; sys.path.insert(0,'scripts'); from runner_config import model_to_slug; print(model_to_slug('$MODEL'))")"
 info "Command:"

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -1561,6 +1561,13 @@ def _parse_args() -> argparse.Namespace:
         "whose window Claude Code cannot detect. 0 leaves it unset.",
     )
     parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        help="Override: wall-clock timeout for a single task's claude -p run. "
+        "Raise it for a slow (e.g. dense) model that produces artifacts but "
+        "does not return within the default before the harness kills it.",
+    )
+    parser.add_argument(
         "--concurrency",
         type=int,
         help="Override: how many tasks to run at once (default 1 = serial). "
@@ -1595,6 +1602,7 @@ def main() -> None:
         "max_turns": args.max_turns,
         "max_output_tokens": args.max_output_tokens,
         "context_window": args.context_window,
+        "timeout_seconds": args.timeout_seconds,
         "concurrency": args.concurrency,
     }
     if args.tasks:


### PR DESCRIPTION
gemma-4-31b (dense, slow) produced all four artifacts but claude -p did not return within the default 1800s, so the harness raised a timeout before writing metrics.json -- the task counted as a failure despite the work being done.

Add a `--timeout-seconds` CLI override to the harness (`run-swe-headless.py`) and the orchestrator (`run-e2e-benchmark.sh`), following the same pattern as `--max-output-tokens` / `--context-window`, so a slow model can get a larger per-task wall-clock budget without editing `runner.yaml`. Documented in the orchestrator `--help`.

(Follow-up to #18, which merged before this commit reached its branch.)