### PR TITLE
Add stream_timeout to LiteLLM proxy config

### DIFF
--- a/benchmarks/config/litellm-mantle.yaml
+++ b/benchmarks/config/litellm-mantle.yaml
@@ -274,6 +274,7 @@ litellm_settings:
   drop_params: true          # drop unsupported params instead of erroring
   num_retries: 2
   request_timeout: 300       # 5 min for large models
+  stream_timeout: 120        # kill a stalled SSE stream after 2 min of silence
 
 environment_variables:
   # Force litellm to use /v1/chat/completions (not /v1/responses) for the


### PR DESCRIPTION
## Summary

- Adds `stream_timeout: 120` to `litellm_settings` in the bedrock-mantle proxy config
- Prevents hung connections when bedrock-mantle stalls mid-stream on large-context requests

## Problem

bedrock-mantle can accept a streaming request (HTTP 200) but then go silent -- no more SSE events arrive. The existing `request_timeout: 300` only governs the initial connection, not an already-opened stream. Without a stream timeout, `claude -p` waits indefinitely for the next event, eventually hitting the harness wall-clock timeout (1800s) with 0 artifacts.

## Fix

`stream_timeout: 120` tells LiteLLM to kill a silent stream after 2 minutes and surface a retryable error, so the agent can recover instead of hanging forever.

## Testing

Discovered and validated while benchmarking Qwen3-Coder-480B on mcp-gateway-registry. Before the fix, the run hung after 159 successful API calls when a large-context streaming request stalled. After the fix, the same task completed successfully (4/4 artifacts, 37 turns, 649s).