### PR TITLE
gemma-4-31b (claude-code): /swe2 benchmark run on mcp-gateway-registry

### DIFF
--- a/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/mcp-gateway-registry/run-summary.json
@@ -1,6 +1,7 @@
 {
   "model": "gemma-4-31b",
   "model_slug": "gemma-4-31b",
+  "agent": "claude",
   "scope": "mcp-gateway-registry",
   "provider": "endpoint",
   "ref": "1.24.4",
@@ -14,132 +15,155 @@
     "model": "openai.gpt-5.6-sol",
     "provider": "codex-exec",
     "repo_grounded": true,
-    "evaluated_at": "2026-07-29T05:44:23.768985Z",
+    "evaluated_at": "2026-08-03T01:40:28.726138Z",
     "repo_ref": "1.24.4",
     "reasoning_effort": "high",
     "token_usage": {
-      "input_tokens": 378301,
-      "cached_input_tokens": 326401,
-      "cache_write_input_tokens": 51882,
-      "output_tokens": 8028,
-      "reasoning_output_tokens": 4160
+      "input_tokens": 207466,
+      "cached_input_tokens": 176186,
+      "cache_write_input_tokens": 31264,
+      "output_tokens": 9130,
+      "reasoning_output_tokens": 7224
     },
-    "duration_ms": 229044
+    "duration_ms": 122666
   },
-  "num_tasks": 5,
-  "num_scored": 5,
+  "num_tasks": 4,
+  "num_scored": 4,
   "num_failed": 0,
   "failed_tasks": [],
