### PR TITLE
Add pi coding agent support for self-hosted vLLM

### DIFF
--- a/self-hosted/vllm/README.md
+++ b/self-hosted/vllm/README.md
@@ -574,6 +574,31 @@ opencode models vllm               # confirm the provider is wired
 
 Verified working end-to-end on the reference node: opencode's `build` agent driving the self-hosted `qwen3-coder-30b` through vLLM.
 
+## Drive a coding agent: pi
+
+[pi](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) is another terminal coding agent. Like opencode it speaks the OpenAI-compatible API, so it drives the self-hosted vLLM model through a custom provider. [`run-pi.sh`](scripts/run-pi.sh) discovers the served model id from `/v1/models` and launches pi against it, so you never hand-edit JSON per model:
+
+```bash
+cd self-hosted/vllm/scripts
+
+./run-pi.sh                       # auto-detect the served model, start interactive pi
+./run-pi.sh -p "explain this repo"   # extra args are forwarded straight to pi
+MODEL=glm-5.2 ./run-pi.sh         # override auto-detection
+BASE_URL=http://host:8000/v1 ./run-pi.sh
+```
+
+What it does:
+
+- **Queries `$BASE_URL/models`** and uses the first served model id (override with `MODEL`).
+- **Syncs `~/.pi/agent/models.json`** so the `vllm` provider's `baseUrl` and its single anchor model id match the running server. pi requires a provider to declare at least one model before it registers, but then accepts any `--model` id and passes it straight through. Keeping the anchor id in sync means even a bare `pi` (no wrapper) resolves to the real served model instead of a stale placeholder that 404s.
+- **`exec`s `pi --provider vllm --model <id>`** with your extra args appended.
+
+A reference copy of the provider config lives at [`config/pi-models.json`](config/pi-models.json).
+
+> pi requires Node >= 22.19 (it uses import attributes). On older Node you get `SyntaxError: Unexpected token 'with'`. Install with `npm install -g @earendil-works/pi-coding-agent`.
+
+> **Tool calling must be on**, same as opencode — pi sends `tool_choice: "auto"`. Start vLLM with a tool-call parser (the default in `vllm-serve.sh`), or pi's tools will error.
+
 ---
 
 ## What's inside
@@ -587,12 +612,14 @@ Verified working end-to-end on the reference node: opencode's `build` agent driv
 | [scripts/vllm-metrics.sh](scripts/vllm-metrics.sh) | Start, inspect, or stop the continuous DuckDB metrics collector |
 | [scripts/claude-local.sh](scripts/claude-local.sh) | Launch Claude Code against the vLLM endpoint with temporary settings |
 | [scripts/opencode-setup.sh](scripts/opencode-setup.sh) | Install opencode (if missing) + point it at the vLLM endpoint |
+| [scripts/run-pi.sh](scripts/run-pi.sh) | Launch the pi coding agent against the vLLM endpoint; auto-detects the served model |
 | [clients/hello_inference.py](clients/hello_inference.py) | Minimal Python inference client (openai SDK) |
 | [clients/benchmark_inference.py](clients/benchmark_inference.py) | Concurrent performance benchmark with request, server-metric, and summary CSV output |
 | [clients/collect_metrics.py](clients/collect_metrics.py) | Continuously scrape all vLLM Prometheus metrics into DuckDB |
 | [clients/build_dashboard.py](clients/build_dashboard.py) | Render the collected DuckDB metrics into a self-contained HTML dashboard |
 | [pyproject.toml](pyproject.toml) | `uv`-managed deps for the Python clients |
 | [config/opencode.json](config/opencode.json) | Reference opencode provider config for vLLM |
+| [config/pi-models.json](config/pi-models.json) | Reference pi custom-provider config for vLLM |
 | `logs/` | vLLM server logs (gitignored — never committed) |
 
 > Every script supports `--help` — env vars, defaults, and options.

--- a/self-hosted/vllm/config/pi-models.json
+++ b/self-hosted/vllm/config/pi-models.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Reference pi custom-provider config for a local vLLM server. Copy to ~/.pi/agent/models.json, or let scripts/run-pi.sh generate and keep it in sync with the served model. pi accepts any --model id under a declared provider, so the single model entry below is an anchor; run-pi.sh rewrites its id to match whatever /v1/models reports.",
+  "providers": {
+    "vllm": {
+      "baseUrl": "http://127.0.0.1:8000/v1",
+      "api": "openai-completions",
+      "apiKey": "local",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        {
+          "id": "qwen3-coder-30b",
+          "name": "vLLM: qwen3-coder-30b",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": 200000,
+          "maxTokens": 20000,
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+        }
+      ]
+    }
+  }
+}

