### PR TITLE
Add DeepSeek V3.2 SWE2 benchmark results (mean 52.2, 5/5)

### DIFF
--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,108 @@
+{
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 131072
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-28T22:45:55.378801Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 415456,
+      "cached_input_tokens": 326527,
+      "cache_write_input_tokens": 88915,
+      "output_tokens": 7625,
+      "reasoning_output_tokens": 4203
+    },
+    "duration_ms": 236922
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 52.2,
+  "mean_cost_usd_excl_failed": 50.1,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 177,
+      "input_tokens": 10546149,
+      "output_tokens": 56627,
+      "latency_seconds": 1094.6,
+      "total_cost_usd": 68.87837,
+      "task_score": 59.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 169,
+      "input_tokens": 10038441,
+      "output_tokens": 70147,
+      "latency_seconds": 1257.6,
+      "total_cost_usd": 54.469815000000004,
+      "task_score": 56.4,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 133,
+      "input_tokens": 7780061,
+      "output_tokens": 44539,
+      "latency_seconds": 1015.0,
+      "total_cost_usd": 54.28692999999997,
+      "task_score": 51.2,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 97,
+      "input_tokens": 6356629,
+      "output_tokens": 37021,
+      "latency_seconds": 732.1,
+      "total_cost_usd": 34.258785,
+      "task_score": 48.2,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 95,
+      "input_tokens": 5944547,
+      "output_tokens": 42242,
+      "latency_seconds": 717.4,
+      "total_cost_usd": 38.607735000000005,
+      "task_score": 46.2,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-28"
+}


### PR DESCRIPTION
## Summary

- DeepSeek V3.2 (`deepseek-ai/DeepSeek-V3.2`) benchmarked on the mcp-gateway-registry dataset via /swe2 skill
- Self-hosted on p5en.48xlarge (8x H200), TP=8, 131K context window, `deepseek_v32` tool parser
- 5/5 tasks scored, 0 failures, mean score **52.2**

### Per-task scores

| Task | Score | Turns | Time |
|------|-------|-------|------|
| remove-efs-from-terraform-aws-ecs | 59.0 | 177 | 18 min |
| ssrf-hardening-outbound-url-validation | 56.4 | 169 | 21 min |
| migrate-ecs-env-vars-to-secrets-manager | 51.2 | 133 | 17 min |
| remove-faiss | 48.2 | 97 | 12 min |
| replace-keycloak-db-password-with-rds-iam | 46.2 | 95 | 12 min |

### Configuration

- Instance: p5en.48xlarge (8x NVIDIA H200 141GB)
- vLLM: tensor_parallel=8, max_model_len=131072, gpu_memory_utilization=0.90
- Tool parser: deepseek_v32
- Permission mode: bypassPermissions
- max_turns: 400, timeout: 7200s