### PR TITLE
Add Claude Opus 5 SWE2 benchmark results (mean 77.45, 4/5 scored)

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-opus-5/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,94 @@
+{
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "scope": "mcp-gateway-registry",
+  "provider": "bedrock",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-29T09:27:12.857689Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 782744,
+      "cached_input_tokens": 664582,
+      "cache_write_input_tokens": 118146,
+      "output_tokens": 9590,
+      "reasoning_output_tokens": 5373
+    },
+    "duration_ms": 110599
+  },
+  "num_tasks": 4,
+  "num_scored": 4,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 77.45,
+  "mean_cost_usd_excl_failed": 54.41,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 154,
+      "input_tokens": 4043,
+      "output_tokens": 182800,
+      "latency_seconds": 6087.5,
+      "total_cost_usd": 49.03930774999998,
+      "task_score": 89.2,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 201,
+      "input_tokens": 9087,
+      "output_tokens": 291764,
+      "latency_seconds": 5375.5,
+      "total_cost_usd": 61.402961,
+      "task_score": 78.6,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 130,
+      "input_tokens": 27064,
+      "output_tokens": 301289,
+      "latency_seconds": 6770.0,
+      "total_cost_usd": 50.59741775,
+      "task_score": 72.4,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 96,
+      "input_tokens": 126,
+      "output_tokens": 152799,
+      "latency_seconds": 3729.5,
+      "total_cost_usd": 56.618285000000014,
+      "task_score": 69.6,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-29"
+}


### PR DESCRIPTION
## Summary

- Claude Opus 5 (`us.anthropic.claude-opus-5`) benchmarked on mcp-gateway-registry dataset via /swe2 skill
- Amazon Bedrock, 1M context window (explicit `[1m]` suffix to prevent premature compaction)
- 4/5 tasks scored, 0 failures, mean score **77.45** (new highest)
- 1 task (migrate-ecs) produced only 3/6 artifacts before hitting the 7200s timeout

### Per-task scores

| Task | Score | Turns | Time |
|------|-------|-------|------|
| remove-efs-from-terraform-aws-ecs | 89.2 | 154 | 101 min |
| ssrf-hardening-outbound-url-validation | 78.6 | 201 | 90 min |
| replace-keycloak-db-password-with-rds-iam | 72.4 | 130 | 113 min |
| remove-faiss | 69.6 | 96 | 62 min |
| migrate-ecs-env-vars-to-secrets-manager | - | - | timeout |

### Configuration

- Provider: Amazon Bedrock (us-east-1)
- Model: us.anthropic.claude-opus-5[1m]
- Permission mode: bypassPermissions
- max_turns: 400, timeout: 7200s, max_output_tokens: 32000

### Notes

- Used `[1m]` context window suffix to ensure Claude Code uses the full 1M window and avoids mid-task compaction (which caused artifact loss in earlier runs)
- Opus 5 produces exceptionally detailed, deeply verified design artifacts but is significantly slower than Opus 4.8 (60-113 min/task vs 12-38 min/task)