### PR TITLE
metrics serving block + commit RUN-SUMMARY.json as the per-run record

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -30,7 +30,7 @@ Collect these three, in order. Do not guess -- ask if any is missing.
 2. **Bring up / confirm the backing service** for the chosen path. For **vllm**: check the HF token, then (re)start the vLLM server on the requested model -- stopping any other model first -- using the model guide's serve command at its largest context window; **check the served window against the 200K recommended floor** (>=200K proceed; somewhat below, e.g. 128K, warn and confirm; a tiny ~16K window is not benchmarkable and stops the run); then start the DuckDB collector. For litellm/bedrock: confirm the proxy/credentials.
 3. **Dry-run the pre-flight** so the user sees what will happen before anything runs.
 4. **Run the orchestrator**, streaming its output, and tell the user what to tail.
-5. **Wrap up and report**: (vllm) stop the collector and archive its DuckDB snapshot tagged with model/scope/timestamp; write a `RUN-SUMMARY.md` (results table + notes) into the run's `{model-slug}/{scope}/` folder; then report where the results landed.
+5. **Wrap up and report**: (vllm) stop the collector and archive its DuckDB snapshot tagged with model/scope/timestamp; run `summarize_run.py` to write `RUN-SUMMARY.json` (machine-readable, for charting) and `RUN-SUMMARY.md` into the run's `{model-slug}/{scope}/` folder; then report where the results landed.
 
 Keep the user informed at every step: before each long-running command, print it verbatim and give the tail/status command to watch it.
 
@@ -226,58 +226,17 @@ cd self-hosted/vllm && uv run python -m clients.build_dashboard \
   --output benchmark-output/dashboard_{model-slug}_{scope}_{timestamp}.html
 ```
 
-**5c. Write a run summary** to `benchmarks/swe-benchmark-data/{model-slug}/{scope}/RUN-SUMMARY.md` (one per model+dataset run, alongside the per-task folders) so the outcome is captured on disk, not just in the chat. Do this on **every** path (bedrock/litellm/vllm), after scoring. Gather the numbers from the artifacts rather than retyping them -- read each task's `metrics.json` (`metrics_that_matter`: `num_turns`, `input_tokens`, `output_tokens`, `latency_seconds`) and `eval.json` (`task_score`):
+**5c. Write the run summary** with the summarizer script, which reads the run's per-task `metrics.json` + `eval.json` and writes **both** a machine-readable `RUN-SUMMARY.json` (for later charting/aggregation) and a human-readable `RUN-SUMMARY.md`, into `benchmarks/swe-benchmark-data/{model-slug}/{scope}/`. Do this on **every** path (bedrock/litellm/vllm), after scoring. Do not hand-write the summary -- the script computes the failed-task-excluded mean, the serving block, and the per-task table consistently:
 
 ```bash
