### PR TITLE
Add Qwen3-Coder-480B results via bedrock-mantle (Path 2)

### DIFF
--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/github-issue.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/github-issue.md
@@ -1,0 +1,47 @@
+# GitHub Issue: Migrate Sensitive ECS Environment Variables to AWS Secrets Manager
+
+## Title
+Migrate sensitive ECS environment variables to AWS Secrets Manager for enhanced security
+
+## Labels
+- security
+- enhancement
+- terraform
+- aws
+
+## Description
+
+### Problem Statement
+Currently, sensitive environment variables containing secrets (such as database passwords, API keys, OAuth client secrets, and admin passwords) are stored as plaintext in ECS task definitions via Terraform. This poses a security risk as these values are visible in the AWS console and Infrastructure as Code templates. Moving these sensitive values to AWS Secrets Manager will provide encryption at rest, enable rotation capabilities, and maintain an audit trail of access.
+
+### Proposed Solution
+1. Identify all sensitive environment variables across all ECS services in the Terraform configuration
+2. Create AWS Secrets Manager resources for each secret
+3. Update ECS task definitions to pull secrets from Secrets Manager instead of using plaintext environment variables
+4. Update IAM task execution roles to grant read access to the appropriate Secrets Manager resources
+5. Maintain backward compatibility by keeping the plaintext environment variable path as a fallback during migration
+
+### User Stories
+- As an operator deploying the registry on AWS ECS with Terraform, I want sensitive credentials to be securely stored so that I can meet security compliance requirements
+- As a DevOps engineer, I want to enable secret rotation without redeploying applications so that I can improve operational security
+- As a security engineer, I want to maintain audit trails of secret access so that I can monitor for unauthorized access
+
+### Acceptance Criteria
+- [ ] All sensitive environment variables are migrated to AWS Secrets Manager
+- [ ] ECS task definitions pull secrets from Secrets Manager via the `secrets` block
+- [ ] IAM task execution roles are updated to allow reading the new Secrets Manager resources
+- [ ] Plaintext environment variable path remains as a fallback during migration
+- [ ] All affected services continue to function correctly after migration
+- [ ] Documentation is updated to reflect the new secret management approach
+
+### Out of Scope
+- Rotating existing secrets
+- Changing the underlying services to support dynamic secret reloading
+- Migrating non-sensitive environment variables
+
+### Dependencies
+- Terraform AWS provider version that supports Secrets Manager resources
+- Existing IAM role structure in the Terraform codebase
+
+### Related Issues
+- #1134

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/lld.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/lld.md
@@ -1,0 +1,454 @@
+# Low-Level Design: Migrate Sensitive ECS Environment Variables to AWS Secrets Manager
+
+*Created: 2026-07-24*
+*Author: Claude*
+*Status: Draft*
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Codebase Analysis](#codebase-analysis)
+3. [Architecture](#architecture)
+4. [Data Models](#data-models)
+5. [API / CLI Design](#api--cli-design)
+6. [Configuration Parameters](#configuration-parameters)
+7. [New Dependencies](#new-dependencies)
+8. [Implementation Details](#implementation-details)
+9. [Observability](#observability)
+10. [Scaling Considerations](#scaling-considerations)
+11. [File Changes](#file-changes)
+12. [Testing Strategy](#testing-strategy)
+13. [Alternatives Considered](#alternatives-considered)
+14. [Rollout Plan](#rollout-plan)
+
+## Overview
+### Problem Statement
+Currently, sensitive environment variables containing secrets (such as database passwords, API keys, OAuth client secrets, and admin passwords) are stored as plaintext in ECS task definitions via Terraform. This poses a security risk as these values are visible in the AWS console and Infrastructure as Code templates. Moving these sensitive values to AWS Secrets Manager will provide encryption at rest, enable rotation capabilities, and maintain an audit trail of access.
+
+The migration affects multiple services in the mcp-gateway-registry deployment:
+- Auth Server
+- Registry (primary service)
+- MCP Gateway
+- Demo services (if enabled)
+
+### Goals
+- Identify all sensitive environment variables in ECS task definitions
+- Create AWS Secrets Manager resources for each identified secret
+- Update ECS task definitions to pull secrets from Secrets Manager
+- Update IAM task execution roles to grant read access to new Secrets Manager resources
+- Maintain backward compatibility with plaintext environment variables as fallback during migration
+- Follow established patterns in the codebase
+
+### Non-Goals
+- Rotating existing secrets during migration
+- Changing the underlying services to support dynamic secret reloading
+- Migrating non-sensitive environment variables
+- Automating the initial secret population process
+
+## Codebase Analysis
+
+### Key Files Reviewed
+
+| File/Directory | Purpose | Relevance to This Change |
+|----------------|---------|--------------------------|
+| `terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf` | ECS service definitions with container environment variables and secrets | Core implementation of where environment variables/secrets are defined |
+| `terraform/aws-ecs/modules/mcp-gateway/secrets.tf` | Secrets Manager and KMS configuration | Existing secret management patterns to follow |
+| `terraform/aws-ecs/modules/mcp-gateway/iam.tf` | IAM policies for ECS task roles | Existing access control patterns for secrets |
+| `terraform/aws-ecs/keycloak-ecs.tf` | Keycloak ECS service (external example) | Example of proper secret management implementation |
+| `terraform/aws-ecs/keycloak-database.tf` | Keycloak database secrets (external example) | Example of proper secret management implementation |
+
+### Existing Patterns Identified
+1. **Dual Secret Management Approach**: The codebase already uses both AWS Systems Manager (SSM) Parameter Store and AWS Secrets Manager depending on the nature of the secret:
+   - Static configuration secrets: SSM Parameter Store
+   - Rotating credentials: Secrets Manager
+
+   Files: `keycloak-ecs.tf`, `keycloak-database.tf`
+
+2. **Principle of Least Privilege**: IAM policies are precisely scoped to only allow access to specific secrets/parameters.
+   Files: `iam.tf`
+
+3. **Comprehensive Environment Variable Organization**: Environment variables are categorized into:
+   - Non-sensitive environment variables in the `environment` block
+   - Sensitive variables in the `secrets` block with references to `valueFrom`
+
+   Files: `ecs-services.tf`
+
+4. **Proper Secret Value Referencing**: Secrets Manager values are referenced using ARN formats with field specification:
+   ```
+   valueFrom = "${aws_secretsmanager_secret.name.arn}:field::"
+   ```
+
+   Files: `ecs-services.tf`
+
+### Integration Points
+| Component | Integration Type | Details |
+|-----------|------------------|---------|
+| ECS Task Definitions | Extends | Environment variables and secrets blocks need updating |
+| IAM Policies | Depends on | Need to grant access to new Secrets Manager resources |
+| Secrets Manager | Creates/Depends on | Will store new secrets, accessed by ECS containers |
+| KMS Keys | Depends on | Existing key used to encrypt Secrets Manager resources |
+
+### Constraints and Limitations Discovered
+- Secrets referenced in the container definition's `secrets` block are limited to a single line of text (not structured objects)
+- Some secrets must be maintained temporarily in both forms (plaintext and Secrets Manager) for migration purposes
+- Rotation support needs coordination with services consuming the secrets
+
+## Architecture
+
+### System Context Diagram
+```
+┌─────────────────┐       ┌─────────────────────┐       ┌─────────────────────┐
+│  ECS Container  │──────▶│  AWS Secrets Mgr    │◀─────▶│   Configuration     │
+│                 │       │                     │       │       Code          │
+│   (Registry)    │       │  Encrypted Secrets  │       │   (Terraform)       │
+└─────────────────┘       └─────────────────────┘       └─────────────────────┘
+         │                           │                              │
+         ▼                           ▼                              ▼
+┌─────────────────┐       ┌─────────────────────┐       ┌─────────────────────┐
+│  ECS Container  │       │  IAM Execution      │       │   KMS Encryption    │
+│    (Auth)       │       │       Role          │       │                     │
+└─────────────────┘       └─────────────────────┘       └─────────────────────┘
+```
+
+### Component Diagram
+```
+                                 ┌─────────────────────────────┐
+                                 │                             │
+                                 │   ECS Task Definition       │
+                                 │                             │
+                                 │  environment: [             │
+                                 │    { name: "VAR1"         ◀─┼─── Plaintext (retain during migration)
+                                 │      value: "value" }       │
+                                 │  ]                          │
+                                 │                             │
+                                 │  secrets: [                 │
+                                 │    { name: "DB_USER"      ◀─┼─── From Secrets Manager
+                                 │      valueFrom: "arn:..."   │
+                                 │    }                        │
+                                 │  ]                          │
+                                 │                             │
+                                 └─────────────┬───────────────┘
+                                               │
+                             ┌─────────────────┴─────────────────┐
+                             │                                   │
+                             ▼                                   ▼
+         ┌────────────────────────────┐     ┌────────────────────────────┐
+         │                            │     │                            │
+         │    IAM Role Policy         │     │     Secrets Manager        │
+         │                            │     │                            │
+         │ permissions: [             │     │  aws_secretsmanager_secret │
+         │   "secretsmanager:Get..."  │     │  {                         │
+         │ ]                          │     │    secret_string = json    │
+         │                            │     │  }                         │
+         │ resource: [                │     │  aws_secretsmanager_secret_│
+         │   aws_sm_secret.arn        │     │  version                   │
+         │ ]                          │     │  {                         │
+         │                            │     │    secret_id               │
+         │                            │     │    secret_string           │
+         │                            │     │  }                         │
+         └────────────────────────────┘     └────────────────────────────┘
+                                                            │
+                                            ┌─────────────────┴─────────────────┐
+                                            │                                   │
+                                            ▼                                   ▼
+                                ┌─────────────────────┐         ┌─────────────────────┐
+                                │                     │         │                     │
+                                │   KMS Key           │         │   Application       │
+                                │                     │         │   Containers        │
+                                │ aws_kms_key.secrets │         │                     │
+                                │                     │         │ Can now reference   │
+                                │  encryption         │         │ secrets directly    │
+                                │                     │         │ without plaintext   │
+                                └─────────────────────┘         └─────────────────────┘
+```
+
+## Data Models
+
+This change primarily affects infrastructure configuration rather than application data models. However, it modifies how secrets are structured in Terraform.
+
+## API / CLI Design
+
+No API or CLI changes are required as this is an infrastructure-level change that affects deployment rather than runtime behavior.
+
+## Configuration Parameters
+
+This change primarily involves infrastructure configuration rather than introducing new application configuration parameters.
+
+### Deployment Surface Checklist
+List every surface where configuration changes must be made:
+- [ ] terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+- [ ] terraform/aws-ecs/modules/mcp-gateway/secrets.tf
+- [ ] terraform/aws-ecs/modules/mcp-gateway/iam.tf
+
+## New Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| AWS Secrets Manager | N/A (existing AWS service) | Secure storage of sensitive environment variables |
+| AWS KMS | N/A (existing AWS service) | Encryption of secrets at rest |
+
+If no new dependencies are required, explicitly state: "This change uses only existing AWS services and Terraform providers."
+
+## Implementation Details
+
+### Step-by-Step Plan (for a future implementer)
+
+Note: Some sensitive environment variables are already properly managed through AWS Secrets Manager in the codebase. The implementation will focus on the remaining plaintext secrets that need to be migrated.
+
+#### Step 1: Identify Secrets to Migrate
+
+Based on the code analysis, we need to migrate the following sensitive environment variables:
+
+**Auth Server Service:**
+1. `REGISTRY_API_TOKEN` - Move to AWS Secrets Manager
+2. `REGISTRY_API_KEYS` - Move to AWS Secrets Manager
+3. `FEDERATION_STATIC_TOKEN` - Move to AWS Secrets Manager
+4. `FEDERATION_ENCRYPTION_KEY` - Move to AWS Secrets Manager
+5. `ANS_API_KEY` - Move to AWS Secrets Manager
+6. `ANS_API_SECRET` - Move to AWS Secrets Manager
+7. `GITHUB_APP_PRIVATE_KEY` - Move to AWS Secrets Manager
+8. `REGISTRATION_WEBHOOK_AUTH_TOKEN` - Move to AWS Secrets Manager
+9. `REGISTRATION_GATE_OAUTH2_CLIENT_SECRET` - Move to AWS Secrets Manager
+
+**Registry Service:**
+1. `REGISTRY_API_TOKEN` - Move to AWS Secrets Manager
+2. `REGISTRY_API_KEYS` - Move to AWS Secrets Manager
+3. `FEDERATION_STATIC_TOKEN` - Move to AWS Secrets Manager
+4. `FEDERATION_ENCRYPTION_KEY` - Move to AWS Secrets Manager
+5. `ANS_API_KEY` - Move to AWS Secrets Manager
+6. `ANS_API_SECRET` - Move to AWS Secrets Manager
+7. `GITHUB_APP_PRIVATE_KEY` - Move to AWS Secrets Manager
+8. `REGISTRATION_WEBHOOK_AUTH_TOKEN` - Move to AWS Secrets Manager
+9. `REGISTRATION_GATE_OAUTH2_CLIENT_SECRET` - Move to AWS Secrets Manager
+
+#### Step 2: Create AWS Secrets Manager Resources (secrets.tf)
+
+For each service requiring secret migration, we'll follow the pattern established in the codebase. Here's an implementation example for one secret:
+
+```terraform
+# Secrets Manager resource for Registry API Token
+resource "aws_secretsmanager_secret" "registry_api_token" {
+  name_prefix             = "${local.name_prefix}-registry-api-token-"
+  description             = "Registry API token for authentication"
+  recovery_window_in_days = 0
+  kms_key_id              = aws_kms_key.secrets.id
+  tags                    = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "registry_api_token" {
+  secret_id     = aws_secretsmanager_secret.registry_api_token.id
+  secret_string = var.registry_api_token
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+```
+
+#### Step 3: Update IAM Policies (iam.tf)
+
+We'll need to update the existing IAM policy to include the new secrets:
+
+```terraform
+resource "aws_iam_policy" "ecs_secrets_access" {
+  name_prefix = "${local.name_prefix}-ecs-secrets-"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = concat(
+          [
+            aws_secretsmanager_secret.secret_key.arn,
+            aws_secretsmanager_secret.keycloak_client_secret.arn,
+            aws_secretsmanager_secret.keycloak_m2m_client_secret.arn,
+            aws_secretsmanager_secret.embeddings_api_key.arn,
+            aws_secretsmanager_secret.keycloak_admin_password.arn,
+            # New secrets to be added here:
+            aws_secretsmanager_secret.registry_api_token.arn,
+            aws_secretsmanager_secret.federation_static_token.arn,
+            # Additional new secrets will be added below
+          ],
+          var.documentdb_credentials_secret_arn != "" ? [var.documentdb_credentials_secret_arn] : [],
+          var.entra_enabled ? [aws_secretsmanager_secret.entra_client_secret[0].arn] : [],
+          var.okta_enabled ? [
+            aws_secretsmanager_secret.okta_client_secret[0].arn,
+            aws_secretsmanager_secret.okta_m2m_client_secret[0].arn,
+            aws_secretsmanager_secret.okta_api_token[0].arn
+          ] : [],
+          var.auth0_enabled ? [
+            aws_secretsmanager_secret.auth0_client_secret[0].arn,
+            aws_secretsmanager_secret.auth0_m2m_client_secret[0].arn
+          ] : [],
+          var.enable_observability ? [aws_secretsmanager_secret.metrics_api_key[0].arn] : [],
+          var.enable_observability && var.otel_otlp_endpoint != "" ? [aws_secretsmanager_secret.otlp_exporter_headers[0].arn] : []
+        )
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ]
+        Resource = [
+          aws_kms_key.secrets.arn
+        ]
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+```
+
+#### Step 4: Update ECS Task Definitions (ecs-services.tf)
+
+We'll need to modify the container definitions to reference the new Secrets Manager resources instead of using plaintext environment variables:
+
+Current approach (plaintext):
+```terraform
+{
+  name  = "REGISTRY_API_TOKEN"
+  value = var.registry_api_token
+}
+```
+
+New approach (using Secrets Manager):
+```terraform
+{
+  name      = "REGISTRY_API_TOKEN"
+  valueFrom = aws_secretsmanager_secret.registry_api_token.arn
+}
+```
+
+We'll initially keep both approaches to ensure backward compatibility during migration, then remove the plaintext approach once the migration is complete.
+
+### Error Handling
+Since this is an infrastructure change, errors will manifest as Terraform apply failures:
+1. IAM policy errors due to incorrect ARNs - validate all ARNs before apply
+2. Secret creation errors - ensure proper KMS key access
+3. Secret reference errors in container definitions - verify syntax matches existing patterns
+
+### Logging
+Terraform plan/apply operations will provide visibility into changes. No specific logging is required during runtime as this is an infrastructure-level change.
+
+## Observability
+Infrastructure changes like this are typically observed through:
+1. Terraform execution logs
+2. AWS CloudTrail audit logs for Secrets Manager and IAM changes
+3. Infrastructure drift detection
+
+Application-level observability is not affected by this change.
+
+## Scaling Considerations
+- Secrets Manager has generous service limits that should accommodate the number of secrets in this deployment
+- IAM policies have a practical limit on the number of resources listed - the current approach of concatenating lists should handle the number of secrets needed
+- No performance impact on the application containers as secret retrieval is handled transparently by the ECS agent
+
+## File Changes
+
+### New Files
+
+| File Path | Description |
+|-----------|-------------|
+| None | This change updates existing files rather than creating new ones |
+
+### Modified Files
+
+| File Path | Lines | Change Description |
+|-----------|-------|--------------------|
+| `terraform/aws-ecs/modules/mcp-gateway/secrets.tf` | Various | Add AWS Secrets Manager resources for each identified secret |
+| `terraform/aws-ecs/modules/mcp-gateway/iam.tf` | Lines 15-36 | Update IAM policy to grant access to new Secrets Manager resources |
+| `terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf` | Lines 97-411,698-1308 | Update environment/secrets blocks to reference AWS Secrets Manager instead of plaintext values |
+
+### Estimated Lines of Code
+
+| Category | Lines |
+|----------|-------|
+| New code (secrets.tf additions) | ~100 |
+| New code (iam.tf modifications) | ~10 |
+| Modified code (ecs-services.tf) | ~50 |
+| **Total** | **~160** |
+
+Note that during a transition period, both plaintext and Secrets Manager approaches might coexist, adding some temporary complexity.
+
+## Testing Strategy
+See `testing.md` for the detailed testing plan.
+
+## Alternatives Considered
+
+### Alternative 1: Continue Using SSM Parameter Store
+**Description:** Continue using SSM Parameter Store with SecureString type for all sensitive values
+**Pros:**
+- Less disruption to current architecture
+- Simpler implementation for some values
+- Consistent with existing Keycloak approach for some secrets
+**Cons:**
+- Does not fully address the requirement (which specifies Secrets Manager)
+- Missing advanced Secrets Manager features like automated rotation triggers
+- Inconsistent with established best practices for container-based workloads
+
+**Why Rejected:** This approach would not fulfill the core requirement of moving to Secrets Manager, which offers superior rotation capabilities and more appropriate features for container-based environments.
+
+### Alternative 2: Use External Secrets Operator
+**Description:** Implement Kubernetes External Secrets or AWS Secrets and Configuration Provider (ASCP) for ECS
+**Pros:**
+- Centralized secret management
+- Better integration with external secret stores
+- Advanced synchronization capabilities
+**Cons:**
+- Adds operational complexity
+- Not suitable for pure ECS deployments (External Secrets is Kubernetes-focused)
+- Would require additional infrastructure
+
+**Why Rejected:** The current deployment is pure ECS-based, and adding additional secret management layers would increase complexity unnecessarily.
+
+### Alternative 3: Move All Secrets to Secrets Manager
+**Description:** Consolidate all secrets into Secrets Manager regardless of rotation requirements
+**Pros:**
+- Complete consistency in secret management approach
+- Unified auditing and access control
+- Future-proof for any secrets that might eventually need rotation
+**Cons:**
+- Some complexity in accessing simple configuration values
+- Potentially higher costs for secrets that don't benefit from rotation features
+
+**Why Rejected:** The current hybrid approach of SSM for static configuration and Secrets Manager for rotating credentials is already well-established and appropriate for the use case.
+
+### Comparison Matrix
+
+| Criteria | Chosen Approach | Alt 1 (SSM) | Alt 2 (External Secrets) | Alt 3 (All Secrets Manager) |
+|----------|-----------------|-------------|--------------------------|------------------------------|
+| Security | High | High | Very High | High |
+| Complexity | Low-Medium | Low | High | Low |
+| Cost | Moderate | Low | High | Moderate |
+| Rotation Support | Excellent (targeted) | Limited | Excellent | Excellent |
+| Consistency with Current Architecture | High | Very High | Low | Medium-High |
+| Alignment with Requirements | Perfect | Poor | Moderate | High |
+
+## Rollout Plan
+1. **Phase 1:** Infrastructure Changes
+   - Add AWS Secrets Manager resources for identified secrets
+   - Update IAM policies to grant access to new secrets
+   - Modify ECS task definitions to reference new secrets
+
+2. **Phase 2:** Verification
+   - Execute Terraform plan to validate changes
+   - Perform test deployment in staging environment
+   - Validate secret access from containers
+
+3. **Phase 3:** Production Deployment
+   - Apply changes to production environment
+   - Monitor for any access issues
+   - Remove temporary plaintext environment variables after validation
+
+## Open Questions
+1. Should we provide a migration script to populate Secrets Manager from existing environment variables?
+2. How should we handle secrets that currently have no Terraform variables defined but are passed via tfvars?
+
+## References
+- [AWS Secrets Manager Documentation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html)
+- [ECS Secrets Documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,73 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "qwen.qwen3-coder-480b-a35b-instruct",
+  "model_slug": "qwen.qwen3-coder-480b-a35b-instruct",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4000",
+  "aws_region": null,
+  "artifacts_produced": 0,
+  "artifacts_expected": 4,
+  "generation_tokens_per_sec": 19.6,
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2625523,
+    "output_tokens": 14628,
+    "cache_read_tokens": 5264,
+    "cache_write_tokens": 0,
+    "latency_seconds": 747.5,
+    "num_turns": 37,
+    "generation_tokens_per_sec": 19.6,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "claude_api.usage.input_tokens",
+      "output_tokens": "claude_api.usage.output_tokens",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2625523,
+  "output_tokens": 14628,
+  "latency_seconds": 747.5,
+  "num_turns": 37,
+  "total_cost_usd": 27.790883999999988,
+  "is_error": false,
+  "session_id": "13a840d6-c5e7-4819-ad8e-f103ed363cca",
+  "cache_read_tokens": 5264,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-07-24T20:56:45.413924Z",
+  "run_ended_at": "2026-07-24T21:09:13.527146Z",
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/review.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/review.md
@@ -1,0 +1,239 @@
+# Expert Review: Migrate Sensitive ECS Environment Variables to AWS Secrets Manager
+
+*Created: 2026-07-24*
+*Related LLD: `./lld.md`*
+*Related Issue: `./github-issue.md`*
+
+## Byte (Backend Engineer) Review
+
+### Strengths
+- Clear identification of sensitive environment variables that need migration
+- Follows established patterns in the codebase for using AWS Secrets Manager
+- Uses proper IAM principle of least privilege with precise resource scoping
+- Maintains backward compatibility with plaintext environment variables during migration
+- Well-defined step-by-step implementation plan
+- Proper separation of concerns in Terraform modules (secrets.tf, iam.tf, ecs-services.tf)
+- Uses KMS encryption for secrets at rest
+- Good understanding of existing architecture and patterns
+
+### Concerns
+- Migration process doesn't specify how existing secrets will be populated into Secrets Manager
+- No clear rollback strategy if migration fails
+- Implementation plan mentions keeping both approaches during migration but doesn't detail the cutover process
+- Doesn't address potential race conditions during the migration phase
+- The LLD doesn't cover testing scenarios specific to the migration process
+- No monitoring or alerting for secret access failures after migration
+
+### New libraries / infra dependencies
+- AWS Secrets Manager service (already in use for some secrets)
+- AWS KMS service (already in use)
+- No new application-level dependencies required
+
+### Better alternatives considered
+The LLD properly evaluated alternatives:
+- Continuing with SSM Parameter Store (rejected because it doesn't fully address requirements)
+- Using External Secrets Operator (rejected due to operational complexity and ECS compatibility)
+- Moving all secrets to Secrets Manager (rejected because current hybrid approach is appropriate)
+
+### Recommendations
+1. Add a migration script or process to populate Secrets Manager with existing secret values
+2. Define explicit cutover process and timeline for removing plaintext environment variables
+3. Add monitoring and alerting for secret access failures
+4. Include rollback procedures in case of migration issues
+5. Add specific testing scenarios for the migration process itself
+6. Document the secret rotation process for operators
+
+### Questions for author
+1. How will existing secret values be migrated to AWS Secrets Manager? Is there an automated process planned?
+2. What is the detailed cutover process for removing plaintext environment variables after migration?
+3. How will rollback be handled if issues occur after migration?
+4. Are there any specific monitoring requirements for secret access after migration?
+5. Is there a process for regular verification that secrets are being retrieved correctly?
+
+### Verdict
+APPROVED WITH CHANGES
+
+The design follows established patterns and addresses the core requirements. However, it needs additional details around the migration execution plan, particularly around populating existing secrets, cutover process, rollback strategy, and monitoring/alerting. These aspects should be clarified before implementation begins.
+
+## Cipher (Security Engineer) Review
+
+### Strengths
+- The current implementation already uses AWS Secrets Manager for sensitive credentials like Keycloak secrets, database credentials, and API keys
+- Proper IAM policies are in place to restrict access to only the specific secrets required by each service
+- KMS encryption is used for all Secrets Manager resources with proper key rotation enabled
+- The design correctly separates secrets from environment variables in ECS task definitions using the `secrets` block
+- Secrets are referenced by ARN rather than hardcoded values, maintaining security in the Terraform state
+
+### Concerns
+- Some sensitive environment variables may still be passed as plaintext in ECS task definitions rather than using Secrets Manager
+- Not all IdP (Identity Provider) secrets are being rotated automatically - they have lifecycle ignore changes which could lead to stale credentials
+- No clear migration strategy for existing plaintext environment variables during the transition period
+- Missing centralized secret rotation mechanisms for third-party provider secrets (Auth0, Okta, Entra ID)
+
+### New libraries / infra dependencies
+- Existing AWS Secrets Manager and KMS infrastructure is already in place
+- No additional libraries required as the migration leverages existing Terraform modules and AWS services
+
+### Better alternatives considered
+- Using AWS Systems Manager Parameter Store with SecureString parameters instead of Secrets Manager (would be less expensive but lacks automatic rotation features)
+- HashiCorp Vault integration (more complex but provides more advanced secret management features)
+- Direct environment variable injection via encrypted S3 objects (less secure and harder to manage)
+
+### Recommendations
+1. Audit all current environment variables in ECS task definitions to identify any remaining sensitive values that should be moved to Secrets Manager
+2. Implement automated secret rotation for all third-party provider secrets rather than relying on manual updates
+3. Add a migration toggle mechanism to cleanly switch between plaintext environment variables and Secrets Manager during the transition
+4. Enhance monitoring and alerting for secret access and rotation events
+5. Implement a secrets inventory to track all secrets and their usage across services
+
+### Questions for author
+1. Have all current environment variables been classified to determine which ones contain sensitive data requiring migration?
+2. What is the rollback strategy if issues arise during the migration from plaintext to Secrets Manager?
+3. How will the rotation of third-party provider secrets (Auth0, Okta, Entra ID) be handled after migration?
+4. Are there any compliance requirements (such as SOC 2, HIPAA) that dictate specific secret handling procedures?
+
+### Verdict
+APPROVED WITH CHANGES
+
+The overall design follows security best practices by leveraging AWS Secrets Manager for sensitive data. However, several improvements are needed to ensure complete migration of all sensitive environment variables and to establish proper secret rotation mechanisms for all credential types. The existing infrastructure provides a solid foundation for the migration.
+
+## Circuit (SRE/DevOps Engineer) Review
+
+### Strengths
+- Well-defined implementation using Terraform with clear separation of concerns
+- Follows established infrastructure patterns in the codebase
+- Proper consideration for IAM policies and access control
+- Good understanding of migration complexity and phased approach requirements
+- Addresses encryption requirements with KMS integration
+
+### Concerns
+- No detailed implementation timeline or rollout strategy provided
+- Missing specific monitoring and alerting implementation details
+- No mention of backup/restore procedures for secrets
+- Lack of rollback procedures in case of migration failures
+- No detailed process for handling secret rotation in production
+
+### New libraries / infra dependencies
+- Leverages existing AWS services (Secrets Manager, KMS)
+- Uses established Terraform AWS provider
+- No new application-level dependencies required
+
+### Better alternatives considered
+- The LLD properly evaluates and rejects alternatives like SSM Parameter Store and External Secrets Operator
+- Maintains appropriate hybrid approach for different types of secrets
+
+### Recommendations
+1. Define detailed implementation phases with specific milestones
+2. Add monitoring and alerting for secret access and rotation events
+3. Implement backup and restore procedures for critical secrets
+4. Develop detailed rollback procedures and document them
+5. Create operational runbooks for secret management in production
+6. Add validation steps to verify secret access during deployment
+
+### Questions for author
+1. What are the specific monitoring and alerting requirements for secret access?
+2. How should secret rotation events be handled in production?
+3. Are there specific SLAs for secret availability and access?
+4. What operational procedures need to be documented for the SRE team?
+
+### Verdict
+APPROVED WITH CHANGES
+
+The design follows established infrastructure practices and appropriately leverages AWS services. However, it requires additional operational details around monitoring, alerting, backup/restore procedures, and rollback strategies before it can be fully approved for production implementation.
+
+## Sage (SMTS) Review
+
+### Strengths
+- **Security Best Practices**: The implementation correctly uses AWS Secrets Manager to store sensitive information like API keys, client secrets, and passwords instead of environment variables
+- **KMS Encryption**: All secrets are encrypted with KMS keys with automatic key rotation enabled, providing strong encryption at rest
+- **Proper Access Control**: IAM policies are properly configured to grant least-privilege access to ECS tasks for accessing Secrets Manager
+- **Separation of Concerns**: The Terraform module cleanly separates secret management from other infrastructure components
+- **Scalable Approach**: The design supports different types of secrets (IdP credentials, database credentials, API keys) with appropriate handling for each
+- **Safe Defaults**: Recovery window is set to 0 for immediate deletion and secrets have proper tagging for governance
+
+### Concerns
+- **Manual Secret Updates**: Several comments indicate that secrets like Keycloak client secrets and IdP credentials require manual updates through init scripts or external processes, which could lead to operational overhead and potential inconsistencies
+- **Limited Rotation Strategy**: Most secrets have the checkov skip comment "not rotatable via Secrets Manager" suggesting there's no automated rotation strategy for many critical secrets
+- **Lack of Documentation**: No explicit documentation or diagrams showing the migration process or how teams should manage secrets post-migration
+- **Complexity in Multi-Provider Support**: With support for multiple identity providers (Auth0, Okta, Entra, Keycloak), the secret management becomes complex and error-prone
+
+### New libraries / infra dependencies
+- **AWS Secrets Manager**: Core dependency for storing all sensitive configuration
+- **AWS KMS**: Required for encryption of secrets
+- **Terraform AWS Provider**: Updated versions to support the latest Secrets Manager features
+- **IAM Policies**: Additional policies for ECS task roles to access Secrets Manager
+
+### Better alternatives considered
+- **HashiCorp Vault**: Could provide more advanced secret management features but adds infrastructure complexity
+- **AWS Systems Manager Parameter Store**: Simpler alternative but less feature-rich for secrets compared to Secrets Manager
+- **External secrets operators**: For Kubernetes-based deployments, but the project seems focused on ECS
+
+### Recommendations
+1. **Implement Automated Secret Rotation**: Develop a strategy for rotating critical secrets automatically rather than relying on manual processes
+2. **Enhance Monitoring**: Add CloudWatch alarms for unauthorized access attempts to secrets
+3. **Improve Documentation**: Create detailed guides for managing secrets throughout their lifecycle
+4. **Consider Secret Versioning**: Implement a more robust versioning strategy for secrets that change frequently
+5. **Add Backup/Restore Procedures**: Document procedures for backing up and restoring secrets in disaster recovery scenarios
+
+### Questions for author
+1. How are secrets synchronized across multiple regions/environments?
+2. What is the process for rotating secrets that currently require manual intervention?
+3. Are there any backup/recovery procedures for secrets in case of accidental deletion?
+4. How are development environments handled differently from production regarding secrets?
+
+### Verdict
+APPROVED WITH CHANGES
+
+The design properly addresses the core requirement of moving sensitive configuration from environment variables to AWS Secrets Manager with good security practices. However, the lack of automated secret rotation and reliance on manual processes for some critical secrets needs to be addressed before full production deployment. The implementation follows AWS best practices for secret management but requires additional operational tooling to be truly production-ready.
+
+## Pixel (Frontend Engineer) Review
+
+### Strengths
+- Clear understanding of infrastructure changes and their impact
+- Recognition that this is primarily a backend/infrastructure concern
+- Proper evaluation of alternatives and their applicability to the ECS environment
+
+### Concerns
+- Limited understanding of the actual codebase structure and existing patterns
+- Some confusion between Helm chart approaches (this is a Terraform-based deployment)
+- Not fully aligned with the specific requirements of the ECS implementation
+
+### New libraries / infra dependencies
+- Misinterpretation of the deployment model (focused on Helm rather than Terraform)
+
+### Better alternatives considered
+- Recommended approaches that aren't aligned with the ECS/Terraform architecture
+
+### Recommendations
+- Better align review with the actual architecture (ECS/Terraform rather than Kubernetes/Helm)
+
+### Questions for author
+- Misaligned questions based on misunderstanding of architecture
+
+### Verdict
+APPROVED WITH CHANGES
+
+The review would benefit from better alignment with the actual ECS/Terraform architecture. The core design is sound from a backend perspective, but the frontend review needs adjustment to match the deployment model.
+
+## Review Summary
+
+| Reviewer | Verdict | Blockers | Key Recommendations |
+|----------|---------|----------|---------------------|
+| Backend (Byte) | APPROVED WITH CHANGES | 6 | Add migration process details, define cutover strategy, implement monitoring and rollback procedures |
+| Security (Cipher) | APPROVED WITH CHANGES | 5 | Audit all environment variables, implement automated rotation, enhance monitoring |
+| SRE (Circuit) | APPROVED WITH CHANGES | 5 | Add operational details, implement monitoring/alerting, define rollback procedures |
+| SMTS (Sage) | APPROVED WITH CHANGES | 4 | Implement automated secret rotation, improve documentation, add operational procedures |
+| Frontend (Pixel) | APPROVED WITH CHANGES | 3 | Align review with actual ECS/Terraform architecture |
+
+## Next Steps
+
+1. Address the reviewers' recommendations by enhancing the implementation plan with:
+   - Detailed migration processes and timelines
+   - Clear cutover and rollback strategies
+   - Comprehensive monitoring and alerting
+   - Automated secret rotation mechanisms
+   - Operational documentation and procedures
+
+2. Update the LLD document to incorporate these improvements
+
+3. Conduct a follow-up review once changes are implemented

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/testing.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/testing.md
@@ -1,0 +1,231 @@
+# Testing Plan: Migrate Sensitive ECS Environment Variables to AWS Secrets Manager
+
+*Created: 2026-07-24*
+*Related LLD: `./lld.md`*
+*Related Issue: `./github-issue.md`*
+
+## Overview
+### Scope of Testing
+This testing plan covers the migration of sensitive ECS environment variables to AWS Secrets Manager. The tests will verify that:
+1. All sensitive environment variables are properly migrated to AWS Secrets Manager
+2. ECS task definitions correctly reference AWS Secrets Manager resources
+3. IAM policies grant appropriate access to Secrets Manager resources
+4. Applications continue to function correctly with secrets retrieved from AWS Secrets Manager
+5. Backward compatibility is maintained during the migration process
+
+### Prerequisites
+- [ ] AWS account with appropriate permissions for Secrets Manager, IAM, and ECS
+- [ ] Existing mcp-gateway-registry deployment with Terraform
+- [ ] Test environment that mirrors production setup
+- [ ] Access to AWS CLI and Terraform CLI
+
+### Shared Variables
+```bash
+export AWS_REGION="us-west-2"
+export TERRAFORM_DIR="/path/to/terraform/aws-ecs"
+export TEST_ENVIRONMENT="staging"
+```
+
+## 1. Functional Tests
+
+### 1.1 Terraform Plan Tests
+Test that Terraform plans correctly with the new Secrets Manager resources and IAM policy updates.
+
+```bash
+cd $TERRAFORM_DIR
+terraform init
+terraform plan -out=tfplan
+terraform show -json tfplan | jq '.planned_values.root_module.resources[] | select(.type=="aws_secretsmanager_secret") | .name' | grep -q "registry-api-token" && echo "PASS: New Secrets Manager resources planned"
+```
+
+**Expected Result:** Terraform plan should include new AWS Secrets Manager resources and updated IAM policies without errors.
+
+### 1.2 Secret Creation Tests
+Test that AWS Secrets Manager resources are created correctly with proper encryption.
+
+```bash
+# After terraform apply, verify secrets exist and are encrypted
+aws secretsmanager list-secrets --region $AWS_REGION | jq '.SecretList[].Name' | grep -q "registry-api-token" && echo "PASS: Secrets created"
+aws secretsmanager list-secrets --region $AWS_REGION | jq '.SecretList[] | select(.Name | contains("registry-api-token")) | .KmsKeyId' | grep -q "arn:aws:kms" && echo "PASS: Secrets encrypted with KMS"
+```
+
+**Expected Result:** Secrets should be created with proper KMS encryption and accessible via AWS CLI.
+
+### 1.3 IAM Policy Tests
+Test that IAM policies are updated to grant access to new Secrets Manager resources.
+
+```bash
+# Get the IAM policy ARN from Terraform outputs or state
+POLICY_ARN=$(terraform output -raw ecs_secrets_access_policy_arn)
+aws iam get-policy-version --policy-arn $POLICY_ARN --version-id v1 | jq '.PolicyVersion.Document.Statement[].Resource[]' | grep -q "arn:aws:secretsmanager" && echo "PASS: IAM policy grants Secrets Manager access"
+```
+
+**Expected Result:** IAM policies should include references to the new Secrets Manager resources.
+
+## 2. Backwards Compatibility Tests
+
+### 2.1 Environment Variable Fallback Tests
+Test that services continue to function when using plaintext environment variables as fallback.
+
+```bash
+# Temporarily disable secrets access to force fallback to environment variables
+aws iam detach-role-policy --role-name test-task-exec-role --policy-arn $POLICY_ARN
+# Restart ECS service
+aws ecs update-service --cluster test-cluster --service test-service --force-new-deployment
+# Monitor service health
+aws ecs describe-services --cluster test-cluster --services test-service | jq '.services[].runningCount' | grep -q "1" && echo "PASS: Service running with fallback"
+```
+
+**Expected Result:** Services should continue to function using plaintext environment variables when Secrets Manager access is unavailable.
+
+### 2.2 Gradual Migration Tests
+Test that services can be migrated gradually from environment variables to Secrets Manager.
+
+```bash
+# Migrate one service at a time
+# Verify each service functions correctly after migration
+for service in auth-server registry mcpgw; do
+  echo "Testing $service migration..."
+  # Apply partial Terraform configuration
+  # Verify service health
+  aws ecs describe-services --cluster test-cluster --services $service | jq '.services[].runningCount' | grep -q "1" && echo "PASS: $service running after migration"
+done
+```
+
+**Expected Result:** Individual services should be migratable without affecting other services.
+
+## 3. UX Tests
+
+### 3.1 Configuration Documentation Tests
+**Not Applicable** - This change primarily affects infrastructure configuration rather than user interface elements.
+
+### 3.2 Error Message Clarity Tests
+Test that error messages are clear when secret access fails.
+
+```bash
+# Intentionally misconfigure IAM policy
+# Attempt to deploy service
+# Check CloudWatch logs for error messages
+aws logs filter-log-events --log-group-name "/ecs/test-service" --start-time $(($(date +%s)-300)*1000) | grep -q "AccessDeniedException" && echo "PASS: Clear error message for access denial"
+```
+
+**Expected Result:** Error messages should clearly indicate when secret access is denied and provide guidance for resolution.
+
+## 4. Deployment Surface Tests
+
+### 4.1 Terraform Module Wiring Tests
+Test that Terraform modules correctly wire in the new Secrets Manager resources.
+
+```bash
+# Check that secrets.tf contains new secret definitions
+grep -q "registry_api_token" $TERRAFORM_DIR/modules/mcp-gateway/secrets.tf && echo "PASS: Secrets module updated"
+# Check that iam.tf contains new policy statements
+grep -q "aws_secretsmanager_secret.registry_api_token.arn" $TERRAFORM_DIR/modules/mcp-gateway/iam.tf && echo "PASS: IAM module updated"
+```
+
+**Expected Result:** Terraform modules should reference the new Secrets Manager resources in the correct locations.
+
+### 4.2 ECS Task Definition Wiring Tests
+Test that ECS task definitions correctly reference Secrets Manager resources.
+
+```bash
+# Get task definition
+TASK_DEF_ARN=$(aws ecs describe-services --cluster test-cluster --services test-service | jq -r '.services[].taskDefinition')
+aws ecs describe-task-definition --task-definition $TASK_DEF_ARN | jq '.taskDefinition.containerDefinitions[].secrets[].name' | grep -q "REGISTRY_API_TOKEN" && echo "PASS: Task definition references secrets"
+```
+
+**Expected Result:** ECS task definitions should reference Secrets Manager resources in the secrets block rather than environment block.
+
+### 4.3 Deploy and Verify Tests
+Test that services deploy correctly with secrets from AWS Secrets Manager.
+
+```bash
+# Deploy updated configuration
+terraform apply -auto-approve
+# Wait for deployment
+sleep 60
+# Verify service health
+aws ecs describe-services --cluster test-cluster --services test-service | jq '.services[].runningCount' | grep -q "1" && echo "PASS: Service deployed with Secrets Manager"
+# Verify secrets are being used
+aws logs filter-log-events --log-group-name "/ecs/test-service" --start-time $(($(date +%s)-300)*1000) | grep -q "Successfully retrieved secret" && echo "PASS: Secrets retrieved from Secrets Manager"
+```
+
+**Expected Result:** Services should deploy successfully and retrieve secrets from AWS Secrets Manager.
+
+### 4.4 Rollback Verification Tests
+Test that rollback to environment variables works correctly.
+
+```bash
+# Revert Terraform changes
+terraform plan -destroy
+terraform destroy -auto-approve
+# Redeploy original configuration
+# terraform apply -auto-approve with original configuration
+# Verify service health with environment variables
+aws ecs describe-services --cluster test-cluster --services test-service | jq '.services[].runningCount' | grep -q "1" && echo "PASS: Service rolled back to environment variables"
+```
+
+**Expected Result:** Services should successfully roll back to using environment variables when Secrets Manager configuration is removed.
+
+## 5. End-to-End API Tests
+
+### 5.1 Secret Retrieval Workflow Tests
+Test the end-to-end workflow of retrieving secrets from AWS Secrets Manager in a running container.
+
+```bash
+# Execute command in container to verify secret access
+aws ecs execute-command --cluster test-cluster --task $(aws ecs list-tasks --cluster test-cluster | jq -r '.taskArns[0]') --container test-container --command "printenv | grep REGISTRY_API_TOKEN" --interactive
+# Expected: Should show that REGISTRY_API_TOKEN is available
+```
+
+**Expected Result:** Applications should be able to retrieve secrets from AWS Secrets Manager at runtime.
+
+### 5.2 Application Functionality Tests
+Test that applications function correctly when using secrets from AWS Secrets Manager.
+
+```bash
+# For services that use secrets, test core functionality
+# Example: Test registry API with authentication
+curl -H "Authorization: Bearer $(aws secretsmanager get-secret-value --secret-id registry-api-token --query SecretString --output text)" https://test-registry.example.com/api/health | grep -q "healthy" && echo "PASS: Registry API working with Secrets Manager secrets"
+```
+
+**Expected Result:** Applications should function identically whether using secrets from AWS Secrets Manager or environment variables.
+
+## 6. Test Execution Checklist
+- [ ] Section 1 (Functional) passes
+- [ ] Section 2 (Backwards Compat) verified
+- [ ] Section 3 (UX) verified or marked Not Applicable
+- [ ] Section 4 (Deployment) verified
+- [ ] Section 5 (E2E) verified
+- [ ] Unit tests added under `tests/unit/`
+- [ ] Integration tests added under `tests/integration/`
+- [ ] `terraform validate` passes with no errors
+- [ ] All security scans pass with no new findings
+
+## 7. Post-Migration Validation Tests
+
+### 7.1 Secret Rotation Tests
+Test that secrets can be rotated without service interruption.
+
+```bash
+# Update secret value
+aws secretsmanager put-secret-value --secret-id registry-api-token --secret-string "new-test-token"
+# Force ECS service update to refresh secrets
+aws ecs update-service --cluster test-cluster --service test-service --force-new-deployment
+# Wait for deployment
+sleep 60
+# Verify service is using new secret
+# This would require application-specific validation
+```
+
+**Expected Result:** Services should seamlessly adopt new secret values after rotation.
+
+### 7.2 Audit Trail Verification Tests
+Test that secret access is properly audited.
+
+```bash
+# Check CloudTrail logs for secret access events
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=GetSecretValue --max-results 10 | grep -q "secretsmanager" && echo "PASS: Secret access audited"
+```
+
+**Expected Result:** All secret access should be logged in CloudTrail for audit purposes.

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/github-issue.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/github-issue.md
@@ -1,0 +1,49 @@
+# GitHub Issue: Remove EFS from Terraform AWS ECS Deployment
+
+## Title
+Remove EFS from Terraform AWS ECS Deployment
+
+## Labels
+- enhancement
+- infra
+- terraform
+
+## Description
+
+### Problem Statement
+EFS (Elastic File System) is no longer needed in this deployment as the application now uses S3/DocumentDB for all persistent storage. EFS adds unnecessary cost and complexity to the infrastructure without providing value. All services that previously used EFS-mounted volumes have been migrated to use DocumentDB for structured data and S3 for unstructured data.
+
+### Proposed Solution
+Remove all EFS-related resources from the Terraform AWS ECS deployment:
+1. Delete the EFS file system, mount targets, and security groups
+2. Remove volume mounts from ECS task definitions
+3. Update variables.tf and terraform.tfvars.example to remove EFS configuration
+4. Update module wiring and outputs to remove EFS references
+5. Ensure terraform validate and terraform plan still succeed after changes
+
+### User Stories
+- As an operator, I want to deploy the MCP Gateway Registry without EFS to reduce infrastructure costs
+- As a developer, I want a simplified deployment that uses only S3/DocumentDB for storage
+- As an SRE, I want to eliminate unnecessary infrastructure components to reduce complexity and potential failure points
+
+### Acceptance Criteria
+- [ ] All EFS resources (file system, mount targets, security groups) are removed from Terraform
+- [ ] Volume mounts referencing EFS are removed from ECS task definitions
+- [ ] EFS-related variables are removed from variables.tf and terraform.tfvars.example
+- [ ] Module wiring is updated to remove EFS dependencies
+- [ ] Output variables related to EFS are removed
+- [ ] terraform validate succeeds without errors
+- [ ] terraform plan succeeds without errors
+- [ ] All services continue to function correctly using S3/DocumentDB for storage
+
+### Out of Scope
+- Changing the application code to remove EFS references
+- Modifying the storage logic in services (assumed to already use S3/DocumentDB)
+- Updating documentation or README files
+
+### Dependencies
+- Confirmation that all services have been successfully migrated to S3/DocumentDB
+- Verification that no service still depends on the EFS mount
+
+### Related Issues
+- #1286

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/lld.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/lld.md
@@ -1,0 +1,410 @@
+# Low-Level Design: Remove EFS from Terraform AWS ECS Deployment
+
+*Created: 2026-07-25*
+*Author: Claude*
+*Status: Draft*
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Codebase Analysis](#codebase-analysis)
+3. [Architecture](#architecture)
+4. [Data Models](#data-models)
+5. [API / CLI Design](#api--cli-design)
+6. [Configuration Parameters](#configuration-parameters)
+7. [New Dependencies](#new-dependencies)
+8. [Implementation Details](#implementation-details)
+9. [Observability](#observability)
+10. [Scaling Considerations](#scaling-considerations)
+11. [File Changes](#file-changes)
+12. [Testing Strategy](#testing-strategy)
+13. [Alternatives Considered](#alternatives-considered)
+14. [Rollout Plan](#rollout-plan)
+
+## Overview
+### Problem Statement
+EFS (Elastic File System) is no longer needed in the MCP Gateway Registry Terraform AWS ECS deployment as the application now uses S3/DocumentDB for all persistent storage. EFS adds unnecessary cost and complexity to the infrastructure without providing value. All services that previously used EFS-mounted volumes have been migrated to use DocumentDB for structured data and S3 for unstructured data.
+
+The goal is to remove all EFS-related resources from the Terraform AWS ECS deployment to reduce infrastructure costs and simplify the architecture while ensuring continued functionality of all services.
+
+### Goals
+- Remove all EFS resources from Terraform (file system, mount targets, security groups)
+- Eliminate EFS volume mounts from ECS task definitions
+- Clean up EFS-related variables, outputs, and configuration
+- Ensure terraform validate and terraform plan still succeed
+- Maintain application functionality using only S3/DocumentDB for storage
+
+### Non-Goals
+- Changing the application code to remove EFS references (assumed already migrated)
+- Modifying the storage logic in services (already using S3/DocumentDB)
+- Updating documentation or README files
+- Addressing any application-level data migration issues
+
+## Codebase Analysis
+
+### Key Files Reviewed
+
+| File/Directory | Purpose | Relevance to This Change |
+|----------------|---------|--------------------------|
+| `terraform/aws-ecs/modules/mcp-gateway/storage.tf` | Defines EFS resources using terraform-aws-modules/efs/aws | Primary file to remove EFS implementation |
+| `terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf` | ECS service definitions with EFS volume mounts | Need to remove volume mounts and mountPoints |
+| `terraform/aws-ecs/modules/mcp-gateway/variables.tf` | Module variables including EFS settings | Remove EFS-related variables |
+| `terraform/aws-ecs/modules/mcp-gateway/outputs.tf` | Module outputs including EFS details | Remove EFS-related outputs |
+| `terraform/aws-ecs/variables.tf` | Root module variables | Remove EFS-related variables |
+| `terraform/aws-ecs/terraform.tfvars.example` | Example variables file | Remove EFS-related examples |
+| `terraform/aws-ecs/outputs.tf` | Root module outputs | Remove EFS-related outputs |
+| `terraform/aws-ecs/main.tf` | Root module configuration | Remove EFS module references |
+
+### Existing Patterns Identified
+1. **Modular Terraform Structure**: Clean separation between root module and mcp-gateway submodule
+   - Files: `terraform/aws-ecs/main.tf`, `terraform/aws-ecs/modules/mcp-gateway/`
+   - How a future implementer should follow this: Maintain consistency with existing patterns when removing EFS resources
+
+2. **Consistent Variable Management**: Variables defined with defaults, validation, and descriptions
+   - Files: `variables.tf` in both root and module directories
+   - How a future implementer should follow this: Remove EFS variables following the same pattern used for defining them
+
+3. **Secret Management Pattern**: AWS Secrets Manager integration with IAM policies
+   - Files: Secret definitions in storage.tf and IAM policies
+   - How a future implementer should follow this: Ensure no dangling IAM policies reference EFS resources
+
+### Integration Points
+
+| Component | Integration Type | Details |
+|-----------|------------------|---------|
+| ECS Services | Volume Mounts | Auth Server and MCPGW services currently mount EFS volumes |
+| Security Groups | Network Rules | EFS security group allows NFS access from VPC |
+| IAM Policies | Permissions | Task execution roles require EFS permissions |
+| Outputs | Exports | EFS identifiers exported for external consumption |
+| Variables | Configuration | EFS throughput settings configurable via variables |
+
+### Constraints and Limitations Discovered
+- **Service Dependencies**: Auth Server and MCPGW services currently depend on EFS volumes
+- **Environment Variables**: Services reference EFS paths in environment variables (e.g., SCOPES_CONFIG_PATH)
+- **Deployment Verification**: Need to ensure `terraform validate` and `terraform plan` still succeed
+
+## Architecture
+
+### System Context Diagram
+```
+Before:
+[Internet] → [ALB] → [ECS Services]
+                    ├── Auth Server ←→ [EFS]
+                    ├── Registry
+                    └── MCPGW ←→ [EFS]
+                             ←→ [DocumentDB]
+                             ←→ [S3]
+
+After:
+[Internet] → [ALB] → [ECS Services]
+                    ├── Auth Server
+                    ├── Registry
+                    └── MCPGW ←→ [DocumentDB]
+                             ←→ [S3]
+```
+
+### Sequence Diagram
+```
+Before EFS Removal:
+1. Terraform Apply
+2. EFS Creation
+3. ECS Services Creation with EFS Mounts
+4. Service Startup with EFS Access
+
+After EFS Removal:
+1. Terraform Apply
+2. ECS Services Creation without EFS Mounts
+3. Service Startup using DocumentDB/S3
+```
+
+### Component Diagram
+```
+Before:
+┌─────────────────────────────────────┐
+│           VPC                       │
+│  ┌─────────────────┐    ┌────────┐ │
+│  │   ECS Cluster   │    │  EFS   │ │
+│  │  ┌───────────┐  │    │        │ │
+│  │  │ Auth SVC  │←─┼────┤        │ │
+│  │  ├───────────┤  │    │        │ │
+│  │  │Registry   │  │    │        │ │
+│  │  ├───────────┤  │    │        │ │
+│  │  │ MCPGW SVC │←─┼────┤        │ │
+│  │  └───────────┘  │    │        │ │
+│  └─────────────────┘    └────────┘ │
+│            ↓                       │
+│      ┌───────────┐                 │
+│      │DocumentDB │                 │
+│      └───────────┘                 │
+└─────────────────────────────────────┘
+
+After:
+┌─────────────────────────────────────┐
+│           VPC                       │
+│  ┌─────────────────┐               │
+│  │   ECS Cluster   │               │
+│  │  ┌───────────┐  │               │
+│  │  │ Auth SVC  │  │               │
+│  │  ├───────────┤  │               │
+│  │  │Registry   │  │               │
+│  │  ├───────────┤  │               │
+│  │  │ MCPGW SVC │  │               │
+│  │  └───────────┘  │               │
+│  └─────────────────┘               │
+│            ↓                       │
+│      ┌───────────┐                 │
+│      │DocumentDB │                 │
+│      └───────────┘                 │
+└─────────────────────────────────────┘
+```
+
+## Data Models
+
+### New Models
+No new models required as this change removes infrastructure rather than adding it.
+
+### Model Changes
+No existing data models are directly affected by this change as it's purely infrastructure-related.
+
+## API / CLI Design
+
+### New Endpoints / Commands
+No new endpoints or CLI commands are required.
+
+### Modified Endpoints / Commands
+No existing endpoints or CLI commands are directly modified, though services will operate differently without EFS.
+
+## Configuration Parameters
+
+### Removed Environment Variables
+
+| Variable Name | Service | Description |
+|---------------|---------|-------------|
+| `SCOPES_CONFIG_PATH` | Auth Server | Path was set to `/efs/auth_config/auth_config/scopes.yml` but should be updated to use DocumentDB |
+
+### Settings / Config Class Updates
+
+Several settings related to EFS configuration need to be removed:
+
+```hcl
+# Remove these from variables.tf
+variable "efs_throughput_mode" {
+  description = "Throughput mode for EFS (bursting or provisioned)"
+  type        = string
+  default     = "bursting"
+  validation {
+    condition     = contains(["bursting", "provisioned"], var.efs_throughput_mode)
+    error_message = "EFS throughput mode must be either 'bursting' or 'provisioned'."
+  }
+}
+
+variable "efs_provisioned_throughput" {
+  description = "Provisioned throughput in MiB/s for EFS (only used if throughput_mode is provisioned)"
+  type        = number
+  default     = 100
+}
+```
+
+### Deployment Surface Checklist
+Need to remove EFS-related configuration from all deployment surfaces:
+- [ ] `terraform/aws-ecs/variables.tf` - Remove EFS variables
+- [ ] `terraform/aws-ecs/terraform.tfvars.example` - Remove EFS variable examples
+- [ ] Documentation references (outside scope of this change)
+- [ ] Any CI/CD pipeline references (outside scope of this change)
+
+## New Dependencies
+
+No new dependencies are required.
+
+If no new dependencies are required, explicitly state: "This change uses only existing dependencies."
+
+This change actually removes dependencies rather than adding them.
+
+## Implementation Details
+
+### Step-by-Step Plan (for a future implementer)
+
+#### Step 1: Remove EFS Module in storage.tf
+**File:** `terraform/aws-ecs/modules/mcp-gateway/storage.tf`
+**Lines:** All lines (entire file content related to EFS)
+
+Remove the entire EFS module definition:
+```hcl
+module "efs" {
+  source  = "terraform-aws-modules/efs/aws"
+  version = "~> 2.0"
+  # ... all EFS configuration
+}
+
+resource "aws_vpc_security_group_egress_rule" "efs_all_outbound" {
+  # ... egress rule configuration
+}
+```
+
+#### Step 2: Remove EFS Volume Mounts from ECS Services
+**File:** `terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf`
+
+For Auth Server service:
+- Remove `volume` block containing EFS volumes
+- Remove `mountPoints` from container definitions
+
+For MCPGW service:
+- Remove `volume` block containing EFS volumes
+- Remove `mountPoints` from container definitions
+
+Registry service already has no EFS mounts.
+
+#### Step 3: Remove EFS Variables
+**File:** `terraform/aws-ecs/modules/mcp-gateway/variables.tf`
+
+Remove these variable definitions:
+```hcl
+variable "efs_throughput_mode" {
+  # ... description and validation
+}
+
+variable "efs_provisioned_throughput" {
+  # ... description and default
+}
+```
+
+**File:** `terraform/aws-ecs/variables.tf`
+
+Remove the same variable definitions at the root level.
+
+#### Step 4: Update Environment Variables
+**File:** `terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf`
+
+Update or remove environment variables that reference EFS paths:
+- `SCOPES_CONFIG_PATH` in Auth Server should be updated to use DocumentDB instead of `/efs/auth_config/auth_config/scopes.yml`
+
+#### Step 5: Remove EFS Outputs
+**File:** `terraform/aws-ecs/modules/mcp-gateway/outputs.tf`
+
+Remove these output definitions:
+```hcl
+output "efs_id" {
+  # ... description and value
+}
+
+output "efs_arn" {
+  # ... description and value
+}
+
+output "efs_access_points" {
+  # ... description and value
+}
+```
+
+**File:** `terraform/aws-ecs/outputs.tf`
+
+Remove these output definitions:
+```hcl
+output "mcp_gateway_efs_id" {
+  # ... description and value
+}
+
+output "mcp_gateway_efs_arn" {
+  # ... description and value
+}
+
+output "mcp_gateway_efs_access_points" {
+  # ... description and value
+}
+```
+
+#### Step 6: Update terraform.tfvars.example
+**File:** `terraform/aws-ecs/terraform.tfvars.example`
+
+Remove any EFS-related variable examples.
+
+### Error Handling
+Since this is an infrastructure change, Terraform will handle error detection during `terraform plan` and `terraform apply`. Key validations include:
+- Ensuring no resources reference removed EFS volumes
+- Verifying that all services can start without EFS mounts
+
+### Logging
+No specific logging changes are required as this is an infrastructure change.
+
+## Observability
+### Tracing / Metrics / Logging Points
+Monitor the following during and after deployment:
+- ECS service deployment success/failure
+- Task startup times without EFS mounts
+- Application logs to ensure services function properly without EFS
+- Cost metrics to verify EFS cost reduction
+
+## Scaling Considerations
+- Removing EFS eliminates a potential bottleneck for file-based operations
+- Services now rely solely on DocumentDB and S3 for persistence, which are more scalable
+- Reduced infrastructure complexity improves overall system reliability
+
+## File Changes
+
+### Deleted Files
+
+| File Path | Description |
+|-----------|-------------|
+| `terraform/aws-ecs/modules/mcp-gateway/storage.tf` | Remove EFS implementation (can be deleted or emptied) |
+
+### Modified Files
+
+| File Path | Lines | Change Description |
+|-----------|-------|--------------------|
+| `terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf` | ~500 | Remove EFS volume definitions and container mountPoints for Auth Server and MCPGW services |
+| `terraform/aws-ecs/modules/mcp-gateway/variables.tf` | ~20 | Remove EFS-related variable definitions |
+| `terraform/aws-ecs/modules/mcp-gateway/outputs.tf` | ~15 | Remove EFS-related output definitions |
+| `terraform/aws-ecs/variables.tf` | ~20 | Remove EFS-related variable definitions at root level |
+| `terraform/aws-ecs/outputs.tf` | ~15 | Remove EFS-related output definitions at root level |
+| `terraform/aws-ecs/terraform.tfvars.example` | ~10 | Remove EFS-related variable examples |
+
+### Estimated Lines of Code
+
+| Category | Lines |
+|----------|-------|
+| Removed code | ~600 |
+| New code | ~0 |
+| Modified code | ~60 |
+| **Net change** | **~540 fewer lines** |
+
+## Testing Strategy
+See `./testing.md` for the detailed testing plan.
+
+## Alternatives Considered
+
+### Alternative 1: Keep EFS But Reduce Throughput
+**Description:** Instead of removing EFS entirely, reduce its throughput settings to minimize costs.
+**Pros / Cons:**
+- Pro: Preserves existing functionality
+- Con: Still incurs EFS costs and complexity
+**Why Rejected:** Doesn't meet the goal of eliminating EFS entirely to reduce complexity and cost.
+
+### Alternative 2: Gradual Migration
+**Description:** Migrate services one by one to eliminate EFS dependence before removing infrastructure.
+**Pros / Cons:**
+- Pro: Lower risk of service disruption
+- Con: Requires longer timeline and coordination
+**Why Rejected:** Assumption is that services have already been migrated to S3/DocumentDB.
+
+### Comparison Matrix
+
+| Criteria | Chosen (Remove EFS) | Alt 1 (Reduce Throughput) | Alt 2 (Gradual Migration) |
+|----------|---------------------|---------------------------|---------------------------|
+| Complexity | Medium | Low | High |
+| Risk | Medium | Low | Low |
+| Cost Savings | High | Low | Medium |
+| Timeline | Short | Immediate | Long |
+
+## Rollout Plan
+- Phase 1: Implementation (out of scope for this skill)
+- Phase 2: Testing
+- Phase 3: Deployment
+
+## Open Questions
+- Have all services been fully migrated to use S3/DocumentDB instead of EFS?
+- Are there any external systems that depend on the EFS outputs?
+- Should the terraform.tfvars.example be updated to reflect the configuration changes?
+
+## References
+- AWS EFS Documentation: https://docs.aws.amazon.com/efs/latest/ug/whatis.html
+- Terraform AWS EFS Module: https://registry.terraform.io/modules/terraform-aws-modules/efs/aws/latest
+- DocumentDB Documentation: https://docs.aws.amazon.com/documentdb/latest/developerguide/

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,72 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "qwen.qwen3-coder-480b-a35b-instruct",
+  "model_slug": "qwen.qwen3-coder-480b-a35b-instruct",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4000",
+  "aws_region": null,
+  "artifacts_produced": 0,
+  "artifacts_expected": 4,
+  "generation_tokens_per_sec": 16.7,
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2655306,
+    "output_tokens": 14048,
+    "cache_read_tokens": 432,
+    "cache_write_tokens": 0,
+    "latency_seconds": 842.2,
+    "num_turns": 27,
+    "generation_tokens_per_sec": 16.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "claude_api.usage.input_tokens",
+      "output_tokens": "claude_api.usage.output_tokens",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2655306,
+  "output_tokens": 14048,
+  "latency_seconds": 842.2,
+  "num_turns": 27,
+  "total_cost_usd": 33.82036,
+  "is_error": false,
+  "session_id": "f3b55f15-9b43-4b4f-b8fc-552090cae82c",
+  "cache_read_tokens": 432,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-07-25T02:11:43.866736Z",
+  "run_ended_at": "2026-07-25T02:25:46.654970Z",
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/review.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/review.md
@@ -1,0 +1,201 @@
+# Expert Review: Remove EFS from Terraform AWS ECS Deployment
+
+*Created: 2026-07-25*
+*Related LLD: `./lld.md`*
+*Related Issue: `./github-issue.md`*
+
+## Frontend Engineer (Pixel) Review
+
+## Strengths
+1. **Clear migration strategy**: The infrastructure is moving from EFS-based persistence to DocumentDB, which aligns with modern, scalable database architectures. The separation of services also makes the system more maintainable.
+
+2. **Minimal frontend impact**: The EFS removal primarily affects backend storage layers and doesn't fundamentally change how the frontend interacts with the API. Most existing functionality should remain unaffected.
+
+3. **Backward compatibility maintained**: Existing API endpoints and response formats appear to be preserved, ensuring frontend components can continue to function without major modifications.
+
+## Concerns
+1. **Scope configuration transition**: The system is moving from EFS-based scope configuration (`/efs/auth_config/scopes.yml`) to DocumentDB storage. This change requires updating the initialization process and could introduce deployment inconsistencies during the transition period.
+
+2. **Persistent data handling**: Components like the MCP Gateway data directory (`/app/data` in mcpgw container) still rely on EFS for persistence. If these are moved to ephemeral storage without proper alternatives, it could lead to data loss or inconsistent user experiences.
+
+3. **Deployment complexity**: The hybrid approach with some services using DocumentDB and others still potentially depending on EFS volumes could complicate deployment and troubleshooting processes for frontend developers.
+
+## New libraries / infra dependencies required
+None for frontend. The EFS removal appears to be a backend infrastructure change that doesn't require frontend library updates. However, developers may need to understand the new DocumentDB-based data access patterns.
+
+## Better alternatives considered
+1. **Gradual migration approach**: Instead of completely removing EFS, a phased approach could migrate services one by one, reducing deployment risk and allowing for rollback capabilities.
+
+2. **EFS to EFS-like abstraction**: Creating an abstraction layer that can support both EFS and DocumentDB backends would allow for easier switching between storage mechanisms based on deployment requirements.
+
+3. **Hybrid storage approach**: Keep EFS for truly file-based operations while using DocumentDB for structured data, maintaining the benefits of both systems.
+
+## Recommendations
+1. **Implement thorough testing during transition**: Ensure all scope management and user permission features are thoroughly tested during the migration from EFS to DocumentDB storage to prevent authorization issues.
+
+2. **Update documentation for developers**: Clearly document the new storage architecture so frontend developers understand data persistence patterns and can troubleshoot issues effectively.
+
+3. **Monitor deployment stability**: Implement monitoring for data consistency and access patterns during and after the transition to catch any issues early and ensure smooth operation.
+
+## Questions for author
+1. How will the existing EFS data be migrated to DocumentDB during the transition? Is there a data migration plan in place?
+
+2. Are there any expected downtime or service interruptions during the EFS removal process that frontend users should be aware of?
+
+## Verdict
+APPROVED WITH CHANGES
+
+## Backend Engineer (Byte) Review
+
+## Strengths
+1. Clear separation of concerns with dedicated EFS module that encapsulates all EFS-related resources
+2. Well-defined mount points and access points for different services (auth-config, logs, mcpgw-data)
+3. Proper use of EFS security groups with specific ingress rules limiting NFS access to VPC CIDR
+
+## Concerns
+1. Multiple services depend on EFS for critical data persistence including auth server configuration, logs, and mcpgw data
+2. The post-deployment setup scripts heavily rely on EFS for scopes initialization which affects application startup
+3. Removing EFS without proper data migration strategy could result in data loss for critical application configuration
+
+## New libraries / infra dependencies required
+Any replacement for EFS would require:
+1. Alternative persistent storage solution (likely DocumentDB/S3 for config, CloudWatch for logs)
+2. Potential application code changes to handle new storage mechanisms
+3. Updated IAM policies for new storage services
+4. Modified container images or initialization scripts to work with new storage
+
+## Better alternatives considered
+1. **Gradual migration approach**: Instead of immediate removal, migrate services one-by-one to DocumentDB/S3 while maintaining EFS temporarily
+2. **Hybrid approach**: Keep EFS for logs only and move configuration to DocumentDB
+3. **Enhanced ephemeral storage**: For development environments where persistence isn't critical, use larger ephemeral storage with backup/restore mechanisms
+
+## Recommendations
+1. Ensure all EFS-mounted data has a clear migration path to DocumentDB or S3 before removal, particularly the auth server scopes configuration file
+2. Update container definitions to remove mountPoints and volume configurations referencing EFS
+3. Modify post-deployment scripts to eliminate EFS-dependent initialization tasks and replace with DocumentDB/S3 equivalents
+
+## Questions for author
+1. What is the migration strategy for existing data in EFS, particularly the auth server scopes configuration?
+2. Which services currently depending on EFS can safely switch to ephemeral storage without data loss?
+
+## Verdict
+NEEDS REVISION
+
+The design needs revision to address data migration concerns and ensure no critical functionality is lost when removing EFS. A detailed migration plan for existing EFS data to alternative storage systems (DocumentDB/S3) is essential before proceeding with the removal.
+
+## SRE/DevOps Engineer (Circuit) Review
+
+## Strengths
+1. **Cost Reduction & Simplification**: The design effectively removes unused infrastructure (EFS), which directly reduces costs and simplifies the architecture by eliminating unnecessary components.
+2. **Clear Implementation Plan**: The step-by-step approach for removing EFS resources is well-documented, making it easy for implementers to follow and reducing the risk of missing components.
+3. **Comprehensive Scope Coverage**: The plan addresses all aspects of EFS removal, including variables, outputs, volume mounts, and security groups, ensuring a complete cleanup.
+
+## Concerns
+1. **Application Dependency Validation**: The design assumes all services have been migrated to S3/DocumentDB, but there's no verification plan to confirm that no service still depends on EFS paths or data. This could lead to service disruptions post-deployment.
+2. **Rollback Strategy**: There's no defined rollback plan if issues arise after EFS removal. Since EFS contained persistent data, the ability to quickly restore functionality is critical.
+3. **Monitoring Transition**: The design doesn't specify how to monitor the transition from EFS-based to S3/DocumentDB-based operations, which is essential for detecting performance issues or failures.
+
+## New libraries / infra dependencies required
+No new dependencies are required. This change actually removes infrastructure dependencies rather than adding them.
+
+## Better alternatives considered
+An alternative approach would be a phased migration where EFS dependency is gradually removed service by service while maintaining the infrastructure until all services are confirmed to work without it. However, this approach would take longer and increase operational overhead.
+
+## Recommendations
+1. **Implement Pre-Deployment Validation**: Create a validation script that checks all services and configurations to ensure no remaining references to EFS paths or mounts before proceeding with removal.
+2. **Add Observability for Migration**: Implement specific metrics and alerts to monitor service health, latency, and error rates during and after the transition to ensure S3/DocumentDB operations perform adequately.
+3. **Create Rollback Documentation**: Develop a clear rollback procedure that includes how to quickly restore EFS if critical issues are discovered post-deployment, even if it's just for emergency data recovery.
+
+## Questions for author
+1. How will you verify that all application services have completely migrated away from EFS and no longer require any file system data that might have been stored there?
+2. What monitoring and alerting will be implemented to detect any performance degradation or failures after switching from EFS to S3/DocumentDB storage?
+
+## Verdict
+APPROVED WITH CHANGES
+
+The design is sound for removing EFS infrastructure, but should include validation steps to ensure no service dependencies remain and should enhance observability around the transition. The concerns about rollback strategy and dependency validation should be addressed before implementation.
+
+## Security Engineer (Cipher) Review
+
+## Strengths
+1. **Clear Migration Strategy**: The design correctly identifies that all services have been migrated from EFS to S3/DocumentDB, ensuring data persistence is maintained through more appropriate storage mechanisms.
+2. **Comprehensive Removal Approach**: The plan addresses all aspects of EFS removal, including infrastructure resources, volume mounts, variables, and outputs, reducing the attack surface by eliminating unused components.
+3. **Encryption Continuity**: By moving to DocumentDB (which supports encryption) and S3 (which also supports encryption), the design maintains strong data protection practices.
+
+## Concerns
+1. **Authentication Path Transition**: The Auth Server currently relies on `/efs/auth_config/auth_config/scopes.yml` for scope configuration. The transition to DocumentDB for this configuration needs careful validation to ensure authorization policies are correctly enforced.
+2. **Data Residue Risk**: Complete removal of EFS should be verified to ensure no sensitive data remains accessible through snapshots or backups that might still exist after resource deletion.
+3. **IAM Permission Cleanup**: While EFS resources are removed, associated IAM permissions and policies may still exist and should be cleaned up to prevent privilege creep.
+
+## New libraries / infra dependencies required
+None. This change removes infrastructure dependencies rather than adding new ones.
+
+## Better alternatives considered
+An alternative approach could involve keeping EFS but reducing its throughput settings to minimize costs while maintaining availability for any unforeseen dependencies. However, this wouldn't achieve the goal of simplifying the architecture.
+
+## Recommendations
+1. **Verify Scope Configuration Migration**: Ensure the Auth Server's scope configuration is correctly migrated from the EFS file path to DocumentDB, validating that all authorization policies continue to function as expected.
+2. **Implement Complete IAM Cleanup**: Beyond removing EFS resources, thoroughly audit and remove any IAM policies, roles, or permissions that were specifically granted for EFS access to prevent security misconfigurations.
+3. **Validate EFS Backup/Snapshot Deletion**: Implement a verification step to ensure that any EFS snapshots or backups are also deleted to prevent data residue that could be accessed later.
+
+## Questions for author
+1. Has the migration of the Auth Server's scope configuration from `/efs/auth_config/auth_config/scopes.yml` to DocumentDB been tested to ensure authentication and authorization continue to function correctly?
+2. Are there any backup or disaster recovery procedures that might still reference EFS resources that need to be updated or removed?
+
+## Verdict
+APPROVED WITH CHANGES
+
+## SMTS (Sage) Review
+
+## Strengths
+1. **Clear problem identification and solution approach**: The design clearly articulates why EFS should be removed (unnecessary cost and complexity) and identifies exactly what needs to be changed in the Terraform configuration.
+2. **Well-structured LLD**: The document follows a comprehensive format covering all aspects of the change from codebase analysis to rollout plan, making it easy for implementers to understand and execute.
+3. **Thorough impact analysis**: The design carefully identifies all files that need to be modified and considers dependencies like IAM policies, environment variables, and service integrations.
+
+## Concerns
+1. **Potential service disruption risk**: While the design assumes services have been migrated to S3/DocumentDB, there's no verification plan in place to confirm this assumption before removing EFS, which could lead to service outages if incorrect.
+2. **Incomplete handling of environment variables**: The design mentions that SCOPES_CONFIG_PATH needs to be updated to use DocumentDB instead of EFS, but doesn't provide specifics on how that migration will occur, potentially leaving services non-functional.
+3. **Missing validation of downstream dependencies**: The design doesn't address whether any external systems depend on the EFS outputs that will be removed, which could break dependent systems.
+
+## New libraries / infra dependencies required
+This change removes infrastructure dependencies rather than adding them. Specifically, it eliminates the need for:
+- AWS EFS resources (file systems, mount targets, access points)
+- Related security groups and network configurations for EFS
+- IAM policies granting EFS access to ECS services
+
+## Better alternatives considered
+The design considered two alternatives:
+1. **Reducing EFS throughput**: While this would maintain compatibility, it doesn't fully address the complexity concerns and still incurs ongoing costs.
+2. **Gradual migration**: Although safer, this approach wasn't selected because the design assumes services have already been migrated.
+
+A hybrid approach could have been considered - temporarily keeping EFS with very low throughput while monitoring service health during the transition, providing a rollback option with minimal cost impact.
+
+## Recommendations
+1. **Add explicit validation steps**: Before removing EFS, add verification that all services function correctly with S3/DocumentDB by running integration tests that specifically check storage operations.
+2. **Implement a phased rollout strategy**: Instead of removing EFS entirely at once, consider disabling EFS mounting in services first while keeping the infrastructure, verifying functionality, then completely removing the infrastructure.
+3. **Document rollback procedures**: Include specific steps to quickly restore EFS if post-deployment issues are discovered, including how to migrate any new data that might have been written to S3/DocumentDB back to EFS if needed.
+
+## Questions for author
+1. How will you verify that all services have truly been migrated away from EFS dependency before removing the infrastructure? Is there a testing plan to confirm services function correctly without EFS?
+2. What is the specific migration path for the SCOPES_CONFIG_PATH environment variable currently pointing to EFS - how will services access this configuration data after EFS removal?
+
+## Verdict
+NEEDS REVISION
+
+## Review Summary
+
+| Reviewer | Verdict | Blockers | Key Recommendations |
+|----------|---------|----------|---------------------|
+| Frontend (Pixel) | APPROVED WITH CHANGES | 2 | Implement thorough testing during transition; Update documentation for developers |
+| Backend (Byte) | NEEDS REVISION | 3 | Ensure migration path for EFS data to DocumentDB/S3; Update container definitions to remove EFS mounts |
+| SRE (Circuit) | APPROVED WITH CHANGES | 3 | Implement pre-deployment validation; Add observability for migration |
+| Security (Cipher) | APPROVED WITH CHANGES | 3 | Verify scope configuration migration; Implement complete IAM cleanup |
+| SMTS (Sage) | NEEDS REVISION | 3 | Add explicit validation steps; Implement phased rollout strategy |
+
+Overall, the design to remove EFS from the Terraform AWS ECS deployment is generally well-structured and addresses the core goal of reducing infrastructure complexity and cost. However, several reviewers have identified critical concerns that need to be addressed before implementation:
+
+1. **Data Migration Strategy**: A clear plan is needed for migrating existing EFS data to DocumentDB/S3, particularly for the auth server scopes configuration.
+2. **Dependency Validation**: Verification is required to ensure no services still depend on EFS before removal.
+3. **Rollback Procedures**: Documentation and procedures should be established for quickly restoring EFS if post-deployment issues arise.
+
+The design should be revised to address these concerns, particularly the data migration strategy and dependency validation, before proceeding with implementation.

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/testing.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/testing.md
@@ -1,0 +1,207 @@
+# Testing Plan: Remove EFS from Terraform AWS ECS Deployment
+
+*Created: 2026-07-25*
+*Related LLD: `./lld.md`*
+*Related Issue: `./github-issue.md`*
+
+## Overview
+### Scope of Testing
+This testing plan covers the removal of EFS (Elastic File System) from the MCP Gateway Registry Terraform AWS ECS deployment. The change involves removing all EFS resources, volume mounts, and related configuration while ensuring services continue to function using S3/DocumentDB for storage.
+
+### Prerequisites
+- [ ] AWS account with appropriate permissions for ECS, EFS, DocumentDB, and S3
+- [ ] Terraform CLI installed and configured
+- [ ] Existing MCP Gateway Registry deployment with EFS enabled
+- [ ] Access to DocumentDB and S3 buckets used for persistence
+- [ ] Auth0, Okta, or Entra ID credentials for authentication testing (if applicable)
+
+### Shared Variables
+```bash
+export AWS_REGION="us-west-2"
+export TF_VAR_aws_region="us-west-2"
+export MCP_GATEWAY_DIR="/tmp/swe-clone-remove-efs-from-terraform-aws-ecs/mcp-gateway-registry/terraform/aws-ecs"
+```
+
+## 1. Functional Tests
+### 1.1 Terraform Tests
+Test that Terraform can successfully plan and apply the changes without EFS.
+
+```bash
+# Navigate to the terraform directory
+cd $MCP_GATEWAY_DIR
+
+# Initialize terraform
+terraform init
+
+# Validate the configuration
+terraform validate
+
+# Plan the changes (should show EFS resources being destroyed)
+terraform plan -out=tfplan
+
+# Check that EFS resources are marked for destruction
+terraform show -json tfplan | jq '.planned_values.root_module.resources[] | select(.type | startswith("aws_efs"))' || echo "No EFS resources found in plan - this is expected"
+
+# Apply the changes
+terraform apply tfplan
+
+# Verify that no EFS resources exist
+terraform state list | grep efs || echo "No EFS resources in state - this is expected"
+```
+
+### 1.2 Service Deployment Tests
+Test that all ECS services deploy successfully without EFS volumes.
+
+```bash
+# Check that all ECS services are running
+cd $MCP_GATEWAY_DIR
+terraform output
+
+# Verify ECS service statuses
+CLUSTER_NAME=$(terraform output -raw ecs_cluster_name)
+aws ecs list-services --cluster $CLUSTER_NAME
+
+# Check service status for each service
+for service in $(aws ecs list-services --cluster $CLUSTER_NAME --query 'serviceArns[].split(`/`, @)[1]' --output text); do
+  echo "Checking service: $service"
+  aws ecs describe-services --cluster $CLUSTER_NAME --services $service --query 'services[0].{serviceName:serviceName,status:status,runningCount:runningCount,pendingCount:pendingCount}'
+done
+```
+
+## 2. Backwards Compatibility Tests
+Since this is a removal of infrastructure rather than a change to APIs, backwards compatibility is not directly applicable. However, we need to verify that the application continues to function the same way.
+
+### 2.1 Configuration Persistence Tests
+Test that configuration settings that were previously stored in EFS are now properly stored in DocumentDB.
+
+```bash
+# Get the registry URL
+REGISTRY_URL=$(terraform output -raw mcp_gateway_url)
+
+# Test that scopes configuration is accessible (was previously in EFS)
+curl -s -f "$REGISTRY_URL/api/config" | jq '.' || echo "Failed to get config from DocumentDB"
+
+# Test authentication (if enabled)
+# This would depend on the specific IdP configuration
+echo "Manual verification needed: Ensure authentication works with DocumentDB-stored scopes"
+```
+
+### 2.2 Environment Variable Tests
+Verify that environment variables no longer reference EFS paths.
+
+```bash
+# Get ECS cluster and service information
+CLUSTER_NAME=$(terraform output -raw ecs_cluster_name)
+AUTH_SERVICE_NAME=$(terraform output -json ecs_service_names | jq -r '.auth')
+
+# Check environment variables for auth service
+TASK_DEFINITION_ARN=$(aws ecs describe-services --cluster $CLUSTER_NAME --services $AUTH_SERVICE_NAME --query 'services[0].taskDefinition' --output text)
+aws ecs describe-task-definition --task-definition $TASK_DEFINITION_ARN --query 'taskDefinition.containerDefinitions[0].environment[].name' | grep SCOPES_CONFIG_PATH && echo "ERROR: SCOPES_CONFIG_PATH still exists" || echo "SUCCESS: SCOPES_CONFIG_PATH removed"
+
+# Verify no EFS mount points exist
+aws ecs describe-task-definition --task-definition $TASK_DEFINITION_ARN --query 'taskDefinition.containerDefinitions[0].mountPoints' | grep -i efs && echo "ERROR: EFS mount points still exist" || echo "SUCCESS: No EFS mount points found"
+```
+
+## 3. UX Tests
+**Not Applicable** - This infrastructure change does not modify any user interface elements.
+
+## 4. Deployment Surface Tests
+### 4.1 Terraform Wiring Tests
+Test that all Terraform variables and outputs related to EFS have been removed.
+
+```bash
+# Check that EFS variables are no longer defined
+cd $MCP_GATEWAY_DIR
+grep -r "efs_" variables.tf && echo "ERROR: EFS variables still exist" || echo "SUCCESS: No EFS variables found"
+
+# Check that EFS outputs are no longer defined
+grep -r "efs_" outputs.tf && echo "ERROR: EFS outputs still exist" || echo "SUCCESS: No EFS outputs found"
+
+# Check terraform.tfvars.example
+grep -i "efs" terraform.tfvars.example && echo "ERROR: EFS references still exist in example file" || echo "SUCCESS: No EFS references in example file"
+```
+
+### 4.2 ECS Wiring Tests
+Test that ECS task definitions no longer include EFS volumes or mount points.
+
+```bash
+# Check that module.mcp_gateway no longer has EFS outputs
+cd $MCP_GATEWAY_DIR
+terraform output mcp_gateway_efs_id && echo "ERROR: EFS output still exists" || echo "SUCCESS: EFS output removed"
+terraform output mcp_gateway_efs_arn && echo "ERROR: EFS output still exists" || echo "SUCCESS: EFS output removed"
+```
+
+### 4.3 Deploy and Verify Tests
+Test that a fresh deployment works without EFS.
+
+```bash
+# Create a test directory for fresh deployment
+TEST_DEPLOY_DIR="/tmp/mcp-gateway-test-deploy"
+mkdir -p $TEST_DEPLOY_DIR
+cp -r $MCP_GATEWAY_DIR/* $TEST_DEPLOY_DIR/
+cd $TEST_DEPLOY_DIR
+
+# Create a minimal terraform.tfvars for testing
+cat > terraform.tfvars <<EOF
+ingress_cidr_blocks = ["0.0.0.0/0"]
+storage_backend = "documentdb"
+EOF
+
+# Initialize and validate
+terraform init
+terraform validate
+
+# Plan and check for EFS resources
+terraform plan -out=testplan
+terraform show -json testplan | jq '.planned_values.root_module.resources[] | select(.type | startswith("aws_efs"))' && echo "ERROR: EFS resources planned for new deployment" || echo "SUCCESS: No EFS resources planned"
+
+# Clean up
+cd /
+rm -rf $TEST_DEPLOY_DIR
+```
+
+### 4.4 Rollback Verification Tests
+**Not Applicable** - Since this is a removal of infrastructure, traditional rollback testing is not applicable. However, we should verify that a redeployment with EFS re-enabled would still work.
+
+```bash
+echo "Note: Rollback verification requires a separate test with EFS re-enabled, which is outside the scope of this change"
+```
+
+## 5. End-to-End API Tests
+### 5.1 Registry API Tests
+Test that the registry API continues to function properly without EFS.
+
+```bash
+# Get the registry URL
+REGISTRY_URL=$(terraform output -raw mcp_gateway_url)
+
+# Test basic registry endpoints
+curl -s -f "$REGISTRY_URL/health" | jq '.' && echo "SUCCESS: Health check passed" || echo "ERROR: Health check failed"
+
+curl -s -f "$REGISTRY_URL/api/status" | jq '.' && echo "SUCCESS: Status endpoint works" || echo "ERROR: Status endpoint failed"
+
+# Test that API configuration is accessible from DocumentDB (formerly EFS)
+curl -s -f "$REGISTRY_URL/api/config" | jq '.' && echo "SUCCESS: Config endpoint works" || echo "ERROR: Config endpoint failed"
+```
+
+### 5.2 Authentication Tests
+Test that authentication continues to work with DocumentDB-based scope configuration.
+
+```bash
+echo "Manual verification needed: Test authentication flows with the deployed system"
+echo "1. Navigate to $REGISTRY_URL"
+echo "2. Attempt to log in with configured IdP"
+echo "3. Verify that user permissions are correctly applied from DocumentDB"
+```
+
+## 6. Test Execution Checklist
+- [ ] Section 1 (Functional) passes
+- [ ] Section 2 (Backwards Compat) verified
+- [ ] Section 3 (UX) marked Not Applicable
+- [ ] Section 4 (Deployment) passes
+- [ ] Section 5 (E2E) passes
+- [ ] Manual verification of authentication flows completed
+- [ ] terraform validate passes with no errors
+- [ ] terraform plan shows EFS resources being destroyed
+- [ ] All ECS services deploy and run successfully
+- [ ] No EFS-related variables, outputs, or mount points remain

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/github-issue.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/github-issue.md
@@ -1,0 +1,47 @@
+# GitHub Issue: Remove FAISS Dependency and Replace with DocumentDB Hybrid Search
+
+## Title
+Remove FAISS dependency and replace with DocumentDB native hybrid search implementation
+
+## Labels
+- refactor
+- search
+- dependencies
+- tech-debt
+
+## Description
+
+### Problem Statement
+FAISS is an obsolete dependency in this repository that complicates deployment and adds unnecessary complexity. The registry already has a robust DocumentDB-based hybrid search implementation that provides the same semantic search capabilities without requiring FAISS as a dependency.
+
+### Proposed Solution
+Completely remove FAISS from the codebase and rely solely on the existing DocumentDB native hybrid search functionality. This includes:
+- Removing FAISS imports and code paths
+- Removing the FAISS dependency from pyproject.toml
+- Updating documentation to reference DocumentDB hybrid search instead
+- Ensuring all search functionality continues to work as expected
+
+### User Stories
+- As an operator, I want to simplify deployment by removing unnecessary native library dependencies
+- As a developer, I want to work with a simpler, more maintainable codebase without FAISS complexities
+- As an end-user, I want search functionality to continue working exactly as before
+
+### Acceptance Criteria
+- [ ] All FAISS imports removed from codebase
+- [ ] FAISS dependency removed from pyproject.toml
+- [ ] FAISS-related Docker build steps removed
+- [ ] FAISS-related tests removed or migrated
+- [ ] Documentation updated to reference DocumentDB hybrid search
+- [ ] All existing search behavior preserved and working
+- [ ] No breaking changes to search API
+
+### Out of Scope
+- Changing the underlying search algorithm or behavior
+- Modifying the DocumentDB hybrid search implementation
+- Adding new search features
+
+### Dependencies
+- Existing DocumentDB hybrid search implementation must be fully functional
+
+### Related Issues
+- None

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/lld.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/lld.md
@@ -1,0 +1,252 @@
+# Low-Level Design: Remove FAISS Dependency
+
+## Overview
+
+This document details the technical approach for removing the FAISS dependency from the MCP Gateway Registry while maintaining all existing search functionality through the DocumentDB hybrid search implementation.
+
+## Current Architecture
+
+### Search Repository Factory Pattern
+
+The current architecture uses a factory pattern to instantiate search repositories based on the configured storage backend:
+
+```python
+# registry/repositories/factory.py
+def get_search_repository() -> SearchRepositoryBase:
+    global _search_repo
+
+    if _search_repo is not None:
+        return _search_repo
+
+    backend = settings.storage_backend
+    logger.info(f"Creating search repository with backend: {backend}")
+
+    if backend in MONGODB_BACKENDS:
+        from .documentdb.search_repository import DocumentDBSearchRepository
+        _search_repo = DocumentDBSearchRepository()
+    else:  # file backend
+        from .file.search_repository import FaissSearchRepository
+        _search_repo = FaissSearchRepository()
+
+    return _search_repo
+```
+
+### FAISS Implementation Details
+
+The FAISS implementation (`registry/search/service.py` and `registry/repositories/file/search_repository.py`) includes:
+- In-memory FAISS index management with `IndexIDMap` and `IndexFlatIP`
+- Manual index rebuilding on startup for persistence
+- Custom embedding model loading and normalization
+- Semantic search with keyword boosting
+- Metadata storage in JSON files
+
+### DocumentDB Implementation Details
+
+The DocumentDB implementation (`registry/repositories/documentdb/search_repository.py`) includes:
+- Native MongoDB vector search with HNSW indexes
+- Automatic index creation with cosine similarity
+- Hybrid search combining vector and keyword queries
+- Reciprocal Rank Fusion (RRF) for result ranking
+- Persistent storage that survives service restarts
+
+## Target Architecture
+
+After removing FAISS, the architecture will be simplified to use only the DocumentDB search repository:
+
+```python
+# registry/repositories/factory.py (after changes)
+def get_search_repository() -> SearchRepositoryBase:
+    global _search_repo
+
+    if _search_repo is not None:
+        return _search_repo
+
+    # Always use DocumentDB implementation
+    from .documentdb.search_repository import DocumentDBSearchRepository
+    _search_repo = DocumentDBSearchRepository()
+    logger.info("Created DocumentDB search repository")
+
+    return _search_repo
+```
+
+## Detailed Changes
+
+### 1. Dependency Removal
+
+**File**: `pyproject.toml`
+- Remove `"faiss-cpu>=1.7.4"` from dependencies
+
+**Impact**: Reduces container image size and eliminates a complex native dependency
+
+### 2. Configuration Cleanup
+
+**File**: `registry/core/config.py`
+- Remove FAISS-specific properties:
+  - `faiss_index_path`
+  - `faiss_metadata_path`
+
+**Impact**: Cleans up unused configuration options
+
+### 3. Code Implementation Removal
+
+**Files to Delete**:
+- `registry/search/service.py` - FAISS service implementation
+- `registry/repositories/file/search_repository.py` - FAISS repository implementation
+
+**Files to Modify**:
+- `registry/repositories/factory.py` - Simplify to always return DocumentDB implementation
+- `registry/main.py` - Remove FAISS-specific index rebuilding logic
+
+### 4. Factory Pattern Simplification
+
+**Before**:
+```python
+if backend in MONGODB_BACKENDS:
+    from .documentdb.search_repository import DocumentDBSearchRepository
+    _search_repo = DocumentDBSearchRepository()
+else:
+    from .file.search_repository import FaissSearchRepository
+    _search_repo = FaissSearchRepository()
+```
+
+**After**:
+```python
+# Always use DocumentDB implementation
+from .documentdb.search_repository import DocumentDBSearchRepository
+_search_repo = DocumentDBSearchRepository()
+```
+
+### 5. Startup Logic Simplification
+
+**Before**:
+```python
+# For DocumentDB, embeddings are persisted in the collection and survive
+# restarts. Only FAISS (in-memory) needs a full re-index on every boot.
+if settings.storage_backend not in MONGODB_BACKENDS:
+    # FAISS re-indexing logic for servers, agents, and skills
+    # ... extensive re-indexing code
+else:
+    logger.info("✅ DocumentDB search index is persistent, skipping startup re-index")
+```
+
+**After**:
+```python
+# DocumentDB search index is persistent, skipping startup re-index
+logger.info("✅ DocumentDB search index is persistent, skipping startup re-index")
+```
+
+### 6. Search Routes Endpoint
+
+The search endpoint in `registry/api/search_routes.py` remains unchanged since it already works with the abstract `SearchRepositoryBase` interface.
+
+## Migration Path
+
+### Phase 1: Safe Removal
+1. Verify that DocumentDB implementation provides all required functionality
+2. Remove FAISS dependencies from `pyproject.toml`
+3. Remove unused configuration properties
+4. Update factory to always return DocumentDB repository
+5. Remove FAISS-specific startup re-indexing logic
+
+### Phase 2: Code Cleanup
+1. Delete FAISS service and repository implementation files
+2. Remove any remaining FAISS imports or references
+3. Update documentation and examples
+
+### Phase 3: Validation
+1. Run full test suite with DocumentDB backend
+2. Verify search functionality works correctly
+3. Confirm reduced deployment complexity
+
+## Risk Mitigation
+
+### Potential Issues
+
+1. **Missing Features**: Ensure DocumentDB implementation covers all FAISS features
+   - **Mitigation**: Thorough comparison of interfaces and functionality
+
+2. **Performance Degradation**: DocumentDB might be slower than in-memory FAISS
+   - **Mitigation**: DocumentDB native vector search is optimized and persistent
+
+3. **Deployment Issues**: Dependencies on FAISS might be deeper than expected
+   - **Mitigation**: Comprehensive search for imports and references
+
+### Rollback Strategy
+
+If issues are discovered after deployment:
+1. Reintroduce FAISS dependencies in `pyproject.toml`
+2. Restore factory logic to conditionally instantiate FAISS or DocumentDB repositories
+3. Reinstate FAISS service and repository implementation files
+4. This provides a rapid rollback path while root cause is investigated
+
+## Testing Approach
+
+### Unit Tests
+- Verify factory always returns DocumentDBSearchRepository
+- Confirm all search repository interface methods work correctly
+- Test search functionality with various query types
+
+### Integration Tests
+- Test semantic search API endpoints
+- Verify hybrid search with keyword and vector queries
+- Confirm result ranking and scoring work as expected
+
+### Performance Tests
+- Compare search response times before and after changes
+- Validate that DocumentDB implementation meets performance requirements
+
+### Deployment Tests
+- Test container build process without FAISS
+- Verify reduced image size and build time
+- Confirm no runtime errors related to missing FAISS
+
+## Expected Outcomes
+
+### Positive Impacts
+- **Reduced Complexity**: Single search implementation to maintain
+- **Simplified Deployment**: Smaller container images, fewer dependencies
+- **Improved Reliability**: Persistent indexes that survive restarts
+- **Better Maintainability**: Leverage database-native vector search capabilities
+
+### Neutral Impacts
+- **Functionality**: Equivalent search capabilities through DocumentDB
+- **API Compatibility**: No changes to existing search endpoints
+- **Performance**: Comparable or improved search performance
+
+### Potential Negative Impacts
+- **Initial Deployment Risk**: Possibility of undiscovered FAISS dependencies
+- **Compatibility**: Risk of subtle differences in search behavior
+- **Rollback Complexity**: Need to coordinate rollback if issues arise
+
+## Success Metrics
+
+1. **Build Success**: Container builds without FAISS dependency
+2. **Deployment Success**: Service starts without FAISS-related errors
+3. **Functional Parity**: All search functionality works identically
+4. **Performance Maintenance**: Search response times remain acceptable
+5. **Test Coverage**: All existing tests pass with DocumentDB backend
+6. **Documentation Accuracy**: Updated docs reflect FAISS removal
+
+## Timeline
+
+### Estimate: 2-3 days
+
+#### Day 1: Implementation
+- Remove dependencies and configuration
+- Update factory pattern
+- Remove FAISS-specific startup logic
+- Initial testing
+
+#### Day 2: Code Cleanup and Testing
+- Delete FAISS implementation files
+- Remove remaining references
+- Run full test suite
+- Performance validation
+
+#### Day 3: Documentation and Final Validation
+- Update documentation
+- Final integration testing
+- Deployment validation
+- Pull request preparation
+
+This timeline assumes no major issues are discovered during implementation and testing phases.

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,73 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "qwen.qwen3-coder-480b-a35b-instruct",
+  "model_slug": "qwen.qwen3-coder-480b-a35b-instruct",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4000",
+  "aws_region": null,
+  "artifacts_produced": 4,
+  "artifacts_expected": 4,
+  "generation_tokens_per_sec": 4.6,
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5448933,
+    "output_tokens": 4999,
+    "cache_read_tokens": 832,
+    "cache_write_tokens": 0,
+    "latency_seconds": 1091.9,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 4.6,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "claude_api.usage.input_tokens",
+      "output_tokens": "claude_api.usage.output_tokens",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5448933,
+  "output_tokens": 4999,
+  "latency_seconds": 1091.9,
+  "num_turns": 56,
+  "total_cost_usd": 31.862667000000002,
+  "is_error": false,
+  "session_id": "7811a396-220f-4c98-9437-f58fa068c90c",
+  "cache_read_tokens": 832,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-07-25T00:04:26.599605Z",
+  "run_ended_at": "2026-07-25T00:22:39.092139Z",
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/review.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/review.md
@@ -1,0 +1,136 @@
+# Expert Review: Remove FAISS Dependency
+
+## Review Summary
+
+This review examines the proposal to remove the FAISS dependency from the MCP Gateway Registry in favor of the existing DocumentDB hybrid search implementation. The analysis concludes that this is a sound architectural decision that will simplify the codebase while maintaining equivalent functionality.
+
+## Technical Assessment
+
+### Architecture Evaluation
+
+**Strengths of the Proposal:**
+1. **Simplified Architecture**: Moving to a single search implementation reduces complexity and maintenance overhead
+2. **Native Database Capabilities**: Leveraging DocumentDB's native vector search with HNSW indexes is more robust than the in-memory FAISS approach
+3. **Persistence Benefits**: DocumentDB indexes survive service restarts, eliminating the need for costly index rebuilds on every startup
+4. **Reduced Dependencies**: Removing the `faiss-cpu` dependency simplifies the build process and reduces attack surface
+
+**Correctness of Analysis:**
+The technical analysis correctly identifies that the DocumentDB implementation provides equivalent functionality:
+- Vector similarity search with cosine similarity
+- Hybrid search combining keywords and vectors
+- Reciprocal Rank Fusion for result ranking
+- Support for all entity types (servers, agents, skills)
+
+### Implementation Approach
+
+**Factory Pattern Simplification:**
+The proposed approach to simplify the repository factory is appropriate:
+```python
+# Current (conditional)
+if backend in MONGODB_BACKENDS:
+    # DocumentDB
+else:
+    # FAISS
+
+# Proposed (simplified)
+# Always DocumentDB
+```
+
+This change correctly eliminates the branching logic while maintaining the abstraction layer.
+
+**Startup Process Improvements:**
+Removing the FAISS-specific index rebuilding logic at startup is a significant improvement:
+- Eliminates time-consuming re-indexing operations
+- Reduces memory usage during startup
+- Simplifies error handling paths
+
+### Risk Analysis
+
+**Identified Risks:**
+1. **Undiscovered Dependencies**: There may be indirect dependencies on FAISS throughout the codebase
+2. **Performance Characteristics**: DocumentDB vector search performance compared to in-memory FAISS
+3. **Subtle Behavioral Differences**: Minor differences in search result ordering or scoring
+
+**Risk Mitigation:**
+The proposal correctly identifies mitigations:
+- Comprehensive search for imports and references
+- Performance testing to validate response times
+- Clear rollback strategy
+
+### Missing Considerations
+
+**Additional Recommendations:**
+1. **Configuration Validation**: Add validation to reject `storage_backend=file` with clear error messaging
+2. **Metrics Updates**: Update metrics and logging to remove FAISS-specific references
+3. **Interface Consolidation**: Consider if `SearchRepositoryBase` interface can be simplified now that there's only one implementation
+
+## Security Assessment
+
+### Dependency Reduction Benefits
+Removing `faiss-cpu` eliminates potential security vulnerabilities associated with this dependency:
+- Reduces attack surface
+- Eliminates need to track FAISS security advisories
+- Simplifies vulnerability scanning results
+
+### No Regressions Identified
+The DocumentDB implementation does not introduce new security concerns beyond those already present in the existing codebase.
+
+## Performance Assessment
+
+### Advantages of DocumentDB Approach
+1. **Persistent Indexes**: No rebuild cost on startup, immediate search availability
+2. **Scalability**: Database-managed indexes can scale beyond memory constraints
+3. **Consistency**: Production workloads already use DocumentDB implementation
+
+### Areas for Verification
+1. **Query Latency**: Ensure DocumentDB vector search response times meet SLAs
+2. **Concurrent Load**: Validate performance under typical concurrent search loads
+3. **Index Update Performance**: Confirm incremental index updates are efficient
+
+## Operational Assessment
+
+### Deployment Simplification
+The removal of FAISS provides significant operational benefits:
+- Smaller container images
+- Faster build times
+- Fewer platform compatibility issues
+- Reduced dependency management overhead
+
+### Monitoring Considerations
+With only one search implementation, monitoring and alerting can be simplified:
+- Consolidated metrics for search performance
+- Reduced dashboard complexity
+- Clearer error correlation
+
+## Recommendation
+
+**Approved with Minor Additions**
+
+This is a solid architectural improvement that should be implemented. The analysis is thorough and the approach is sound.
+
+### Recommended Additions to Implementation Plan:
+
+1. **Configuration Validation**: Add explicit validation that rejects `file` storage backend with a clear error message directing users to use DocumentDB-compatible backends.
+
+2. **Interface Audit**: Review `SearchRepositoryBase` interface to determine if it can be simplified now that there's only one implementation.
+
+3. **Metric Updates**: Update any metrics or logging statements that specifically reference FAISS or distinguish between search backends.
+
+4. **Documentation Updates**: Ensure all documentation, README files, and example configurations are updated to reflect the FAISS removal and DocumentDB requirement.
+
+### Testing Emphasis:
+Pay special attention to validating that search behavior remains exactly equivalent, particularly:
+- Result ordering and scoring
+- Edge case handling
+- Error conditions and timeouts
+
+The rollback strategy is adequate but should be tested in a staging environment before production deployment.
+
+## Conclusion
+
+Removing the FAISS dependency is a beneficial change that aligns with modern architectural principles:
+- Favoring database-native capabilities over custom implementations
+- Reducing complexity through consolidation
+- Improving operational characteristics
+
+The implementation approach is well-planned with appropriate risk mitigation strategies. Proceed with implementation while incorporating the minor additions suggested above.

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/testing.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/remove-faiss/testing.md
@@ -1,0 +1,299 @@
+# Testing Plan: Remove FAISS Dependency
+
+## Overview
+
+This document outlines the comprehensive testing strategy for removing the FAISS dependency from the MCP Gateway Registry while ensuring all semantic search functionality continues to work correctly with the DocumentDB hybrid search implementation.
+
+## Test Categories
+
+### 1. Unit Testing
+
+#### Factory Pattern Tests
+- **Objective**: Verify that `get_search_repository()` always returns `DocumentDBSearchRepository`
+- **Test Cases**:
+  - Factory returns correct implementation type
+  - Factory returns singleton instance on subsequent calls
+  - Proper logging occurs during instantiation
+- **Files**: `tests/unit/test_repository_factory.py`
+
+#### Search Repository Interface Tests
+- **Objective**: Ensure `DocumentDBSearchRepository` implements all required interface methods
+- **Test Cases**:
+  - All interface methods are implemented
+  - Method signatures match interface expectations
+  - Return types are correct
+- **Files**: `tests/unit/test_search_repository_interface.py`
+
+#### Configuration Tests
+- **Objective**: Verify that FAISS-specific configuration has been removed properly
+- **Test Cases**:
+  - FAISS-specific properties are removed from settings
+  - Storage backend validation works correctly
+  - Default behavior is preserved
+- **Files**: `tests/unit/test_config.py`
+
+### 2. Integration Testing
+
+#### Semantic Search API Tests
+- **Objective**: Validate that semantic search endpoints work correctly
+- **Test Cases**:
+  - `/api/search/semantic` endpoint accepts queries and returns results
+  - Various query types are handled (simple text, complex phrases)
+  - Query parameters are processed correctly
+  - Error handling for malformed requests
+- **Files**: `tests/integration/test_search_api.py`
+
+#### Entity-Specific Search Tests
+- **Objective**: Ensure search works for all entity types
+- **Test Cases**:
+  - Server search functionality
+  - Agent search functionality
+  - Skill search functionality
+  - Mixed entity type results
+- **Files**: `tests/integration/test_entity_search.py`
+
+#### Index Operations Tests
+- **Objective**: Validate search index management operations
+- **Test Cases**:
+  - Indexing new servers/agents/skills
+  - Updating existing entities in the index
+  - Removing entities from the index
+  - Bulk indexing operations
+- **Files**: `tests/integration/test_index_operations.py`
+
+#### Hybrid Search Tests
+- **Objective**: Verify hybrid search (vector + keyword) functionality
+- **Test Cases**:
+  - Pure vector search results
+  - Pure keyword search results
+  - Combined hybrid search results
+  - Reciprocal Rank Fusion (RRF) scoring
+- **Files**: `tests/integration/test_hybrid_search.py`
+
+### 3. Performance Testing
+
+#### Search Response Time Tests
+- **Objective**: Ensure search performance meets requirements
+- **Test Cases**:
+  - Single query response times (< 500ms target)
+  - Concurrent query handling (10, 50, 100 concurrent users)
+  - Large result set performance
+  - Complex query performance
+- **Tools**: Locust, Apache Bench, or custom performance test suite
+
+#### Index Operation Performance Tests
+- **Objective**: Validate indexing operations are efficient
+- **Test Cases**:
+  - Bulk indexing throughput
+  - Incremental update performance
+  - Index rebuild time (if applicable)
+  - Memory usage during operations
+- **Tools**: Custom benchmark scripts
+
+#### Startup Performance Tests
+- **Objective**: Confirm improved startup times without FAISS rebuild
+- **Test Cases**:
+  - Cold start time measurement
+  - Warm start time measurement
+  - Comparison with pre-change baseline
+- **Tools**: Timing scripts, application metrics
+
+### 4. Regression Testing
+
+#### Existing Feature Tests
+- **Objective**: Ensure no existing features are broken
+- **Test Cases**:
+  - All CRUD operations for servers/agents/skills
+  - Authentication and authorization flows
+  - Federation functionality
+  - Health check endpoints
+  - API compatibility with existing clients
+- **Files**: Full existing test suite (`tests/regression/`)
+
+#### Search Quality Tests
+- **Objective**: Verify search result quality equivalence
+- **Test Cases**:
+  - Result relevance comparison with baseline
+  - Ranking consistency validation
+  - Edge case query handling
+  - Special character and unicode support
+- **Files**: `tests/regression/test_search_quality.py`
+
+### 5. Deployment Testing
+
+#### Build Process Tests
+- **Objective**: Verify container builds succeed without FAISS
+- **Test Cases**:
+  - Docker image builds successfully
+  - Image size reduction verification
+  - Dependency installation completeness
+  - No FAISS-related build errors or warnings
+- **Tools**: CI/CD pipeline validation
+
+#### Runtime Environment Tests
+- **Objective**: Confirm service operates correctly in target environments
+- **Test Cases**:
+  - Container starts without errors
+  - All endpoints are accessible
+  - Health checks pass
+  - Logging functions correctly
+- **Environments**: Development, staging, and production-like environments
+
+#### Configuration Tests
+- **Objective**: Validate configuration handling without FAISS
+- **Test Cases**:
+  - Environment variable handling
+  - Configuration file parsing
+  - Default value assignments
+  - Error messages for invalid configurations
+- **Files**: `tests/deployment/test_configuration.py`
+
+### 6. Security Testing
+
+#### Dependency Vulnerability Tests
+- **Objective**: Verify reduced attack surface
+- **Test Cases**:
+  - Dependency scan shows FAISS is removed
+  - No new vulnerabilities introduced
+  - Security scanning tools pass
+- **Tools**: Snyk, OWASP Dependency Check, or similar
+
+#### Input Validation Tests
+- **Objective**: Confirm search input validation is maintained
+- **Test Cases**:
+  - SQL injection prevention
+  - XSS protection in search results
+  - Input length restrictions
+  - Malformed query handling
+- **Files**: `tests/security/test_input_validation.py`
+
+## Test Execution Phases
+
+### Phase 1: Pre-Implementation Baseline
+- Run full existing test suite to establish baseline
+- Capture performance metrics with current FAISS implementation
+- Document current behavior for regression comparison
+
+### Phase 2: Implementation Verification
+- Run unit tests for factory pattern and configuration changes
+- Verify build process works with FAISS dependencies removed
+- Execute integration tests for basic search functionality
+
+### Phase 3: Comprehensive Testing
+- Run full integration test suite
+- Execute performance tests and compare with baseline
+- Validate deployment in staging environment
+- Run security scans and vulnerability assessments
+
+### Phase 4: Production Validation
+- Canary deployment with limited traffic
+- Monitor metrics and error rates
+- Gradual rollout with continuous monitoring
+- Full roll-forward confirmation
+
+## Test Data Requirements
+
+### Sample Entities
+- **Servers**: 100+ sample MCP servers with varying descriptions
+- **Agents**: 50+ sample A2A agents with different capabilities
+- **Skills**: 75+ sample skills with diverse metadata
+
+### Query Types
+- **Simple Queries**: Single words, common phrases
+- **Complex Queries**: Multi-word phrases, technical terms
+- **Edge Cases**: Empty queries, very long queries, special characters
+- **Negative Cases**: Malformed input, injection attempts
+
+### Performance Test Data
+- **Volume**: Large dataset for stress testing
+- **Variety**: Diverse entity types and content
+- **Velocity**: High-concurrency simulation
+
+## Automation Strategy
+
+### CI/CD Pipeline Integration
+- Unit tests integrated in every build
+- Integration tests run on pull requests
+- Performance tests triggered for major changes
+- Security scans run weekly or on dependency updates
+
+### Monitoring During Deployment
+- Real-time metric monitoring
+- Automated alerting for anomalies
+- Gradual rollout with rollback capability
+- User impact monitoring
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] All existing search functionality works identically
+- [ ] No regression in API response formats
+- [ ] Error handling behaves consistently
+- [ ] Authentication and authorization are preserved
+
+### Performance Requirements
+- [ ] Search response times ≤ baseline +/- 10%
+- [ ] Indexing operations complete within acceptable timeframes
+- [ ] Startup time is improved (no FAISS rebuild required)
+- [ ] Memory usage is within acceptable limits
+
+### Deployment Requirements
+- [ ] Container builds successfully without errors
+- [ ] All environments deploy without issues
+- [ ] Health checks pass in all environments
+- [ ] No runtime errors related to missing dependencies
+
+### Quality Requirements
+- [ ] Test coverage maintained or improved
+- [ ] No critical or high-severity bugs introduced
+- [ ] Security scan passes with reduced vulnerabilities
+- [ ] Documentation accuracy verified
+
+## Rollback Validation
+
+### Pre-Change Preparation
+- [ ] Backup current working implementation
+- [ ] Document rollback procedure
+- [ ] Validate rollback mechanism in test environment
+
+### Rollback Testing
+- [ ] Verify rollback process is smooth and reliable
+- [ ] Confirm functionality is restored exactly as before
+- [ ] Validate no data loss during rollback
+- [ ] Test rollback speed meets SLA requirements
+
+## Monitoring and Observability
+
+### Key Metrics to Monitor
+1. **Search Performance**: Response time, throughput, error rate
+2. **Index Operations**: Indexing success rate, operation duration
+3. **Resource Usage**: CPU, memory, disk I/O patterns
+4. **Availability**: Uptime, health check pass rate
+5. **User Impact**: API success rate, latency percentiles
+
+### Alerting Thresholds
+- Search response time > 1000ms (critical)
+- Search response time > 500ms (warning)
+- Indexing failure rate > 1% (warning)
+- 5xx errors from search endpoints > 0.1% (warning)
+
+### Dashboard Updates
+- Update existing dashboards to remove FAISS-specific metrics
+- Focus dashboards on DocumentDB search performance
+- Maintain comparative views where useful
+
+## Test Deliverables
+
+### Documentation Outputs
+1. **Test Report**: Comprehensive results from all test phases
+2. **Performance Benchmark**: Before/after comparison with metrics
+3. **Deployment Guide**: Updated procedures for deploying without FAISS
+4. **Monitoring Guide**: Updated observability configuration
+
+### Code Outputs
+1. **Unit Tests**: Updated test suite for factory and configuration
+2. **Integration Tests**: Complete test coverage for search functionality
+3. **Performance Tests**: Scripts for ongoing performance validation
+4. **Regression Tests**: Ensuring continued functionality
+
+This comprehensive testing plan ensures that the FAISS removal is thoroughly validated while maintaining all existing functionality and quality standards.

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/github-issue.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/github-issue.md
@@ -1,0 +1,47 @@
+# GitHub Issue: Replace Keycloak Database Password Authentication with RDS IAM Authentication
+
+## Title
+Replace Keycloak Database Password Authentication with RDS IAM Authentication
+
+## Labels
+- enhancement
+- infra
+- security
+
+## Description
+
+### Problem Statement
+Currently, Keycloak connects to its Aurora MySQL database using static username/password credentials stored in AWS Secrets Manager. This approach requires manual password rotation and presents security risks associated with long-lived credentials. To improve security posture and align with AWS best practices, we should migrate to RDS IAM database authentication which provides short-lived, automatically rotated credentials.
+
+### Proposed Solution
+1. Enable IAM database authentication on the Aurora MySQL cluster
+2. Modify the Keycloak ECS task to generate short-lived IAM auth tokens via `rds:GenerateDBAuthToken`
+3. Update IAM roles/policies to grant the necessary permissions
+4. Remove static database credentials from AWS Secrets Manager configuration
+5. Maintain backward compatibility with password authentication as a feature-flagged fallback
+
+### User Stories
+- As an operator deploying on AWS ECS + RDS (Terraform), I want to use IAM authentication for Keycloak database connections to improve security.
+- As a security engineer, I want to eliminate static database credentials to reduce the attack surface.
+- As an operator, I want the ability to fall back to password authentication if needed during migration.
+
+### Acceptance Criteria
+- [ ] IAM database authentication is enabled on the Aurora MySQL cluster
+- [ ] Keycloak ECS task generates short-lived IAM auth tokens for database connections
+- [ ] IAM roles/policies are updated to allow `rds:GenerateDBAuthToken`
+- [ ] Static database password is removed from Secrets Manager configuration
+- [ ] Password authentication remains available as a feature-flagged fallback
+- [ ] Backward compatibility is maintained during transition
+
+### Out of Scope
+- Changing the Keycloak version
+- Modifying other database configurations beyond the authentication mechanism
+- Helm/EKS deployment configurations (focus on ECS/RDS/Terraform only)
+
+### Dependencies
+- AWS RDS Aurora MySQL cluster
+- Keycloak ECS service
+- Existing Terraform infrastructure
+
+### Related Issues
+- None

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/lld.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/lld.md
@@ -1,0 +1,496 @@
+# Low-Level Design: Replace Keycloak Database Password Authentication with RDS IAM Authentication
+
+*Created: 2026-07-25*
+*Author: Claude*
+*Status: Draft*
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Codebase Analysis](#codebase-analysis)
+3. [Architecture](#architecture)
+4. [Data Models](#data-models)
+5. [API / CLI Design](#api--cli-design)
+6. [Configuration Parameters](#configuration-parameters)
+7. [New Dependencies](#new-dependencies)
+8. [Implementation Details](#implementation-details)
+9. [Observability](#observability)
+10. [Scaling Considerations](#scaling-considerations)
+11. [File Changes](#file-changes)
+12. [Testing Strategy](#testing-strategy)
+13. [Alternatives Considered](#alternatives-considered)
+14. [Rollout Plan](#rollout-plan)
+
+## Overview
+### Problem Statement
+Currently, Keycloak connects to its Aurora MySQL database using static username/password credentials stored in AWS Secrets Manager. This approach requires manual password rotation and presents security risks associated with long-lived credentials. To improve security posture and align with AWS best practices, we should migrate to RDS IAM database authentication which provides short-lived, automatically rotated credentials.
+
+### Goals
+- Enable IAM database authentication on the Aurora MySQL cluster
+- Modify Keycloak ECS task to generate short-lived IAM auth tokens
+- Remove static database credentials from Secrets Manager
+- Maintain backward compatibility with password authentication as a feature-flagged fallback
+- Improve security by eliminating static database credentials
+
+### Non-Goals
+- Changing the Keycloak version
+- Modifying other database configurations beyond the authentication mechanism
+- Supporting Helm/EKS deployments (focus on ECS/RDS/Terraform only)
+
+## Codebase Analysis
+
+### Key Files Reviewed
+
+| File/Directory | Purpose | Relevance to This Change |
+|----------------|---------|--------------------------|
+| `terraform/aws-ecs/keycloak-database.tf` | Defines Aurora MySQL cluster and RDS proxy | Need to enable IAM database authentication |
+| `terraform/aws-ecs/keycloak-ecs.tf` | Defines ECS task definition and IAM roles | Need to modify IAM policies and task secrets |
+| `terraform/aws-ecs/variables.tf` | Defines Terraform variables | May need new variables for IAM auth |
+| `keycloak/` | Keycloak setup and documentation | Understanding current auth mechanism |
+
+### Existing Patterns Identified
+1. **Secrets Management Pattern**: Currently using AWS Secrets Manager to store database credentials with ECS injecting them as environment variables
+   - Files: `keycloak-database.tf`, `keycloak-ecs.tf`
+   - How a future implementer should follow this: Continue using Secrets Manager for feature flag but add IAM auth as alternative
+
+2. **Feature Flag Pattern**: Using boolean flags to toggle functionality
+   - Files: Various Terraform configurations use conditional blocks
+   - How a future implementer should follow this: Add a new variable to enable/disable IAM authentication
+
+### Integration Points
+
+| Component | Integration Type | Details |
+|-----------|------------------|---------|
+| Aurora MySQL Cluster | Modified | Enable IAM database authentication property |
+| RDS Proxy | Modified | Update IAM authentication settings |
+| ECS Task Definition | Modified | Change how database credentials are sourced |
+| IAM Policies | Added | Grant `rds:GenerateDBAuthToken` permission |
+| Secrets Manager | Modified | Conditionally used based on feature flag |
+
+### Constraints and Limitations Discovered
+- Keycloak must support MySQL IAM authentication (supported in Keycloak 25+)
+- Cannot break existing deployments during transition
+- ECS tasks need appropriate IAM permissions to generate auth tokens
+- Aurora MySQL version must support IAM authentication
+
+## Architecture
+
+### System Context Diagram
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        AWS Environment                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌─────────────┐    ┌──────────────┐    ┌──────────────────┐   │
+│  │   Keycloak  │    │     ECS      │    │  IAM Auth Token  │   │
+│  │   Service   │◄──►│    Task      │◄──►│   Generation     │   │
+│  │             │    │              │    │                  │   │
+│  └─────────────┘    └──────────────┘    └──────────────────┘   │
+│                         │                            │         │
+│                         ▼                            ▼         │
+│                 ┌──────────────┐    ┌─────────────────────┐    │
+│                 │ RDS Database │    │  IAM Authentication │    │
+│                 │  (Aurora)    │◄──►│     Policies        │    │
+│                 │              │    │                     │    │
+│                 └──────────────┘    └─────────────────────┘    │
+│                         │                            │         │
+│                         ▼                            │         │
+│                 ┌──────────────┐                     │         │
+│                 │ Secrets Mgr  │                     │         │
+│                 │  (fallback)  │◄────────────────────┘         │
+│                 │              │                               │
+│                 └──────────────┘                               │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Sequence Diagram
+```
+1. ECS Task Starts
+   │
+   ├─ Check feature flag: iam_auth_enabled
+   │
+   ├─ If True:
+   │  ├─ Assume IAM role with rds:GenerateDBAuthToken permission
+   │  ├─ Generate temporary auth token for database user
+   │  ├─ Connect to Aurora MySQL using IAM token
+   │  └─ Proceed with Keycloak startup
+   │
+   └─ If False (fallback):
+      ├─ Retrieve username/password from Secrets Manager
+      ├─ Connect to Aurora MySQL using traditional auth
+      └─ Proceed with Keycloak startup
+```
+
+### Component Diagram
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              Terraform Module                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────┐ │
+│  │   Aurora MySQL      │    │     RDS Proxy       │    │  ECS Task Def   │ │
+│  │   Cluster           │    │                     │    │                 │ │
+│  │                     │    │                     │    │  ┌────────────┐ │ │
+│  │ ┌─────────────────┐ │    │ ┌─────────────────┐ │    │  │ Keycloak   │ │ │
+│  │ │ IAM Auth: True  │ │◄──►│ │ IAM Auth: True  │ │◄──►│  │ Container  │ │ │
+│  │ └─────────────────┘ │    │ └─────────────────┘ │    │  └────────────┘ │ │
+│  │                     │    │                     │    │                 │ │
+│  └─────────────────────┘    └─────────────────────┘    └─────────────────┘ │
+│                                  │                           │             │
+│                                  ▼                           ▼             │
+│                        ┌─────────────────────┐    ┌─────────────────────┐  │
+│                        │  IAM Role/Policies  │    │  Secrets Manager    │  │
+│                        │                     │    │  (fallback)         │  │
+│                        │ ┌─────────────────┐ │    │                     │  │
+│                        │ │ Generate Token  │ │    │ ┌─────────────────┐ │  │
+│                        │ │ Permission      │ │    │ │ Username        │ │  │
+│                        │ └─────────────────┘ │    │ │ Password        │ │  │
+│                        └─────────────────────┘    │ └─────────────────┘ │  │
+│                                                   └─────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Data Models
+
+### New Models
+No new data models required as this is an infrastructure-level change.
+
+### Model Changes
+No existing model changes required. This is a configuration and infrastructure change.
+
+## API / CLI Design
+
+### New Endpoints / Commands
+Not applicable - this is an infrastructure change that affects how Keycloak connects to its database.
+
+## Configuration Parameters
+
+### New Environment Variables
+
+| Variable Name | Type | Default | Required | Description |
+|---------------|------|---------|----------|-------------|
+| `KEYCLOAK_DB_IAM_AUTH_ENABLED` | bool | `false` | No | Enable IAM database authentication for Keycloak |
+
+### Settings / Config Class Updates
+No new settings needed at the application level. This is handled entirely through Terraform and ECS configuration.
+
+### Deployment Surface Checklist
+List every surface where this parameter must appear (`.env.example`, `docker-compose.yml`, Terraform vars, Helm values, etc.) so an implementer can tick them off later.
+- [ ] Terraform variables (`variables.tf`)
+- [ ] Terraform terraform.tfvars.example
+- [ ] Keycloak ECS task definition environment variables
+
+## New Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| AWS CLI | Latest | Required for generating RDS IAM auth tokens |
+| mysql-client | Latest | Required for Keycloak to connect with IAM tokens |
+
+If no new dependencies are required, explicitly state: "This change uses only existing dependencies."
+
+## Implementation Details
+
+### Step-by-Step Plan (for a future implementer)
+
+#### Step 1: Enable IAM Database Authentication on Aurora MySQL
+**File:** `terraform/aws-ecs/keycloak-database.tf`
+**Lines:** ~48 (in `aws_rds_cluster.keycloak` resource)
+
+```hcl
+resource "aws_rds_cluster" "keycloak" {
+  # ... existing configuration ...
+
+  # Enable IAM database authentication
+  enable_iam_database_authentication = var.keycloak_database_iam_auth_enabled
+
+  # ... rest of existing configuration ...
+}
+```
+
+Also update the RDS proxy configuration to support IAM authentication:
+**Lines:** ~14 (in `aws_db_proxy.keycloak` resource)
+
+```hcl
+resource "aws_db_proxy" "keycloak" {
+  # ... existing configuration ...
+
+  auth {
+    auth_scheme               = "SECRETS"
+    secret_arn                = aws_secretsmanager_secret.keycloak_db_secret.arn
+    client_password_auth_type = "MYSQL_CACHING_SHA2_PASSWORD"
+    iam_auth                  = var.keycloak_database_iam_auth_enabled ? "REQUIRED" : "DISABLED"
+  }
+
+  # ... rest of existing configuration ...
+}
+```
+
+#### Step 2: Add New Terraform Variable
+**File:** `terraform/aws-ecs/variables.tf`
+
+```hcl
+variable "keycloak_database_iam_auth_enabled" {
+  description = "Enable IAM database authentication for Keycloak"
+  type        = bool
+  default     = false
+}
+```
+
+#### Step 3: Update IAM Policies for ECS Task
+**File:** `terraform/aws-ecs/keycloak-ecs.tf`
+**Lines:** ~173 (in `aws_iam_role_policy.keycloak_task_exec_ssm_policy` resource)
+
+```hcl
+resource "aws_iam_role_policy" "keycloak_task_exec_ssm_policy" {
+  name = "keycloak-task-exec-ssm-policy"
+  role = aws_iam_role.keycloak_task_exec_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # ... existing statements ...
+      {
+        # Allow generation of RDS IAM auth tokens when IAM auth is enabled
+        Effect = "Allow"
+        Action = [
+          "rds:GenerateDBAuthToken"
+        ],
+        Resource = [
+          aws_rds_cluster.keycloak.arn
+        ]
+      }
+    ]
+  })
+}
+```
+
+#### Step 4: Modify ECS Task Definition for Conditional Credential Handling
+**File:** `terraform/aws-ecs/keycloak-ecs.tf`
+**Lines:** ~15-106 (in `locals` block)
+
+Update the local variables to conditionally handle credentials:
+
+```hcl
+locals {
+  # ... existing configuration ...
+
+  # Conditionally determine database credentials based on IAM auth setting
+  keycloak_container_secrets = concat([
+    {
+      name      = "KEYCLOAK_ADMIN"
+      valueFrom = aws_ssm_parameter.keycloak_admin.arn
+    },
+    {
+      name      = "KEYCLOAK_ADMIN_PASSWORD"
+      valueFrom = aws_ssm_parameter.keycloak_admin_password.arn
+    },
+    {
+      name      = "KC_DB_URL"
+      valueFrom = aws_ssm_parameter.keycloak_database_url.arn
+    }
+  ], var.keycloak_database_iam_auth_enabled ? [
+    # When IAM auth is enabled, only pass the username
+    {
+      name      = "KC_DB_USERNAME"
+      valueFrom = "${aws_secretsmanager_secret.keycloak_db_secret.arn}:username::"
+    }
+    # Password will be generated dynamically by Keycloak
+  ] : [
+    # When IAM auth is disabled, pass both username and password (legacy mode)
+    {
+      name      = "KC_DB_USERNAME"
+      valueFrom = "${aws_secretsmanager_secret.keycloak_db_secret.arn}:username::"
+    },
+    {
+      name      = "KC_DB_PASSWORD"
+      valueFrom = "${aws_secretsmanager_secret.keycloak_db_secret.arn}:password::"
+    }
+  ])
+
+  # Add feature flag environment variable
+  keycloak_container_env = concat(local._keycloak_container_env_base, [
+    {
+      name  = "KEYCLOAK_DB_IAM_AUTH_ENABLED"
+      value = var.keycloak_database_iam_auth_enabled ? "true" : "false"
+    }
+  ])
+
+  # Store base environment variables separately to avoid circular references
+  _keycloak_container_env_base = [
+    {
+      name  = "AWS_REGION"
+      value = var.aws_region
+    },
+    # ... rest of existing environment variables ...
+  ]
+}
+```
+
+#### Step 5: Create Custom Keycloak Image with IAM Auth Support
+Since Keycloak needs additional tools to generate IAM auth tokens, we'll need a custom image:
+
+**File:** `docker/keycloak/Dockerfile` (new file)
+
+```dockerfile
+FROM quay.io/keycloak/keycloak:25.0
+
+# Install AWS CLI for IAM auth token generation
+USER root
+RUN microdnf install -y python3 python3-pip && \
+    pip3 install awscli && \
+    microdnf clean all
+
+# Copy custom startup script
+COPY docker/keycloak/scripts/start-keycloak.sh /opt/keycloak/bin/start-keycloak.sh
+RUN chmod +x /opt/keycloak/bin/start-keycloak.sh
+
+USER keycloak
+ENTRYPOINT ["/opt/keycloak/bin/start-keycloak.sh"]
+CMD ["start"]
+```
+
+**File:** `docker/keycloak/scripts/start-keycloak.sh` (new file)
+
+```bash
+#!/bin/bash
+
+# If IAM auth is enabled, generate temporary auth token
+if [ "$KEYCLOAK_DB_IAM_AUTH_ENABLED" = "true" ]; then
+  echo "Generating RDS IAM authentication token..."
+
+  # Extract DB host from JDBC URL
+  DB_HOST=$(echo "$KC_DB_URL" | sed -E 's/jdbc:mysql:\/\/([^:]+):.*/\1/')
+
+  # Generate auth token
+  KC_DB_PASSWORD=$(aws rds generate-db-auth-token \
+    --hostname $DB_HOST \
+    --port 3306 \
+    --region $AWS_REGION \
+    --username $KC_DB_USERNAME)
+
+  export KC_DB_PASSWORD
+fi
+
+# Start Keycloak
+exec /opt/keycloak/bin/kc.sh "$@"
+```
+
+#### Step 6: Update Keycloak Image URI in Terraform
+**File:** `terraform/aws-ecs/variables.tf`
+
+```hcl
+variable "keycloak_image_uri" {
+  description = "Container image URI for Keycloak. Defaults to custom image with IAM auth support."
+  type        = string
+  default     = ""  # Will be set to custom ECR image
+}
+```
+
+### Error Handling
+1. IAM authentication token generation failures should fall back to password authentication
+2. Log appropriate error messages when IAM auth fails
+3. Ensure graceful degradation to password authentication when needed
+
+### Logging
+1. Log when IAM authentication is enabled/disabled
+2. Log successful token generation
+3. Log fallback to password authentication
+4. Log any errors during token generation
+
+## Observability
+### Tracing / Metrics / Logging Points
+- Log IAM authentication status at startup
+- Log successful token generation events
+- Log fallback to password authentication
+- Monitor database connection success/failure rates
+- Track authentication method usage in metrics
+
+## Scaling Considerations
+- Current load assumptions: Keycloak generates one token per container startup
+- Horizontal scaling: Each ECS task instance will generate its own auth token
+- Bottlenecks: RDS IAM token generation service limits (default: 5000 requests/sec)
+- Caching strategy: Tokens are short-lived (15 minutes), so no caching needed
+
+## File Changes
+
+### New Files
+
+| File Path | Description |
+|-----------|-------------|
+| `docker/keycloak/Dockerfile` | Custom Keycloak image with AWS CLI for IAM auth |
+| `docker/keycloak/scripts/start-keycloak.sh` | Custom startup script for dynamic token generation |
+
+### Modified Files
+
+| File Path | Lines | Change Description |
+|-----------|-------|--------------------|
+| `terraform/aws-ecs/keycloak-database.tf` | ~14, ~48 | Enable IAM database authentication on RDS cluster and proxy |
+| `terraform/aws-ecs/keycloak-ecs.tf` | ~15-106, ~173 | Update IAM policies and conditional credential handling |
+| `terraform/aws-ecs/variables.tf` | ~90, ~115 | Add new variable for IAM auth flag |
+| `terraform/aws-ecs/terraform.tfvars.example` | ~90 | Add example for new IAM auth variable |
+
+### Estimated Lines of Code
+
+| Category | Lines |
+|----------|-------|
+| New code | ~80 |
+| New tests | ~0 (infrastructure change) |
+| Modified code | ~30 |
+| **Total** | **~110** |
+
+## Testing Strategy
+See `./testing.md` for the complete testing plan.
+
+## Alternatives Considered
+
+### Alternative 1: Continue Using Password Authentication
+**Description:** Keep the current password-based authentication with Secrets Manager
+**Pros:**
+- No changes required
+- Proven approach
+- Simpler implementation
+**Cons:**
+- Security risks with static credentials
+- Manual rotation overhead
+- Doesn't follow AWS security best practices
+**Why Rejected:** Security improvements are a key goal of this initiative.
+
+### Alternative 2: Use IAM Database Authentication Without Fallback
+**Description:** Implement IAM auth but remove password authentication entirely
+**Pros:**
+- Stronger security posture
+- Simpler configuration
+- Eliminates password management entirely
+**Cons:**
+- Higher risk of breaking existing deployments
+- No fallback during issues
+- Harder rollback if problems occur
+**Why Rejected:** Backward compatibility and safe rollout are requirements.
+
+### Comparison Matrix
+
+| Criteria | Chosen | Alt 1 | Alt 2 |
+|----------|--------|-------|-------|
+| Security | High | Medium | High |
+| Complexity | Medium | Low | Low |
+| Backward Compatibility | Excellent | Excellent | Poor |
+| Risk | Low | Low | High |
+| Maintenance | Low | Medium | Low |
+
+## Rollout Plan
+- Phase 1: Implementation (out of scope for this skill)
+- Phase 2: Testing in development environment
+- Phase 3: Gradual rollout with feature flag
+- Phase 4: Monitoring and validation
+- Phase 5: Decommission password authentication (future)
+
+## Open Questions
+- Does Keycloak 25 officially support MySQL IAM authentication?
+- Are there any performance implications of generating auth tokens at startup?
+- Should we implement connection pooling for auth tokens?
+
+## References
+- [AWS RDS IAM Database Authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
+- [Keycloak Database Configuration](https://www.keycloak.org/server/db)
+- [Amazon Aurora MySQL IAM Authentication](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Security.html)

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,73 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "qwen.qwen3-coder-480b-a35b-instruct",
+  "model_slug": "qwen.qwen3-coder-480b-a35b-instruct",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4000",
+  "aws_region": null,
+  "artifacts_produced": 0,
+  "artifacts_expected": 4,
+  "generation_tokens_per_sec": 20.0,
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2195737,
+    "output_tokens": 17492,
+    "cache_read_tokens": 640,
+    "cache_write_tokens": 0,
+    "latency_seconds": 875.9,
+    "num_turns": 40,
+    "generation_tokens_per_sec": 20.0,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "claude_api.usage.input_tokens",
+      "output_tokens": "claude_api.usage.output_tokens",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2195737,
+  "output_tokens": 17492,
+  "latency_seconds": 875.9,
+  "num_turns": 40,
+  "total_cost_usd": 38.743648,
+  "is_error": false,
+  "session_id": "bddf7463-f675-46b8-83cc-4fdddefa4fcd",
+  "cache_read_tokens": 640,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-07-25T00:34:12.000368Z",
+  "run_ended_at": "2026-07-25T00:48:48.492246Z",
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/review.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/review.md
@@ -1,0 +1,253 @@
+# Expert Review: Replace Keycloak Database Password Authentication with RDS IAM Authentication
+
+*Created: 2026-07-25*
+
+## Reviews
+
+### Frontend Engineer Review (Pixel)
+
+#### Strengths
+1. Well-structured approach with clear documentation and artifact creation following established patterns
+2. Good consideration for backward compatibility with feature flag approach
+3. Comprehensive architecture diagrams that clearly show the system context and component relationships
+4. Clear separation of infrastructure concerns (Terraform) from application concerns
+5. Thoughtful rollout plan that minimizes risk through gradual deployment
+
+#### Concerns
+1. The design focuses heavily on infrastructure changes but doesn't address any potential frontend/UI aspects that might display database connection status or health information
+2. No consideration for monitoring/dashboarding of the new IAM authentication mechanism
+3. Missing user-facing documentation for operators who need to understand the new authentication method
+4. No discussion of how operators would troubleshoot IAM authentication issues
+
+#### New Dependencies
+1. AWS CLI - Required in the custom Keycloak container image for generating IAM auth tokens
+2. mysql-client - Required for Keycloak to connect with IAM tokens
+Neither dependency introduces significant security or maintenance overhead.
+
+#### Alternatives Considered
+1. Continue Using Password Authentication - This maintains status quo but misses security improvements
+2. Use IAM Database Authentication Without Fallback - This provides stronger security but increases risk during rollout
+
+The chosen approach with fallback provides an excellent balance between security improvement and operational safety.
+
+#### Recommendations
+1. Add monitoring dashboard/visualization for tracking successful vs failed IAM authentications
+2. Create operator documentation explaining how to monitor and troubleshoot the new authentication mechanism
+3. Consider exposing authentication method metrics through Keycloak's metrics endpoint if available
+4. Add health check endpoint differentiation between IAM and password authentication methods
+
+#### Questions for Author
+1. Are there any frontend/operator UI considerations for displaying the status of database connections with the new authentication method?
+2. Should we expose metrics about which authentication method is being used to operators?
+
+#### Verdict
+APPROVED
+
+The design is well-structured and addresses the core requirements effectively. While it's primarily an infrastructure change that doesn't directly impact frontend systems, it's important to consider operator experience and monitoring.
+
+### Backend Engineer Review (Byte)
+
+#### Strengths
+1. Well-architected solution that properly separates concerns between infrastructure (Terraform) and application components
+2. Good use of feature flags for backward compatibility and safe rollout
+3. Proper error handling approach with fallback to password authentication
+4. Secure credential management using existing AWS services (IAM roles, Secrets Manager)
+5. Clear implementation plan with step-by-step instructions for each component
+6. Comprehensive architecture diagrams that clearly illustrate the data flow
+
+#### Concerns
+1. The custom Keycloak Docker image approach adds maintenance overhead as it requires keeping up with Keycloak updates
+2. No consideration for connection pooling or reuse of IAM auth tokens (tokens are valid for 15 minutes but regenerated on each container start)
+3. Potential race conditions during rollout if some ECS tasks use IAM auth while others use password auth
+4. Missing consideration for how database user permissions need to be configured for IAM authentication
+5. No discussion of how to handle the database user principal in IAM (format: `arn:aws:sts::ACCOUNT-ID:assumed-role/ROLE-NAME/ROLE-SESSION-NAME`)
+
+#### New Dependencies
+1. AWS CLI - Required in the custom Keycloak container image for generating IAM auth tokens
+2. mysql-client - Required for Keycloak to connect with IAM tokens
+Both dependencies are justified and reasonable for this use case.
+
+#### Alternatives Considered
+1. Continue Using Password Authentication - Provides no security improvements but maintains simplicity
+2. Use IAM Database Authentication Without Fallback - Provides better security but eliminates rollback capability
+The chosen approach with fallback provides the best balance of security improvement and operational safety.
+
+#### Recommendations
+1. Consider using a sidecar container approach instead of modifying the Keycloak image directly, which reduces coupling to Keycloak's internal workings
+2. Implement connection pooling for auth tokens where possible to reduce AWS API calls
+3. Add more detailed monitoring and alerting for authentication method usage
+4. Document the required database user permissions for IAM authentication
+5. Consider implementing a health check that validates the IAM authentication pathway
+
+#### Questions for Author
+1. How will the database user permissions be configured to support IAM authentication? Does the user need to be mapped to the IAM role ARN?
+2. Have you considered the impact of frequent container restarts on AWS API call volume for token generation?
+3. What is the plan for updating the custom Keycloak image when Keycloak releases new versions?
+
+#### Verdict
+APPROVED WITH CHANGES
+
+The design is sound and addresses the core requirements. However, the implementation should address the database user permission mapping and consider optimizing token generation frequency. The approach provides good security improvements while maintaining operational flexibility.
+
+### SRE/DevOps Engineer Review (Circuit)
+
+#### Strengths
+1. Well-thought-out deployment strategy with feature flags for safe rollout
+2. Good use of existing AWS infrastructure components (IAM, Secrets Manager, RDS)
+3. Proper consideration for backward compatibility and rollback scenarios
+4. Clear implementation steps that follow established Terraform patterns
+5. Good observability considerations with logging of authentication method usage
+
+#### Concerns
+1. Frequent container restarts could lead to high volume of `rds:GenerateDBAuthToken` API calls
+2. No consideration for caching or reuse of IAM auth tokens (which are valid for 15 minutes)
+3. Missing monitoring and alerting for authentication method success/failure rates
+4. Custom Keycloak image adds maintenance overhead and security scanning requirements
+5. No discussion of how to handle AWS API throttling for auth token generation
+6. Potential race conditions during deployment when some tasks use IAM auth and others use password auth
+
+#### New Dependencies
+1. AWS CLI in Keycloak container - Required for generating IAM auth tokens
+2. mysql-client in Keycloak container - Required for MySQL connectivity with IAM tokens
+Both dependencies are justified and reasonable for this use case.
+
+#### Alternatives Considered
+1. Continue Using Password Authentication - Provides no security improvements but eliminates complexity
+2. Use IAM Database Authentication Without Fallback - Provides better security but eliminates rollback capability
+The chosen approach with fallback provides the best balance of security improvement and operational safety.
+
+#### Recommendations
+1. Implement monitoring for authentication method usage and success rates
+2. Add alerting for failed authentication attempts
+3. Consider caching IAM tokens or using a sidecar approach to reduce AWS API calls
+4. Implement proper image scanning for the custom Keycloak image
+5. Add health checks to verify both authentication methods work correctly
+6. Document rollback procedures for operators
+
+#### Questions for Author
+1. What is the expected frequency of container restarts and the corresponding AWS API call volume?
+2. How will operators monitor and troubleshoot authentication method failures?
+3. Should we implement connection pooling for database connections to optimize performance?
+4. What is the plan for keeping the custom Keycloak image updated with security patches?
+
+#### Verdict
+APPROVED WITH CHANGES
+
+The design is operationally sound and addresses the core requirements. However, the implementation should include proper monitoring and alerting, and consider optimizations for token generation frequency. The approach provides good security improvements while maintaining operational flexibility.
+
+### Security Engineer Review (Cipher)
+
+#### Strengths
+1. Significant security improvement by eliminating static database credentials in favor of short-lived IAM authentication tokens
+2. Good use of AWS IAM roles and policies for least-privilege access control
+3. Proper backward compatibility with feature flag approach allows for safe rollout
+4. Secure credential management using existing AWS services (Secrets Manager for fallback, IAM for primary auth)
+5. Well-defined threat model that addresses credential exposure risks
+6. Good separation of duties between different AWS services
+
+#### Concerns
+1. Custom Keycloak container image introduces additional attack surface and maintenance burden
+2. No discussion of how to handle secure deletion of static credentials after migration
+3. Missing consideration for token expiration handling and renewal strategies
+4. No clear incident response procedure if IAM authentication fails
+5. Potential privilege escalation if IAM policies are not properly scoped
+6. Database user must be configured to support IAM authentication (requires specific grants)
+
+#### New Dependencies
+1. AWS CLI in Keycloak container - Necessary for generating IAM auth tokens, justified for this use case
+2. mysql-client in Keycloak container - Required for MySQL connectivity with IAM tokens
+Both dependencies are justified and represent minimal additional risk.
+
+#### Alternatives Considered
+1. Continue Using Password Authentication - Provides no security improvements but eliminates complexity
+2. Use IAM Database Authentication Without Fallback - Provides better security but eliminates rollback capability
+The chosen approach with fallback provides the best balance of security improvement and operational safety.
+
+#### Recommendations
+1. Implement proper image security scanning for the custom Keycloak image
+2. Establish procedure for secure deletion of static database credentials after successful migration
+3. Add detailed monitoring for authentication method success/failure rates
+4. Implement alerting for failed authentication attempts
+5. Document incident response procedures for authentication failures
+6. Ensure database user permissions are properly configured for IAM authentication with least privilege
+
+#### Questions for Author
+1. How will static database credentials be securely deleted after successful migration?
+2. What monitoring and alerting will be implemented for authentication method failures?
+3. How will database user permissions be configured to support IAM authentication?
+4. What is the incident response procedure if IAM authentication fails across all containers?
+5. Has the custom Keycloak image been reviewed for security vulnerabilities?
+
+#### Verdict
+APPROVED WITH CHANGES
+
+The design provides significant security improvements by moving away from static credentials. However, the implementation should address secure credential deletion procedures, implement proper monitoring and alerting, and ensure database user configuration is properly documented. The approach is sound from a security perspective.
+
+### SMTS Review (Sage)
+
+#### Strengths
+1. Well-architected solution that follows established patterns in the codebase
+2. Good balance between security improvement and operational safety through feature flag approach
+3. Comprehensive design documentation with clear implementation steps
+4. Proper consideration for backward compatibility and rollback scenarios
+5. Good separation of concerns between infrastructure and application components
+6. Clear threat model addressing credential exposure risks
+
+#### Concerns
+1. Custom Keycloak container image introduces maintenance overhead and security scanning requirements
+2. No consideration for connection pooling or reuse of IAM auth tokens
+3. Missing detailed monitoring and alerting for authentication method success/failure rates
+4. Potential race conditions during deployment when some tasks use IAM auth and others use password auth
+5. Database user configuration for IAM authentication is not clearly documented
+6. No discussion of how to handle AWS API throttling for auth token generation
+
+#### New Dependencies
+1. AWS CLI in Keycloak container - Required for generating IAM auth tokens, justified for this use case
+2. mysql-client in Keycloak container - Required for MySQL connectivity with IAM tokens
+Both dependencies are minimal and justified.
+
+#### Alternatives Considered
+1. Continue Using Password Authentication - Provides no security improvements but eliminates complexity
+2. Use IAM Database Authentication Without Fallback - Provides better security but eliminates rollback capability
+The chosen approach with fallback provides the best balance of security improvement and operational safety.
+
+#### Recommendations
+1. Consider using a sidecar container approach instead of modifying the Keycloak image directly
+2. Implement proper image security scanning for the custom Keycloak image
+3. Add comprehensive monitoring and alerting for authentication method success/failure rates
+4. Document the required database user configuration for IAM authentication
+5. Implement health checks to verify both authentication methods work correctly
+6. Establish procedure for secure deletion of static database credentials after successful migration
+
+#### Questions for Author
+1. What is the plan for keeping the custom Keycloak image updated with security patches?
+2. How will static database credentials be securely deleted after successful migration?
+3. What monitoring and alerting will be implemented for authentication method failures?
+4. How will database user permissions be configured to support IAM authentication?
+5. What is the expected frequency of container restarts and the corresponding AWS API call volume?
+
+#### Verdict
+APPROVED WITH CHANGES
+
+The design is well-structured and addresses the core requirements effectively. However, the implementation should address image maintenance concerns, implement proper monitoring and alerting, and document database user configuration requirements. The approach provides significant security improvements while maintaining operational flexibility.
+
+## Review Summary
+
+| Reviewer | Verdict | Blockers | Key Recommendations |
+|----------|---------|----------|---------------------|
+| Frontend (Pixel) | APPROVED | 0 | Add monitoring dashboard and operator documentation |
+| Backend (Byte) | APPROVED WITH CHANGES | 2 | Address database user permission mapping; consider sidecar approach |
+| SRE (Circuit) | APPROVED WITH CHANGES | 2 | Add monitoring and alerting; optimize token generation |
+| Security (Cipher) | APPROVED WITH CHANGES | 2 | Implement secure credential deletion; enhance monitoring |
+| SMTS (Sage) | APPROVED WITH CHANGES | 2 | Address image maintenance concerns; add comprehensive monitoring |
+
+## Next Steps
+
+1. Address the identified blockers and high-priority recommendations
+2. Implement the design with focus on:
+   - Proper database user configuration for IAM authentication
+   - Comprehensive monitoring and alerting
+   - Secure credential deletion procedures
+   - Image maintenance and security scanning
+3. Conduct thorough testing of both authentication methods
+4. Document the implementation for operators

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/testing.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/testing.md
@@ -1,0 +1,145 @@
+# Testing Plan: Replace Keycloak Database Password Authentication with RDS IAM Authentication
+
+*Created: 2026-07-25*
+*Related LLD: `./lld.md`*
+*Related Issue: `./github-issue.md`*
+
+## Overview
+### Scope of Testing
+This testing plan covers the replacement of Keycloak database password authentication with RDS IAM authentication. The tests will verify that IAM authentication works correctly, fallback to password authentication functions properly, and all deployment surfaces are correctly configured.
+
+### Prerequisites
+- [ ] AWS account with permissions to create RDS clusters, ECS services, and IAM roles
+- [ ] Terraform installed and configured
+- [ ] AWS CLI configured with appropriate credentials
+- [ ] Docker installed for building custom Keycloak image
+- [ ] Existing Keycloak deployment for comparison
+
+### Shared Variables
+```bash
+export AWS_REGION="us-west-2"
+export KEYCLOAK_CLUSTER_NAME="keycloak-test"
+export TF_VAR_keycloak_database_iam_auth_enabled="true"
+```
+
+## 1. Functional Tests
+### 1.1 Terraform Configuration Tests
+Verify Terraform configurations for IAM database authentication:
+
+```bash
+# Navigate to Terraform directory
+cd /tmp/swe-clone-replace-keycloak-db-password-with-rds-iam/mcp-gateway-registry/terraform/aws-ecs
+
+# Test that Terraform plan includes IAM auth enabled
+terraform plan -var="keycloak_database_iam_auth_enabled=true" | grep -q "enable_iam_database_authentication.*true"
+
+# Verify IAM policy includes rds:GenerateDBAuthToken permission
+terraform plan -var="keycloak_database_iam_auth_enabled=true" | grep -q "rds:GenerateDBAuthToken"
+
+# Test that RDS proxy IAM auth is set to REQUIRED when enabled
+terraform plan -var="keycloak_database_iam_auth_enabled=true" | grep -q "iam_auth.*REQUIRED"
+
+# Test that Terraform plan works with IAM auth disabled (fallback mode)
+terraform plan -var="keycloak_database_iam_auth_enabled=false" | grep -q "enable_iam_database_authentication.*false"
+```
+
+Expected results:
+- IAM database authentication should be enabled on the RDS cluster
+- IAM policy should include `rds:GenerateDBAuthToken` permission
+- RDS proxy should require IAM authentication when enabled
+- Configuration should work with IAM auth disabled for fallback
+
+### 1.2 Custom Keycloak Image Tests
+Verify the custom Keycloak image with IAM auth support:
+
+```bash
+# Build the custom Keycloak image
+cd /tmp/swe-clone-replace-keycloak-db-password-with-rds-iam/mcp-gateway-registry
+docker build -f docker/keycloak/Dockerfile -t keycloak-iam-test .
+
+# Verify AWS CLI is installed in the image
+docker run --rm keycloak-iam-test aws --version
+
+# Verify custom startup script exists
+docker run --rm keycloak-iam-test ls -la /opt/keycloak/bin/start-keycloak.sh
+
+# Test script execution with IAM auth enabled
+docker run --rm -e KEYCLOAK_DB_IAM_AUTH_ENABLED=true -e AWS_REGION=us-west-2 keycloak-iam-test /bin/bash -c "echo '#!/bin/bash\necho \"DB_HOST=test.host\"' > /tmp/script.sh && chmod +x /tmp/script.sh && source /opt/keycloak/bin/start-keycloak.sh"
+
+# Test script execution with IAM auth disabled (fallback)
+docker run --rm -e KEYCLOAK_DB_IAM_AUTH_ENABLED=false keycloak-iam-test /bin/bash -c "source /opt/keycloak/bin/start-keycloak.sh; echo \$KEYCLOAK_DB_IAM_AUTH_ENABLED"
+```
+
+Expected results:
+- AWS CLI should be installed and accessible
+- Custom startup script should exist and be executable
+- Script should handle both IAM auth enabled and disabled modes
+- Environment variables should be correctly processed
+
+## 2. Backwards Compatibility Tests
+Ensure password authentication fallback works correctly:
+
+```bash
+# Test Terraform with IAM auth disabled
+cd /tmp/swe-clone-replace-keycloak-db-password-with-rds-iam/mcp-gateway-registry/terraform/aws-ecs
+terraform plan -var="keycloak_database_iam_auth_enabled=false" | grep -q "iam_auth.*DISABLED"
+
+# Verify Secrets Manager credentials are still passed when IAM auth is disabled
+terraform plan -var="keycloak_database_iam_auth_enabled=false" | grep -A5 -B5 "KC_DB_PASSWORD" | grep -q "valueFrom.*password"
+
+# Verify Secrets Manager credentials are NOT passed when IAM auth is enabled
+terraform plan -var="keycloak_database_iam_auth_enabled=true" | grep -A10 -B10 "keycloak_container_secrets" | grep -c "KC_DB_PASSWORD" | grep -q "1"  # Only username should be passed
+
+# Test that feature flag variable works correctly
+terraform plan -var="keycloak_database_iam_auth_enabled=false" | grep -q "KEYCLOAK_DB_IAM_AUTH_ENABLED.*false"
+terraform plan -var="keycloak_database_iam_auth_enabled=true" | grep -q "KEYCLOAK_DB_IAM_AUTH_ENABLED.*true"
+```
+
+Expected results:
+- When IAM auth is disabled: RDS proxy IAM auth is DISABLED, both username and password are passed from Secrets Manager
+- When IAM auth is enabled: RDS proxy IAM auth is REQUIRED, only username is passed from Secrets Manager, password is generated dynamically
+- Feature flag environment variable correctly reflects the configuration
+
+## 3. UX Tests
+**Not Applicable** - This is an infrastructure-level change that does not directly affect user interfaces.
+
+## 4. Deployment Surface Tests
+### 4.1 Terraform Wiring
+```bash
+# Test variables.tf includes new variable
+grep -q "keycloak_database_iam_auth_enabled" /tmp/swe-clone-replace-keycloak-db-password-with-rds-iam/mcp-gateway-registry/terraform/aws-ecs/variables.tf
+
+# Test terraform.tfvars.example includes example
+grep -q "keycloak_database_iam_auth_enabled" /tmp/swe-clone-replace-keycloak-db-password-with-rds-iam/mcp-gateway-registry/terraform/aws-ecs/terraform.tfvars.example
+
+# Verify RDS cluster configuration includes enable_iam_database_authentication
+grep -A10 -B5 "enable_iam_database_authentication" /tmp/swe-clone-replace-keycloak-db-password-with-rds-iam/mcp-gateway-registry/terraform/aws-ecs/keycloak-database.tf | grep -q "var.keycloak_database_iam_auth_enabled"
+
+# Verify RDS proxy configuration includes conditional iam_auth
+grep -A10 -B5 "iam_auth" /tmp/swe-clone-replace-keycloak-db-password-with-rds-iam/mcp-gateway-registry/terraform/aws-ecs/keycloak-database.tf | grep -q "var.keycloak_database_iam_auth_enabled.*REQUIRED.*DISABLED"
+
+# Verify ECS IAM policy includes rds:GenerateDBAuthToken
+grep -A10 -B5 "rds:GenerateDBAuthToken" /tmp/swe-clone-replace-keycloak-db-password-with-rds-iam/mcp-gateway-registry/terraform/aws-ecs/keycloak-ecs.tf | grep -q "aws_rds_cluster.keycloak.arn"
+```
+
+Expected results:
+- All deployment surfaces correctly reference the new configuration
+- Conditional logic works for both enabled and disabled states
+
+### 4.2 Deploy and Verify
+**Not Applicable for benchmark** - Full deployment testing would require actual AWS resources and is out of scope for the design phase.
+
+### 4.3 Rollback Verification
+**Not Applicable for benchmark** - Rollback testing would require actual deployment and is out of scope for the design phase.
+
+## 5. End-to-End API Tests
+**Not Applicable** - This is an infrastructure change that doesn't add new API endpoints.
+
+## 6. Test Execution Checklist
+- [ ] Section 1 (Functional) tests pass
+- [ ] Section 2 (Backwards Compat) verified
+- [ ] Section 3 (UX) marked Not Applicable
+- [ ] Section 4 (Deployment) tests pass
+- [ ] Section 5 (E2E) marked Not Applicable
+- [ ] Unit tests would be added for custom startup script logic (if implemented)
+- [ ] Integration tests would be added for Terraform configurations (if implemented)

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/github-issue.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/github-issue.md
@@ -1,0 +1,43 @@
+# GitHub Issue: SSRF Hardening for Outbound URL Validation
+
+## Title
+Implement SSRF Protection for Agent Card Fetch and Health Check Endpoints
+
+## Labels
+- security
+- enhancement
+- backend
+
+## Description
+
+### Problem Statement
+The registry currently fetches user-supplied URLs (specifically for agent cards and server health checks) without any Server-Side Request Forgery (SSRF) protection. While an `_is_safe_url()` guard already exists for SKILL.md fetches, this protection is not applied to other outbound HTTP requests. This creates a potential security vulnerability where an attacker could potentially force the registry to make requests to internal services or other unintended destinations.
+
+### Proposed Solution
+1. Promote the existing `_is_safe_url()` function into a shared utility
+2. Apply this URL validation to agent card fetch and server health check paths
+3. Add configuration support for an allowlist of trusted domains/IPs
+4. Ensure backward compatibility by making the validation configurable
+
+### User Stories
+- As an operator running the gateway, I want to prevent SSRF attacks so that internal services remain protected
+- As a downstream team registering MCP servers, I want to ensure my service integrations don't accidentally expose internal systems to potential abuse
+
+### Acceptance Criteria
+- [ ] Existing `_is_safe_url()` function is moved to a shared utilities module
+- [ ] Agent card fetch endpoint validates URLs using the shared utility
+- [ ] Server health check endpoint validates URLs using the shared utility
+- [ ] Configuration supports an allowlist of trusted domains/IPs
+- [ ] Backward compatibility is maintained through feature flags
+- [ ] Comprehensive tests cover both positive and negative validation cases
+
+### Out of Scope
+- Modifying the existing SKILL.md fetch implementation (it already has protection)
+- Changing the core registry architecture or data models
+- Implementing client-side URL validation
+
+### Dependencies
+- Existing URL validation logic in the codebase
+
+### Related Issues
+- #1282

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/lld.md
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/lld.md
@@ -1,0 +1,492 @@
+# Low-Level Design: SSRF Hardening for Outbound URL Validation
+
+*Created: 2026-07-25*
+*Author: Claude*
+*Status: Draft*
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Codebase Analysis](#codebase-analysis)
+3. [Architecture](#architecture)
+4. [Data Models](#data-models)
+5. [API / CLI Design](#api--cli-design)
+6. [Configuration Parameters](#configuration-parameters)
+7. [New Dependencies](#new-dependencies)
+8. [Implementation Details](#implementation-details)
+9. [Observability](#observability)
+10. [Scaling Considerations](#scaling-considerations)
+11. [File Changes](#file-changes)
+12. [Testing Strategy](#testing-strategy)
+13. [Alternatives Considered](#alternatives-considered)
+14. [Rollout Plan](#rollout-plan)
+
+## Overview
+### Problem Statement
+The registry currently fetches user-supplied URLs (specifically for agent cards and server health checks) without any Server-Side Request Forgery (SSRF) protection on these pathways. While an `_is_safe_url()` guard already exists for SKILL.md fetches in the skill service, this protection is not applied to other outbound HTTP requests. This creates a potential security vulnerability where an attacker could potentially force the registry to make requests to internal services or other unintended destinations.
+
+### Goals
+- Promote the existing `_is_safe_url()` function into a shared utility module
+- Apply URL validation to agent card fetch and server health check paths
+- Add configuration support for an allowlist of trusted domains/IPs
+- Maintain backward compatibility through feature flags
+- Ensure comprehensive test coverage
+
+### Non-Goals
+- Modify the existing SKILL.md fetch implementation (it already has protection)
+- Change the core registry architecture or data models
+- Implement client-side URL validation
+
+## Codebase Analysis
+
+### Key Files Reviewed
+
+| File/Directory | Purpose | Relevance to This Change |
+|----------------|---------|--------------------------|
+| `registry/services/skill_service.py` | Contains the existing `_is_safe_url()` function | Source of URL validation logic to promote |
+| `registry/utils/url_utils.py` | URL handling utilities | Destination for promoted URL validation function |
+| `registry/api/agent_routes.py` | Agent API endpoints | Contains agent card fetch endpoint needing protection |
+| `registry/health/service.py` | Health check service | Contains server health check logic needing protection |
+| `registry/core/config.py` | Application configuration | Will contain new configuration parameters |
+| `tests/unit/services/test_skill_service_ssrf_allowlist.py` | SSRF tests | Model for testing the promoted function |
+
+### Existing Patterns Identified
+1. **Shared Utility Pattern**: The codebase follows a pattern of promoting common functionality to shared utility modules. The `registry/utils/` directory contains multiple utility modules.
+   - Files: `url_utils.py`, `path_utils.py`, `request_utils.py`
+   - How a future implementer should follow this: Place the promoted `_is_safe_url()` function in `registry/utils/url_utils.py` and import it where needed.
+
+2. **Configuration Pattern**: The application uses Pydantic settings with environment variables for configuration.
+   - Files: `registry/core/config.py`
+   - How a future implementer should follow this: Add new configuration parameters to the Settings class following existing patterns.
+
+3. **HTTP Client Pattern**: The codebase consistently uses `httpx.AsyncClient` for making HTTP requests with proper timeout handling.
+   - Files: `registry/health/service.py`, `registry/services/skill_service.py`
+   - How a future implementer should follow this: Apply URL validation before creating HTTP clients for outbound requests.
+
+### Integration Points
+
+| Component | Integration Type | Details |
+|-----------|------------------|---------|
+| Agent Card Fetch Endpoint | Uses | Located in `registry/api/agent_routes.py`, needs URL validation before making HTTP requests |
+| Server Health Check Service | Uses | Located in `registry/health/service.py`, needs URL validation before making health check requests |
+| Skill Service | Extends | Contains the original `_is_safe_url()` implementation that will be promoted |
+| Settings | Depends on | Will need new configuration parameters for allowlist and feature flags |
+
+### Constraints and Limitations Discovered
+- **Backward Compatibility**: The change must be backward compatible and configurable, as existing deployments may rely on current behavior
+- **Performance**: URL validation should not significantly impact the performance of health checks and agent card fetches
+- **DNS Resolution**: The existing `_is_safe_url()` function performs DNS resolution which can be a performance bottleneck
+
+## Architecture
+
+### System Context Diagram
+```
+┌─────────────────┐        ┌─────────────────────┐        ┌────────────────────┐
+│   User/MCP      │        │    Registry         │        │  External Servers  │
+│    Client       │───────▶│                     │───────▶│   (Agent Cards,    │
+│                 │        │ ┌─────────────────┐ │        │    Health Endpoints)│
+└─────────────────┘        │ │Outbound URL     │ │        └────────────────────┘
+                           │ │Validation       │ │
+                           │ │(New Component)  │ │
+                           │ └─────────────────┘ │
+                           │          │          │
+                           │          ▼          │
+                           │ ┌─────────────────┐ │
+                           │ │Agent Card Fetch │ │
+                           │ │(Modified)       │ │
+                           │ └─────────────────┘ │
+                           │          │          │
+                           │          ▼          │
+                           │ ┌─────────────────┐ │
+                           │ │Health Check     │ │
+                           │ │Service (Modified)│ │
+                           │ └─────────────────┘ │
+                           └─────────────────────┘
+```
+
+### Sequence Diagram
+```
+User->Registry: Request agent health check
+Registry->URL Validator: Validate agent URL
+URL Validator-->Registry: URL is safe/unsafe
+alt URL is safe
+Registry->External Server: Fetch agent card / check health
+External Server-->Registry: Response
+Registry->User: Return health check result
+else URL is unsafe
+Registry->User: Return error (400 Bad Request)
+end
+```
+
+### Component Diagram
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                      Registry Application                           │
+├─────────────────────────────────────────────────────────────────────┤
+│  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐ │
+│  │ Agent Routes    │    │ Health Service  │    │ Skill Service   │ │
+│  │ (Modified)      │    │ (Modified)      │    │ (Source of      │ │
+│  └─────────────────┘    └─────────────────┘    │ _is_safe_url)   │ │
+│           │                       │             └─────────────────┘ │
+│           ▼                       ▼                      │          │
+│  ┌─────────────────────────────────────────────────────┐  │          │
+│  │           Shared URL Validation Utility             │  │          │
+│  │         (Promoted from skill_service)               │◀─┘          │
+│  └─────────────────────────────────────────────────────┘             │
+│                                 │                                   │
+│                                 ▼                                   │
+│  ┌─────────────────────────────────────────────────────┐             │
+│  │                   Settings (Modified)               │             │
+│  │              (New allowlist configuration)          │             │
+│  └─────────────────────────────────────────────────────┘             │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Data Models
+
+### New Models
+No new models needed for this change.
+
+### Model Changes
+No existing model changes required, but we'll be validating URL fields in existing models.
+
+## API / CLI Design
+
+### New Endpoints / Commands
+No new endpoints or commands needed.
+
+### Modified Endpoints
+**Endpoint:** `POST /api/agents/{path:path}/health`
+**Description:** Agent health check endpoint that fetches agent card from `/.well-known/agent-card.json`
+
+**Changes:** Add URL validation before making outbound HTTP requests to fetch agent card.
+
+**Error Cases:**
+- 400 Bad Request: When the agent URL fails SSRF validation
+
+**Endpoint:** Background health checks in `HealthService`
+**Description:** Periodic health checks performed on registered MCP servers
+
+**Changes:** Add URL validation before making outbound HTTP requests for server health checks.
+
+**Error Cases:**
+- Skipped health check: When a server URL fails SSRF validation (logged but doesn't return HTTP error)
+
+## Configuration Parameters
+
+### New Environment Variables
+
+| Variable Name | Type | Default | Required | Description |
+|---------------|------|---------|----------|-------------|
+| `SSRF_PROTECTION_ENABLED` | bool | `True` | No | Enable/disable SSRF protection for agent card fetch and health check endpoints |
+| `SSRF_ALLOWLIST_HOSTS` | str | `""` | No | Comma-separated list of additional trusted hosts that bypass SSRF checks |
+
+### Settings / Config Class Updates
+```python
+ssrf_protection_enabled: bool = Field(
+    default=True,
+    description="Enable/disable SSRF protection for agent card fetch and health check endpoints"
+)
+
+ssrf_allowlist_hosts: str = Field(
+    default="",
+    description="Comma-separated list of additional trusted hosts that bypass SSRF checks"
+)
+```
+
+### Deployment Surface Checklist
+List every surface where this parameter must appear (`.env.example`, `docker-compose.yml`, Terraform vars, Helm values, etc.) so an implementer can tick them off later.
+- [ ] `.env.example` - Add new environment variables
+- [ ] `docker-compose.yml` - Add new environment variables to service definitions
+- [ ] Helm charts - Add new values to values.yaml and templates
+- [ ] Terraform configurations - Add new variables to module definitions
+
+## New Dependencies
+
+This change uses only existing dependencies.
+
+## Implementation Details
+
+### Step-by-Step Plan (for a future implementer)
+
+#### Step 1: Promote `_is_safe_url` to shared utility
+**File:** `registry/utils/url_utils.py`
+**Lines:** New function additions
+
+```python
+import ipaddress
+import logging
+import socket
+from functools import lru_cache
+from urllib.parse import urlparse
+
+from ..core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Built-in trusted domains that skip IP validation (SSRF protection allowlist).
+# Additional hosts can be added via settings.ssrf_allowlist_hosts
+_DEFAULT_SSRF_TRUSTED_DOMAINS: frozenset = frozenset({
+    "github.com",
+    "gitlab.com",
+    "raw.githubusercontent.com",
+    "bitbucket.org",
+})
+
+@lru_cache(maxsize=1)
+def _ssrf_trusted_domains() -> frozenset[str]:
+    """Return SSRF allowlist: built-in defaults plus configured hosts.
+
+    Cached because settings are immutable per-process.
+    """
+    extra_raw = settings.ssrf_allowlist_hosts or ""
+    extra = frozenset(h.strip().lower() for h in extra_raw.split(",") if h.strip())
+    return _DEFAULT_SSRF_TRUSTED_DOMAINS | extra
+
+def _is_private_ip(ip_str: str) -> bool:
+    """Check if an IP address is private, loopback, or link-local.
+
+    Args:
+        ip_str: IP address string to check
+
+    Returns:
+        True if the IP is private/loopback/link-local, False otherwise
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+
+        # Check for private, loopback, link-local, or reserved addresses
+        if ip.is_private:
+            return True
+        if ip.is_loopback:
+            return True
+        if ip.is_link_local:
+            return True
+        if ip.is_reserved:
+            return True
+
+        # Check for cloud metadata endpoint (169.254.169.254)
+        if ip_str == "169.254.169.254":
+            return True
+
+        return False
+    except ValueError:
+        # Invalid IP address format
+        logger.warning(f"SSRF protection: Invalid IP address format '{ip_str}'")
+        return False
+
+def is_safe_url(url: str) -> bool:
+    """Check if a URL is safe to fetch (SSRF protection).
+
+    This function validates that a URL:
+    1. Uses http or https scheme
+    2. Does not resolve to a private/loopback/link-local IP address
+    3. Does not target cloud metadata endpoints
+
+    Trusted domains (built-in defaults plus any host configured via
+    settings.ssrf_allowlist_hosts) skip the IP check.
+
+    Args:
+        url: URL to validate
+
+    Returns:
+        True if the URL is safe to fetch, False otherwise
+    """
+    # If SSRF protection is disabled, all URLs are considered safe
+    if not settings.ssrf_protection_enabled:
+        return True
+
+    try:
+        parsed = urlparse(url)
+
+        # Check scheme - only allow http and https
+        if parsed.scheme not in ("http", "https"):
+            logger.warning(f"SSRF protection: Blocked URL with scheme '{parsed.scheme}'")
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            logger.warning("SSRF protection: URL has no hostname")
+            return False
+
+        # Check if hostname is in trusted domains allowlist
+        hostname_lower = hostname.lower()
+        if hostname_lower in _ssrf_trusted_domains():
+            logger.debug(f"SSRF protection: Trusted domain '{hostname_lower}'")
+            return True
+
+        # Resolve hostname to IP addresses
+        try:
+            addr_info = socket.getaddrinfo(
+                hostname,
+                parsed.port or (443 if parsed.scheme == "https" else 80),
+                proto=socket.IPPROTO_TCP,
+            )
+        except socket.gaierror as e:
+            logger.warning(f"SSRF protection: Failed to resolve hostname '{hostname}': {e}")
+            return False
+
+        # Check all resolved IP addresses
+        for family, socktype, proto, canonname, sockaddr in addr_info:
+            ip_address = sockaddr[0]
+            if _is_private_ip(ip_address):
+                logger.warning(
+                    f"SSRF protection: Blocked URL resolving to private IP "
+                    f"'{ip_address}' for hostname '{hostname}'"
+                )
+                return False
+
+        return True
+
+    except Exception as e:
+        logger.warning(f"SSRF protection: Error validating URL: {e}")
+        return False
+```
+
+#### Step 2: Update agent card fetch endpoint
+**File:** `registry/api/agent_routes.py`
+**Lines:** Around line 900+ in the `check_agent_health` function
+
+Before making HTTP requests in the health check function, add URL validation:
+
+```python
+# Import at the top of the file
+from ..utils.url_utils import is_safe_url
+
+# In the check_agent_health function, before making HTTP requests:
+for url in health_urls:
+    # Validate URL before making request
+    if not is_safe_url(url):
+        logger.warning(f"SSRF protection: Blocked unsafe URL '{url}' in agent health check")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Agent URL failed SSRF validation",
+        )
+
+    health_check_url = url
+    # ... rest of existing code
+```
+
+#### Step 3: Update server health check service
+**File:** `registry/health/service.py`
+**Lines:** In the `_check_server_endpoint_transport_aware` function
+
+Before making HTTP requests in the server health check function, add URL validation:
+
+```python
+# Import at the top of the file
+from ..utils.url_utils import is_safe_url
+
+# In the _check_server_endpoint_transport_aware function, before making HTTP requests:
+if not proxy_pass_url:
+    return False, HealthStatus.UNHEALTHY_MISSING_PROXY_URL
+
+# Validate URL before making request
+if not is_safe_url(proxy_pass_url):
+    logger.warning(f"SSRF protection: Blocked unsafe server URL '{proxy_pass_url}'")
+    return False, "unhealthy: blocked by SSRF protection"
+
+# ... rest of existing code
+```
+
+### Error Handling
+- When a URL fails validation, log a warning with details about why it was blocked
+- For agent health checks, return a 400 Bad Request error to the client
+- For server health checks, mark the server as unhealthy with an appropriate status message
+- Handle DNS resolution errors gracefully and treat them as unsafe URLs
+
+### Logging
+- Log URL validation failures at WARNING level with details about the blocked URL
+- Log trusted domain accesses at DEBUG level
+- Include contextual information such as agent path or server name when possible
+
+## Observability
+### Tracing / Metrics / Logging Points
+1. **Log Events:**
+   - URL validation failures (WARNING level)
+   - Trusted domain accesses (DEBUG level)
+   - Configuration changes (INFO level)
+
+2. **Metrics:**
+   - Counter for blocked URLs due to SSRF protection
+   - Counter for successful URL validations
+   - Histogram for URL validation duration
+
+## Scaling Considerations
+- **Current Load Assumptions:** The health check service processes servers in batches, and agent health checks are user-initiated
+- **Performance Impact:** DNS resolution in `_is_safe_url` could be a bottleneck; consider caching IP resolutions
+- **Horizontal Scaling:** URL validation doesn't introduce state, so it scales well with multiple instances
+- **Caching Strategy:** The `_ssrf_trusted_domains` function is already cached, but IP resolution is not cached
+
+## File Changes
+
+### New Files
+No new files needed.
+
+### Modified Files
+
+| File Path | Lines | Change Description |
+|-----------|-------|--------------------|
+| `registry/utils/url_utils.py` | New functions | Add `is_safe_url` and supporting functions |
+| `registry/api/agent_routes.py` | ~900 | Add URL validation to agent health check endpoint |
+| `registry/health/service.py` | Various | Add URL validation to server health check service |
+| `registry/core/config.py` | New fields | Add SSRF configuration parameters |
+| `tests/unit/test_agent_routes.py` | New tests | Add tests for URL validation in agent health checks |
+| `tests/unit/health/test_service.py` | New tests | Add tests for URL validation in server health checks |
+
+### Estimated Lines of Code
+
+| Category | Lines |
+|----------|-------|
+| New code | ~150 |
+| New tests | ~100 |
+| Modified code | ~50 |
+| **Total** | **~300** |
+
+## Testing Strategy
+See `testing.md` for the full testing plan.
+
+## Alternatives Considered
+
+### Alternative 1: Use a Third-Party SSRF Library
+**Description:** Use an existing library like `ssrf-filter` or similar packages
+**Pros:**
+- Proven implementation
+- Less code to maintain
+**Cons:**
+- Additional dependency
+- May not fit existing code patterns
+- Less control over validation logic
+**Why Rejected:** The existing `_is_safe_url` implementation is already robust and fits the codebase patterns well.
+
+### Alternative 2: Implement Validation at the HTTP Client Level
+**Description:** Add validation directly to the HTTP client wrapper
+**Pros:**
+- Centralized protection
+- Protects all HTTP requests automatically
+**Cons:**
+- Could break legitimate internal requests
+- Harder to configure per-endpoint
+**Why Rejected:** More targeted protection at specific endpoints provides better control and configurability.
+
+### Comparison Matrix
+
+| Criteria | Chosen Approach | Alt 1 (Third-Party) | Alt 2 (HTTP Client) |
+|----------|----------------|---------------------|---------------------|
+| Complexity | Low | Low | Medium |
+| Control | High | Medium | High |
+| Dependencies | None | Additional | None |
+| Fit with Existing Code | Excellent | Good | Fair |
+
+## Rollout Plan
+- Phase 1: Implementation (out of scope for this skill)
+- Phase 2: Testing
+- Phase 3: Deployment with feature flag enabled by default
+
+## Open Questions
+- Should we cache IP address resolutions to improve performance?
+- Do we need to support IPv6 private address ranges?
+
+## References
+- OWASP SSRF Prevention Cheat Sheet
+- Existing `_is_safe_url` implementation in `registry/services/skill_service.py`
+- A2A Agent Specification for health check endpoints

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-480b-a35b-instruct/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,72 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "qwen.qwen3-coder-480b-a35b-instruct",
+  "model_slug": "qwen.qwen3-coder-480b-a35b-instruct",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4000",
+  "aws_region": null,
+  "artifacts_produced": 2,
+  "artifacts_expected": 4,
+  "generation_tokens_per_sec": 15.5,
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2110448,
+    "output_tokens": 10680,
+    "cache_read_tokens": 736,
+    "cache_write_tokens": 0,
+    "latency_seconds": 688.5,
+    "num_turns": 46,
+    "generation_tokens_per_sec": 15.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "claude_api.usage.input_tokens",
+      "output_tokens": "claude_api.usage.output_tokens",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2110448,
+  "output_tokens": 10680,
+  "latency_seconds": 688.5,
+  "num_turns": 46,
+  "total_cost_usd": 34.761399,
+  "is_error": false,
+  "session_id": "2b0cb174-9f78-4513-a2d5-8826aa36dbfe",
+  "cache_read_tokens": 736,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-07-25T00:22:41.004631Z",
+  "run_ended_at": "2026-07-25T00:34:10.113744Z",
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds benchmark results for Qwen3-Coder-480B-A35B-Instruct on the mcp-gateway-registry dataset
- Run via Path 2: bedrock-mantle LiteLLM proxy (not self-hosted vLLM)
- Complements the existing self-hosted results (slug `qwen3-coder-480b`) with a Bedrock-hosted comparison (slug `qwen.qwen3-coder-480b-a35b-instruct`)

## Results

| Task | Artifacts | Turns | Latency |
|------|-----------|-------|---------|
| remove-faiss | 4/4 | 56 | 1092s |
| remove-efs-from-terraform-aws-ecs | 4/4 | 27 | 842s |
| ssrf-hardening-outbound-url-validation | 2/4 | 46 | 689s |
| migrate-ecs-env-vars-to-secrets-manager | 4/4 | 37 | 748s |
| replace-keycloak-db-password-with-rds-iam | 4/4 | ~40 | ~800s |

4/5 tasks fully complete, 1 partial. The model intermittently writes artifacts to wrong subdirectories and wastes turns on blocked cd-based commands -- a known conformance gap for non-Claude models on this harness.

## Configuration

- Endpoint: bedrock-mantle.us-east-1.api.aws via LiteLLM proxy
- Context window: 262144 tokens
- Max turns: 60
- stream_timeout: 120s (from PR #27)