### PR TITLE
Add Claude Haiku 4.5 SWE2 benchmark results (mean 47.92, 5/5)

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,108 @@
+{
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5-20251001-v1:0",
+  "scope": "mcp-gateway-registry",
+  "provider": "bedrock",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-29T18:40:09.054372Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 621278,
+      "cached_input_tokens": 508802,
+      "cache_write_input_tokens": 112460,
+      "output_tokens": 10796,
+      "reasoning_output_tokens": 6582
+    },
+    "duration_ms": 166153
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 47.92,
+  "mean_cost_usd_excl_failed": 1.31,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 55,
+      "input_tokens": 76,
+      "output_tokens": 32916,
+      "latency_seconds": 459.0,
+      "total_cost_usd": 1.9677078999999993,
+      "task_score": 55.8,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 85,
+      "output_tokens": 28005,
+      "latency_seconds": 275.8,
+      "total_cost_usd": 0.8209678499999999,
+      "task_score": 49.8,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 95,
+      "input_tokens": 53,
+      "output_tokens": 47707,
+      "latency_seconds": 453.2,
+      "total_cost_usd": 2.02826485,
+      "task_score": 49.2,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 45,
+      "input_tokens": 102,
+      "output_tokens": 37667,
+      "latency_seconds": 329.5,
+      "total_cost_usd": 1.1030070999999997,
+      "task_score": 48.6,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 42,
+      "input_tokens": 103,
+      "output_tokens": 19426,
+      "latency_seconds": 187.7,
+      "total_cost_usd": 0.6225822999999999,
+      "task_score": 36.2,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-29"
+}


### PR DESCRIPTION
## Summary

- Claude Haiku 4.5 benchmarked on mcp-gateway-registry dataset via /swe2 skill
- Amazon Bedrock (us-east-1), 200K context window
- 5/5 tasks scored, 0 failures, mean score **47.92**
- Fastest and cheapest Claude model on this benchmark

### Per-task scores

| Task | Score | Turns | Time |
|------|-------|-------|------|
| remove-efs-from-terraform-aws-ecs | 55.8 | 55 | 8 min |
| ssrf-hardening-outbound-url-validation | 49.8 | 56 | 5 min |
| migrate-ecs-env-vars-to-secrets-manager | 49.2 | 95 | 8 min |
| replace-keycloak-db-password-with-rds-iam | 48.6 | 45 | 6 min |
| remove-faiss | 36.2 | 42 | 3 min |

### Configuration

- Provider: Amazon Bedrock (us-east-1)
- Model: us.anthropic.claude-haiku-4-5-20251001-v1:0
- Permission mode: bypassPermissions
- max_turns: 400, timeout: 7200s, max_output_tokens: 32000

### Pricing context

- Input: $1/M tokens, Output: $5/M tokens
- Roughly 10x cheaper than Opus 4.8 per task
- ~30 min total for all 5 tasks (vs 2 hrs for Opus 4.8, 6 hrs for Opus 5)