-  "mean_task_score_excl_failed": 48.4,
-  "mean_cost_usd_excl_failed": 30.87,
+  "mean_task_score_excl_failed": 51.6,
+  "mean_cost_usd_excl_failed": 29.39,
   "tasks": [
     {
-      "task": "ssrf-hardening-outbound-url-validation",
+      "task": "remove-efs-from-terraform-aws-ecs",
       "complexity": "medium",
       "artifacts_produced": 6,
       "artifacts_expected": 6,
-      "num_turns": 59,
-      "input_tokens": 5026315,
-      "output_tokens": 26985,
-      "latency_seconds": 2568.4,
-      "total_cost_usd": 34.280950000000004,
-      "task_score": 64.6,
+      "num_turns": 51,
+      "input_tokens": 3871045,
+      "output_tokens": 34046,
+      "latency_seconds": 2255.1,
+      "total_cost_usd": 23.224369999999993,
+      "task_score": 63.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.7411,
+      "generation_tokens_per_sec": 15.1,
+      "kv_cache_usage": {
+        "peak": 0.2047,
+        "mean": 0.0879
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
       "eval_scores": {
         "github_issue": {
-          "completeness": 19,
-          "correctness": 16,
-          "specificity": 20,
-          "risk_awareness": 17,
-          "total": 72,
-          "notes": "The issue clearly identifies direct SSRF targets, affected workflows, explicit exclusions, and testable private, loopback, link-local, metadata, and compatibility outcomes. The cited guards in registry/services/skill_service.py and outbound paths in agent_validator.py, agent_routes.py, and health/service.py all exist. Its largest flaw is claiming that pre-request DNS resolution prevents DNS rebinding, although the proposed check and subsequent HTTP request resolve independently; redirects are also omitted. No independent task statement was supplied, and the claimed related issue #1282 and assertion of no dependencies could not be verified from the repository."
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 10,
+          "total": 59,
+          "notes": "The issue clearly identifies EFS infrastructure, security groups, ECS mounts, validation, and plan-level acceptance criteria. Its largest deficiency is treating storage migration as complete and declaring no dependencies despite the LLD's own required checks for logs, auth configuration, and persistent data. The supplied diff confirms the named EFS module, mount points, outputs, and module variables, but it also shows no EFS variables in the root variables file that the issue explicitly requires updating. No independent task statement or repository evidence establishes that S3 and DocumentDB have replaced every EFS use."
         },
         "lld": {
-          "completeness": 17,
-          "correctness": 15,
-          "specificity": 19,
-          "risk_awareness": 17,
-          "total": 68,
-          "notes": "The design is grounded in real symbols, including _check_endpoint_reachability, check_agent_health, _check_server_endpoint_transport_aware, and SkillService's existing private-IP guard. It commits to schemes, fail-closed resolution, IPv4 and IPv6 handling, all-address checks, and an exact-host allowlist setting. The check-then-request design knowingly leaves DNS rebinding unresolved and does not address redirect destinations or blocking socket.getaddrinfo calls from asynchronous request and health-check paths. Its backward-compatibility claim is unsupported for existing private agents, and blocked-request behavior, configuration exposure, tests, rollout, and rollback remain underspecified."
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 76,
+          "notes": "The LLD is strongest in its concrete mapping of storage.tf, ecs-services.tf, outputs, module variables, post-deployment setup, and run-scopes-init-task.sh to exact changes reflected in the patch. Its main gap is that it acknowledges DocumentDB can be absent but never decides whether that configuration must be rejected, while its rollout removes the fallback and destroys EFS in one phase. The named symbols module.efs, efs_all_outbound, efs_throughput_mode, and _initialize_scopes all agree with the submitted source context. The assertion that all persistence has already migrated to S3 or DocumentDB remains unverified, and observability and rollback are incorrectly treated as largely inapplicable to a destructive storage change."
         },
         "review": {
-          "completeness": 17,
-          "correctness": 18,
-          "specificity": 18,
-          "risk_awareness": 18,
-          "total": 71,
-          "notes": "The strongest finding correctly identifies the DNS time-of-check/time-of-use gap and recommends socket-level validation or IP pinning. It also raises multiple-address resolution, IPv6, fail-closed DNS errors, and health-loop latency, all relevant to the repository's synchronous resolver design. However, it makes rebinding mitigation optional despite the issue's acceptance criterion, misses redirect-based SSRF and compatibility with existing tests, and incorrectly describes http://1.2.3.4 as having no hostname. Claims that the utility placement avoids circular dependencies are plausible from the checked imports, but the requested strict allowlist validation is not defined concretely."
+          "completeness": 14,
+          "correctness": 15,
+          "specificity": 16,
+          "risk_awareness": 16,
+          "total": 61,
+          "notes": "The review identifies concrete runtime risks involving missing mount paths, writable-layer exhaustion, secret migration, backups, and unintended Terraform replacements. Its largest deficiency is approving the design without resolving those prerequisites or challenging the undefined behavior when DocumentDB is unavailable. The warnings correspond to the removed /app/logs, /efs/auth_config, and /app/data mounts and to the EFS fallback visible in _initialize_scopes. Claims about completed backend migration and orphaned EFS snapshots are not substantiated, and the review misses output-consumer compatibility and staged deletion concerns."
         },
         "testing": {
-          "completeness": 15,
-          "correctness": 13,
-          "specificity": 16,
-          "risk_awareness": 14,
-          "total": 58,
-          "notes": "The plan supplies concrete inputs and expected allow or block results for loopback, private, link-local, IPv6, DNS, schemes, and configured hosts. It does not name test files or mocking strategy and largely tests is_safe_url directly rather than proving that each real call site suppresses its HTTP request. The repository uses registry/ rather than src/, so uv run bandit -r src/ is incorrect, while uv run pytest is consistent with pyproject.toml. Rebinding, redirects, multiple integration paths, malformed allowlist values, resolver blocking, and the existing skill-service test contract are not covered, and tests relying on live example.com DNS would be nondeterministic."
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 13,
+          "risk_awareness": 16,
+          "total": 54,
+          "notes": "The plan covers startup, persistence, Terraform validation and planning, stale references, missing DocumentDB, and operational disk risks. Its largest correctness defect is expecting aws_ecs_task_definition to update in place even though ECS task-definition changes create a new immutable revision, and its DocumentDB-missing oracle expects failure while the patch explicitly logs a skip and succeeds. The hard-coded TF_DIR does not match the supplied checkout, terraform init and environment-specific variables are omitted, and grep -r will find the retained EFS comment and unrelated files. Health-check URLs, API requests, restart procedures, and persistence payloads are not concrete enough to execute or independently verify."
         },
         "implementation": {
-          "completeness": 15,
-          "correctness": 10,
-          "specificity": 17,
-          "risk_awareness": 12,
-          "total": 54,
-          "notes": "The patch targets real source context and centralizes the existing guard while adding checks to the principal agent and health paths plus federation and MCP clients. It removes _trusted_domains and _is_safe_url from skill_service.py without updating tests/unit/services/test_skill_service_ssrf_allowlist.py, whose tests import and patch those exact symbols, so the existing suite will fail. The synchronous, timeout-free socket.getaddrinfo check remains vulnerable to DNS rebinding and can block async paths, while health/service.py follows redirects and get_mcp_connection_result can use an unvalidated server_info mcp_endpoint after validating only base_url. No tests accompany the patch, so the summary's verification and backward-compatibility claims are unsubstantiated and overstate end-to-end coverage."
+          "completeness": 19,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 10,
+          "total": 67,
+          "notes": "The patch coherently removes module.efs, its outputs and variables, all three ECS mounts and volumes, the root outputs, the required-output check, and the EFS initialization script. Its largest behavioral defect is silently skipping scope initialization when DocumentDB is absent, contradicting the testing plan's required clear failure and leaving a misconfigured deployment apparently successful. The exact changes around ecs_service_auth, ecs_service_mcpgw, efs_all_outbound, and _initialize_scopes are internally consistent, though storage.tf retains a stale EFS-only comment and no focused validation is added. Independent git apply and repository-wide reference checks could not be completed because the read-only command sandbox failed before command execution, so patch applicability and remaining dead scope-initialization assets are material evidence gaps."
         }
       },
       "is_error": false,
       "failed": false
     },
     {
-      "task": "remove-efs-from-terraform-aws-ecs",
+      "task": "ssrf-hardening-outbound-url-validation",
       "complexity": "medium",
       "artifacts_produced": 6,
       "artifacts_expected": 6,
-      "num_turns": 55,
-      "input_tokens": 4483254,
-      "output_tokens": 22653,
-      "latency_seconds": 1805.2,
-      "total_cost_usd": 23.96906,
-      "task_score": 53.6,
+      "num_turns": 74,
+      "input_tokens": 6692051,
+      "output_tokens": 27237,
+      "latency_seconds": 2135.4,
+      "total_cost_usd": 35.69435000000001,
+      "task_score": 52.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8193,
+      "generation_tokens_per_sec": 12.8,
+      "kv_cache_usage": {
+        "peak": 0.1607,
+        "mean": 0.0922
+      },
+      "agent_invocations": 3,
+      "topped_up_artifacts": [
+        "patch.diff",
+        "implementation.md"
+      ],
       "eval_scores": {
         "github_issue": {
-          "completeness": 18,
-          "correctness": 14,
+          "completeness": 20,
+          "correctness": 17,
           "specificity": 19,
-          "risk_awareness": 9,
-          "total": 60,
-          "notes": "The issue's strongest aspect is its concrete resource, mount, variable, and output acceptance criteria plus explicit non-goals. Repository checks confirm the named EFS module, ECS mounts, and outputs, but operational consumers in `scripts/post-deployment-setup.sh` and `run-scopes-init-task.sh` are absent from the criteria. The plan cannot show only EFS resource deletions because changing ECS volumes and environment variables necessarily revises task definitions, and the root `variables.tf` and `terraform.tfvars.example` contain no EFS variables. With no independent task statement, the claimed completed migration and issue #1286 are unverifiable, while destructive-data and rollback risks are only assumed away."
+          "risk_awareness": 17,
+          "total": 73,
+          "notes": "The issue clearly identifies the SSRF threat, affected request categories, explicit exclusions, and testable blocked-address and public-URL outcomes. Its largest gap is that allowlist matching, redirect behavior, DNS rebinding, and the meaning of backward compatibility are not defined precisely enough to prevent security or migration ambiguity. The submitted patch preimage supports the claims that skill_service.py contains _is_safe_url and that agent_routes.py and health/service.py use httpx.AsyncClient. No independent task statement exists, and repository command execution failed, so related issue #1282 and the complete outbound-request inventory could not be verified."
         },
         "lld": {
-          "completeness": 16,
-          "correctness": 12,
-          "specificity": 19,
-          "risk_awareness": 12,
-          "total": 59,
-          "notes": "The LLD is well grounded in real files and accurately locates `module \"efs\"`, the task-definition mounts, outputs, variables, and deployment scripts. Its largest defect is Step 5's instruction to delete `_initialize_scopes` entirely: the existing function also detects DocumentDB and invokes `run-documentdb-init.sh`, so this would remove required initialization for the default backend. Step 0 identifies `FileScopeRepository` and `scopes_loader.py` but leaves supported file-backend behavior as a verification exercise rather than making a decision. It also omits the `elasticfilesystem:*` documentation in `terraform/aws-ecs/README.md` and provides no staged destruction, backup confirmation, or rollback procedure."
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 16,
+          "risk_awareness": 17,
+          "total": 56,
+          "notes": "The LLD names concrete files, identifies DNS TOCTOU, offloads resolution from the event loop, and proposes centralized enforcement and observability. Its central design is technically unsound because rewriting an HTTPS URL to an IP and setting Host does not preserve TLS SNI or hostname certificate verification, while redirect handling remains unspecified. The design also promises an error contract, TTL cache, metric, and mcp_client.py migration without defining their actual integration or compatibility with github_extra_hosts. Exact handlers, metrics conventions, and remaining outbound callers could not be independently verified because repository commands were unavailable."
         },
         "review": {
-          "completeness": 15,
-          "correctness": 14,
-          "specificity": 18,
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 15,
           "risk_awareness": 17,
-          "total": 64,
-          "notes": "The review usefully surfaces application-path coupling, environment-specific state plans, IAM cleanup, and fragile line-number guidance. It nevertheless misses the LLD's most consequential error: deleting `_initialize_scopes` also deletes the current DocumentDB initialization branch. The Byte concern is marked resolved merely because a verification step was added, despite the root module still supporting `file` and external MongoDB backends and no behavior decision being recorded. No EFS permission exists in the checked task-role Terraform, although `terraform/aws-ecs/README.md` does retain a broad `elasticfilesystem:*` deployment permission, and the migration claim remains unverifiable."
+          "total": 57,
+          "notes": "The review surfaces concrete high-value risks including DNS rebinding, blocking DNS calls, redirect bypasses, and observability. Its largest defect is approving the design despite leaving redirects as an either-or choice and overlooking that an IP URL plus Host header does not preserve HTTPS SNI. Item 5 claims resolution, but the LLD contains no redirect-chain algorithm, and the proposed request override would not automatically validate redirects handled inside httpx.send. The review also misses GHES allowlist migration, exception-to-API mapping, IPv6 handling, and the unverified repository integration details."
         },
         "testing": {
-          "completeness": 16,
-          "correctness": 10,
-          "specificity": 14,
-          "risk_awareness": 13,
-          "total": 53,
-          "notes": "The plan covers static Terraform checks, task-definition inspection, runtime startup, storage operations, scripts, and staged environments. Its central plan oracle is incorrect because removing mounts and environment variables must modify ECS task definitions rather than produce only EFS resource destructions. `terraform validate` is plausible but initialization and environment inputs are unspecified, while generated-JSON inspection and runtime storage operations lack executable steps and precise state assertions. It also fails to test preservation of `run-documentdb-init.sh`, supported non-DocumentDB backends, shell syntax, migration confirmation, or rollback after destructive apply."
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 13,
+          "risk_awareness": 12,
+          "total": 46,
+          "notes": "The plan provides concrete expected outcomes for loopback, RFC1918, metadata, public, and allowlisted destinations across unit and service levels. Its primary unit target is is_safe_url, but the LLD and patch define only is_private_ip and is_safe_ip, and its expected error body contradicts the LLD's URL_SSRF_BLOCKED contract. It lacks detailed redirect, DNS-rebinding, HTTPS/SNI, IPv6, multiple-address, malformed URL, and exact allowlist-matching tests, while several cases depend on uncontrolled public DNS. The submitted endpoint paths, Sentry assumption, and direct pytest commands could not be verified against repository routing and tooling because command execution failed."
         },
         "implementation": {
           "completeness": 9,
-          "correctness": 3,
-          "specificity": 16,
-          "risk_awareness": 4,
-          "total": 32,
-          "notes": "The Terraform deletions target real repository symbols and correctly remove the EFS module, variables, outputs, mounts, and volume definitions. The root `outputs.tf` hunk adds a new `monitoring_sns_topic` block while retaining the existing block, creating a duplicate output declaration that makes validation fail. Despite the summary, the patch contains neither changes to `post-deployment-setup.sh` nor deletion of `run-scopes-init-task.sh`, leaving `mcp_gateway_efs_id` required after that output is removed and guaranteeing post-deployment failure. The claimed script cleanup, application verification, and clean simulated plan therefore overstate the submitted diff, with no effective mitigation for the resulting operational breakage."
+          "correctness": 4,
+          "specificity": 13,
+          "risk_awareness": 5,
+          "total": 31,
+          "notes": "The patch partially implements the design through a concrete client, IP helpers, configuration field, exception, and migrations in three request surfaces. The core is unsafe and operationally broken: an IP-pinned HTTPS URL uses the IP for TLS SNI and certificate validation, and redirects processed internally by httpx are not revalidated despite removal of the prior final-URL checks. It also omits the designed mcp_client.py migration, tests, metric, TTL cache, API error-code mapping, scheme validation, and github_extra_hosts compatibility while the summary claims all outbound requests are protected. I could not independently run git apply --check or inspect remaining callers because read-only command execution failed with a bwrap loopback error, so applicability and additional source impacts remain unverified."
         }
       },
       "is_error": false,
@@ -150,108 +174,62 @@
       "complexity": "high",
       "artifacts_produced": 6,
       "artifacts_expected": 6,
-      "num_turns": 51,
-      "input_tokens": 3638528,
-      "output_tokens": 53083,
-      "latency_seconds": 3068.5,
-      "total_cost_usd": 23.688015,
-      "task_score": 48.4,
+      "num_turns": 42,
+      "input_tokens": 4678980,
+      "output_tokens": 31810,
+      "latency_seconds": 2155.1,
+      "total_cost_usd": 35.84664999999999,
+      "task_score": 48.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.7092,
+      "generation_tokens_per_sec": 14.8,
+      "kv_cache_usage": {
+        "peak": 0.2588,
+        "mean": 0.1182
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
       "eval_scores": {
         "github_issue": {
           "completeness": 16,
-          "correctness": 11,
-          "specificity": 14,
-          "risk_awareness": 12,
-          "total": 53,
-          "notes": "The strongest aspect is the clear security motivation, migration scope, IAM requirement, and explicit exclusions. The largest defect is the acceptance criterion requiring plaintext environment variables as fallbacks: ECS secret retrieval failure prevents task startup, as the LLD later acknowledges, so this is not a valid fallback. The repository confirms plaintext values such as REGISTRY_API_TOKEN in terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf and an existing aws_iam_policy.ecs_secrets_access pattern. No independent task statement was supplied, related issue #1134 is not verifiable from the checkout, and the issue never enumerates what \u201call identified\u201d secrets means."
+          "correctness": 10,
+          "specificity": 13,
+          "risk_awareness": 11,
+          "total": 50,
+          "notes": "The issue clearly identifies ECS task definitions, Secrets Manager, and the execution-role policy, with useful non-goals and dependencies. Its largest deficiency is requiring plaintext fallbacks as an acceptance criterion without defining their removal, which preserves the stated Terraform-state and console exposure. The claim that rotation can occur without service redeployment is incorrect for ECS-injected environment values, and the submitted implementation's aws_secretsmanager_secret_version resources would also retain values in Terraform state. No independent task statement was supplied, so the exact secret inventory and related issue #1134 could not be independently established."
         },
         "lld": {
           "completeness": 14,
-          "correctness": 9,
-          "specificity": 17,
-          "risk_awareness": 15,
-          "total": 55,
-          "notes": "The strongest aspect is repository grounding: all three primary files exist, and the documented ECS secrets, KMS key, and IAM policy patterns match the source. The largest defect is failure to preserve the existing mongodb_connection_string_secret_arn interface and conditional behavior; unconditional injection of a newly empty secret conflicts with the repository\u2019s existing plaintext-or-external-ARN selection. The proposed policy split also omits current ecs_secrets_access consumers in the MCPGW and optional metrics services, while the claimed CloudWatch metric filter has no defined event-to-log delivery path or file change. Avoiding secret versions, using a recovery window, and recognizing startup failure are sound, but the stated canary rollout has no Terraform mechanism, atomic staging boundary, or concrete rollback procedure."
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 10,
+          "total": 47,
+          "notes": "The LLD names concrete files and real-looking integration symbols that also appear in the patch, including ecs_service_auth, ecs_service_registry, aws_iam_policy.ecs_secrets_access, and Settings. Its core security design remains unsound because assigning Terraform variables to secret_string leaves those values in state even after the proposed plaintext-fallback removal. Grouping ANS credentials into one JSON secret is not reconciled with the promised per-variable shadow loading, and the design never maps several listed registration and GitHub secrets to a consuming container. The rollout also lacks the required application-before-task-definition ordering, while its shadow variables cannot rescue a task when ECS itself fails to retrieve a referenced secret."
         },
         "review": {
-          "completeness": 15,
-          "correctness": 16,
-          "specificity": 17,
-          "risk_awareness": 18,
-          "total": 66,
-          "notes": "The review\u2019s strongest contribution is identifying two real high-impact errors: Terraform-managed secret values leaking into state and ECS lacking runtime plaintext fallback after secret resolution failure. It also gives concrete mitigations for IAM scope, deletion recovery, and rollout rather than merely approving the design. Its \u201call blockers resolved\u201d verdict is too strong because it misses the existing external MongoDB ARN path, unconditional optional secrets, and ecs_secrets_access references in ecs-services.tf and observability.tf that must survive or be migrated. The review also calls the rollout comprehensive despite no implementable canary or rollback design, and the absent independent task statement prevents verifying inventory completeness."
-        },
-        "testing": {
-          "completeness": 12,
-          "correctness": 9,
-          "specificity": 12,
-          "risk_awareness": 10,
-          "total": 43,
-          "notes": "The strongest aspect is inclusion of concrete runtime oracles such as ECS RUNNING state, HTTP 200 health, successful OAuth flow, secret existence, and an allowed IAM simulation result. The largest defect is that the supplied defaults do not match the repository: the cluster defaults to mcp-gateway-ecs-cluster and the region to us-west-2, while the plan uses mcp-gateway, us-east-1, and an undefined DOMAIN. It omits terraform fmt/validate despite the repository workflow running them, does not assert removal of plaintext task-definition entries, does not test denied access to unrelated secrets, and provides no missing-secret failure test. \u201cCrashLoopBackOff\u201d is not an ECS state, the health check does not prove each migrated value is correct, and the plan does not cover the GitHub credential path or existing MongoDB ARN compatibility."
-        },
-        "implementation": {
-          "completeness": 6,
-          "correctness": 2,
-          "specificity": 9,
-          "risk_awareness": 8,
-          "total": 25,
-          "notes": "The fenced diff targets real files and matching source context, and it correctly creates KMS-backed secret shells without Terraform-managed secret versions. The largest defect is fatal: iam.tf removes aws_iam_policy.ecs_secrets_access, but the patch does not update references in ecs-services.tf or observability.tf, so Terraform validation cannot succeed. It also removes GITHUB_PAT, GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY while adding no GitHub entries to the registry secrets block, and it unconditionally duplicates MONGODB_CONNECTION_STRING when the existing external ARN is configured. The summary falsely claims IAM attachment and MCPGW changes absent from the diff; mandatory empty secret shells, omitted alerting, and no focused validation or tests make the implementation unsafe to deploy despite the seven-day recovery setting."
-        }
-      },
-      "is_error": false,
-      "failed": false
-    },
-    {
-      "task": "remove-faiss",
-      "complexity": "medium",
-      "artifacts_produced": 4,
-      "artifacts_expected": 6,
-      "num_turns": 94,
-      "input_tokens": 8766487,
-      "output_tokens": 26275,
-      "latency_seconds": 3380.2,
-      "total_cost_usd": 55.00012500000001,
-      "task_score": 38.0,
-      "eval_scores": {
-        "github_issue": {
           "completeness": 17,
           "correctness": 13,
-          "specificity": 19,
-          "risk_awareness": 8,
-          "total": 57,
-          "notes": "The issue provides concrete acceptance criteria tied to real locations such as `pyproject.toml`, `uv.lock`, and `registry/core/config.py`. Its largest flaw is treating FAISS as redundant while `Settings.storage_backend` still defaults to `file` and `get_search_repository()` selects `FaissSearchRepository` for that default. Declaring no dependencies also ignores the operational DocumentDB requirement and the need to define migration or failure behavior for file-backend users. No independent task statement or repository evidence for related issue #1285 was supplied."
-        },
-        "lld": {
-          "completeness": 10,
-          "correctness": 9,
           "specificity": 17,
-          "risk_awareness": 7,
-          "total": 43,
-          "notes": "The design correctly identifies real classes and methods including `FaissService`, `FaissSearchRepository`, `SearchRepositoryBase.index_server`, and `DocumentDBSearchRepository`. Its central factory decision is unsound: returning the DocumentDB repository for the default file backend would attempt a MongoDB connection while entity repositories remain file-based. The call-site inventory is substantially incomplete, omitting numerous FAISS calls in `server_routes.py`, telemetry behavior, `build_and_run.sh`, metrics storage schemas, Terraform scripts, and extensive documentation. It provides no migration, reindexing, rollback, or clear unsupported-backend strategy, so the claimed regression-free transition cannot be verified."
-        },
-        "review": {
-          "completeness": 11,
-          "correctness": 9,
-          "specificity": 13,
-          "risk_awareness": 8,
-          "total": 41,
-          "notes": "The QA feedback usefully identifies the need to preserve generic search coverage and test hybrid ranking rather than simply deleting tests. The review notices the file-backend question but recommends defaulting it to `DocumentDBSearchRepository`, despite `storage_backend` defaulting to `file` and the repository requiring a live MongoDB-compatible connection. It fails to challenge the LLD's incomplete call-site and operational cleanup inventory, including many remaining imports in `registry/api/server_routes.py`. Claims that the design has no security or architectural concerns are not supported by analysis of migration, availability, rollback, or deployment configuration."
+          "risk_awareness": 18,
+          "total": 65,
+          "notes": "The review's strongest work is identifying both Terraform-state persistence and the fact that ECS secret-retrieval failures prevent task startup. It also raises concrete IAM propagation, plaintext-removal, startup-observability, and secret-version management concerns. Its resolution then incorrectly claims the shadow pattern prevents task-startup failure, and it does not carry the recommendation to manage secret values outside Terraform into the revised design. It also misses the deployment-order compatibility hazard and the unresolved parsing contract for grouped JSON secrets."
         },
         "testing": {
-          "completeness": 15,
-          "correctness": 12,
-          "specificity": 11,
-          "risk_awareness": 11,
-          "total": 49,
-          "notes": "The plan covers search modes, lifecycle indexing, access control, startup without FAISS, dependency inspection, latency, and ranking quality. It incorrectly names `/api/tags`; `registry/main.py` mounts the search router at `/api/search`, making the actual endpoint `/api/search/tags`. Most cases lack concrete fixtures, payloads, expected ordering, timing bounds, or a defined golden-query baseline, so assertions such as comparable ranking are not reproducible or decisive. It also omits the highest-risk default file-backend behavior, stale imports across lifecycle routes, telemetry changes, and operational-script verification."
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 13,
+          "risk_awareness": 12,
+          "total": 48,
+          "notes": "The plan spans prioritization, fallback, IAM denial, rolling deployment, rollback, Terraform application, and business workflows. However, env | grep _SECRET exposes secret values, the ECS Exec procedure lacks the required task, container, command, and interactive parameters, and the Terraform commands provide no module or deployment-root working directory. Hard-coded names and endpoints such as mcp-gateway-cluster, /auth/login, and /registry/servers are not substantiated, while several expected results merely say the application functions. No focused Settings test, grouped-ANS parsing test, conditional-secret case, KMS failure case, or assertion that sensitive values are absent from task definitions and Terraform state is provided."
         },
         "implementation": {
-          "completeness": 0,
-          "correctness": 0,
-          "specificity": 0,
-          "risk_awareness": 0,
-          "total": 0,
-          "notes": "The implementation artifact is empty, so no patch or implementation summary was submitted and all four criteria score zero. There is no code change to compare with the design or repository conventions. No diff targets, symbol context, application check, or implementation tests were available. This absence is the artifact's decisive limitation rather than a repository defect."
+          "completeness": 8,
+          "correctness": 4,
+          "specificity": 13,
+          "risk_awareness": 5,
+          "total": 30,
+          "notes": "The patch concretely edits the configuration loader, both ECS task definitions, the secret-access policy, and Secrets Manager resources, implementing the basic shadow-name mechanism for several existing entries. Its largest functional defect is that ECS injects ANS_API_CREDENTIALS_SECRET containing JSON while _resolve_secrets only reads ANS_API_KEY_SECRET and ANS_API_SECRET_SECRET, so those credentials cannot take the intended path. Several created secrets, including registration and GitHub values, are never injected or resolved, and the new mongodb_connection_string secret is unused because ECS still references var.mongodb_connection_string_secret_arn. Every new secret version copies a Terraform variable into secret_string and therefore preserves state exposure, while the summary overclaims complete migration, fallback coverage, and structural verification without tests or evidence for optional and empty values."
         }
       },
       "is_error": false,
@@ -262,57 +240,67 @@
       "complexity": "high",
       "artifacts_produced": 6,
       "artifacts_expected": 6,
-      "num_turns": 75,
-      "input_tokens": 2767834,
-      "output_tokens": 31186,
-      "latency_seconds": 1959.0,
-      "total_cost_usd": 17.41851,
-      "task_score": 37.4,
+      "num_turns": 23,
+      "input_tokens": 2636335,
+      "output_tokens": 16695,
+      "latency_seconds": 1055.7,
+      "total_cost_usd": 22.795240000000003,
+      "task_score": 42.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.7417,
+      "generation_tokens_per_sec": 15.8,
+      "kv_cache_usage": {
+        "peak": 0.1989,
+        "mean": 0.1008
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
       "eval_scores": {
         "github_issue": {
           "completeness": 17,
-          "correctness": 14,
-          "specificity": 17,
-          "risk_awareness": 13,
-          "total": 61,
-          "notes": "The issue clearly identifies the credential risk, ECS/RDS/Terraform scope, explicit non-goals, and a testable authentication toggle. The repository confirms the baseline: keycloak-database.tf configures password authentication and keycloak-ecs.tf injects KC_DB_PASSWORD from Secrets Manager. Its largest defect is requiring both removal of static passwords and a working static-password fallback without defining a transitional state; it also omits database-user provisioning, proxy behavior, TLS, and token lifecycle concerns. No independent task statement was supplied, and related issue #1303 could not be verified in the repository."
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 56,
+          "notes": "The issue clearly bounds the security problem and provides explicit acceptance criteria, fallback behavior, dependencies, and exclusions. Its central runtime proposal is unsound: a token generated only at task startup cannot authenticate new pooled connections after its 15-minute validity window, and `rds:GenerateDBAuthToken` is not an IAM action or service API. The submitted patch context supports the named cluster, proxy, and task-role integration points, but the issue omits proxy-specific authorization, token renewal, TLS, and a measurable definition of removing secret exposure. No independent task statement was supplied, so the intended scope and related issue #1303 could not be verified."
         },
         "lld": {
-          "completeness": 9,
-          "correctness": 4,
-          "specificity": 11,
-          "risk_awareness": 9,
-          "total": 33,
-          "notes": "The strongest aspect is its use of real Terraform files and its recognition of the 15-minute token lifetime and custom-image requirement. The central design is not viable: it proposes the invalid proxy value iam_auth = \"ENABLED\", uses cluster_identifier instead of an RDS resource ID in the connect ARN, points the JDBC URL at the cluster while claiming proxy use, and never provisions an IAM-enabled database user or enables the JDBC IAM plugin. It also names a new root Dockerfile although the repository uses docker/keycloak/Dockerfile, omits a compatible image publishing strategy, and contradicts itself by both choosing and rejecting the AWS JDBC driver. Transparent refresh and the proposed driver artifact cannot be verified from repository evidence and are unsupported by the supplied configuration."
+          "completeness": 12,
+          "correctness": 8,
+          "specificity": 14,
+          "risk_awareness": 13,
+          "total": 47,
+          "notes": "The LLD names concrete Terraform files and correctly rejects startup-only token generation because new connections require fresh tokens. Its load-bearing implementation choices remain unresolved: wrapper delivery is either a custom image or volume, URL selection is a script or possibly SSM, and the feature flag has no operational configuration mechanism. The `rds-db:connect` ARN targets the cluster resource ID even though authentication is presented to the RDS Proxy, and no complete wrapper classpath, driver selection, or password-injection change is defined. The rollout recognizes token lifetime and staging validation, but it does not establish that static-password fallback remains valid after proxy authentication changes or provide a complete rollback path."
         },
         "review": {
-          "completeness": 8,
-          "correctness": 9,
-          "specificity": 8,
-          "risk_awareness": 10,
-          "total": 35,
-          "notes": "The review correctly identifies token expiration and a missing AWS CLI as fatal flaws in a startup-only wrapper approach, and recommending a JDBC integration is directionally sound. All five reviewer personas repeat essentially the same observation and appear to review a stale wrapper design rather than stress the revised LLD. It misses the invalid proxy enum, wrong IAM ARN, missing database-user migration, absent IAM plugin configuration, image-tag failure, and continued password injection, while incorrectly declaring the policy scope resolved. Repository evidence therefore does not support its claim that the revised design is production-stable."
+          "completeness": 7,
+          "correctness": 6,
+          "specificity": 9,
+          "risk_awareness": 8,
+          "total": 30,
+          "notes": "The review usefully identifies token expiration and container tooling as concrete risks rather than merely approving the original startup-token approach. Its approvals contradict the LLD: it says the fragile shell wrapper was removed and dependency delivery is clear, while the LLD retains a `sh -c` startup wrapper and leaves the JAR delivery mechanism undecided. It misses the proxy-versus-cluster IAM resource mismatch, absent driver integration, hardcoded false flag, and unproven password fallback. Declaring zero blockers and complete resolution is therefore not supported by the design it reviews."
         },
         "testing": {
-          "completeness": 11,
-          "correctness": 6,
-          "specificity": 11,
-          "risk_awareness": 9,
-          "total": 37,
-          "notes": "The plan covers IAM startup, operation beyond 20 minutes, password fallback, infrastructure inspection, rollback, and representative Keycloak operations. Its primary oracle cannot prove IAM authentication because the task still receives KC_DB_PASSWORD, and there is no poisoned-password or denied-IAM test to distinguish the authentication paths. The ECS command tails a nonexistent container log file despite the repository using the /ecs/keycloak awslogs group, the Docker command will be intercepted by the image's fixed Keycloak entrypoint, and the proxy query does not correctly select IAMAuth from the Auth array. It also omits Terraform validation/plan, image build and tag checks, database-user/plugin setup, static-secret removal, and negative permission coverage."
+          "completeness": 16,
+          "correctness": 10,
+          "specificity": 16,
+          "risk_awareness": 15,
+          "total": 57,
+          "notes": "The plan covers IAM success, denied permission, password fallback, Terraform wiring, rollback, OIDC behavior, and operation beyond the token lifetime. Its primary IAM oracle is an exact `Database connection established using IAM authentication` log message that neither the design nor patch implements. Waiting 20 minutes and performing ordinary operations does not guarantee creation of a new physical connection, so the test can pass without exercising token regeneration; the hardcoded feature flag also makes the stated toggling procedure incomplete. The plan does not specify Terraform working-directory or input setup, restoration after destructive permission testing, or a test proving static credentials are absent from the IAM path."
         },
         "implementation": {
           "completeness": 5,
           "correctness": 2,
           "specificity": 10,
-          "risk_awareness": 4,
-          "total": 21,
-          "notes": "The patch hunk contexts and named symbols match the real Dockerfile and three Terraform files, and it concretely attempts the feature flag, cluster setting, task policy, URL, and driver image changes. It cannot deploy as written because the AWS provider accepts REQUIRED or DISABLED for proxy iam_auth, not ENABLED, and the default image becomes the nonexistent quay.io/keycloak/keycloak:25.0-iam while repository build tooling publishes keycloak:latest. The connect ARN uses cluster_identifier rather than the cluster or proxy resource ID, the URL bypasses the proxy, no IAM database user or wrapper IAM plugin is configured, and keycloak_database_password, its secret, rotation, and KC_DB_PASSWORD injection all remain. The driver download was not verifiable from repository evidence, no tests are added, and the default-on flag makes the implementation summary's replacement and fallback claims materially inaccurate."
+          "risk_awareness": 5,
+          "total": 22,
+          "notes": "The patch addresses the intended Terraform surfaces by changing cluster and proxy authentication settings, adding a task-role policy, and attempting conditional JDBC configuration. The command string contains unescaped Terraform interpolation syntax `${KC_DB_URL#jdbc:mysql://}`, so the configuration cannot parse; even after escaping, it constructs `jdbc:aws-wrapper:<host>` instead of `jdbc:aws-wrapper:mysql://<host>`. The existing diff context says the image entrypoint is `kc.sh`, making `command = [\"sh\", \"-c\", ...]` arguments to Keycloak rather than a shell command, while the wrapper JAR is not delivered and the IAM policy targets the cluster instead of the proxy. The summary's claim of exact LLD implementation contradicts its admitted missing dependency, and repository applicability could not be independently checked because read-only shell execution failed during sandbox initialization."
         }
       },
       "is_error": false,
       "failed": false
     }
   ],
-  "run_date": "2026-07-29"
+  "run_date": "2026-08-03"
 }


### PR DESCRIPTION
## Summary

Adds the `run-summary.json` for a `/swe2` benchmark run of **gemma-4-31b** driven by **Claude Code** over the `mcp-gateway-registry` dataset, self-hosted on vLLM.

## Run configuration

| | |
|---|---|
| Model | gemma-4-31b (self-hosted vLLM) |
| Agent | claude-code |
| Dataset | `dataset/mcp-gateway-registry.yaml` @ ref 1.24.4 |
| Serving | g6e.12xlarge (4x L40S), TP=4, 200000-token context window |
| Judge | `codex_judge.py` -- `codex exec`, `openai.gpt-5.6-sol`, high reasoning effort, repo-grounded at ref 1.24.4 |

## Results

Mean over the 4 completed tasks: **51.60** (mean cost $29.39).

| Task | Artifacts | Turns | Wall | % of 60-min cap | Prefix cache | Cost (est $) | Judge score |
|---|---|---|---|---|---|---|---|
| remove-efs-from-terraform-aws-ecs | 6/6 | 51 | 37.6 min | 63% | 74.1% | 23.22 | 63.4 |
| ssrf-hardening-outbound-url-validation (topped up) | 6/6 | 74 | 35.6 min | 59% | 81.9% | 35.69 | 52.6 |
| migrate-ecs-env-vars-to-secrets-manager | 6/6 | 42 | 35.9 min | 60% | 70.9% | 35.85 | 48.0 |
| replace-keycloak-db-password-with-rds-iam | 6/6 | 23 | 17.6 min | 29% | 74.2% | 22.80 | 42.4 |

Every score comes from the repo-grounded `codex_judge.py` path -- each `eval.json` records `provider: codex-exec`, `model: openai.gpt-5.6-sol`, `repo_grounded: true`. Cost is a token-based estimate for a self-hosted model, not metered spend.

**No completed task exceeded 63% of the 60-minute per-task cap** (`timeout_seconds: 3600` in `benchmarks/config/runner.yaml`), so none of these four was time-constrained -- there are no near-misses hiding behind the scores. Throughput was steady at 29-51 s/turn across all tasks, independent of task complexity.

## Timing

| Segment | Duration |
|---|---|
| Agent execution, 4 completed tasks | 2h 07m |
| Agent execution, remove-faiss (both attempts) | 1h 56m |
| Total agent execution | 4h 03m |
| Total wall span (incl. clone setup, judge passes, rescoring) | 10h 33m |

## Excluded task: remove-faiss

The dataset has **5** tasks; this summary covers **4**. `remove-faiss` is not included, and the headline mean above is therefore not a full-dataset score.

- **Attempt 1** hit the 60-minute wall-clock cap after 112 of its 250 available turns. It produced 4 of 6 artifacts and no `metrics.json`, so `summarize_run.py` omits it rather than scoring it 0.
- **Attempt 2**, re-run with `--max-turns 400 --timeout-seconds 14400`, took **238 turns over 116 minutes** across two invocations (52.2 min main run producing 4 of 6 artifacts, then a 63.8 min top-up for the missing two). It used only **48% of its wall-clock budget and 60% of its turns**, so neither limit bound it. It stopped on its own having again produced 4 of 6 artifacts.

Attempt 2 is the more informative result. It genuinely edited the clone -- the trace shows edits to `registry/metrics/client.py` and `tests/unit/api/test_search_routes.py` as late as 71 minutes into the top-up -- and described the complete implementation in prose (repository abstraction, factory changes, telemetry renames, test removals). It simply never ran `git diff` to capture `patch.diff`, nor wrote `implementation.md`, despite `/swe2` requiring all six artifacts. The clone at `/tmp/swe-clone-remove-faiss` was cleaned up on exit, so that work is unrecoverable.

This is an **instruction-following failure, not a resource limit**, and raising the turn ceiling did not address it -- turns were never the binding constraint. It is the same premature-stop behaviour seen on `replace-keycloak-db-password-with-rds-iam` attempt 1. $75.15 of estimated cost went to a task that produced no patch. A further attempt would need a different intervention (for example, prompting the patch to be captured incrementally rather than at the end) rather than a larger budget.

This task is excluded deliberately so the 4 completed tasks are not held up; it will be addressed separately.

## Files

One file, a generated metrics artifact: `benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/mcp-gateway-registry/run-summary.json`. The rest of the artifact tree is gitignored (`.gitignore:38`); only `run-summary.json` is force-added, matching the existing convention. No source, config, or script changes.
