### PR TITLE
docs: per-agent results docs + generator, with a per-harness table in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ The single task score hides *how* a model earns it. The radar below breaks the j
 
 The shape is as informative as the size: qwen3.6-35b leads on specificity and its review/testing artifacts; gemma-4-31b is strongest on risk-awareness; the coder-tuned qwen3-coder-30b trails on every axis and collapses on implementation. Every model dips hardest on **implementation** and **correctness** -- landing working code is the hard part. This view currently covers the models whose runs carry the per-artifact breakdown; the rest are being backfilled. Regenerate with `uv run scripts/plot_quality_radar.py` (add `--dark`) from `benchmarks/`.
 
+### Results by harness
+
+The same models can be driven by different coding agents (harnesses). Each harness has its own results document -- one running table of every model benchmarked under that agent, plus its cost-quality and quality-radar charts -- generated from the committed run-summaries by `gen_agent_report.py`. The cross-agent write-up compares them head to head.
+
+| Harness | Results doc | Status |
+|---|---|---|
+| Claude Code | [docs/harness-claude-code.md](docs/harness-claude-code.md) | 14 models |
+| pi | [docs/harness-pi.md](docs/harness-pi.md) | 3 models |
+| opencode | _coming_ ([#72](https://github.com/aarora79/agentic-coding-harness-benchmarks/issues/72)) | not yet wired |
+| kiro-cli | _coming_ ([#73](https://github.com/aarora79/agentic-coding-harness-benchmarks/issues/73)) | not yet wired |
+| _cross-agent comparison_ | [docs/harness-comparison.md](docs/harness-comparison.md) | Claude Code vs pi |
+
 ## The three hosting paths
 
 Whichever path you choose, the agent (Claude Code), the tasks, the `/swe` skill, and the scoring are identical -- only *where the model runs and how the request reaches it* changes.
@@ -288,7 +300,7 @@ Where to read more, by topic:
 | [docs/vision.md](docs/vision.md) | The north star: a cost-aware harness that routes each task (and each phase) to the right model on the frontier -- frontier / workhorse / budget -- switching automatically. |
 | [benchmarks/README.md](benchmarks/README.md) | The benchmark harness landing page: the three hosting paths, how a run works, and how to reproduce the results above. |
 | [benchmarks/docs/harness-reference.md](benchmarks/docs/harness-reference.md) | Full harness reference: config, the `/swe2` flow, context-window/auto-compaction, and the LLM-as-judge scoring. |
-| [docs/harness-comparison.md](docs/harness-comparison.md) | Claude Code vs pi on the same models and tasks: Claude Code is a few points more accurate, pi is far more token-efficient (and thus faster and, when self-hosting, much cheaper). Living doc, updated as more results land. |
+| [docs/harness-comparison.md](docs/harness-comparison.md) | Claude Code vs pi on the same models and tasks: Claude Code is a few points more accurate, pi is far more token-efficient (and thus faster and, when self-hosting, much cheaper). Living doc, updated as more results land. See the [per-harness results docs](#results-by-harness) for each agent's full table and charts. |
 | [benchmarks/docs/path-anthropic-on-bedrock.md](benchmarks/docs/path-anthropic-on-bedrock.md) | Path 1 setup: benchmarking the Anthropic family (Claude Opus/Sonnet/Haiku) directly on Amazon Bedrock. |
 | [benchmarks/docs/path-open-weight-on-bedrock-litellm.md](benchmarks/docs/path-open-weight-on-bedrock-litellm.md) | Path 2 setup: open-weight models on Amazon Bedrock through the LiteLLM proxy. |
 | [benchmarks/docs/path-self-hosted-vllm.md](benchmarks/docs/path-self-hosted-vllm.md) | Path 3 setup: self-hosting a model on vLLM and pointing the harness at it. |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 > It is not meant for production use. Review and harden all scripts, configurations,
 > and IAM permissions before using in any production or sensitive environment.
 
+## Why this exists
+
+Enterprises are adopting coding agents and models at scale, and the bill grows with every developer and every task. The two big levers on that bill -- **which harness** drives the work and **which model** it drives -- are usually chosen on gut feel or on public leaderboards that may already be **saturated**: models can be tuned toward well-known public test sets, so a high headline number does not reliably predict performance on a team's actual, messy, long-horizon coding work.
+
+This repo measures the thing that actually matters instead: **harness x model, on real agentic software-engineering tasks against real repositories**, reporting all three axes a buyer trades off -- **cost, latency, and accuracy**. Crossing harnesses with models gives real **optionality**: the same model can be a few points more accurate under one agent yet several times cheaper and faster under another (see the [harness comparison](docs/harness-comparison.md)). With those numbers in hand, an organization can make an **informed, defensible decision** about the cost/latency/accuracy trade-off for its own workload -- and, very often, **lower its coding bill substantially** by picking a cheaper harness-and-model pairing that is more than good enough, rather than defaulting to the most expensive option. That is the deliverable: an evidence base for smart, budget-aware choices on work that looks like yours, not like a leaderboard.
+
 ## Overview
 
 This repository is a **benchmark and harness for measuring how well different LLMs perform real-world software-engineering tasks** when driven by a coding agent. It supports **two coding agents (harnesses)** today -- [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Anthropic's command-line coding agent, and [pi](https://github.com/earendil-works/pi-coding-agent), a lightweight open-source agent -- with [opencode](https://opencode.ai) being added soon. Each is wired to run with a model hosted in any of **three different places**, so you can put many models through the *same* tasks with the *same* harness and compare them directly on both quality and cost. Pick the harness per run with `--agent claude` (default) or `--agent pi`; results are kept separate on disk (`<model>/<harness>/<repo>/<task>`) so the two agents never overwrite each other.

--- a/benchmarks/scripts/gen_agent_report.py
+++ b/benchmarks/scripts/gen_agent_report.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Generate a per-agent (per-harness) results document from committed summaries.
+
+For one coding agent (``claude-code``, ``pi``, ...) this walks every model's
+committed ``run-summary.json`` under that harness and renders a single Markdown
+file with:
+
+  * a per-model results table (mean score, completion, tokens, wall-clock,
+    hardware-derived cost), and
+  * the two headline charts for that harness (cost-vs-quality Pareto and the
+    quality radar), which the chart scripts render with harness-suffixed names.
+
+The doc is regenerated from data, so it never drifts from the run-summaries.
+Charts are NOT rendered here -- run ``plot_cost_quality.py --harness <h>`` and
+``plot_quality_radar.py --harness <h>`` first; this only embeds them.
+
+Usage:
+    uv run scripts/gen_agent_report.py --harness pi
+    uv run scripts/gen_agent_report.py --harness claude-code --out-dir ../docs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_BENCHMARKS_DIR = _SCRIPTS_DIR.parent
+_REPO_ROOT = _BENCHMARKS_DIR.parent
+DEFAULT_DATA_DIR = _BENCHMARKS_DIR / "swe-benchmark-data"
+DEFAULT_OUT_DIR = _REPO_ROOT / "docs"
+RUN_SUMMARY_FILENAME = "run-summary.json"
+
+# g6e.12xlarge on-demand, the default self-hosted node here. Cost on a rented GPU
+# is hardware-derived: ($/hr / 3600) x wall-clock seconds (see
+# docs/cost-per-task-methodology.md). This is a display default only.
+DEFAULT_DOLLARS_PER_HOUR = 10.49
+
+# Human labels for the harness slug used in the doc title and prose.
+HARNESS_LABELS = {
+    "claude-code": "Claude Code",
+    "pi": "pi",
+    "opencode": "opencode",
+    "kiro-cli": "kiro-cli",
+}
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    """Return the parsed JSON object at ``path``, or None if absent/invalid."""
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _run_totals(summary: dict[str, Any]) -> dict[str, Any]:
+    """Sum a run's per-task tokens and wall-clock into headline totals.
+
+    Args:
+        summary: One model's run-summary dict.
+
+    Returns:
+        Dict with total input/output tokens and total latency seconds.
+    """
+    tasks = summary.get("tasks", []) or []
+    tin = sum((t.get("input_tokens") or 0) for t in tasks)
+    tout = sum((t.get("output_tokens") or 0) for t in tasks)
+    tsec = sum((t.get("latency_seconds") or 0) for t in tasks)
+    return {"input_tokens": tin, "output_tokens": tout, "latency_seconds": tsec}
+
+
+def _collect(data_dir: Path, harness: str, repo: str) -> list[dict[str, Any]]:
+    """Return one row per model that has a run-summary under this harness.
+
+    Reads ``<data-dir>/<model>/<harness>/<repo>/run-summary.json``. Rows are
+    sorted by mean score (a None mean -- a full harness collapse -- sorts last).
+    """
+    rows: list[dict[str, Any]] = []
+    for model_dir in sorted(p for p in data_dir.iterdir() if p.is_dir()):
+        summary = _read_json(model_dir / harness / repo / RUN_SUMMARY_FILENAME)
+        if summary is None:
+            continue
+        totals = _run_totals(summary)
+        rows.append(
+            {
+                "model": summary.get("model") or model_dir.name,
+                "mean": summary.get("mean_task_score_excl_failed"),
+                "num_scored": summary.get("num_scored"),
+                "num_tasks": summary.get("num_tasks"),
+                "failed_tasks": summary.get("failed_tasks") or [],
+                "run_date": summary.get("run_date"),
+                **totals,
+            }
+        )
+    rows.sort(key=lambda r: (r["mean"] is None, -(r["mean"] or 0.0)))
+    return rows
+
+
+def _fmt_cost(latency_seconds: float, dollars_per_hour: float) -> str:
+    """Hardware-derived run cost = ($/hr / 3600) x wall-clock seconds."""
+    if not latency_seconds:
+        return "--"
+    return f"${latency_seconds * dollars_per_hour / 3600.0:.2f}"
+
+
+def _render(
+    rows: list[dict[str, Any]],
+    *,
+    harness: str,
+    repo: str,
+    dollars_per_hour: float,
+    out_dir: Path,
+) -> str:
+    """Render the per-agent Markdown doc from the collected rows."""
+    label = HARNESS_LABELS.get(harness, harness)
+    # Charts live in docs/images; link relative to the doc's out_dir.
+    img = (out_dir / "images").resolve()
+    cq = img / (
+        "cost-quality.png"
+        if harness == "claude-code"
+        else f"cost-quality-{harness}.png"
+    )
+    radar = img / (
+        "quality-radar.png"
+        if harness == "claude-code"
+        else f"quality-radar-{harness}.png"
+    )
+
+    def _rel(p: Path) -> str:
+        try:
+            return p.relative_to(out_dir.resolve()).as_posix()
+        except ValueError:
+            return p.as_posix()
+
+    lines = [
+        f"# Results: {label} harness",
+        "",
+        f"Benchmark results for every model run under the **{label}** coding agent "
+        f"on `{repo}`, generated from the committed `run-summary.json` files. "
+        "Regenerate with `uv run scripts/gen_agent_report.py --harness "
+        f"{harness}`. Companion to the cross-agent [harness comparison]"
+        "(harness-comparison.md).",
+        "",
+        "## Results by model",
+        "",
+        "| Model | Mean score | Completed | Total tokens | Wall-clock | Run cost* |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for r in rows:
+        mean = "-- (0 scored)" if r["mean"] is None else f"{r['mean']:.2f}"
+        completed = f"{r['num_scored']}/{r['num_tasks']}"
+        tok = f"{r['input_tokens'] + r['output_tokens']:,}"
+        mins = (r["latency_seconds"] or 0) / 60.0
+        wall = f"{mins:.1f}m" if mins else "--"
+        cost = _fmt_cost(r["latency_seconds"], dollars_per_hour)
+        lines.append(
+            f"| {r['model']} | {mean} | {completed} | {tok} | {wall} | {cost} |"
+        )
+    lines += [
+        "",
+        f"\\* Run cost is the whole {rows[0]['num_tasks'] if rows else 5}-task run, "
+        f"hardware-derived at g6e.12xlarge on-demand (${dollars_per_hour}/hr): "
+        "`($/hr / 3600) x wall-clock seconds`. On a rented GPU there is no "
+        "per-token bill, so time is the cost -- see "
+        "[cost-per-task-methodology.md](cost-per-task-methodology.md).",
+        "",
+        "A task scoring 0 (missing/empty artifacts) is a model failure, excluded "
+        "from the mean but counted in `Completed`. A model with 0 scored tasks "
+        "did not complete any task under this harness.",
+        "",
+        "## Charts",
+        "",
+        "### Cost vs. quality (Pareto frontier)",
+        "",
+        f"![Cost vs quality, {label} harness]({_rel(cq)})",
+        "",
+        "### Quality by dimension (radar)",
+        "",
+        f"![Quality radar, {label} harness]({_rel(radar)})",
+    ]
+    # Exactly one trailing newline (the end-of-file-fixer hook strips extras).
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate a per-agent results doc from committed run-summaries.",
+        epilog="Example: uv run scripts/gen_agent_report.py --harness pi",
+    )
+    parser.add_argument(
+        "--harness",
+        required=True,
+        help="Harness slug: claude-code, pi, opencode, kiro-cli.",
+    )
+    parser.add_argument("--repo", default="mcp-gateway-registry", help="Dataset scope.")
+    parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help="Directory to write harness-<slug>.md into (default: docs/).",
+    )
+    parser.add_argument(
+        "--dollars-per-hour",
+        type=float,
+        default=DEFAULT_DOLLARS_PER_HOUR,
+        help="Instance $/hr for the hardware-derived cost column.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Collect one harness's run-summaries and write its results doc."""
+    args = _parse_args()
+    data_dir = args.data_dir.expanduser().resolve()
+    rows = _collect(data_dir, args.harness, args.repo)
+    if not rows:
+        raise SystemExit(
+            f"no run-summary.json found under {data_dir}/*/{args.harness}/{args.repo}"
+        )
+    doc = _render(
+        rows,
+        harness=args.harness,
+        repo=args.repo,
+        dollars_per_hour=args.dollars_per_hour,
+        out_dir=args.out_dir.expanduser().resolve(),
+    )
+    out_dir = args.out_dir.expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"harness-{args.harness}.md"
+    out_path.write_text(doc, encoding="utf-8")
+    logger.info("wrote %s (%d models)", out_path, len(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/harness-claude-code.md
+++ b/docs/harness-claude-code.md
@@ -1,0 +1,36 @@
+# Results: Claude Code harness
+
+Benchmark results for every model run under the **Claude Code** coding agent on `mcp-gateway-registry`, generated from the committed `run-summary.json` files. Regenerate with `uv run scripts/gen_agent_report.py --harness claude-code`. Companion to the cross-agent [harness comparison](harness-comparison.md).
+
+## Results by model
+
+| Model | Mean score | Completed | Total tokens | Wall-clock | Run cost* |
+|---|---:|---:|---:|---:|---:|
+| us.anthropic.claude-opus-5[1m] | 77.45 | 4/4 | 968,972 | 366.0m | $64.00 |
+| us.anthropic.claude-opus-4-8 | 75.32 | 5/5 | 507,617 | 127.9m | $22.36 |
+| us.anthropic.claude-sonnet-5 | 72.84 | 5/5 | 1,009,920 | 267.7m | $46.81 |
+| glm-5.2 | 61.96 | 5/5 | 50,051,636 | 65.0m | $11.37 |
+| kimi-k2.7-code | 58.68 | 5/5 | 47,675,538 | 130.3m | $22.79 |
+| deepseek-v3.2 | 52.20 | 5/5 | 40,916,403 | 80.3m | $14.04 |
+| minimax-m2.5 | 51.56 | 5/5 | 33,957,716 | 22.7m | $3.97 |
+| qwen3.6-35b | 50.32 | 5/5 | 23,541,194 | 88.4m | $15.46 |
+| nemotron-ultra-550b | 50.20 | 4/5 | 32,802,785 | 70.2m | $12.27 |
+| gemma-4-31b | 48.40 | 5/5 | 24,842,600 | 213.0m | $37.24 |
+| us.anthropic.claude-haiku-4-5-20251001-v1:0 | 47.92 | 5/5 | 166,140 | 28.4m | $4.97 |
+| qwen3-coder-480b | 44.95 | 4/5 | 66,233,836 | 68.2m | $11.93 |
+| devstral-2-123b | 43.12 | 5/5 | 28,118,483 | 50.6m | $8.84 |
+| qwen3-coder-30b | 30.20 | 4/5 | 50,725,919 | 84.2m | $14.71 |
+
+\* Run cost is the whole 4-task run, hardware-derived at g6e.12xlarge on-demand ($10.49/hr): `($/hr / 3600) x wall-clock seconds`. On a rented GPU there is no per-token bill, so time is the cost -- see [cost-per-task-methodology.md](cost-per-task-methodology.md).
+
+A task scoring 0 (missing/empty artifacts) is a model failure, excluded from the mean but counted in `Completed`. A model with 0 scored tasks did not complete any task under this harness.
+
+## Charts
+
+### Cost vs. quality (Pareto frontier)
+
+![Cost vs quality, Claude Code harness](images/cost-quality.png)
+
+### Quality by dimension (radar)
+
+![Quality radar, Claude Code harness](images/quality-radar.png)

--- a/docs/harness-pi.md
+++ b/docs/harness-pi.md
@@ -1,0 +1,25 @@
+# Results: pi harness
+
+Benchmark results for every model run under the **pi** coding agent on `mcp-gateway-registry`, generated from the committed `run-summary.json` files. Regenerate with `uv run scripts/gen_agent_report.py --harness pi`. Companion to the cross-agent [harness comparison](harness-comparison.md).
+
+## Results by model
+
+| Model | Mean score | Completed | Total tokens | Wall-clock | Run cost* |
+|---|---:|---:|---:|---:|---:|
+| qwen3.6-35b | 47.15 | 4/5 | 627,404 | 29.4m | $5.14 |
+| gemma-4-31b | 43.52 | 5/5 | 600,667 | 60.8m | $10.63 |
+| qwen3-coder-30b | -- (0 scored) | 0/5 | 410,050 | 17.0m | $2.98 |
+
+\* Run cost is the whole 5-task run, hardware-derived at g6e.12xlarge on-demand ($10.49/hr): `($/hr / 3600) x wall-clock seconds`. On a rented GPU there is no per-token bill, so time is the cost -- see [cost-per-task-methodology.md](cost-per-task-methodology.md).
+
+A task scoring 0 (missing/empty artifacts) is a model failure, excluded from the mean but counted in `Completed`. A model with 0 scored tasks did not complete any task under this harness.
+
+## Charts
+
+### Cost vs. quality (Pareto frontier)
+
+![Cost vs quality, pi harness](images/cost-quality-pi.png)
+
+### Quality by dimension (radar)
+
+![Quality radar, pi harness](images/quality-radar-pi.png)


### PR DESCRIPTION
## Summary

Adds a per-agent (per-harness) results document and the generator that produces it, plus a per-harness results table in the README.

Each coding agent now has its own results doc -- one running table of every model benchmarked under that harness (mean score, completion, total tokens, wall-clock, hardware-derived run cost) followed by that harness's cost-quality (Pareto) and quality-radar (spider) charts. The docs are **generated from the committed run-summaries**, so they never drift from the data.

## Changes

- **`benchmarks/scripts/gen_agent_report.py`** (new): `--harness <slug>` walks `<model>/<slug>/<repo>/run-summary.json` for every model and writes `docs/harness-<slug>.md` with the running table + both embedded charts. Read-only reporter (no subprocess, network, or user input).
- **`docs/harness-pi.md`** (new, 3 models) and **`docs/harness-claude-code.md`** (new, 14 models): generated.
- **`README.md`**: new "Results by harness" table listing each harness's results doc -- Claude Code and pi live, opencode (#72) and kiro-cli (#73) marked as coming, and the cross-agent comparison doc.

## How to regenerate

```
cd benchmarks
uv run scripts/plot_cost_quality.py --harness pi --out ../docs/images/cost-quality-pi.png   # + --dark
uv run scripts/plot_quality_radar.py --harness pi --out-dir ../docs/images                   # + --dark
uv run scripts/gen_agent_report.py --harness pi                                              # -> docs/harness-pi.md
```

The same three commands with `--harness opencode` / `--harness kiro-cli` produce those docs once #72 / #73 land -- this is the artifact those issues call for.

## Validation

- Security gate (Cipher): APPROVED -- read-only script, bandit clean, no secrets/PII/local-paths in generated docs.
- pre-commit hooks (ruff lint + format, end-of-file, trailing-whitespace) pass.
- Charts referenced already exist on `main` (from #69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)