### PR TITLE
Backfill serving block for the Qwen g6e.12xlarge runs

### DIFF
--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/mcp-gateway-registry/RUN-SUMMARY.json
@@ -4,7 +4,12 @@
   "scope": "mcp-gateway-registry",
   "provider": "endpoint",
   "ref": "1.24.4",
-  "serving": null,
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "BF16",
+    "context_window": 200000
+  },
   "judge": {
     "model": "openai.gpt-5.6-sol",
     "provider": "codex-exec",

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/mcp-gateway-registry/RUN-SUMMARY.json
@@ -4,7 +4,12 @@
   "scope": "mcp-gateway-registry",
   "provider": "endpoint",
   "ref": "1.24.4",
-  "serving": null,
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "BF16",
+    "context_window": 200000
+  },
   "judge": {
     "model": "openai.gpt-5.6-sol",
     "provider": "codex-exec",


### PR DESCRIPTION
qwen3.6-35b and qwen3-coder-30b ran on this g6e.12xlarge (4x L40S) today, before the metrics `serving` block existed, so their committed RUN-SUMMARY.json had `"serving": null`.

Backfill the known values -- `{instance_type: g6e.12xlarge, tensor_parallel_size: 4, precision: BF16, context_window: 200000}` -- into their metrics.json and regenerate the summaries. Means unchanged (56.25, 40.88).

All three models served on this machine (gemma-4-31b, qwen3.6-35b, qwen3-coder-30b) now carry the serving block. The 8x H200 runs (glm-5.2, kimi-k2.7-code, minimax-m2.5) stay null -- they ran on a separate box and their exact TP/precision/window aren't ours to assert; they'll populate on a re-run.

Only the two RUN-SUMMARY.json are committed (metrics.json is gitignored). Scanned clean of secrets.