### PR TITLE
Commit RUN-SUMMARY.json as the reproducible per-run record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,17 +16,23 @@ self-hosted/vllm/benchmark-output/
 .env.*
 .scratchpad/
 
-# Benchmark run outputs (generated artifacts, metrics, and locally cloned target
-# repos) are produced per run and never committed. The double-glob form also
-# catches nested copies a tool/cwd mistake might create.
-benchmarks/swe-benchmark-data/
-**/benchmarks/swe-benchmark-data/
-# We commit ONLY the Hello-World example and the README under swe-benchmark-data
-# (force-added despite the ignore above, as a worked example). Everything else a
-# customer generates -- including their own runs against mcp-gateway-registry --
-# stays local so it can never be committed by accident.
-benchmarks/swe-benchmark-data/mcp-gateway-registry/
-**/benchmarks/swe-benchmark-data/mcp-gateway-registry/
+# Benchmark run outputs. Per-run design artifacts (github-issue/lld/review/
+# testing .md), eval.json, and raw metrics.json stay LOCAL -- they quote cloned
+# third-party source and metrics.json carries session ids / endpoints, so they
+# are never committed. The ONE committed result per run is RUN-SUMMARY.json: a
+# small, scrubbed rollup (scores, cost, serving block, judge metadata) that backs
+# the README leaderboard and is safe + reproducible in git. To allow that one
+# file deep inside the ignored tree, the intervening directories are re-included.
+benchmarks/swe-benchmark-data/**
+# Re-include subdirectories (so git can descend) and the committed files.
+!benchmarks/swe-benchmark-data/*/
+!benchmarks/swe-benchmark-data/**/
+!benchmarks/swe-benchmark-data/README.md
+!benchmarks/swe-benchmark-data/**/RUN-SUMMARY.json
+# The Hello-World worked example is an intentional exception: its full artifacts
+# (already committed) stay tracked so readers can see exactly what /swe produces.
+# New real runs commit only RUN-SUMMARY.json per the rule above.
+!benchmarks/swe-benchmark-data/*/Hello-World/**
 # Per-task target-repo clones. The harness clones into
 # <clone_dir>/swe-clone-<task-id>/ (clone_dir defaults to /tmp, outside the
 # repo) and deletes them after each task; this ignore is a backstop for a config

--- a/benchmarks/scripts/summarize_run.py
+++ b/benchmarks/scripts/summarize_run.py
@@ -100,6 +100,11 @@ def _summarize(folder: Path, run_date: str | None) -> dict[str, Any]:
 
     # Identity/serving from the first task's metrics (uniform across a run).
     first = _read_json(folder / rows[0]["task"] / "metrics.json") or {}
+    # RUN-SUMMARY.json is committed to git, so drop the judge block's local-only
+    # temp path (repo_root, e.g. /tmp/swe-judge-repos/...); it is machine-specific
+    # noise, not provenance worth committing.
+    judge = dict((first.get("evaluation") or {}).get("judge") or {})
+    judge.pop("repo_root", None)
     scored = [r for r in rows if not r["failed"]]
     failed = [r for r in rows if r["failed"]]
     mean_score = (
@@ -115,7 +120,7 @@ def _summarize(folder: Path, run_date: str | None) -> dict[str, Any]:
         "provider": first.get("provider"),
         "ref": first.get("ref"),
         "serving": first.get("serving"),
-        "judge": (first.get("evaluation") or {}).get("judge"),
+        "judge": judge or None,
         "num_tasks": len(rows),
         "num_scored": len(scored),
         "num_failed": len(failed),

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,110 @@
+{
+  "model": "gemma-4-31b",
+  "model_slug": "gemma-4-31b",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "BF16",
+    "context_window": 200000
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-24T19:34:27.935661Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 444725,
+      "cached_input_tokens": 375927,
+      "cache_write_input_tokens": 68778,
+      "output_tokens": 7341,
+      "reasoning_output_tokens": 3496
+    },
+    "duration_ms": 189933
+  },
+  "num_tasks": 5,
+  "num_scored": 4,
+  "num_failed": 1,
+  "failed_tasks": [
+    "remove-faiss"
+  ],
+  "mean_task_score_excl_failed": 55.12,
+  "mean_cost_usd_excl_failed": 13.2,
+  "tasks": [
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 27,
+      "input_tokens": 1412216,
+      "output_tokens": 16928,
+      "latency_seconds": 1874.9,
+      "total_cost_usd": 14.031350000000002,
+      "task_score": 63.25,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 35,
+      "input_tokens": 1121854,
+      "output_tokens": 30800,
+      "latency_seconds": 1914.9,
+      "total_cost_usd": 13.320165,
+      "task_score": 59.5,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 25,
+      "input_tokens": 1225853,
+      "output_tokens": 13754,
+      "latency_seconds": 914.8,
+      "total_cost_usd": 10.315885,
+      "task_score": 52.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 43,
+      "input_tokens": 1272610,
+      "output_tokens": 31959,
+      "latency_seconds": 2026.8,
+      "total_cost_usd": 15.142489999999997,
+      "task_score": 45.75,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 3,
+      "artifacts_expected": 4,
+      "num_turns": 34,
+      "input_tokens": 1977190,
+      "output_tokens": 11781,
+      "latency_seconds": 1735.8,
+      "total_cost_usd": 18.224745,
+      "task_score": 0.0,
+      "is_error": false,
+      "failed": true
+    }
+  ],
+  "run_date": "2026-07-24"
+}

--- a/benchmarks/swe-benchmark-data/glm-5.2/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/glm-5.2/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,103 @@
+{
+  "model": "glm-5.2",
+  "model_slug": "glm-5.2",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": null,
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-24T14:05:08.190344Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 262615,
+      "cached_input_tokens": 218742,
+      "cache_write_input_tokens": 43859,
+      "output_tokens": 7772,
+      "reasoning_output_tokens": 6473
+    },
+    "duration_ms": 146600
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 72.75,
+  "mean_cost_usd_excl_failed": 28.18,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 54,
+      "input_tokens": 3309436,
+      "output_tokens": 42110,
+      "latency_seconds": 853.2,
+      "total_cost_usd": 26.783854999999996,
+      "task_score": 79.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 28,
+      "input_tokens": 1492051,
+      "output_tokens": 36994,
+      "latency_seconds": 706.6,
+      "total_cost_usd": 20.1747,
+      "task_score": 76.75,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 27,
+      "input_tokens": 1186975,
+      "output_tokens": 34289,
+      "latency_seconds": 730.0,
+      "total_cost_usd": 20.553505,
+      "task_score": 73.5,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 37,
+      "input_tokens": 2528799,
+      "output_tokens": 45828,
+      "latency_seconds": 846.8,
+      "total_cost_usd": 23.942494999999997,
+      "task_score": 68.5,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 35,
+      "input_tokens": 2835053,
+      "output_tokens": 46051,
+      "latency_seconds": 1256.9,
+      "total_cost_usd": 49.44449500000001,
+      "task_score": 66.0,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-24"
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,105 @@
+{
+  "model": "kimi-k2.7-code",
+  "model_slug": "kimi-k2.7-code",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": null,
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-24T04:10:52.681832Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 154890,
+      "cached_input_tokens": 127851,
+      "cache_write_input_tokens": 27027,
+      "output_tokens": 6236,
+      "reasoning_output_tokens": 5320
+    },
+    "duration_ms": 129064
+  },
+  "num_tasks": 5,
+  "num_scored": 4,
+  "num_failed": 1,
+  "failed_tasks": [
+    "replace-keycloak-db-password-with-rds-iam"
+  ],
+  "mean_task_score_excl_failed": 73.69,
+  "mean_cost_usd_excl_failed": 28.82,
+  "tasks": [
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 100,
+      "input_tokens": 3577390,
+      "output_tokens": 30869,
+      "latency_seconds": 1115.9,
+      "total_cost_usd": 44.109034999999984,
+      "task_score": 75.5,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 33,
+      "input_tokens": 809868,
+      "output_tokens": 16680,
+      "latency_seconds": 501.4,
+      "total_cost_usd": 22.943170000000002,
+      "task_score": 75.25,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 2,
+      "input_tokens": 124065,
+      "output_tokens": 4968,
+      "latency_seconds": 54.1,
+      "total_cost_usd": 43.06495499999998,
+      "task_score": 72.75,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 32,
+      "input_tokens": 819203,
+      "output_tokens": 11264,
+      "latency_seconds": 213.5,
+      "total_cost_usd": 5.153795000000001,
+      "task_score": 71.25,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 2,
+      "artifacts_expected": 4,
+      "num_turns": 61,
+      "input_tokens": 3566106,
+      "output_tokens": 58605,
+      "latency_seconds": 1186.5,
+      "total_cost_usd": 36.745899999999985,
+      "task_score": 0.0,
+      "is_error": true,
+      "failed": true
+    }
+  ],
+  "run_date": "2026-07-24"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,103 @@
+{
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": null,
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-24T17:13:23.065584Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 99679,
+      "cached_input_tokens": 76706,
+      "cache_write_input_tokens": 22963,
+      "output_tokens": 4803,
+      "reasoning_output_tokens": 4000
+    },
+    "duration_ms": 118774
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 51.35,
+  "mean_cost_usd_excl_failed": 7.39,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 24,
+      "input_tokens": 1226449,
+      "output_tokens": 9428,
+      "latency_seconds": 87.0,
+      "total_cost_usd": 6.367944999999999,
+      "task_score": 58.5,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 25,
+      "input_tokens": 1210461,
+      "output_tokens": 11539,
+      "latency_seconds": 118.6,
+      "total_cost_usd": 6.340780000000001,
+      "task_score": 55.75,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 25,
+      "input_tokens": 1264401,
+      "output_tokens": 14127,
+      "latency_seconds": 136.3,
+      "total_cost_usd": 6.675179999999999,
+      "task_score": 49.5,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 33,
+      "input_tokens": 1631007,
+      "output_tokens": 15499,
+      "latency_seconds": 169.8,
+      "total_cost_usd": 13.002109999999995,
+      "task_score": 48.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 16,
+      "input_tokens": 861795,
+      "output_tokens": 10637,
+      "latency_seconds": 93.1,
+      "total_cost_usd": 4.5748999999999995,
+      "task_score": 45.0,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-24"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,105 @@
+{
+  "model": "qwen3-coder-30b",
+  "model_slug": "qwen3-coder-30b",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": null,
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-24T13:20:46.345863Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 974247,
+      "cached_input_tokens": 910719,
+      "cache_write_input_tokens": 63484,
+      "output_tokens": 11101,
+      "reasoning_output_tokens": 6923
+    },
+    "duration_ms": 236091
+  },
+  "num_tasks": 5,
+  "num_scored": 4,
+  "num_failed": 1,
+  "failed_tasks": [
+    "ssrf-hardening-outbound-url-validation"
+  ],
+  "mean_task_score_excl_failed": 40.88,
+  "mean_cost_usd_excl_failed": 16.78,
+  "tasks": [
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 26,
+      "input_tokens": 2664033,
+      "output_tokens": 9477,
+      "latency_seconds": 222.0,
+      "total_cost_usd": 13.560275,
+      "task_score": 49.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 26,
+      "input_tokens": 1932691,
+      "output_tokens": 9171,
+      "latency_seconds": 165.8,
+      "total_cost_usd": 9.896115,
+      "task_score": 45.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 30,
+      "input_tokens": 2495335,
+      "output_tokens": 10593,
+      "latency_seconds": 526.4,
+      "total_cost_usd": 33.543895000000006,
+      "task_score": 36.25,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 25,
+      "input_tokens": 1938033,
+      "output_tokens": 16991,
+      "latency_seconds": 243.4,
+      "total_cost_usd": 10.118345000000001,
+      "task_score": 33.25,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 0,
+      "artifacts_expected": 4,
+      "num_turns": 61,
+      "input_tokens": 4736204,
+      "output_tokens": 12092,
+      "latency_seconds": 311.5,
+      "total_cost_usd": 24.613324999999996,
+      "task_score": 0.0,
+      "is_error": true,
+      "failed": true
+    }
+  ],
+  "run_date": "2026-07-24"
+}

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,103 @@
+{
+  "model": "qwen3.6-35b",
+  "model_slug": "qwen3.6-35b",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": null,
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-24T01:29:56.571658Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 367984,
+      "cached_input_tokens": 310519,
+      "cache_write_input_tokens": 57449,
+      "output_tokens": 7861,
+      "reasoning_output_tokens": 4434
+    },
+    "duration_ms": 139192
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 56.25,
+  "mean_cost_usd_excl_failed": 20.14,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 26,
+      "input_tokens": 755789,
+      "output_tokens": 19408,
+      "latency_seconds": 329.9,
+      "total_cost_usd": 9.857805,
+      "task_score": 63.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 40,
+      "input_tokens": 1332185,
+      "output_tokens": 27090,
+      "latency_seconds": 870.9,
+      "total_cost_usd": 27.140770000000003,
+      "task_score": 59.25,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 64,
+      "input_tokens": 1895077,
+      "output_tokens": 43646,
+      "latency_seconds": 713.3,
+      "total_cost_usd": 22.895679999999995,
+      "task_score": 55.75,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 24,
+      "input_tokens": 1303482,
+      "output_tokens": 23563,
+      "latency_seconds": 631.1,
+      "total_cost_usd": 17.577835000000004,
+      "task_score": 54.5,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 4,
+      "num_turns": 42,
+      "input_tokens": 2264680,
+      "output_tokens": 38086,
+      "latency_seconds": 754.9,
+      "total_cost_usd": 23.236315000000005,
+      "task_score": 48.75,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-24"
+}


### PR DESCRIPTION
Follow-up to #22 (merged), which landed the serving block + summarizer but merged before this commit reached its branch.

**Decision (debated in-thread):** the per-run `RUN-SUMMARY.json` (~3 KB, scrubbed) is the one benchmark artifact worth committing to git -- it backs the README leaderboard and is reproducible/auditable. The bulky, leak-prone per-task outputs (four design .md, eval.json, raw metrics.json -- which quote cloned third-party source and carry session ids/endpoints) stay gitignored and local. No external data store is warranted at 2.8 MB of text.

- `summarize_run.py`: drop the judge block's local `repo_root` (/tmp path) from RUN-SUMMARY.json now that it is committed (machine-specific noise, not provenance).
- `.gitignore`: ignore everything under `swe-benchmark-data` EXCEPT `RUN-SUMMARY.json`, the README, and the already-committed Hello-World worked example.
- Commit RUN-SUMMARY.json for all six models run so far (gemma-4-31b, glm-5.2, kimi-k2.7-code, minimax-m2.5, qwen3-coder-30b, qwen3.6-35b). Means match the published leaderboard; scanned clean of tokens/urls/session ids.