### PR TITLE
benchmark: run the /swe2 task with the pi coding agent (--agent pi)

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -24,6 +24,10 @@ Collect these three, in order. Do not guess -- ask if any is missing.
 2. **model** -- the model id / served-model-name. Examples: `us.anthropic.claude-opus-4-8` (bedrock), `moonshotai.kimi-k2-thinking` (litellm), `qwen3-coder-30b` (vllm).
 3. **dataset** -- a dataset YAML under `benchmarks/dataset/`. Default to `dataset/mcp-gateway-registry.yaml`; suggest `dataset/hello-world.yaml` for a quick sanity check.
 
+Optional fourth input:
+
+4. **agent** -- which coding agent drives the task, passed as `--agent` to the orchestrator. Default `claude` (Claude Code). Pass `pi` to drive the same `/swe2` task with the [pi coding agent](../../../self-hosted/vllm/scripts/run-pi.sh) instead; the task, artifacts, and judge are identical, only the agent changes. **`--agent pi` works only on the `vllm`/`litellm` paths** (it speaks the OpenAI-compatible endpoint); it has no native Amazon Bedrock mode, so it cannot run `--provider bedrock`. Only ask about this if the user brings it up -- otherwise default to `claude`.
+
 ## Workflow
 
 1. **Gather the three inputs** -- provider, model, dataset. Confirm them back to the user.
@@ -150,7 +154,7 @@ aws sts get-caller-identity
 
 ## Step 3 - Pre-flight (see what will happen first)
 
-**3a. Both coding-agent CLIs must be installed, and both are expected to be wired to Amazon Bedrock.** The harness runs `claude -p` to produce the artifacts, and the judge runs `codex exec` to score them. Confirm both are on PATH:
+**3a. Both coding-agent CLIs must be installed, and both are expected to be wired to Amazon Bedrock.** The harness runs `claude -p` to produce the artifacts (or `pi -p` when `--agent pi` is chosen -- then confirm `pi` is on PATH instead of `claude`), and the judge runs `codex exec` to score them. Confirm both are on PATH:
 
 ```bash
 command -v claude && command -v codex || echo "MISSING a required CLI"
@@ -181,7 +185,7 @@ Run the end-to-end script from `benchmarks/`. It re-runs every pre-flight check 
 
 ```bash
 cd benchmarks