--- a/self-hosted/vllm/scripts/run-pi.sh
+++ b/self-hosted/vllm/scripts/run-pi.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# run-pi.sh - Start pi against whatever model the local vLLM server is serving.
+#
+# vLLM exposes an OpenAI-compatible API; pi reaches it via the "vllm" custom
+# provider declared in ~/.pi/agent/models.json. This script discovers the served
+# model id from /v1/models so you never hand-edit JSON per model. It also syncs
+# the provider's baseUrl and its single anchor model id in models.json to match
+# the running server, so even a bare `pi` (no wrapper) resolves to a real model
+# instead of a stale placeholder that 404s.
+#
+# Usage:
+#   ./run-pi.sh                       # auto-detect model, start interactive pi
+#   ./run-pi.sh -p "fix the bug"      # extra args are forwarded to pi
+#   MODEL=glm-5.2 ./run-pi.sh         # override auto-detection
+#   BASE_URL=http://host:8000/v1 ./run-pi.sh
+#
+# Env:
+#   BASE_URL   vLLM OpenAI-compatible endpoint (default: http://127.0.0.1:8000/v1)
+#   MODEL      served model id to use (default: first id reported by the server)
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8000/v1}"
+MODEL="${MODEL:-}"
+MODELS_JSON="${PI_MODELS_JSON:-$HOME/.pi/agent/models.json}"
+
+# Discover the served model id when not overridden.
+if [ -z "$MODEL" ]; then
+  models_json="$(curl -fsS --max-time 5 "$BASE_URL/models" 2>/dev/null || true)"
+  if [ -z "$models_json" ]; then
+    echo "run-pi.sh: no response from vLLM at $BASE_URL/models" >&2
+    echo "           is the server up? try: curl $BASE_URL/models" >&2
+    exit 1
+  fi
+  MODEL="$(printf '%s' "$models_json" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin).get("data",[]); print(d[0]["id"] if d else "")')"
+  if [ -z "$MODEL" ]; then
+    echo "run-pi.sh: server returned no models at $BASE_URL/models" >&2
+    exit 1
+  fi
+fi
+
+# Sync models.json so the vllm provider's baseUrl and anchor model id match the
+# running server. Keeps a single-model provider block; a bare `pi` then resolves
+# to the real served id instead of a stale placeholder.
+MODEL="$MODEL" BASE_URL="$BASE_URL" MODELS_JSON="$MODELS_JSON" python3 <<'PY'
+import json, os, pathlib
+
+path = pathlib.Path(os.environ["MODELS_JSON"])
+model = os.environ["MODEL"]
+base_url = os.environ["BASE_URL"]
+
+data = {}
+if path.exists():
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        data = {}
+
+providers = data.setdefault("providers", {})
+vllm = providers.setdefault("vllm", {})
+vllm["baseUrl"] = base_url
+vllm.setdefault("api", "openai-completions")
+vllm.setdefault("apiKey", "local")
+vllm.setdefault("compat", {"supportsDeveloperRole": False, "supportsReasoningEffort": False})
+vllm["models"] = [{
+    "id": model,
+    "name": f"vLLM: {model}",
+    "reasoning": False,
+    "input": ["text"],
+    "contextWindow": 200000,
+    "maxTokens": 20000,
+    "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+}]
+
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+
+echo "run-pi.sh: using model '$MODEL' at $BASE_URL" >&2
+exec pi --provider vllm --model "$MODEL" "$@"


### PR DESCRIPTION
## Summary

Adds support for driving the self-hosted vLLM model with the [pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent), alongside the existing opencode and Claude Code paths.

pi speaks the OpenAI-compatible API, so it reaches the vLLM server through a custom provider declared in `~/.pi/agent/models.json`. The challenge pi introduces: it has no `--base-url` flag, and it requires a provider to declare at least one model before the provider registers, yet the served model changes between benchmark runs. Hand-editing JSON per model is the friction this PR removes.

## Changes

- **`self-hosted/vllm/scripts/run-pi.sh`** - wrapper that:
  - queries `$BASE_URL/models` and uses the first served model id (override with `MODEL`);
  - syncs `~/.pi/agent/models.json` so the `vllm` provider's `baseUrl` and its single anchor model id match the running server, so even a bare `pi` (no wrapper) resolves to the real served model instead of a stale placeholder that 404s;
  - `exec`s `pi --provider vllm --model <id>` with any extra args forwarded.
- **`self-hosted/vllm/config/pi-models.json`** - reference provider config, mirroring the existing `config/opencode.json`.
- **`self-hosted/vllm/README.md`** - a "Drive a coding agent: pi" section (setup, the Node >= 22.19 requirement, the tool-calling prerequisite) plus two rows in the file table.

## Usage

```bash
cd self-hosted/vllm/scripts
./run-pi.sh                       # auto-detect served model, interactive
./run-pi.sh -p "explain this repo"   # extra args forwarded to pi
MODEL=glm-5.2 ./run-pi.sh         # override auto-detection
BASE_URL=http://host:8000/v1 ./run-pi.sh
```

## Testing

- `bash -n run-pi.sh` passes; `pi-models.json` validated as JSON.
- End-to-end verified on the reference node: `run-pi.sh` auto-detected the served model and pi returned a completion. A bare `pi --provider vllm` (post-sync) also resolved to the real model with no 404.

## Notes

pi requires Node >= 22.19 (it uses import attributes; older Node fails with `SyntaxError: Unexpected token 'with'`). Install with `npm install -g @earendil-works/pi-coding-agent`.

## Security

Reviewed with the `security-check` gate (Cipher persona): the model id reaches pi as a quoted argv element via `exec` (no shell interpolation) and enters `models.json` through `json.dumps`; the only credential is the throwaway client key `local`; the target endpoint defaults to `127.0.0.1`. Verdict: APPROVED.
