### PR TITLE
Add Claude Sonnet 5 /swe2 benchmark results (mean 72.27, 3/5)

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,80 @@
+{
+  "model": "us.anthropic.claude-sonnet-5",
+  "model_slug": "claude-sonnet-5",
+  "scope": "mcp-gateway-registry",
+  "provider": "bedrock",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-28T03:02:06.964116Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 562586,
+      "cached_input_tokens": 472125,
+      "cache_write_input_tokens": 90445,
+      "output_tokens": 9880,
+      "reasoning_output_tokens": 5823
+    },
+    "duration_ms": 118209
+  },
+  "num_tasks": 3,
+  "num_scored": 3,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 72.27,
+  "mean_cost_usd_excl_failed": 19.98,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 199,
+      "input_tokens": 382,
+      "output_tokens": 132588,
+      "latency_seconds": 2765.7,
+      "total_cost_usd": 23.78184555000002,
+      "task_score": 80.2,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 173,
+      "input_tokens": 4566,
+      "output_tokens": 127530,
+      "latency_seconds": 1603.3,
+      "total_cost_usd": 16.009423350000006,
+      "task_score": 77.8,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 158,
+      "input_tokens": 258,
+      "output_tokens": 205884,
+      "latency_seconds": 3296.2,
+      "total_cost_usd": 20.1509694,
+      "task_score": 58.8,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-28"
+}


### PR DESCRIPTION
## Summary

Claude Sonnet 5 /swe2 benchmark on mcp-gateway-registry. 3/5 tasks complete (6/6 artifacts each); 2 tasks timed out at 3600s during the implementation phase.

## Results

| Task | Score | Artifacts | Turns | Time |
|------|-------|-----------|-------|------|
| remove-efs-from-terraform-aws-ecs | 80.2 | 6/6 | 199 | 46 min |
| migrate-ecs-env-vars-to-secrets-manager | 77.8 | 6/6 | 173 | 27 min |
| replace-keycloak-db-password-with-rds-iam | 58.8 | 6/6 | 158 | 55 min |
| remove-faiss | timeout | 4/6 | 400 (max) | 60 min (hit 3600s) |
| ssrf-hardening | timeout | - | - | hit 3600s |
| **Mean (3 scored)** | **72.27** | | | |

## Comparison with Opus 4.8

| Metric | Opus 4.8 | Sonnet 5 |
|--------|----------|----------|
| Mean score | **75.32** | 72.27 |
| Tasks complete | **5/5** | 3/5 |
| remove-efs score | 79.6 | **80.2** |
| migrate-ecs score | 70.6 | **77.8** |
| replace-keycloak score | **76.6** | 58.8 |

Sonnet beats Opus on 2/3 completed tasks but times out on harder ones due to more exhaustive exploration (409 file reads + 19 subagents on a single task vs Opus completing all 5 in 566 total turns).

## Configuration

- Provider: bedrock (us-east-1)
- Claude Code: v2.1.220
- max_turns: 400, max_output_tokens: 32000, timeout_seconds: 3600
- permission_mode: bypassPermissions
- Judge: codex exec, openai.gpt-5.6-sol, high reasoning effort