### PR TITLE
swe2: add repo-path discipline to the implementation step (Step 8.5)

### DIFF
--- a/.claude/skills/swe2/SKILL.md
+++ b/.claude/skills/swe2/SKILL.md
@@ -721,6 +721,19 @@ This is the one step that distinguishes `/swe2` from `/swe`. Having designed the
 
 ### 8.5.1 Implement against the LLD
 
+> **CRITICAL - the code lives in `{repo-path}`, NOT your working directory. Anchor every edit to it or you will loop and run out of turns.** The cloned repo you are editing is a **separate folder** (a temp checkout, e.g. `/tmp/swe-clone-<task>/<repo-name>`), *not* the directory the harness runs you from. This is the single most common way this step fails: the model edits a guessed or working-dir-relative path (e.g. `src/registry/api/server_routes.py`), the file does not exist there, the `Edit`/`Write` silently no-ops or errors, the model re-describes the same edit, gets told "the file still contains the original code," tries again, and burns the entire turn budget without landing a single change - producing 4/6 artifacts (design only, no `patch.diff`). Avoid it with this discipline:
+>
+> 1. **Record the absolute repo root once, up front, and treat it as fixed for the whole step.** At the start of 8.5, resolve and remember it:
+>    ```bash
+>    REPO="{repo-path}"            # the exact clone path from Step 1.4, e.g. /tmp/swe-clone-remove-faiss/mcp-gateway-registry
+>    git -C "$REPO" rev-parse --show-toplevel   # confirm it IS the clone root; use this value as $REPO
+>    ```
+>    Keep `$REPO` in mind for every file operation below. Never let it drift to your cwd, to `benchmarks/...`, or to a path you guessed from the LLD.
+> 2. **Every file path you Read/Edit/Write in the target repo MUST be the absolute `$REPO/<path-relative-to-repo-root>`.** The LLD may write paths relative to the repo root (e.g. `registry/api/server_routes.py`); prepend `$REPO/` to get the real location (`$REPO/registry/api/server_routes.py`). Do **not** invent prefixes like `src/` that the LLD did not state.
+> 3. **VERIFY THE PATH EXISTS BEFORE EDITING IT.** Before the first edit to any file, confirm it is really there - `ls "$REPO/<path>"` or `Read` it. If it is missing, do not guess variants; `find "$REPO" -name '<basename>'` (allowed) to locate the true path, then edit that. A `git -C "$REPO" ls-files | grep <name>` also finds the canonical path fast.
+> 4. **If an edit does not land, STOP and re-locate - never retry the same path.** If `Edit`/`Write` errors, or a follow-up `Read`/`git diff` shows the file unchanged, the path or the `old_string` is wrong. Do **not** re-issue the same edit or reword it in a loop (that is exactly what exhausts the turn budget). Instead: re-find the file under `$REPO`, re-read its current contents, and issue the edit against the confirmed path/text. Two failed attempts on one file = re-locate, do not try a third blind.
+> 5. **Periodically re-ground.** After a batch of edits, run `git -C "$REPO" diff --stat` to confirm your changes are actually accumulating in the clone. If it is empty when you believe you have edited files, your paths are wrong - fix the anchor before continuing, do not keep editing into the void.
+
 Edit the files in `{repo-path}` to realize the design in `lld.md`. Treat the LLD's "Implementation Details" and "File Changes" sections as the plan of record:
 
 - **Follow the LLD.** Make the edits the LLD calls out - new files, modified files, dependency and config changes. If while implementing you discover the LLD is wrong or incomplete, make the smallest correct change AND record the deviation in `implementation.md` (8.5.4); do not silently diverge.


### PR DESCRIPTION
## Problem

`/swe2` Step 8.5 (implementation) sometimes produced only **4/6 artifacts** — the four design docs but no `patch.diff` / `implementation.md`. Investigating a real run (kimi-k2.7-code on `remove-faiss`) showed this was **not** the model deciding the code files were optional:

- `num_turns: 251`, `result_subtype: error_max_turns` — it hit the 250-turn cap.
- The end-of-run transcript shows it editing a **wrong path** (`src/registry/api/server_routes.py` when the clone has `registry/api/server_routes.py`), the `Edit`/`Write` silently not landing, the harness/model repeating *"the file still contains the original code,"* and the model re-trying the same edit in a loop until the budget was gone.

So it was an **edit-path / retry-loop** failure, not a missing-instruction-about-artifacts failure. A "6 files are mandatory" checklist would not help — the model never managed to land an edit at all.

## Fix

Add an explicit path-discipline block at the top of **Step 8.5.1**:

1. Record the absolute clone root (`$REPO`) once and treat it as fixed — it is a **separate folder** (`/tmp/swe-clone-...`), not the harness working directory.
2. Prepend `$REPO/` to every target path; do not invent prefixes (`src/`) the LLD didn't state.
3. **Verify a file exists** (`ls`/`Read`/`find`) before editing it.
4. **Never retry a failed edit blindly** — two failures on one file ⇒ re-locate the file, don't try a third blind (this is the loop that exhausts the turn budget).
5. Periodically re-ground with `git -C "$REPO" diff --stat` to confirm edits are actually accumulating.

## Notes

- Documentation-only change to `.claude/skills/swe2/SKILL.md`; no code.
- Discovered during the multi-model p5en benchmark sweep; targets the turn-budget-exhausting edit loop directly.