### PR TITLE
Update Devstral 2 123B results with TP=4 (mean 43.12, no regression)

### DIFF
--- a/benchmarks/swe-benchmark-data/devstral-2-123b/mcp-gateway-registry/RUN-SUMMARY.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/mcp-gateway-registry/RUN-SUMMARY.json
@@ -1,0 +1,108 @@
+{
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-07-29T20:07:24.153466Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 413007,
+      "cached_input_tokens": 329674,
+      "cache_write_input_tokens": 83319,
+      "output_tokens": 7899,
+      "reasoning_output_tokens": 4573
+    },
+    "duration_ms": 127535
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 43.12,
+  "mean_cost_usd_excl_failed": 28.8,
+  "tasks": [
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 36,
+      "input_tokens": 3085638,
+      "output_tokens": 26151,
+      "latency_seconds": 586.2,
+      "total_cost_usd": 16.917099999999998,
+      "task_score": 51.8,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 73,
+      "input_tokens": 6581446,
+      "output_tokens": 18941,
+      "latency_seconds": 394.0,
+      "total_cost_usd": 33.38075500000001,
+      "task_score": 47.4,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 69,
+      "input_tokens": 8351286,
+      "output_tokens": 22917,
+      "latency_seconds": 724.5,
+      "total_cost_usd": 42.32935499999999,
+      "task_score": 43.6,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 6300127,
+      "output_tokens": 36389,
+      "latency_seconds": 864.0,
+      "total_cost_usd": 32.410360000000004,
+      "task_score": 42.8,
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 44,
+      "input_tokens": 3671580,
+      "output_tokens": 24008,
+      "latency_seconds": 466.5,
+      "total_cost_usd": 18.958099999999998,
+      "task_score": 30.0,
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-07-29"
+}


### PR DESCRIPTION
## Summary

- Devstral 2 123B re-run at TP=4 (down from TP=8) to validate serving on fewer GPUs
- No quality regression: **43.12** (TP=4) vs 43.24 (TP=8)
- Dense 123B FP8 model (~128 GB) fits comfortably on 4x H200, freeing 4 GPUs

### Per-task scores (TP=4)

| Task | Score | Turns | Time |
|------|-------|-------|------|
| ssrf-hardening-outbound-url-validation | 51.8 | 36 | 10 min |
| remove-efs-from-terraform-aws-ecs | 47.4 | 73 | 7 min |
| remove-faiss | 43.6 | 69 | 12 min |
| migrate-ecs-env-vars-to-secrets-manager | 42.8 | 56 | 14 min |
| replace-keycloak-db-password-with-rds-iam | 30.0 | 44 | 8 min |

### TP=8 vs TP=4 comparison

| Task | TP=8 | TP=4 |
|------|------|------|
| Mean | 43.24 | 43.12 |
| remove-efs | 49.6 | 47.4 |
| ssrf-hardening | 47.2 | 51.8 |
| replace-keycloak | 41.0 | 30.0 |
| remove-faiss | 40.2 | 43.6 |
| migrate-ecs | 38.2 | 42.8 |

### Configuration

- Instance: p5en.48xlarge (using 4 of 8 NVIDIA H200 141GB)
- Model: mistralai/Devstral-2-123B-Instruct-2512 (dense 123B, native FP8)
- vLLM: tensor_parallel=4, max_model_len=262144, gpu_memory_utilization=0.90
- Tool parser: mistral