### PR TITLE
Fix benchmark unit tests drifted from runner-config changes

### DIFF
--- a/benchmarks/tests/test_run_swe_headless.py
+++ b/benchmarks/tests/test_run_swe_headless.py
@@ -88,7 +88,11 @@ class SafeTaskSlugTest(unittest.TestCase):
 class BuildPromptTest(unittest.TestCase):
     def test_prompt_has_all_swe_keys(self) -> None:
         prompt = harness._build_prompt(
-            _task(), Path("/tmp/x/mcp-gateway-registry"), "1.24.4", "qwen3.6-35b"
+            _task(),
+            Path("/tmp/x/mcp-gateway-registry"),
+            "1.24.4",
+            "qwen3.6-35b",
+            Path("/tmp/art"),
         )
         for key in ("repo:", "problem:", "model:", "answers:"):
             self.assertIn(key, prompt)
@@ -100,21 +104,24 @@ class BuildPromptTest(unittest.TestCase):
             Path("/tmp/x/bar"),
             "main",
             "m",
+            Path("/tmp/art"),
         )
         self.assertIn("Reference issue:", prompt)
 
     def test_prompt_has_fallback_answers_when_absent(self) -> None:
         prompt = harness._build_prompt(
-            _task(clarifying_answers=None), Path("/tmp/x/r"), "main", "m"
+            _task(clarifying_answers=None), Path("/tmp/x/r"), "main", "m", Path("/tmp/art")
         )
         self.assertIn("best judgment", prompt)
 
     def test_prompt_invokes_swe2_skill(self) -> None:
         prompt = harness._build_prompt(
-            _task(), Path("/tmp/x/mcp-gateway-registry"), "1.24.4", "m"
+            _task(), Path("/tmp/x/mcp-gateway-registry"), "1.24.4", "m", Path("/tmp/art")
         )
         # The harness drives /swe2 (design + implementation), not /swe.
         self.assertTrue(prompt.startswith("/swe2 "))
+        # The absolute artifacts dir is passed through verbatim as a drift guard.
+        self.assertIn("/tmp/art", prompt)
 
 
 class ArtifactFilenamesTest(unittest.TestCase):

--- a/benchmarks/tests/test_run_swe_headless.py
+++ b/benchmarks/tests/test_run_swe_headless.py
@@ -110,13 +110,21 @@ class BuildPromptTest(unittest.TestCase):
 
     def test_prompt_has_fallback_answers_when_absent(self) -> None:
         prompt = harness._build_prompt(
-            _task(clarifying_answers=None), Path("/tmp/x/r"), "main", "m", Path("/tmp/art")
+            _task(clarifying_answers=None),
+            Path("/tmp/x/r"),
+            "main",
+            "m",
+            Path("/tmp/art"),
         )
         self.assertIn("best judgment", prompt)
 
     def test_prompt_invokes_swe2_skill(self) -> None:
         prompt = harness._build_prompt(
-            _task(), Path("/tmp/x/mcp-gateway-registry"), "1.24.4", "m", Path("/tmp/art")
+            _task(),
+            Path("/tmp/x/mcp-gateway-registry"),
+            "1.24.4",
+            "m",
+            Path("/tmp/art"),
         )
         # The harness drives /swe2 (design + implementation), not /swe.
         self.assertTrue(prompt.startswith("/swe2 "))

--- a/benchmarks/tests/test_runner_config.py
+++ b/benchmarks/tests/test_runner_config.py
@@ -51,7 +51,10 @@ class LoadRunnerConfigTest(unittest.TestCase):
             {"model": "qwen3-coder-30b", "dataset": "dataset/example.yaml"},
         )
         self.assertEqual(config.model, "qwen3-coder-30b")
-        self.assertEqual(config.permission_mode, "acceptEdits")
+        # The shipped config uses bypassPermissions: /swe2 (implementation) needs
+        # it so Claude Code's built-in Bash guard does not block the `cd <repo> &&
+        # git ...` idiom, against throwaway clones. See runner_config.py.
+        self.assertEqual(config.permission_mode, "bypassPermissions")
         self.assertIn("Read", config.allowed_tools)
 
     def test_missing_dataset_raises(self) -> None:
@@ -63,7 +66,7 @@ class LoadRunnerConfigTest(unittest.TestCase):
         config = load_runner_config(_write(_MINIMAL))
         self.assertEqual(config.api_key, "local")
         self.assertEqual(config.permission_mode, "acceptEdits")
-        self.assertEqual(config.max_turns, 60)
+        self.assertEqual(config.max_turns, 250)
         self.assertEqual(config.tasks, [])
         self.assertEqual(config.concurrency, 1)
 
@@ -98,8 +101,16 @@ class LoadRunnerConfigTest(unittest.TestCase):
         with self.assertRaisesRegex(RunnerConfigError, "not found"):
             load_runner_config("/nonexistent/runner.yaml")
 
-    def test_bypass_permissions_rejected(self) -> None:
+    def test_bypass_permissions_accepted(self) -> None:
+        # bypassPermissions is now a valid mode: /swe2 (implementation) requires
+        # it against throwaway clones so Claude Code's Bash guard does not block
+        # the `cd <repo> && git ...` idiom. It must load without error.
         text = _MINIMAL + "permission_mode: bypassPermissions\n"
+        config = load_runner_config(_write(text))
+        self.assertEqual(config.permission_mode, "bypassPermissions")
+
+    def test_invalid_permission_mode_rejected(self) -> None:
+        text = _MINIMAL + "permission_mode: nonsense\n"
         with self.assertRaisesRegex(RunnerConfigError, "permission_mode"):
             load_runner_config(_write(text))
 


### PR DESCRIPTION
## Summary

The `benchmarks` unit tests had drifted from intentional changes to `runner_config.py` and `run-swe-headless.py` and were failing in CI (surfaced by the CI run on #34, but unrelated to that PR's skill-doc change). This brings the tests back in line with the current code.

## Fixes

- **`DEFAULT_MAX_TURNS` is now 250** (was 60) → `test_defaults_applied` updated.
- **The shipped runner config uses `permission_mode: bypassPermissions`** (required by `/swe2` so Claude Code's Bash guard doesn't block `cd <repo> && git ...` against throwaway clones) → `test_shipped_config_loads_with_cli_model_and_dataset` updated.
- **`bypassPermissions` is now a valid mode, not rejected** → replaced `test_bypass_permissions_rejected` with `test_bypass_permissions_accepted`, and added `test_invalid_permission_mode_rejected` to keep covering the reject path.
- **`_build_prompt` now requires an `artifacts_dir` argument** (the absolute artifact-dir drift guard) → updated the four `BuildPromptTest` calls and added an assertion that the dir is passed through into the prompt.

## Validation

`uv run ruff check .`, `uv run mypy scripts/dataset_loader.py scripts/runner_config.py`, and `uv run python -m unittest discover -s tests` all pass locally (165 tests).