-cd benchmarks/swe-benchmark-data/{model-slug}/{scope}
-python3 - <<'PY'
-import json, os
-rows=[]
-for t in sorted(os.listdir('.')):
-    if not os.path.isdir(t):
-        continue
-    m=json.load(open(f'{t}/metrics.json')).get('metrics_that_matter',{})
-    e=json.load(open(f'{t}/eval.json'))
-    rows.append((t, m.get('num_turns'), m.get('input_tokens'),
-                 m.get('output_tokens'), m.get('latency_seconds'), e.get('task_score')))
-for r in sorted(rows, key=lambda r: -(r[5] or 0)):
-    print(r)
-PY
+cd benchmarks
+uv run python scripts/summarize_run.py \
+  --folder swe-benchmark-data/{model-slug}/{scope} --run-date "$(date -u +%Y-%m-%d)"
 ```
 
-Then write `RUN-SUMMARY.md` with this structure (fill the front-matter from the run's actual inputs; sort the table by judge score, highest first):
+The script treats a 0-score task as a model failure (missing artifacts) and excludes it from the headline mean, matching the leaderboard convention, while still listing it. Read the resulting `RUN-SUMMARY.md` back to the user; if a task failed, its 0 and the `failed_tasks` list make that visible -- do not present a partial run as a clean sweep.
 
-```markdown
-# Benchmark run summary: {model} on {scope}
-
-- Provider: {provider}
-- Model: {model}
-- Dataset: {dataset} ({N} tasks, ref {ref})
-- Served context window: {window if vllm/litellm, else n/a}; auto-compaction at {floor(window*0.9)}
-- Run date: {UTC date}
-
-{one-line headline: how many tasks succeeded (K/N with 4/4 artifacts), and whether any retries/crashes/compaction events occurred}
-
-## Results
-
-| Task | Turns | Input tokens | Output tokens | Latency (s) | Judge score |
-|---|---|---|---|---|---|
-| ... one row per task, sorted by judge score desc ... |
-
-Token counts are cumulative across all turns of a task, not a single request. The judge is calibrated so a median artifact lands around 60-70.
-
-## Notes
-
-- {anything notable: did compaction fire? were there failures and why? server/window changes made mid-run?}
-- Each task is a fresh `claude -p` process: independent context, per-task window, no cross-task carryover.
-
-## Artifacts
-
-- Per-task results under `benchmarks/swe-benchmark-data/{model-slug}/{scope}/<task>/` (four design artifacts + `metrics.json` + `eval.json`).
-- {if vllm: GPU time series snapshot path from 5b}
-```
-
-If a task failed (fewer than 4/4 artifacts, or `is_error`), say so in the headline and note the cause from its `metrics.json` (`error`/`api_error_status`). Do not present a partial run as a clean sweep.
+The `RUN-SUMMARY.json` carries the structured data (per-task scores/turns/cost, the `serving` block with instance_type / tensor_parallel_size / precision / context_window, mean_task_score_excl_failed, failed_tasks) so runs can be charted or aggregated later without re-parsing every task folder.
 
 **5d. Report** where the results are and what they contain:
 

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -46,6 +46,10 @@ set -euo pipefail
 #   --timeout-seconds N    override the per-task wall-clock timeout (raise it for
 #                          a slow/dense model that produces artifacts but does not
 #                          return before the default cutoff)
+#   --tensor-parallel-size N  record the vLLM tensor-parallel size in the metrics
+#                          serving block (provenance only; does not change serving)
+#   --precision NAME       record the served weight precision (e.g. BF16, FP8) in
+#                          the metrics serving block
 #   --skip-judge           run the harness only; score later
 #   --yes                  clear pre-existing artifact folders without asking
 # ---------------------------------------------------------------------------
@@ -62,6 +66,8 @@ DATASET=""
 COUNT="0"                 # 0 = all tasks
 MAX_OUTPUT_TOKENS=""      # empty = use the config value
 TIMEOUT_SECONDS=""        # empty = use the config value
+TENSOR_PARALLEL_SIZE=""   # empty = use the config value
+PRECISION=""              # empty = use the config value
 ENDPOINT=""               # derived from provider unless overridden
 AWS_REGION_ARG="${AWS_REGION:-us-east-1}"
 ASSUME_YES=0
@@ -94,6 +100,8 @@ while [[ $# -gt 0 ]]; do
         --count)    COUNT="${2:?--count needs a value}"; shift 2 ;;
         --max-output-tokens) MAX_OUTPUT_TOKENS="${2:?--max-output-tokens needs a value}"; shift 2 ;;
         --timeout-seconds) TIMEOUT_SECONDS="${2:?--timeout-seconds needs a value}"; shift 2 ;;
+        --tensor-parallel-size) TENSOR_PARALLEL_SIZE="${2:?--tensor-parallel-size needs a value}"; shift 2 ;;
+        --precision) PRECISION="${2:?--precision needs a value}"; shift 2 ;;
         --endpoint) ENDPOINT="${2:?--endpoint needs a value}"; shift 2 ;;
         --aws-region) AWS_REGION_ARG="${2:?--aws-region needs a value}"; shift 2 ;;
         --config)   CONFIG="${2:?--config needs a value}"; shift 2 ;;
@@ -306,6 +314,8 @@ BENCH_ARGS=(--config "$CONFIG" --provider "$HARNESS_PROVIDER" --model "$MODEL" -
 [[ -n "${VLLM_CONTEXT_WINDOW:-}" ]] && BENCH_ARGS+=(--context-window "$VLLM_CONTEXT_WINDOW")
 [[ -n "$MAX_OUTPUT_TOKENS" ]] && BENCH_ARGS+=(--max-output-tokens "$MAX_OUTPUT_TOKENS")
 [[ -n "$TIMEOUT_SECONDS" ]] && BENCH_ARGS+=(--timeout-seconds "$TIMEOUT_SECONDS")
+[[ -n "$TENSOR_PARALLEL_SIZE" ]] && BENCH_ARGS+=(--tensor-parallel-size "$TENSOR_PARALLEL_SIZE")
+[[ -n "$PRECISION" ]] && BENCH_ARGS+=(--precision "$PRECISION")
 
 SLUG="$(uv run python -c "import sys; sys.path.insert(0,'scripts'); from runner_config import model_to_slug; print(model_to_slug('$MODEL'))")"
 info "Command:"
@@ -336,6 +346,17 @@ else
     ( cd scripts && uv run python codex_judge.py --recursive --no-overwrite --folder "../$JUDGE_TARGET" ) \
         || die "judge run failed. See the log above; re-run just the judge with the command shown."
     ok "Scoring complete."
+
+    # Write the machine-readable RUN-SUMMARY.json + human-readable RUN-SUMMARY.md
+    # from the scored artifacts, so the run is summarized on disk for later
+    # charting without re-parsing every task folder. Best-effort: a summary
+    # failure must not fail an otherwise-good scored run.
+    if uv run python scripts/summarize_run.py --folder "$JUDGE_TARGET" \
+        --run-date "$(date -u +%Y-%m-%d)"; then
+        ok "Run summary written: $JUDGE_TARGET/RUN-SUMMARY.{json,md}"
+    else
+        warn "Could not write RUN-SUMMARY (scores are still in each task's eval.json)."
+    fi
 fi
 
 # =============================================================================

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -1186,7 +1186,16 @@ def _save_metrics(
         "provider": config.provider,
         "endpoint": config.endpoint if not config.is_bedrock else None,
         "aws_region": config.resolved_region() if config.is_bedrock else None,
-        "instance_type": config.resolved_instance_type(),
+        # Serving provenance: the hardware and how the model was served. Grouped
+        # in one block rather than scattered top-level fields. context_window is
+        # the served window (0 in config means "unset"); null values mean unknown
+        # (e.g. tensor_parallel_size / precision on the Bedrock path).
+        "serving": {
+            "instance_type": config.resolved_instance_type(),
+            "tensor_parallel_size": config.tensor_parallel_size,
+            "precision": config.precision,
+            "context_window": config.context_window or None,
+        },
         "artifacts_produced": len(produced),
         "artifacts_expected": len(ARTIFACT_FILENAMES),
         "generation_tokens_per_sec": generation_tokens_per_sec,
@@ -1541,6 +1550,17 @@ def _parse_args() -> argparse.Namespace:
         help="Override: EC2 instance type served on (e.g. p5en.48xlarge). "
         "Defaults to the EC2 metadata service when unset.",
     )
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        help="Override: tensor-parallel size (vLLM TP) the model is served with. "
+        "Recorded in the metrics.json serving block.",
+    )
+    parser.add_argument(
+        "--precision",
+        help="Override: served weight precision (e.g. BF16, FP8). Recorded in the "
+        "metrics.json serving block.",
+    )
     parser.add_argument("--dataset", help="Override: dataset YAML path")
     parser.add_argument(
         "--tasks", help="Override: comma-separated task ids to run (default: all)"
@@ -1605,6 +1625,8 @@ def main() -> None:
         "model": args.model,
         "aws_region": args.aws_region,
         "instance_type": args.instance_type,
+        "tensor_parallel_size": args.tensor_parallel_size,
+        "precision": args.precision,
         "dataset": args.dataset,
         "max_turns": args.max_turns,
         "max_output_tokens": args.max_output_tokens,

--- a/benchmarks/scripts/runner_config.py
+++ b/benchmarks/scripts/runner_config.py
@@ -180,6 +180,18 @@ class RunnerConfig(BaseModel):
         "Recorded in each run's metrics.json for hardware provenance. Falls back to "
         "the EC2 instance metadata service (IMDSv2) when unset; null if unavailable.",
     )
+    tensor_parallel_size: int | None = Field(
+        default=None,
+        description="Tensor-parallel size (vLLM --tensor-parallel-size / TP) the "
+        "model is served with. Recorded in the metrics.json serving block for "
+        "provenance; null when unknown (e.g. Bedrock).",
+    )
+    precision: str | None = Field(
+        default=None,
+        description="Weight precision the model is served at, e.g. BF16 or FP8. "
+        "Recorded in the metrics.json serving block for provenance; null when "
+        "unknown.",
+    )
 
     # What to run and where outputs go.
     dataset: str | None = Field(
@@ -428,7 +440,12 @@ def _summarize(config: RunnerConfig) -> None:
     else:
         logger.info("  endpoint: %s", config.endpoint)
     logger.info("  model: %s", config.model)
-    logger.info("  instance_type: %s", config.resolved_instance_type())
+    logger.info(
+        "  serving: instance_type=%s tensor_parallel_size=%s precision=%s",
+        config.resolved_instance_type(),
+        config.tensor_parallel_size,
+        config.precision,
+    )
     logger.info("  dataset: %s", config.dataset)
     logger.info("  output_dir: %s", config.output_dir)
     logger.info("  clone_dir: %s", config.clone_dir)

--- a/benchmarks/scripts/summarize_run.py
+++ b/benchmarks/scripts/summarize_run.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Summarize one model+dataset benchmark run into RUN-SUMMARY.json and .md.
+
+Reads a ``{model-slug}/{scope}/`` folder under ``swe-benchmark-data`` (one
+subfolder per task, each with ``metrics.json`` and, when scored, ``eval.json``)
+and writes two sibling files:
+
+  * ``RUN-SUMMARY.json`` -- machine-readable, for later charting / aggregation.
+  * ``RUN-SUMMARY.md``   -- human-readable, rendered from the same data.
+
+A task that scored 0 is treated as a model failure (missing/empty artifacts) and
+is EXCLUDED from the headline mean (score and cost), matching the leaderboard
+convention; it is still listed with its 0 so the failure stays visible.
+
+Usage:
+    uv run scripts/summarize_run.py --folder ../swe-benchmark-data/gemma-4-31b/mcp-gateway-registry
+    uv run scripts/summarize_run.py --folder <dir> --run-date 2026-07-24
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+ARTIFACT_FILENAMES = ("github-issue.md", "lld.md", "review.md", "testing.md")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    """Return the parsed JSON object at ``path``, or None if absent/invalid."""
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _task_row(task_dir: Path) -> dict[str, Any] | None:
+    """Build one task's summary row from its metrics.json and eval.json.
+
+    Args:
+        task_dir: A single task's artifact directory.
+
+    Returns:
+        A row dict, or None if the folder has no metrics.json (not a task).
+    """
+    metrics = _read_json(task_dir / "metrics.json")
+    if metrics is None:
+        return None
+    mm = metrics.get("metrics_that_matter", {}) or {}
+    eval_data = _read_json(task_dir / "eval.json")
+    score = None
+    if eval_data and isinstance(eval_data.get("task_score"), (int, float)):
+        score = float(eval_data["task_score"])
+    produced = sum(1 for f in ARTIFACT_FILENAMES if (task_dir / f).exists())
+    return {
+        "task": task_dir.name,
+        "complexity": metrics.get("complexity"),
+        "artifacts_produced": produced,
+        "artifacts_expected": len(ARTIFACT_FILENAMES),
+        "num_turns": mm.get("num_turns"),
+        "input_tokens": mm.get("input_tokens"),
+        "output_tokens": mm.get("output_tokens"),
+        "latency_seconds": mm.get("latency_seconds"),
+        "total_cost_usd": metrics.get("total_cost_usd"),
+        "task_score": score,
+        "is_error": metrics.get("is_error"),
+        "failed": not score,  # 0 or missing score == model failure
+    }
+
+
+def _summarize(folder: Path, run_date: str | None) -> dict[str, Any]:
+    """Aggregate every task folder under ``folder`` into a summary dict.
+
+    Args:
+        folder: The ``{model-slug}/{scope}/`` run directory.
+        run_date: Optional ISO date to stamp; omitted when None.
+
+    Returns:
+        The structured summary (also written as RUN-SUMMARY.json).
+
+    Raises:
+        SystemExit: If no task folders with metrics.json are found.
+    """
+    rows = [
+        row
+        for task_dir in sorted(p for p in folder.iterdir() if p.is_dir())
+        if (row := _task_row(task_dir)) is not None
+    ]
+    if not rows:
+        raise SystemExit(f"no task folders with metrics.json under {folder}")
+
+    # Identity/serving from the first task's metrics (uniform across a run).
+    first = _read_json(folder / rows[0]["task"] / "metrics.json") or {}
+    scored = [r for r in rows if not r["failed"]]
+    failed = [r for r in rows if r["failed"]]
+    mean_score = (
+        round(sum(r["task_score"] for r in scored) / len(scored), 2) if scored else None
+    )
+    costs = [r["total_cost_usd"] for r in scored if r["total_cost_usd"] is not None]
+    mean_cost = round(sum(costs) / len(costs), 2) if costs else None
+
+    summary: dict[str, Any] = {
+        "model": first.get("model"),
+        "model_slug": folder.parent.name,
+        "scope": folder.name,
+        "provider": first.get("provider"),
+        "ref": first.get("ref"),
+        "serving": first.get("serving"),
+        "judge": (first.get("evaluation") or {}).get("judge"),
+        "num_tasks": len(rows),
+        "num_scored": len(scored),
+        "num_failed": len(failed),
+        "failed_tasks": [r["task"] for r in failed],
+        "mean_task_score_excl_failed": mean_score,
+        "mean_cost_usd_excl_failed": mean_cost,
+        "tasks": sorted(rows, key=lambda r: r["task_score"] or -1, reverse=True),
+    }
+    if run_date:
+        summary["run_date"] = run_date
+    return summary
+
+
+def _render_markdown(summary: dict[str, Any]) -> str:
+    """Render the human-readable RUN-SUMMARY.md from the summary dict."""
+    s = summary
+    serving = s.get("serving") or {}
+    serving_line = (
+        ", ".join(f"{k}={v}" for k, v in serving.items() if v is not None) or "n/a"
+    )
+    headline = (
+        f"{s['num_scored']} of {s['num_tasks']} tasks scored"
+        + (
+            f"; {s['num_failed']} failed ({', '.join(s['failed_tasks'])}), "
+            "excluded from the mean"
+            if s["num_failed"]
+            else "; no failures"
+        )
+        + "."
+    )
+    lines = [
+        f"# Benchmark run summary: {s['model']} on {s['scope']}",
+        "",
+        f"- Model: {s['model']}",
+        f"- Provider: {s['provider']}",
+        f"- Dataset scope: {s['scope']} ({s['num_tasks']} tasks, ref {s['ref']})",
+        f"- Serving: {serving_line}",
+    ]
+    if s.get("run_date"):
+        lines.append(f"- Run date: {s['run_date']}")
+    lines += [
+        "",
+        headline,
+        "",
+        "## Results",
+        "",
+        "| Task | Artifacts | Turns | Cost (est $) | Judge score |",
+        "|---|---|---|---|---|",
+    ]
+    for r in s["tasks"]:
+        score = "0.0 (model failure)" if r["failed"] else r["task_score"]
+        cost = f"{r['total_cost_usd']:.2f}" if r["total_cost_usd"] is not None else "--"
+        lines.append(
+            f"| {r['task']} | {r['artifacts_produced']}/{r['artifacts_expected']} "
+            f"| {r['num_turns']} | {cost} | {score} |"
+        )
+    lines += [
+        "",
+        f"Mean over the {s['num_scored']} completed tasks: "
+        f"{s['mean_task_score_excl_failed']} "
+        f"(mean cost ${s['mean_cost_usd_excl_failed']}). A 0-score task is a model "
+        "failure (missing artifacts) and is excluded from the means, pending "
+        "investigation. Cost is a token-based estimate for self-hosted models.",
+        "",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Write RUN-SUMMARY.json and RUN-SUMMARY.md for a benchmark run.",
+    )
+    parser.add_argument(
+        "--folder",
+        required=True,
+        type=Path,
+        help="The {model-slug}/{scope}/ run directory under swe-benchmark-data.",
+    )
+    parser.add_argument(
+        "--run-date",
+        default=None,
+        help="Optional ISO date to stamp in the summary (e.g. 2026-07-24).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Summarize a run folder into RUN-SUMMARY.json and RUN-SUMMARY.md."""
+    args = _parse_args()
+    folder = args.folder.expanduser().resolve()
+    if not folder.is_dir():
+        raise SystemExit(f"not a directory: {folder}")
+    summary = _summarize(folder, args.run_date)
+
+    json_path = folder / "RUN-SUMMARY.json"
+    json_path.write_text(
+        json.dumps(summary, indent=2, default=str) + "\n", encoding="utf-8"
+    )
+    md_path = folder / "RUN-SUMMARY.md"
+    md_path.write_text(_render_markdown(summary), encoding="utf-8")
+    logger.info(
+        "wrote %s and %s (%d scored, %d failed, mean %.2f)",
+        json_path,
+        md_path,
+        summary["num_scored"],
+        summary["num_failed"],
+        summary["mean_task_score_excl_failed"] or 0.0,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tests/test_summarize_run.py
+++ b/benchmarks/tests/test_summarize_run.py
@@ -1,0 +1,122 @@
+"""Tests for the run summarizer (RUN-SUMMARY.json / .md)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_SUMMARIZE_PATH = _SCRIPTS_DIR / "summarize_run.py"
+_spec = importlib.util.spec_from_file_location("summarize_run", _SUMMARIZE_PATH)
+assert _spec is not None and _spec.loader is not None
+summarize = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(summarize)
+
+_ARTIFACTS = ("github-issue.md", "lld.md", "review.md", "testing.md")
+
+
+def _write_task(
+    scope_dir: Path,
+    task: str,
+    *,
+    score: float | None,
+    n_artifacts: int = 4,
+    cost: float = 5.0,
+    turns: int = 20,
+) -> None:
+    """Create a task folder with metrics.json, artifacts, and optional eval.json."""
+    d = scope_dir / task
+    d.mkdir(parents=True)
+    for name in _ARTIFACTS[:n_artifacts]:
+        (d / name).write_text(f"# {name}\nbody\n", encoding="utf-8")
+    metrics: dict[str, Any] = {
+        "task": task,
+        "ref": "1.2.3",
+        "model": "test-model",
+        "provider": "endpoint",
+        "complexity": "medium",
+        "serving": {
+            "instance_type": "g6e.12xlarge",
+            "tensor_parallel_size": 4,
+            "precision": "BF16",
+            "context_window": 200000,
+        },
+        "total_cost_usd": cost,
+        "is_error": False,
+        "metrics_that_matter": {
+            "num_turns": turns,
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "latency_seconds": 100.0,
+        },
+    }
+    (d / "metrics.json").write_text(json.dumps(metrics), encoding="utf-8")
+    if score is not None:
+        (d / "eval.json").write_text(
+            json.dumps({"task": task, "model": "test-model", "task_score": score}),
+            encoding="utf-8",
+        )
+
+
+class SummarizeRunTest(unittest.TestCase):
+    def test_clean_run_mean_over_all_tasks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            scope = Path(tmp) / "test-model" / "some-repo"
+            _write_task(scope, "task-a", score=60.0, cost=4.0)
+            _write_task(scope, "task-b", score=50.0, cost=6.0)
+            s = summarize._summarize(scope, run_date="2026-07-24")
+            self.assertEqual(s["num_scored"], 2)
+            self.assertEqual(s["num_failed"], 0)
+            self.assertEqual(s["mean_task_score_excl_failed"], 55.0)
+            self.assertEqual(s["mean_cost_usd_excl_failed"], 5.0)
+            self.assertEqual(s["serving"]["precision"], "BF16")
+            self.assertEqual(s["model_slug"], "test-model")
+
+    def test_failed_task_excluded_from_mean(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            scope = Path(tmp) / "test-model" / "some-repo"
+            _write_task(scope, "good", score=60.0, cost=4.0)
+            # A 0-score task (missing artifact): excluded from the mean, still listed.
+            _write_task(scope, "bad", score=0.0, n_artifacts=3, cost=9.0)
+            s = summarize._summarize(scope, run_date=None)
+            self.assertEqual(s["num_scored"], 1)
+            self.assertEqual(s["failed_tasks"], ["bad"])
+            self.assertEqual(s["mean_task_score_excl_failed"], 60.0)
+            # Failed task's cost is excluded too.
+            self.assertEqual(s["mean_cost_usd_excl_failed"], 4.0)
+
+    def test_missing_eval_counts_as_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            scope = Path(tmp) / "test-model" / "some-repo"
+            _write_task(scope, "unscored", score=None)
+            s = summarize._summarize(scope, run_date=None)
+            self.assertEqual(s["num_failed"], 1)
+            self.assertIsNone(s["mean_task_score_excl_failed"])
+
+    def test_markdown_flags_failure_and_serving(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            scope = Path(tmp) / "test-model" / "some-repo"
+            _write_task(scope, "good", score=60.0)
+            _write_task(scope, "bad", score=0.0, n_artifacts=3)
+            md = summarize._render_markdown(summarize._summarize(scope, run_date=None))
+            self.assertIn("model failure", md)
+            self.assertIn("precision=BF16", md)
+            self.assertIn("1 failed (bad)", md)
+
+    def test_no_tasks_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            scope = Path(tmp) / "empty" / "repo"
+            scope.mkdir(parents=True)
+            with self.assertRaises(SystemExit):
+                summarize._summarize(scope, run_date=None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three related changes so benchmark runs carry hardware provenance and leave a small, reproducible, git-committed record.

## 1. metrics.json `serving` block
Replace the top-level `instance_type` field with a nested block: `{instance_type, tensor_parallel_size, precision, context_window}`. New `--tensor-parallel-size` / `--precision` CLI flags (harness + orchestrator); `precision` is the FP8/BF16 field. Null = unknown (e.g. Bedrock).

## 2. `summarize_run.py` -> RUN-SUMMARY.json + .md
Reads a `{model}/{scope}/` run and writes both a machine-readable `RUN-SUMMARY.json` (per-task scores/turns/cost, serving block, judge metadata, failed-task-excluded mean) and a human `RUN-SUMMARY.md`. A 0-score task counts as a model failure and is excluded from the mean. The orchestrator runs it after scoring; the benchmark skill's Step 5c calls it instead of hand-writing markdown.

## 3. Commit RUN-SUMMARY.json to git (data-storage policy)
**Decision:** the per-run `RUN-SUMMARY.json` (~3 KB, scrubbed) is the one benchmark artifact committed -- it backs the README leaderboard and is reproducible/auditable in git. The bulky, leak-prone per-task outputs (four design .md, eval.json, raw metrics.json -- which quote cloned third-party source and carry session ids/endpoints) stay gitignored and local. No external data store is warranted at 2.8 MB of text.
- `.gitignore`: ignore everything under `swe-benchmark-data` EXCEPT `RUN-SUMMARY.json`, the README, and the already-committed Hello-World worked example (kept as an intentional full example).
- Scrubbed the judge block's local `repo_root` (/tmp path) from RUN-SUMMARY.json.
- Committed RUN-SUMMARY.json for all six models run so far; means match the leaderboard; scanned clean of tokens/urls/session ids.

## Validation
- +5 summarizer tests (108 total pass); ruff, ruff format, mypy (0 on new file), bandit (0), `bash -n` all clean.
- Security gate (Cipher): APPROVED. Leakage scan across all six committed RUN-SUMMARY.json: clean.