### PR TITLE
Add Devstral 2 123B SWE2 benchmark results (mean 43.24, 5/5)

### DIFF
--- a/benchmarks/scripts/run-multi-model-benchmark.sh
+++ b/benchmarks/scripts/run-multi-model-benchmark.sh
@@ -59,6 +59,7 @@ REGISTRY=(
   "qwen3-coder-480b|Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8|200000|qwen3_coder|4|p5en.48xl"
   "kimi-k2.7-code|moonshotai/Kimi-K2.7-Code|131072|kimi_k2|8|p5en.48xl"
   "glm-5.2|zai-org/GLM-5.2-FP8|300000|glm47|8|p5en.48xl"
+  "devstral-2-123b|mistralai/Devstral-2-123B-Instruct-2512|262144|mistral|8|p5en.48xl"
 )
 
 DATASET="dataset/mcp-gateway-registry.yaml"
@@ -163,7 +164,15 @@ stop_all_vllm() {
     kill -9 "$pid" 2>/dev/null || true
   done
   pkill -9 -f "VLLM::EngineCore" 2>/dev/null || true
-  sleep 8
+  pkill -9 -f "vllm serve" 2>/dev/null || true
+  # Wait until GPUs are fully released (up to 60s).
+  local i
+  for i in $(seq 1 12); do
+    local count
+    count="$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | wc -l)"
+    [[ "$count" -eq 0 ]] && break
+    sleep 5
+  done
 }
 
 say "=== START multi-model benchmark: ${MODELS[*]} (dataset=$SCOPE) ==="

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,108 @@
+{
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-29T02:28:03.904412Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 488547,
+      "cached_input_tokens": 395453,
+      "cache_write_input_tokens": 93078,
+      "output_tokens": 9888,
+      "reasoning_output_tokens": 5376
+    },
+    "duration_ms": 110957
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 43.24,
+  "mean_cost_usd_excl_failed": 37.61,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 66,
+      "input_tokens": 7858904,
+      "output_tokens": 18804,
+      "latency_seconds": 286.7,
+      "total_cost_usd": 39.764619999999994,
+      "task_score": 49.6,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 69,
+      "input_tokens": 8126834,
+      "output_tokens": 36772,
+      "latency_seconds": 654.4,
+      "total_cost_usd": 42.41590499999999,
+      "task_score": 47.2,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 43,
+      "input_tokens": 3064146,
+      "output_tokens": 21213,
+      "latency_seconds": 304.0,
+      "total_cost_usd": 20.67199,
+      "task_score": 41.0,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 81,
+      "input_tokens": 10067936,
+      "output_tokens": 22357,
+      "latency_seconds": 544.9,
+      "total_cost_usd": 51.763684999999995,
+      "task_score": 40.2,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 61,
+      "input_tokens": 6555351,
+      "output_tokens": 27177,
+      "latency_seconds": 458.5,
+      "total_cost_usd": 33.456179999999996,
+      "task_score": 38.2,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-29"
+}


### PR DESCRIPTION
## Summary

- Mistral Devstral-2-123B-Instruct-2512 benchmarked on mcp-gateway-registry dataset via /swe2 skill
- Self-hosted on p5en.48xlarge (8x H200), TP=8, 262K context window, `mistral` tool parser
- Dense 123B model, native FP8 (~128 GB on disk)
- 5/5 tasks scored, 0 failures, mean score **43.24**

### Per-task scores

| Task | Score | Turns | Time |
|------|-------|-------|------|
| remove-efs-from-terraform-aws-ecs | 49.6 | 66 | 5 min |
| ssrf-hardening-outbound-url-validation | 47.2 | 69 | 11 min |
| replace-keycloak-db-password-with-rds-iam | 41.0 | 43 | 5 min |
| remove-faiss | 40.2 | 81 | 9 min |
| migrate-ecs-env-vars-to-secrets-manager | 38.2 | 61 | 8 min |

### Configuration

- Instance: p5en.48xlarge (8x NVIDIA H200 141GB)
- Model: mistralai/Devstral-2-123B-Instruct-2512 (dense 123B, native FP8)
- vLLM: tensor_parallel=8, max_model_len=262144, gpu_memory_utilization=0.90
- Tool parser: mistral
- Permission mode: bypassPermissions, max_turns: 400, timeout: 7200s