### PR TITLE
Add Nemotron Ultra 550B /swe2 benchmark results (mean 50.2)

### DIFF
--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,110 @@
+{
+  "model": "nemotron-ultra-550b",
+  "model_slug": "nemotron-ultra-550b",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 131072
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-28T19:08:34.467156Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 630928,
+      "cached_input_tokens": 544165,
+      "cache_write_input_tokens": 86745,
+      "output_tokens": 8957,
+      "reasoning_output_tokens": 4748
+    },
+    "duration_ms": 192805
+  },
+  "num_tasks": 5,
+  "num_scored": 4,
+  "num_failed": 1,
+  "failed_tasks": [
+    "remove-faiss"
+  ],
+  "mean_task_score_excl_failed": 50.2,
+  "mean_cost_usd_excl_failed": 24.41,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 93,
+      "input_tokens": 5640209,
+      "output_tokens": 30491,
+      "latency_seconds": 488.2,
+      "total_cost_usd": 32.42907,
+      "task_score": 55.4,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 51,
+      "input_tokens": 2768866,
+      "output_tokens": 28216,
+      "latency_seconds": 412.6,
+      "total_cost_usd": 17.783555000000003,
+      "task_score": 52.4,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 62,
+      "input_tokens": 2958864,
+      "output_tokens": 49476,
+      "latency_seconds": 651.3,
+      "total_cost_usd": 19.624189999999995,
+      "task_score": 50.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 87,
+      "input_tokens": 4464668,
+      "output_tokens": 45035,
+      "latency_seconds": 579.5,
+      "total_cost_usd": 27.795535000000005,
+      "task_score": 43.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 3,
+      "artifacts_expected": 6,
+      "num_turns": 251,
+      "input_tokens": 16766125,
+      "output_tokens": 50835,
+      "latency_seconds": 2078.2,
+      "total_cost_usd": 152.9046950000001,
+      "task_score": 0.0,
+      "is_error": true,
+      "failed": true
+    }
+  ],
+  "run_date": "2026-07-28"
+}


### PR DESCRIPTION
## Summary

First benchmark of NVIDIA Nemotron-3-Ultra-550B-A55B (NVFP4) on mcp-gateway-registry, self-hosted on p5en.48xlarge (8x H200) via vLLM.

## Results

| Task | Score | Artifacts |
|------|-------|-----------|
| remove-efs-from-terraform-aws-ecs | 55.4 | 6/6 |
| ssrf-hardening-outbound-url-validation | 52.4 | 6/6 |
| migrate-ecs-env-vars-to-secrets-manager | 50.0 | 6/6 |
| replace-keycloak-db-password-with-rds-iam | 43.0 | 6/6 |
| remove-faiss | 0.0 | 3/6 (hit max_turns) |
| **Mean (excl failed)** | **50.2** | |

## Configuration

- Instance: p5en.48xlarge (8x NVIDIA H200, 143 GB each)
- Model: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
- vLLM: 0.26.0, TP=8, max_model_len=131072, gpu_memory_utilization=0.90
- Tool parser: qwen3_coder + reasoning parser: nemotron_v3
- Prefix caching: enabled (76% hit rate observed)
- Judge: codex exec, openai.gpt-5.6-sol, high reasoning effort

## Notes

- Context window was 131K (below 200K recommended floor); KV cache usage was only 0.3-0.4% suggesting room for larger context
- remove-faiss failed due to max_turns (250) exhaustion, not context overflow
- Prefix cache hit rate of 76% is consistent with other self-hosted models