-./scripts/run-e2e-benchmark.sh --provider {provider} --model {model} --dataset {dataset} [--yes] [--count N] [--skip-judge]
+./scripts/run-e2e-benchmark.sh --provider {provider} --model {model} --dataset {dataset} [--agent claude|pi] [--yes] [--count N] [--skip-judge]
 ```
 
 Tell the user, before it runs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,9 @@ def process_data(data):
 
 ### Code Validation
 
-- After editing a Python file, run `uv run python -m py_compile <filename>`.
+- After editing a Python file, run `uv run python -m py_compile <filename>` **and `uv run ruff format <filename>` then `uv run ruff check --fix <filename>`** (run these from the `uv` project that owns the file -- `benchmarks/` or `self-hosted/vllm/`). CI runs `pre-commit` with the `ruff-format` hook and **will fail if a committed file is not ruff-formatted**, so never commit Python you have not just formatted. This has bitten us repeatedly -- treat formatting as part of the edit, not a pre-commit afterthought.
 - After editing a shell script, run `bash -n <filename>`.
+- Better yet, install the hook once so this is mechanical: `uv run pre-commit install` (from the repo root). Then every `git commit` auto-formats.
 
 ## Error Handling
 

--- a/benchmarks/docs/harness-reference.md
+++ b/benchmarks/docs/harness-reference.md
@@ -150,7 +150,8 @@ CLI flags always win, so you can still pin `model`/`dataset` in the file if you 
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `provider` | str | `endpoint` | How `claude -p` reaches the model: `endpoint` (a base URL) or `bedrock` (native Amazon Bedrock). |
+| `agent` | str | `claude` | Coding agent that drives the task: `claude` (Claude Code, `claude -p`) or `pi` (the pi coding agent, `pi -p --mode json`). The `/swe2` task, the six artifacts, and the judge are identical either way -- only the agent binary and its invocation differ. `pi` requires `provider: endpoint` (it has no native Amazon Bedrock mode). See [Choosing the agent](#choosing-the-agent). |
+| `provider` | str | `endpoint` | How the agent reaches the model: `endpoint` (a base URL) or `bedrock` (native Amazon Bedrock). |
 | `endpoint` | str | -- | Base URL of the OpenAI/Anthropic-compatible endpoint the model is served on. Required for `provider: endpoint`; ignored for `provider: bedrock`. |
 | `model` | str | -- | Model name/id passed to `claude --model`. For `provider: bedrock` this is a Bedrock model id or inference profile (e.g. `us.anthropic.claude-opus-4-8`); the harness strips the vendor/region prefix and any `[...]` suffix to derive the `{model-name}` artifact top-level folder (so `us.anthropic.claude-opus-4-8` writes under `claude-opus-4-8/`). Usually supplied with `--model` rather than pinned in the file; required from one source or the other. |
 | `api_key` | str | `local` | API key sent to the endpoint (local servers ignore the value). `provider: endpoint` only. |
@@ -187,6 +188,13 @@ uv run scripts/runner_config.py config/runner.example.yaml \
 4. Removes the temporary clone.
 
 It runs `claude -p` with `--permission-mode acceptEdits` and a narrow `--allowedTools` allowlist; it never uses `bypassPermissions` or `--dangerously-skip-permissions`.
+
+### Choosing the agent
+
+The `agent` field (or `--agent`) selects which coding agent drives the task. The `/swe2` task definition, the six artifacts, the metrics file, and the judge are identical for both; only the agent binary and how it is launched change, so a model's score is comparable across agents.
+
+- **`claude` (default)** -- Claude Code. Invoked as `claude -p "/swe2 ..."`; the skill is auto-loaded from the `/swe2` slash command. Works on every provider (`endpoint` and `bedrock`).
+- **`pi`** -- the [pi coding agent](../../self-hosted/vllm/scripts/run-pi.sh). Invoked as `pi -p --mode json --skill .claude/skills/swe2/SKILL.md "Use the swe2 skill ..."`; the **same** `SKILL.md` is loaded explicitly with `--skill` (pi has no slash commands). pi speaks only an OpenAI-compatible endpoint, so it requires `provider: endpoint` (a local vLLM server or the LiteLLM proxy) and is rejected with `provider: bedrock`. The harness writes an ephemeral pi `models.json` (pointed at the config's endpoint) under a per-run `PI_CODING_AGENT_DIR`, so it never touches a developer's global `~/.pi` config. pi emits a JSON-lines event stream rather than one result object; the harness reads its final `agent_end` event for tokens/turns/stop-reason and normalizes them to the same `metrics.json` fields (labeled `pi_api.*` in `metrics_that_matter.sources`). pi has no `--max-turns` cap and runs tools without an approval gate in `-p` mode, which is what an unattended run needs. Note there is no live streaming trace for pi (the `--stream` claude trace mode does not apply); the run still records full metrics.
 
 ### How `--settings` pins routing
 

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -39,6 +39,10 @@ set -euo pipefail
 #       --dataset dataset/hello-world.yaml --count 1 --yes
 #
 # Optional flags:
+#   --agent NAME           coding agent that runs the task: claude (Claude Code,
+#                          default) or pi (the pi coding agent). Same /swe2 task
+#                          either way. pi works only with --provider vllm/litellm
+#                          (an OpenAI-compatible endpoint); it has no Bedrock mode.
 #   --count N              run only the first N tasks (0 = all, default)
 #   --tasks a,b,c          run only these task ids (comma-separated); scopes the
 #                          folder-clear and the judge to the same set. Useful to
@@ -66,6 +70,7 @@ REPO_ROOT="$(dirname "$BENCHMARKS_DIR")"
 VLLM_DIR="$REPO_ROOT/self-hosted/vllm"
 
 # Defaults
+AGENT="claude"            # coding agent: claude (Claude Code) or pi (pi agent)
 PROVIDER=""
 MODEL=""
 DATASET=""
@@ -102,6 +107,7 @@ usage() {
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --agent)    AGENT="${2:?--agent needs a value}"; shift 2 ;;
         --provider) PROVIDER="${2:?--provider needs a value}"; shift 2 ;;
         --model)    MODEL="${2:?--model needs a value}"; shift 2 ;;
         --dataset)  DATASET="${2:?--dataset needs a value}"; shift 2 ;;
@@ -137,6 +143,15 @@ case "$PROVIDER" in
     bedrock|litellm|vllm) ;;
     *) die "invalid provider '$PROVIDER'. Must be one of: bedrock, litellm, vllm." ;;
 esac
+
+case "$AGENT" in
+    claude|pi) ;;
+    *) die "invalid agent '$AGENT'. Must be one of: claude, pi." ;;
+esac
+# pi speaks only an OpenAI-compatible endpoint; it has no native Amazon Bedrock
+# mode, so it cannot run the --provider bedrock path.
+[[ "$AGENT" == "pi" && "$PROVIDER" == "bedrock" ]] && \
+    die "--agent pi cannot use --provider bedrock (pi has no native Bedrock mode). Use --provider vllm or litellm."
 
 # Resolve the dataset path relative to benchmarks/ and confirm it exists.
 DATASET_PATH="$DATASET"
@@ -177,8 +192,14 @@ ok "runner config: $CONFIG"
 #   - codex  : the judge runs 'codex exec' to score them (unless --skip-judge).
 # Check both here, up front, so a missing codex fails fast instead of after the
 # entire (long) harness run has already completed.
-command -v claude >/dev/null 2>&1 || die "claude CLI not found on PATH (the harness runs 'claude -p'). Install Claude Code."
-ok "claude CLI found: $(command -v claude)"
+# The harness runs the chosen agent: 'claude -p' (Claude Code) or 'pi -p' (pi).
+if [[ "$AGENT" == "pi" ]]; then
+    command -v pi >/dev/null 2>&1 || die "pi CLI not found on PATH (--agent pi runs 'pi -p'). Install the pi coding agent (needs Node >=22)."
+    ok "pi CLI found: $(command -v pi)"
+else
+    command -v claude >/dev/null 2>&1 || die "claude CLI not found on PATH (the harness runs 'claude -p'). Install Claude Code."
+    ok "claude CLI found: $(command -v claude)"
+fi
 if [[ "$SKIP_JUDGE" -eq 1 ]]; then
     command -v codex >/dev/null 2>&1 && ok "codex CLI found: $(command -v codex)" \
         || warn "codex CLI not found, but --skip-judge is set, so scoring is skipped."
@@ -320,7 +341,10 @@ trap _cleanup_clones EXIT
 # =============================================================================
 step "Step 1 - Run the SWE benchmark"
 # =============================================================================
-BENCH_ARGS=(--config "$CONFIG" --provider "$HARNESS_PROVIDER" --model "$MODEL" --dataset "$DATASET" --stream --verbose)
+BENCH_ARGS=(--config "$CONFIG" --agent "$AGENT" --provider "$HARNESS_PROVIDER" --model "$MODEL" --dataset "$DATASET")
+# --stream/--verbose is the Claude Code live-trace mode; pi emits its own JSON
+# event stream and has no equivalent, so only add it for the claude agent.
+[[ "$AGENT" != "pi" ]] && BENCH_ARGS+=(--stream --verbose)
 [[ "$COUNT" != "0" ]] && BENCH_ARGS+=(--count "$COUNT")
 [[ -n "$TASKS" ]] && BENCH_ARGS+=(--tasks "$TASKS")
 [[ "$HARNESS_PROVIDER" == "endpoint" ]] && BENCH_ARGS+=(--endpoint "$ENDPOINT")

--- a/benchmarks/scripts/run-multi-model-benchmark.sh
+++ b/benchmarks/scripts/run-multi-model-benchmark.sh
@@ -26,6 +26,7 @@ set -uo pipefail
 # Options (with defaults):
 #   --dataset PATH        dataset YAML relative to benchmarks/ (mcp-gateway-registry)
 #   --dollars-per-hour N  instance $/hr, recorded in the summary (0 = unset)
+#   --agent NAME          coding agent that runs each task: claude (default) or pi
 #   --no-detach           run in the foreground (do not self-detach)
 #   --skip-judge          run the harness only; score later
 #
@@ -64,6 +65,7 @@ REGISTRY=(
 
 DATASET="dataset/mcp-gateway-registry.yaml"
 DOLLARS_PER_HOUR="0"
+AGENT="claude"
 DETACH=1
 SKIP_JUDGE=""
 MODELS=()
@@ -110,6 +112,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dataset)          DATASET="${2:?}"; shift 2 ;;
     --dollars-per-hour) DOLLARS_PER_HOUR="${2:?}"; shift 2 ;;
+    --agent)            AGENT="${2:?}"; shift 2 ;;
     --no-detach)        DETACH=0; shift ;;
     --skip-judge)       SKIP_JUDGE="--skip-judge"; shift ;;
     -h|--help)          sed -n '4,37p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; print_catalog; exit 0 ;;
@@ -117,6 +120,12 @@ while [[ $# -gt 0 ]]; do
     *)                  MODELS+=("$1"); shift ;;
   esac
 done
+
+# --- Validate the agent -----------------------------------------------------
+case "$AGENT" in
+  claude|pi) ;;
+  *) die "invalid --agent '$AGENT'. Must be one of: claude, pi." ;;
+esac
 
 # --- Fail loudly if no models, or an unknown model, was given ----------------
 if [[ ${#MODELS[@]} -eq 0 ]]; then
@@ -135,7 +144,7 @@ done
 # --- Self-detach so a session teardown cannot kill a multi-hour run ----------
 if [[ "$DETACH" == "1" && -z "${MMB_DETACHED:-}" ]]; then
   MMB_DETACHED=1 setsid nohup "$0" --no-detach \
-    ${SKIP_JUDGE:+--skip-judge} --dataset "$DATASET" \
+    ${SKIP_JUDGE:+--skip-judge} --dataset "$DATASET" --agent "$AGENT" \
     --dollars-per-hour "$DOLLARS_PER_HOUR" "${MODELS[@]}" \
     >>"$SCRATCH/multi-model-benchmark.nohup.log" 2>&1 &
   echo "detached multi-model benchmark (pid $!)."
@@ -207,7 +216,7 @@ for want in "${MODELS[@]}"; do
   ( cd "$VLLM_DIR/scripts" && ./vllm-metrics.sh start >/dev/null 2>&1 || true )
 
   say "  running e2e benchmark for $SLUG ..."
-  ( cd "$BENCH_DIR" && ./scripts/run-e2e-benchmark.sh --provider vllm --model "$SLUG" \
+  ( cd "$BENCH_DIR" && ./scripts/run-e2e-benchmark.sh --agent "$AGENT" --provider vllm --model "$SLUG" \
       --dataset "$DATASET" --yes $SKIP_JUDGE >"$SCRATCH/e2e-$SLUG.log" 2>&1 )
   say "  e2e done for $SLUG (exit $?)"
 

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -61,6 +61,11 @@ IMPLEMENTATION_ARTIFACT_FILENAMES = ("patch.diff", "implementation.md")
 ARTIFACT_FILENAMES = DESIGN_ARTIFACT_FILENAMES + IMPLEMENTATION_ARTIFACT_FILENAMES
 GIT_CLONE_TIMEOUT_SECONDS = 300
 
+# The /swe2 skill file, shared by both agents. Claude Code auto-loads it from the
+# repo's .claude/skills tree via the /swe2 slash command; pi is pointed at the
+# same file explicitly with `--skill` so both agents run the identical task.
+SWE2_SKILL_PATH = REPO_ROOT / ".claude" / "skills" / "swe2" / "SKILL.md"
+
 # The harness scrapes vLLM's entire Prometheus /metrics surface (every family
 # under this prefix) rather than a curated subset, so nothing is omitted and new
 # vLLM metrics appear automatically. These series are SERVER-WIDE and CUMULATIVE:
@@ -192,7 +197,12 @@ def _clone_repo(task: Task, ref: str, clone_dir: str, log_prefix: str = "") -> P
 
 
 def _build_prompt(
-    task: Task, clone_path: Path, ref: str, model: str, artifacts_dir: Path
+    task: Task,
+    clone_path: Path,
+    ref: str,
+    model: str,
+    artifacts_dir: Path,
+    agent: str = "claude",
 ) -> str:
     """Build the non-interactive /swe2 prompt for a task.
 
@@ -208,23 +218,39 @@ def _build_prompt(
     directory the skill writes to) and the task's problem statement and, when
     present, its reference issue URL.
 
+    The only agent-specific difference is how the skill is triggered. Claude Code
+    auto-loads the skill from the ``/swe2`` slash command, so the prompt starts
+    with it. pi loads the same ``SKILL.md`` via ``--skill`` and exposes it as a
+    skill named ``swe2``; it has no slash-command syntax, so the pi prompt names
+    the skill in prose and passes the identical key/value payload. Both carry the
+    exact same values, so the two agents run the same task.
+
     Args:
         task: The task to run.
         clone_path: Local path to the already-cloned repo (the sole code source).
         ref: The git ref checked out.
         model: The model name (also the artifact subfolder name).
         artifacts_dir: Absolute directory the six artifacts must be written to.
+        agent: Which agent will receive the prompt ("claude" or "pi").
 
     Returns:
-        The prompt string to pass to `claude -p`.
+        The prompt string to pass to the agent.
     """
     answers = task.clarifying_answers or (
         "No separate answers provided. Use your best judgment; all needed "
         "information is in the task description below."
     )
+    payload = (
+        f"repo: {clone_path} problem: {task.id} model: {model} "
+        f'tag: {ref} artifacts_dir: {artifacts_dir} answers: "{answers.strip()}"'
+    )
+    if agent == "pi":
+        # pi has no slash commands; name the loaded skill and hand it the payload.
+        invocation = f"Use the swe2 skill to complete this task. {payload}"
+    else:
+        invocation = f"/swe2 {payload}"
     lines = [
-        f"/swe2 repo: {clone_path} problem: {task.id} model: {model} "
-        f'tag: {ref} artifacts_dir: {artifacts_dir} answers: "{answers.strip()}"',
+        invocation,
         "",
         "Task description:",
         task.problem_statement or "(see reference issue)",
@@ -382,6 +408,115 @@ def _build_claude_cmd(
         # stream-json in -p mode requires --verbose to emit per-event objects.
         cmd.append("--verbose")
     return cmd
+
+
+def _write_pi_models_json(config: RunnerConfig, agent_dir: Path) -> None:
+    """Write an ephemeral pi ``models.json`` pointing at the config's endpoint.
+
+    pi resolves providers from ``<agent_dir>/models.json`` (agent_dir defaults to
+    ``~/.pi/agent`` but is overridden per run via ``PI_CODING_AGENT_DIR`` so the
+    benchmark never mutates a developer's global pi config). This writes a single
+    ``vllm`` provider block -- the OpenAI-compatible ``/v1`` base URL and one
+    anchor model whose id matches ``config.model`` -- mirroring
+    ``self-hosted/vllm/scripts/run-pi.sh``. Cost is left at 0 because a
+    self-hosted model has no per-token price; the real cost is hardware-derived
+    separately (see cost-per-task-methodology.md).
+
+    Args:
+        config: The runner config (endpoint + model).
+        agent_dir: The per-run pi agent dir to write ``models.json`` into.
+    """
+    # pi's baseUrl expects the OpenAI-compatible root ending in /v1.
+    base = config.endpoint.rstrip("/")
+    base_url = base if base.endswith("/v1") else f"{base}/v1"
+    window = config.context_window or 200000
+    models_json = {
+        "providers": {
+            "vllm": {
+                "baseUrl": base_url,
+                "api": "openai-completions",
+                "apiKey": config.api_key,
+                "compat": {
+                    "supportsDeveloperRole": False,
+                    "supportsReasoningEffort": False,
+                },
+                "models": [
+                    {
+                        "id": config.model,
+                        "name": f"vLLM: {config.model}",
+                        "reasoning": False,
+                        "input": ["text"],
+                        "contextWindow": window,
+                        "maxTokens": config.max_output_tokens,
+                        "cost": {
+                            "input": 0,
+                            "output": 0,
+                            "cacheRead": 0,
+                            "cacheWrite": 0,
+                        },
+                    }
+                ],
+            }
+        }
+    }
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "models.json").write_text(
+        json.dumps(models_json, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _build_pi_env(config: RunnerConfig, agent_dir: Path) -> dict[str, str]:
+    """Build the environment for the pi subprocess.
+
+    pi routes to the model through its ``models.json`` (written by
+    ``_write_pi_models_json``), not through env vars, so the only override needed
+    is ``PI_CODING_AGENT_DIR`` -- pointing pi at the per-run config dir so the
+    benchmark stays isolated from a developer's global ``~/.pi`` setup.
+
+    Args:
+        config: The runner config (unused today; kept for symmetry with the
+            claude path and future pi env needs).
+        agent_dir: The per-run pi agent config dir.
+
+    Returns:
+        A copy of the current environment with the pi agent dir pinned.
+    """
+    env = os.environ.copy()
+    env["PI_CODING_AGENT_DIR"] = str(agent_dir)
+    return env
+
+
+def _build_pi_cmd(config: RunnerConfig, prompt: str) -> list[str]:
+    """Assemble the ``pi -p`` argument vector for a /swe2 run.
+
+    pi runs headless with ``-p`` (process the prompt and exit) and ``--mode json``
+    (emit a stream of JSON-lines events the harness parses for metrics). Tools run
+    without an approval gate in ``-p`` mode, which is what an unattended benchmark
+    needs. The ``/swe2`` behavior is delivered by loading the same SKILL.md Claude
+    Code uses, via ``--skill``. ``--no-session`` keeps the run ephemeral (no
+    session file written under the agent dir).
+
+    Args:
+        config: The runner config (model, provider=endpoint).
+        prompt: The hydrated /swe2 prompt (see ``_build_prompt`` agent="pi").
+
+    Returns:
+        The command as a list of arguments (never a shell string).
+    """
+    return [
+        "pi",
+        "-p",
+        "--mode",
+        "json",
+        "--no-session",
+        "--provider",
+        "vllm",
+        "--model",
+        config.model,
+        "--skill",
+        str(SWE2_SKILL_PATH),
+        prompt,
+    ]
 
 
 def _utc_now_iso() -> str:
@@ -849,6 +984,128 @@ def _run_claude(cmd: list[str], env: dict[str, str], timeout: int) -> dict[str, 
     return result
 
 
+def _pi_result_from_events(events: list[dict[str, Any]], elapsed: float) -> dict[str, Any]:
+    """Normalize pi's JSON-lines event stream into the claude-shaped result dict.
+
+    pi ``--mode json`` emits a stream of events, not one result object. The final
+    ``agent_end`` carries the settled conversation; the last assistant message's
+    ``usage`` holds cumulative tokens, and ``stopReason`` reports why it stopped.
+    Turns are counted from ``turn_start`` events. This maps those onto the same
+    keys ``_metrics_from_result`` reads for claude (``usage.input_tokens`` etc.,
+    ``num_turns``, ``subtype``, ``is_error``, ``total_cost_usd``) so the rest of
+    the harness is agent-agnostic.
+
+    Args:
+        events: The parsed JSON-lines events pi emitted, in order.
+        elapsed: Wall-clock seconds measured around the subprocess call.
+
+    Returns:
+        A result dict shaped like ``claude -p``'s JSON result.
+
+    Raises:
+        RuntimeError: If the stream carried no ``agent_end`` (pi crashed or
+            produced no parseable result).
+    """
+    num_turns = sum(1 for e in events if e.get("type") == "turn_start")
+    agent_end = next(
+        (e for e in reversed(events) if e.get("type") == "agent_end"), None
+    )
+    if agent_end is None:
+        raise RuntimeError("pi emitted no agent_end event (no parseable result)")
+    messages = agent_end.get("messages") or []
+    last_assistant = next(
+        (
+            m
+            for m in reversed(messages)
+            if isinstance(m, dict) and m.get("role") == "assistant"
+        ),
+        {},
+    )
+    usage = last_assistant.get("usage") or {}
+    stop_reason = last_assistant.get("stopReason")
+    # pi's usage keys (input/output) differ from claude's (input_tokens/...);
+    # remap so _metrics_from_result reads them unchanged. Cache tokens are left
+    # absent (vLLM does not report them; real reuse comes from the Prometheus
+    # block), matching the claude-vs-vLLM behavior.
+    cost = (usage.get("cost") or {}).get("total")
+    # An error retry (pi tried and gave up) or a non-"stop" terminal reason marks
+    # the run failed so the harness's retry/failure logic can react.
+    will_retry = agent_end.get("willRetry", False)
+    is_error = bool(will_retry) or stop_reason not in (None, "stop", "end_turn")
+    return {
+        "usage": {
+            "input_tokens": usage.get("input", 0),
+            "output_tokens": usage.get("output", 0),
+        },
+        "num_turns": num_turns,
+        # pi reports 0 cost against a local vLLM endpoint; the real per-task cost
+        # is hardware-derived (see cost-per-task-methodology.md), so keep None
+        # here rather than a misleading 0.
+        "total_cost_usd": cost if cost else None,
+        "is_error": is_error,
+        # Map pi's stopReason onto the subtype the retry logic keys on. pi has no
+        # turn cap (no error_max_turns analogue), so a clean stop is "success".
+        "subtype": "success" if stop_reason in ("stop", "end_turn") else stop_reason,
+        "duration_ms": round(elapsed * 1000),
+        "result": stop_reason or "",
+    }
+
+
+def _run_pi(cmd: list[str], env: dict[str, str], timeout: int) -> dict[str, Any]:
+    """Run ``pi -p --mode json`` and normalize its event stream to a result dict.
+
+    Args:
+        cmd: The pi command argument vector.
+        env: Environment for the subprocess (pins PI_CODING_AGENT_DIR).
+        timeout: Wall-clock timeout in seconds.
+
+    Returns:
+        The claude-shaped result dict (see ``_pi_result_from_events``).
+
+    Raises:
+        RuntimeError: If pi times out, emits no output, or emits no agent_end.
+    """
+    start = time.time()
+    try:
+        proc = subprocess.run(  # nosec B603 - hardcoded 'pi', list args, no shell
+            cmd,
+            env=env,
+            # Run from the repo root so the skill's artifact paths resolve, exactly
+            # as for the claude path (see the note in _run_claude).
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"pi -p timed out after {timeout}s") from exc
+    elapsed = time.time() - start
+
+    if not proc.stdout.strip():
+        raise RuntimeError(
+            f"pi -p produced no output (exit {proc.returncode}): "
+            f"{proc.stderr.strip()[:500]}"
+        )
+    events: list[dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            # pi may interleave non-JSON diagnostics; skip them, keep the events.
+            continue
+    if not events:
+        raise RuntimeError(
+            f"pi -p output had no JSON events: {proc.stdout.strip()[:500]}"
+        )
+    result = _pi_result_from_events(events, elapsed)
+    result["_elapsed_seconds"] = round(elapsed, 1)
+    return result
+
+
 TOOL_RESULT_PREVIEW_CHARS = 500
 
 
@@ -1072,6 +1329,7 @@ def _summary_metrics(
     vllm_prometheus: dict[str, Any],
     generation_tokens_per_sec: float,
     include_vllm: bool = True,
+    agent: str = "claude",
 ) -> dict[str, Any]:
     """Build the headline "metrics that matter" block for a run.
 
@@ -1112,22 +1370,25 @@ def _summary_metrics(
     prompt_total = counters.get(PROMPT_TOKENS_METRIC)
     prompt_cached = counters.get(PROMPT_TOKENS_CACHED_METRIC)
 
+    # Provenance label for the agent's own reported usage (Claude Code vs pi).
+    api = f"{agent}_api"
+
     # Cache-read: the API number if the backend reported it, else (only when a
     # vLLM server backs the run) vLLM's cached prompt tokens. Cache-write has no
     # direct vLLM counter; the freshly computed (uncached) prefill tokens are the
     # closest equivalent.
     if "cache_read_tokens" in metrics:
         cache_read: int | None = metrics["cache_read_tokens"]
-        cache_read_src = "claude_api.usage.cache_read_input_tokens"
+        cache_read_src = f"{api}.usage.cache_read_input_tokens"
     elif include_vllm:
         cache_read = prompt_cached
         cache_read_src = f"vllm_prometheus.counters.{PROMPT_TOKENS_CACHED_METRIC}"
     else:
         cache_read = None
-        cache_read_src = "claude_api.usage.cache_read_input_tokens (not reported)"
+        cache_read_src = f"{api}.usage.cache_read_input_tokens (not reported)"
     if "cache_creation_tokens" in metrics:
         cache_write: int | None = metrics["cache_creation_tokens"]
-        cache_write_src = "claude_api.usage.cache_creation_input_tokens"
+        cache_write_src = f"{api}.usage.cache_creation_input_tokens"
     elif include_vllm and prompt_total is not None and prompt_cached is not None:
         cache_write = prompt_total - prompt_cached
         cache_write_src = (
@@ -1159,12 +1420,12 @@ def _summary_metrics(
         "generation_tokens_per_sec": generation_tokens_per_sec,
     }
     sources = {
-        "input_tokens": "claude_api.usage.input_tokens",
-        "output_tokens": "claude_api.usage.output_tokens",
+        "input_tokens": f"{api}.usage.input_tokens",
+        "output_tokens": f"{api}.usage.output_tokens",
         "cache_read_tokens": cache_read_src,
         "cache_write_tokens": cache_write_src,
-        "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
-        "num_turns": "claude_api.num_turns",
+        "latency_seconds": f"harness wall-clock (or {api}.duration_ms)",
+        "num_turns": f"{api}.num_turns",
         "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
     }
     # The prefix-cache hit rate is a vLLM-only signal; omit it entirely rather
@@ -1222,6 +1483,7 @@ def _save_metrics(
         "tags": task.tags,
         "model": config.model,
         "model_slug": config.model_slug,
+        "agent": config.agent,
         "provider": config.provider,
         "endpoint": config.endpoint if not config.is_bedrock else None,
         "aws_region": config.resolved_region() if config.is_bedrock else None,
@@ -1239,7 +1501,11 @@ def _save_metrics(
         "artifacts_expected": len(ARTIFACT_FILENAMES),
         "generation_tokens_per_sec": generation_tokens_per_sec,
         "metrics_that_matter": _summary_metrics(
-            metrics, vllm_prometheus, generation_tokens_per_sec, include_vllm
+            metrics,
+            vllm_prometheus,
+            generation_tokens_per_sec,
+            include_vllm,
+            agent=config.agent,
         ),
         **metrics,
     }
@@ -1290,11 +1556,35 @@ def _run_task(
     clone_parent = clone_path.parent
     try:
         prompt = _build_prompt(
-            task, clone_path, ref, config.model_slug, _artifact_dir(config, task)
+            task,
+            clone_path,
+            ref,
+            config.model_slug,
+            _artifact_dir(config, task),
+            agent=config.agent,
         )
-        cmd = _build_claude_cmd(config, prompt, stream=stream, clone_path=clone_path)
-        env = _build_env(config)
-        logger.info("  %s Running claude -p (max_turns=%s)...", label, config.max_turns)
+        # Build the agent-specific command + environment. pi and Claude Code run
+        # the same /swe2 task but take entirely different flags and routing, so
+        # this is the single branch point; everything downstream (metrics,
+        # scraping, artifact checks) is agent-agnostic.
+        if config.is_pi:
+            # Per-run pi config dir under the clone parent so it is cleaned up
+            # with the clone and never touches the developer's global ~/.pi.
+            pi_agent_dir = clone_parent / "pi-agent"
+            _write_pi_models_json(config, pi_agent_dir)
+            cmd = _build_pi_cmd(config, prompt)
+            env = _build_pi_env(config, pi_agent_dir)
+            logger.info(
+                "  %s Running pi -p (agent=pi, no turn cap)...", label
+            )
+        else:
+            cmd = _build_claude_cmd(
+                config, prompt, stream=stream, clone_path=clone_path
+            )
+            env = _build_env(config)
+            logger.info(
+                "  %s Running claude -p (max_turns=%s)...", label, config.max_turns
+            )
         # vLLM Prometheus scraping only applies to an HTTP endpoint; Amazon
         # Bedrock exposes no such surface, so skip it and leave the block marked
         # unavailable. metrics_endpoint is None for provider=bedrock.
@@ -1315,7 +1605,11 @@ def _run_task(
         # claude -p call as the metric snapshots. ISO 8601 with a trailing Z.
         run_started_at = _utc_now_iso()
         with _GaugePoller(metrics_endpoint) as poller:
-            if stream:
+            if config.is_pi:
+                # pi emits a JSON-lines event stream; _run_pi normalizes it to the
+                # same result shape. It has no separate streaming trace mode.
+                result = _run_pi(cmd, env, config.timeout_seconds)
+            elif stream:
                 result = _run_claude_streaming(
                     cmd, env, config.timeout_seconds, verbose=verbose
                 )
@@ -1432,9 +1726,17 @@ def _dry_run(config: RunnerConfig, dataset: Dataset, tasks: list[Task]) -> None:
             / _repo_name(task.repo)
         )
         prompt = _build_prompt(
-            task, placeholder, ref, config.model_slug, _artifact_dir(config, task)
+            task,
+            placeholder,
+            ref,
+            config.model_slug,
+            _artifact_dir(config, task),
+            agent=config.agent,
         )
-        cmd = _build_claude_cmd(config, prompt, clone_path=placeholder)
+        if config.is_pi:
+            cmd = _build_pi_cmd(config, prompt)
+        else:
+            cmd = _build_claude_cmd(config, prompt, clone_path=placeholder)
         print(f"\n=== {task.id} [{task.complexity}] ref={ref} ===")
         print("PROMPT:")
         print(prompt)
@@ -1683,6 +1985,11 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--config", help="Path to the runner config YAML file")
     parser.add_argument(
+        "--agent",
+        help="Override: coding agent that runs the task ('claude' for Claude "
+        "Code, 'pi' for the pi coding agent). pi requires provider=endpoint.",
+    )
+    parser.add_argument(
         "--provider",
         help="Override: routing provider ('endpoint' for a base URL, 'bedrock' "
         "for native Amazon Bedrock)",
@@ -1775,6 +2082,7 @@ def main() -> None:
     """Parse arguments, load config and dataset, and run the benchmark."""
     args = _parse_args()
     overrides: dict[str, Any] = {
+        "agent": args.agent,
         "provider": args.provider,
         "endpoint": args.endpoint,
         "model": args.model,

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -984,7 +984,9 @@ def _run_claude(cmd: list[str], env: dict[str, str], timeout: int) -> dict[str, 
     return result
 
 
-def _pi_result_from_events(events: list[dict[str, Any]], elapsed: float) -> dict[str, Any]:
+def _pi_result_from_events(
+    events: list[dict[str, Any]], elapsed: float
+) -> dict[str, Any]:
     """Normalize pi's JSON-lines event stream into the claude-shaped result dict.
 
     pi ``--mode json`` emits a stream of events, not one result object. The final
@@ -1574,9 +1576,7 @@ def _run_task(
             _write_pi_models_json(config, pi_agent_dir)
             cmd = _build_pi_cmd(config, prompt)
             env = _build_pi_env(config, pi_agent_dir)
-            logger.info(
-                "  %s Running pi -p (agent=pi, no turn cap)...", label
-            )
+            logger.info("  %s Running pi -p (agent=pi, no turn cap)...", label)
         else:
             cmd = _build_claude_cmd(
                 config, prompt, stream=stream, clone_path=clone_path

--- a/benchmarks/scripts/runner_config.py
+++ b/benchmarks/scripts/runner_config.py
@@ -91,6 +91,17 @@ PROVIDER_BEDROCK = "bedrock"
 VALID_PROVIDERS = {PROVIDER_ENDPOINT, PROVIDER_BEDROCK}
 DEFAULT_PROVIDER = PROVIDER_ENDPOINT
 
+# Which coding agent drives the task. "claude" is Claude Code (`claude -p`);
+# "pi" is the pi coding agent (`pi -p --mode json`), which speaks the same
+# OpenAI-compatible endpoint a self-hosted vLLM server exposes. The /swe2 task
+# definition is identical for both -- only the agent binary and its invocation
+# differ. pi has no native Amazon Bedrock mode, so it pairs only with
+# provider=endpoint (validated below).
+AGENT_CLAUDE = "claude"
+AGENT_PI = "pi"
+VALID_AGENTS = {AGENT_CLAUDE, AGENT_PI}
+DEFAULT_AGENT = AGENT_CLAUDE
+
 # Amazon Bedrock model ids carry a region/vendor inference-profile prefix
 # (e.g. "us.anthropic.claude-opus-4-8") and may carry a bracketed context-window
 # suffix (e.g. "[1m]"). The /swe skill strips both to name its artifact folder,
@@ -157,7 +168,16 @@ class RunnerConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    # Routing: how claude -p reaches the model.
+    # Which coding agent drives the /swe2 task: "claude" (Claude Code, the
+    # default) or "pi" (the pi coding agent). The task definition is the same for
+    # both; only the agent binary and how it is invoked differ. See VALID_AGENTS.
+    agent: str = Field(
+        default=DEFAULT_AGENT,
+        description="Coding agent that runs the task: 'claude' (Claude Code) or "
+        "'pi' (pi coding agent). pi requires provider=endpoint.",
+    )
+
+    # Routing: how the agent reaches the model.
     #   "endpoint" (default): route through an OpenAI/Anthropic-compatible base
     #       URL (a local vLLM server, a gateway, or the Anthropic API).
     #   "bedrock": drive models directly on Amazon Bedrock via the native
@@ -264,8 +284,13 @@ class RunnerConfig(BaseModel):
 
     @property
     def is_bedrock(self) -> bool:
-        """True when claude -p should route natively to Amazon Bedrock."""
+        """True when the agent should route natively to Amazon Bedrock."""
         return self.provider == PROVIDER_BEDROCK
+
+    @property
+    def is_pi(self) -> bool:
+        """True when the pi coding agent drives the task (instead of Claude Code)."""
+        return self.agent == AGENT_PI
 
     @property
     def auto_compact_window(self) -> int | None:
@@ -341,6 +366,19 @@ class RunnerConfig(BaseModel):
         if self.provider not in VALID_PROVIDERS:
             raise RunnerConfigError(
                 f"provider '{self.provider}' not in {sorted(VALID_PROVIDERS)}."
+            )
+        if self.agent not in VALID_AGENTS:
+            raise RunnerConfigError(
+                f"agent '{self.agent}' not in {sorted(VALID_AGENTS)}."
+            )
+        # pi speaks only the OpenAI-compatible endpoint path; it has no native
+        # Amazon Bedrock mode, so pair it with provider=endpoint (a local vLLM
+        # server, a gateway, etc.). Claude Code supports both providers.
+        if self.is_pi and self.is_bedrock:
+            raise RunnerConfigError(
+                "agent=pi requires provider=endpoint (pi has no native Amazon "
+                "Bedrock mode). Serve the model on an OpenAI-compatible endpoint "
+                "(e.g. a local vLLM server) and set provider=endpoint."
             )
         if not self.model:
             raise RunnerConfigError(
@@ -451,6 +489,7 @@ def load_runner_config(
 def _summarize(config: RunnerConfig) -> None:
     """Log a short human-readable summary of the runner config."""
     logger.info("Runner config:")
+    logger.info("  agent: %s", config.agent)
     logger.info("  provider: %s", config.provider)
     if config.is_bedrock:
         logger.info("  aws_region: %s", config.resolved_region())
@@ -492,6 +531,9 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("config", help="Path to the runner config YAML file")
     parser.add_argument(
+        "--agent", help="Override: coding agent that runs the task (claude | pi)"
+    )
+    parser.add_argument(
         "--provider", help="Override: routing provider (endpoint | bedrock)"
     )
     parser.add_argument("--endpoint", help="Override: API endpoint base URL")
@@ -511,6 +553,7 @@ def main() -> None:
     """Validate the given runner config file and print a summary."""
     args = _parse_args()
     overrides = {
+        "agent": args.agent,
         "provider": args.provider,
         "endpoint": args.endpoint,
         "model": args.model,


### PR DESCRIPTION
## Summary

Adds an **agent** dimension to the benchmark harness so the *same* `/swe2` task can be driven by either **Claude Code** (default) or the **pi coding agent**. The task definition, the six artifacts, the metrics file, and the codex judge are all unchanged -- only the agent binary and how it is launched differ -- so a model's quality score stays directly comparable across agents.

Requested: keep `/swe2` the same, but let the benchmark skill and scripts run pi instead of Claude Code.

## How it works

- **`--agent claude|pi`** (default `claude`) on `run-swe-headless.py`, `run-e2e-benchmark.sh`, and `run-multi-model-benchmark.sh`; also an `agent` field in the runner config.
- **Same skill, different delivery.** Claude Code auto-loads `/swe2` from the slash command. pi has no slash commands, so the harness loads the identical `.claude/skills/swe2/SKILL.md` with pi's `--skill` flag and phrases the prompt to invoke the `swe2` skill -- carrying the exact same `repo/problem/model/tag/artifacts_dir/answers` payload.
- **Headless pi:** `pi -p --mode json --no-session --provider vllm --model <id> --skill <SKILL.md> <prompt>`. Tools auto-run in `-p` mode (no approval gate), which is what an unattended run needs; the blast radius is the throwaway clone, same justification the harness already documents for Claude Code.
- **Isolated config:** the harness writes an ephemeral pi `models.json` (pointed at the config's endpoint) under a per-run `PI_CODING_AGENT_DIR`, so it never touches a developer's global `~/.pi`.
- **Agent-agnostic metrics:** pi emits a JSON-lines event stream; `_pi_result_from_events` reads the final `agent_end` event and normalizes tokens / turns / stop-reason onto the same keys the Claude result parser uses, so `metrics.json` is identical in shape (provenance labeled `pi_api.*`). The vLLM Prometheus scraping is unchanged (it measures the server, not the agent).

## Constraints enforced

- `--agent pi` requires an OpenAI-compatible endpoint (`provider: endpoint` / `vllm` / `litellm`); it is rejected with `--provider bedrock` (pi has no native Bedrock mode), in both the Python validator and the shell scripts.
- pi has no `--max-turns` cap and no live streaming trace; the claude-only `--stream` mode is skipped for pi. Full metrics are still recorded.

## Verification

Ran end-to-end against a live self-hosted vLLM `gemma-4-31b` server on the `hello-world` task with `--agent pi`: produced **all 6 `/swe2` artifacts** (github-issue, lld, review, testing, patch.diff, implementation), 12 turns, tokens/latency parsed correctly, `metrics.json` recorded `agent: pi` with `pi_api.*` provenance. `py_compile`, `bash -n`, and `bandit` all clean; security gate (Cipher) APPROVED.

## Docs

- `benchmarks/docs/harness-reference.md`: new "Choosing the agent" section + `agent` config-table row.
- `.claude/skills/benchmark/SKILL.md`: documents the optional `--agent` input and the pi preflight.

Builds on the existing pi integration (`self-hosted/vllm/scripts/run-pi.sh`, PR #60). No changes to the /swe2 task or the judge.