### PR TITLE
Add Claude Opus 4.8 /swe2 benchmark results (mean 67.56)

### DIFF
--- a/benchmarks/scripts/plot_cost_quality.py
+++ b/benchmarks/scripts/plot_cost_quality.py
@@ -94,6 +94,7 @@ def _blended_cost_per_token(model: str) -> float | None:
     ]
     return min(rates) if rates else None
 
+
 # Palette (from the dataviz skill's validated reference instance). Marks are a
 # recessive dark neutral; the frontier is the warm accent. Text wears ink tokens.
 _THEME = {

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,108 @@
+{
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "scope": "mcp-gateway-registry",
+  "provider": "bedrock",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-27T04:10:01.018008Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 703341,
+      "cached_input_tokens": 624446,
+      "cache_write_input_tokens": 78873,
+      "output_tokens": 13117,
+      "reasoning_output_tokens": 8026
+    },
+    "duration_ms": 140584
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 67.56,
+  "mean_cost_usd_excl_failed": 18.21,
+  "tasks": [
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 79,
+      "input_tokens": 142,
+      "output_tokens": 86706,
+      "latency_seconds": 1137.4,
+      "total_cost_usd": 19.285352749999998,
+      "task_score": 79.8,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 74,
+      "input_tokens": 135,
+      "output_tokens": 64705,
+      "latency_seconds": 813.8,
+      "total_cost_usd": 6.423753250000001,
+      "task_score": 78.2,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 170,
+      "input_tokens": 263,
+      "output_tokens": 188098,
+      "latency_seconds": 2640.6,
+      "total_cost_usd": 21.941492000000014,
+      "task_score": 69.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 6,
+      "num_turns": 301,
+      "input_tokens": 550,
+      "output_tokens": 199489,
+      "latency_seconds": 3527.7,
+      "total_cost_usd": 36.34325424999998,
+      "task_score": 56.6,
+      "is_error": true,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 105,
+      "output_tokens": 112041,
+      "latency_seconds": 1407.9,
+      "total_cost_usd": 7.051416749999998,
+      "task_score": 54.2,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-27"
+}


### PR DESCRIPTION
## Summary

Full end-to-end /swe2 benchmark run for Claude Opus 4.8 on mcp-gateway-registry (5 tasks, 6 artifacts each: design + implementation), scored by codex judge (gpt-5.6-sol, high reasoning effort).

## Results

| Task | Score | Artifacts | Turns | Time |
|------|-------|-----------|-------|------|
| migrate-ecs-env-vars-to-secrets-manager | 79.8 | 6/6 | 79 | 19 min |
| remove-efs-from-terraform-aws-ecs | 78.2 | 6/6 | 74 | 14 min |
| ssrf-hardening-outbound-url-validation | 69.0 | 6/6 | 170 | 44 min |
| remove-faiss | 56.6 | 4/6 | 301 (max) | 59 min |
| replace-keycloak-db-password-with-rds-iam | 54.2 | 6/6 | 56 | 23 min |
| **Mean** | **67.56** | | | |

## Configuration

- Provider: bedrock (us-east-1)
- Claude Code: v2.1.220
- max_turns: 300
- timeout_seconds: 3600
- Skill: /swe2 (6 artifacts, review-fix loop, implementation)
- Judge: codex exec, openai.gpt-5.6-sol, high reasoning effort