### PR TITLE
qwen3.6-35b (claude): /swe3 benchmark run on mcp-gateway-registry

### DIFF
--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "qwen3.6-35b",
+  "model_slug": "qwen3.6-35b",
+  "agent": "claude",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 200000
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-03T22:06:24.339842Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 181585,
+      "cached_input_tokens": 156462,
+      "cache_write_input_tokens": 25107,
+      "output_tokens": 7404,
+      "reasoning_output_tokens": 5505
+    },
+    "duration_ms": 159215
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 48.16,
+  "mean_cost_usd_excl_failed": 38.92,
+  "tasks": [
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 339,
+      "input_tokens": 13359956,
+      "output_tokens": 84140,
+      "total_tokens": 13444096,
+      "latency_seconds": 1202.8,
+      "total_cost_usd": 68.90328000000001,
+      "result_subtype": "success",
+      "task_score": 57.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.7466,
+      "generation_tokens_per_sec": 70.0,
+      "kv_cache_usage": {
+        "peak": 0.121,
+        "mean": 0.0549
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 76,
+          "notes": "The issue provides concrete scope, exclusions, affected paths, and testable acceptance criteria; patch contexts confirm central symbols such as FaissService, FaissSearchRepository, and faiss-cpu exist. Its largest deficiency is an unresolved choice between removing and merely deprecating the file backend while simultaneously requiring the factory to always use DocumentDB. It correctly preserves non-search file repositories and the embeddings pipeline, but does not specify how the default file configuration or existing users' data will transition. No independent task statement was supplied, so claims that DocumentDB offers equivalent behavior and is maintained could not be independently established."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 12,
+          "total": 59,
+          "notes": "The LLD is unusually concrete about files, factory wiring, route call sites, data flow, and implementation order. However, it incorrectly describes FaissMetadata as using a string id and generic dictionary, while registry/core/schemas.py in the patch has id: int and full_server_info: ServerInfo, and it confuses ALLOWED_STORAGE_BACKENDS with MONGODB_BACKENDS. It leaves settings.storage_backend defaulting to file while proposing that file become invalid, and explicitly declines the required uv.lock update. Its risk section notices missed indexing calls but does not resolve database-unavailable behavior, partial persistence failures, startup reindex cost, rollback, or a reliable migration of file-backed users."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 17,
+          "risk_awareness": 16,
+          "total": 58,
+          "notes": "The review's strongest contribution is identifying real concerns around search repository initialization, uv.lock, Docker references, and the breaking treatment of file storage. Its verdict is nevertheless inconsistent with two CRITICAL findings, and it claims the LLD was revised even though the submitted LLD still punts on uv.lock, describes lazy initialization, and does not address a rebuild endpoint concretely. The recommendation to manually delete lockfile sections is unsafe compared with regenerating the lock, while the claimed path-traversal risk from computed FAISS path properties is unsupported. It also misses the retained file default, the index_agent signature mismatch, destructive test removal, and the operational impact of rebuilding persistent DocumentDB indexes on every startup."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 14,
+          "risk_awareness": 14,
+          "total": 52,
+          "notes": "The plan covers search, indexing, lifecycle, restart, concurrency, deployment, and compatibility scenarios, with several useful state-based oracles. Several key tests target incorrect behavior: the repository evidence shows POST /api/search/semantic rather than GET /api/search, and the deleted integration test expects an empty query to return 422 rather than empty results. Lexical fallback on a failed DocumentDB connection, empty-embedding indexing, and HNSW creation on the first search request are asserted without repository support and conflict with startup initialization in the patch. The plan lacks executable setup and commands, concrete fixtures for ranking assertions, and a replacement for the deleted 1,117-line search integration suite."
+        },
+        "implementation": {
+          "completeness": 12,
+          "correctness": 6,
+          "specificity": 16,
+          "risk_awareness": 6,
+          "total": 40,
+          "notes": "The patch removes the central FAISS service, file search adapter, dependency declaration, configuration properties, and many direct route calls, with target contexts matching the submitted source. Its largest defect is that registry/api/agent_routes.py changes calls to index_agent but retains four arguments after self, including the obsolete entity type, while the repository interface pattern and agent_batch_item_processor.py use three; registration, toggle, and update paths would raise TypeError. It also removes file from ALLOWED_STORAGE_BACKENDS while retaining default=\"file\", omits the required uv.lock update, performs an expensive persistent-index rebuild on every startup, and loads agent state twice. The summary overstates completeness while deleting search integration coverage without replacement and admitting residual FAISS names; the submitted diff is truncated, so complete applyability and later hunks could not be verified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 67,
+      "input_tokens": 4820939,
+      "output_tokens": 31894,
+      "total_tokens": 4852833,
+      "latency_seconds": 424.9,
+      "total_cost_usd": 24.902044999999998,
+      "result_subtype": "success",
+      "task_score": 56.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.7922,
+      "generation_tokens_per_sec": 75.1,
+      "kv_cache_usage": {
+        "peak": 0.1241,
+        "mean": 0.0648
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 9,
+          "total": 55,
+          "notes": "The issue names concrete files, symbols, and testable removals, including module.efs, efs_volume_configuration, variables, outputs, and SCOPES_CONFIG_PATH. The submitted diff confirms those are relevant integration points. Its clean-plan criterion is incorrect for an existing deployment because successful removal should plan EFS resources and outputs for destruction. The no-consumers and no-dependencies claims are unsupported and conflict with the acknowledged mounts and post-deployment scripts, while no independent task statement establishes those assumptions."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 61,
+          "notes": "The LLD provides unusually concrete file-level edits that largely correspond to the submitted Terraform diff. Its most consequential decision, changing SCOPES_CONFIG_PATH to /etc/mcp-gateway/scopes.yml, is asserted without repository evidence and is undermined by implementation.md saying operators may need to populate that path. The claim that the ECS module automatically creates and removes EFS IAM policies is also unsupported, while removing root outputs is a compatibility break that receives no migration treatment. Staging rollout and destruction timing are mentioned, but backup, rollback, script sequencing, and runtime validation of auth-server and mcpgw remain unresolved."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 12,
+          "specificity": 18,
+          "risk_awareness": 18,
+          "total": 64,
+          "notes": "The review identifies specific material risks around the scopes file, IAM permissions, EFS destruction, demo tasks, deployment_summary, and residual references. It nevertheless claims there are no breaking API changes even though patch.diff removes three root outputs and module outputs. Its resolutions convert the unverified scopes path and inferred ECS-module IAM behavior into verified facts without presenting supporting source evidence, and substantial duplicated content weakens prioritization. The state audit, maintenance-window concern, and warning about existing EFS data are useful, but approving with unresolved must-fix findings makes the verdict insufficiently defensible."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 16,
+          "risk_awareness": 10,
+          "total": 48,
+          "notes": "The plan includes concrete validate, static-reference, interface, structure, and patch-application checks with several useful exact oracles. Its central plan test uses backend=false without existing state and expects no EFS text, so it cannot demonstrate removal from a deployed state where EFS destruction and removed output values should appear. The detailed-exitcode result is hidden by tee without pipefail, the variable-count check has no expected number, and required AWS credentials or complete plan inputs are not established. It omits runtime checks for auth-server scopes loading, mcpgw behavior, data preservation, and the acknowledged post-deployment scripts."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 18,
+          "risk_awareness": 9,
+          "total": 56,
+          "notes": "The diff coherently removes storage.tf, both services' mounts and volume definitions, EFS variables, and module and root outputs, matching the core design and its reported statistics. The SCOPES_CONFIG_PATH replacement is not substantiated by application or image source, and implementation.md explicitly suggests separately populating the path, so auth-server can be left pointing at a nonexistent file. The patch also knowingly leaves EFS-dependent deployment scripts while removing outputs they may consume, and it provides no compatibility or recovery treatment for destructive state changes and public output removal. The submitted line context is internally consistent, but git apply --check and repository-wide verification could not be completed because the read-only execution sandbox failed before commands ran."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 12,
+      "input_tokens": 8119320,
+      "output_tokens": 60770,
+      "total_tokens": 8180090,
+      "latency_seconds": 80.5,
+      "total_cost_usd": 42.11585,
+      "result_subtype": "success",
+      "task_score": 53.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.7687,
+      "generation_tokens_per_sec": 754.9,
+      "kv_cache_usage": {
+        "peak": 0.1263,
+        "mean": 0.0619
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 19,
+          "risk_awareness": 15,
+          "total": 71,
+          "notes": "The issue clearly identifies vulnerable flows, motivation, exclusions, configuration, and testable acceptance criteria. The submitted patch corroborates `_is_safe_url`, `_check_endpoint_reachability`, `check_agent_health`, CLI health checks, and `HealthMonitoringService` as relevant symbols. Its largest gap is omitting redirect and DNS-rebinding requirements despite promising comprehensive SSRF protection and unchanged behavior for safe URLs. No independent task statement was supplied, so the asserted exclusions and full required scope cannot be verified."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 54,
+          "notes": "The LLD is concrete about files, call sites, response behavior, configuration, and rollout, with most named symbols corroborated by the diff. It accepts MCP tool validation as a goal but provides no implementation step for it, and it contradicts itself by both rejecting and prescribing `ssrf_url_validation_enabled`. The pre-resolution design remains vulnerable to DNS rebinding, synchronous DNS can block the event loop, and disabling redirects changes behavior for otherwise safe redirecting services. The claimed `register_agent_from_card` integration and sub-millisecond DNS performance are not substantiated by the submitted implementation."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 9,
+          "specificity": 17,
+          "risk_awareness": 11,
+          "total": 52,
+          "notes": "The review's strongest contribution is identifying redirect-based SSRF and deployment, logging, CLI-import, and MCP-client concerns. It incorrectly states that `httpx.get` follows redirects by default and that `urlparse().hostname` decodes hostnames or `ipaddress.ip_address` natively accepts decimal and hexadecimal encodings. Its post-implementation approval also overlooks the DNS resolution race, absent tests, deferred MCP path, and the summary's admission that skill-service requests still follow redirects. Without an independent task statement, the review's decision to defer the MCP path cannot be validated as acceptable scope."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 7,
+          "specificity": 16,
+          "risk_awareness": 11,
+          "total": 47,
+          "notes": "The plan supplies concrete URL cases, expected values, commands, compatibility checks, and several test levels. Two examples contain invalid imports using `registry.utils/url_validation`, and the server-health test mocks the method under test and asserts no behavior at all. The safe-agent test asserts `get` on the wrong mock object, while unsafe tests generally fail to assert that no network request occurred; redirect, DNS-rebinding, CLI, and MCP-path coverage are also missing. Several endpoint and deployment-path claims are not corroborated by the patch, and no independent task statement establishes them."
+        },
+        "implementation": {
+          "completeness": 12,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 8,
+          "total": 45,
+          "notes": "The patch concretely centralizes URL validation and adds guards plus redirect controls to agent validation, agent health, server health, and CLI paths. It does not add the promised tests or MCP-client protection, does not implement the LLD's explicit registration guard, and therefore overstates that every outbound path is covered. The separate DNS lookup and HTTP connection remain vulnerable to rebinding, existing skill fetches reportedly retain `follow_redirects=True`, and disabling health-check redirects contradicts the claimed compatibility for safe URLs. The diff also duplicates the `_is_safe_url` import and returns `None` as the immediate blocked check timestamp despite storing a timestamp; independent apply and test verification was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 100,
+      "input_tokens": 5631261,
+      "output_tokens": 50158,
+      "total_tokens": 5681419,
+      "latency_seconds": 567.7,
+      "total_cost_usd": 29.410255,
+      "result_subtype": "success",
+      "task_score": 39.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8019,
+      "generation_tokens_per_sec": 88.4,
+      "kv_cache_usage": {
+        "peak": 0.1161,
+        "mean": 0.0521
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 11,
+          "correctness": 5,
+          "specificity": 17,
+          "risk_awareness": 9,
+          "total": 42,
+          "notes": "The issue identifies concrete variables, affected Terraform files, and deployment expectations, and the supplied diff corroborates those symbols and locations. Its largest defect is the impossible contradiction between criteria requiring the variables to leave environment blocks and requiring the same plaintext entries to remain as fallbacks. Moving values into aws_secretsmanager_secret_version does not remove them from Terraform state, while ECS secrets are injected as environment variables rather than files; claims about automatic CloudWatch exposure and ECS-level transit are also overstated. No independent task statement was supplied, so broader requirement coverage and the claim that the project uses ECS only could not be established."
+        },
+        "lld": {
+          "completeness": 10,
+          "correctness": 3,
+          "specificity": 16,
+          "risk_awareness": 7,
+          "total": 36,
+          "notes": "The LLD is concrete about ecs-services.tf, observability.tf, secrets.tf, feature gating, resource names, and rollback intent. Its central data-flow decision is wrong: ECS container-definition secrets create environment variables, not /tmp/secrets files, and a secret assigned to the Grafana container would not become available in the sidecar's filesystem. It also attaches access to the task role instead of establishing task-execution-role access, omits kms:Decrypt for the dedicated customer-managed key, and references an Auth0 secret without specifying its resource creation in the change sections. Rotation-triggered task replacement, continued Terraform-state exposure, duplicate environment-name behavior, and a viable fallback are not resolved."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 5,
+          "specificity": 17,
+          "risk_awareness": 8,
+          "total": 43,
+          "notes": "The review supplies prioritized, named findings about feature gating, key proliferation, rotation documentation, and sidecar failure diagnostics. It nevertheless confirms the false mounted-file model and fails to identify the critical execution-role and customer-KMS permissions required for ECS secret injection. Its assertion that actions FINDING-1, FINDING-3, and FINDING-9 were applied is contradicted by the patch, which retains the dedicated key and adds no file retry or existence check. Claims that validation will pass, fallback is maintained, and secret rotation is fully compatible are unsupported and overlook task restart requirements and retained plaintext exposure."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 4,
+          "specificity": 15,
+          "risk_awareness": 10,
+          "total": 43,
+          "notes": "The plan covers feature-flag combinations, resource plans, idempotency, rotation, rolling updates, rollback, and service-level checks. Its principal functional tests require /tmp/secrets/GF_SECURITY_ADMIN_PASSWORD, which ECS does not create, so the intended behavior and oracle are technically invalid. It also asks for expected additions in a plan run after applying, assumes duplicate secrets and environment entries have a documented precedence, and checks aws ecs describe-tasks rather than the task-definition container configuration that contains environment values. It lacks focused checks for task-execution-role GetSecretValue and kms:Decrypt permissions, removal of plaintext entries, and propagation of a rotated value into newly launched tasks."
+        },
+        "implementation": {
+          "completeness": 10,
+          "correctness": 4,
+          "specificity": 15,
+          "risk_awareness": 5,
+          "total": 34,
+          "notes": "The patch targets the stated containers and adds conditionally created Secrets Manager resources and explicit valueFrom references. The Grafana sidecar will execute cat against a nonexistent /tmp/secrets/GF_SECURITY_ADMIN_PASSWORD path, and it has no secrets entry of its own; ECS injects secrets as per-container environment variables rather than mounted files. The added Grafana policy is attached to tasks_iam_role_policies instead of the task execution role, the dedicated KMS key has no demonstrated kms:Decrypt grant, and retaining plaintext duplicate entries leaves the original task-definition exposure intact. The summary also overstates rollback and migration safety, adds an unused random_password resource, and includes no tests; repository-level patch applicability could not be independently confirmed because read-only shell execution failed during sandbox setup."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 91,
+      "input_tokens": 5609740,
+      "output_tokens": 49366,
+      "total_tokens": 5659106,
+      "latency_seconds": 539.3,
+      "total_cost_usd": 29.282849999999993,
+      "result_subtype": "success",
+      "task_score": 33.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8369,
+      "generation_tokens_per_sec": 91.5,
+      "kv_cache_usage": {
+        "peak": 0.1048,
+        "mean": 0.0539
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 13,
+          "correctness": 6,
+          "specificity": 15,
+          "risk_awareness": 7,
+          "total": 41,
+          "notes": "The issue clearly identifies the current credential flow, target operators, fallback requirement, and several explicit non-goals. Its largest deficiency is the absence of testable acceptance criteria and decisions around IAM-enabled database-user provisioning, TLS, and token renewal. Concrete technical errors include naming a nonexistent rds:GenerateDBAuthToken permission, proposing KC_DB_AUTH_TOKEN as though Keycloak consumes it, and changing the username to an RDS instance identifier. No independent task statement was supplied, so requirements beyond the task identifier and artifacts could not be verified."
+        },
+        "lld": {
+          "completeness": 12,
+          "correctness": 2,
+          "specificity": 10,
+          "risk_awareness": 7,
+          "total": 31,
+          "notes": "The LLD is strongest in naming affected files, defining a default-disabled flag, and outlining migration and rollback steps. Its core design is not implementable as written: aws_db_proxy_auth is not an AWS provider resource, singleton resources are incorrectly indexed with [0], aws_db_proxy has no default_username attribute, and merge is used on lists. The command should be aws rds generate-db-auth-token, while no mechanism establishes an IAM-authenticated MySQL user, required TLS, or Keycloak dynamically re-reading KC_DB_PASSWORD_FILE. Rotation also updates the fallback secret while skipping the matching database password change, which would make the promised rollback credentials invalid."
+        },
+        "review": {
+          "completeness": 9,
+          "correctness": 3,
+          "specificity": 12,
+          "risk_awareness": 6,
+          "total": 30,
+          "notes": "The review at least examines security, proxy migration, token lifetime, application pooling, rollback, and operations from several relevant perspectives. Its largest defect is approving every material concern based on unsupported or false resolutions instead of stress-testing them. It calls cluster_identifier/default_username a valid least-privilege connection ARN and claims Keycloak transparently reloads a rewritten password file, neither of which the design establishes. It misses the nonexistent Terraform resource, invalid indexing and list merge, absent database-user migration, incorrect CLI command, and fallback-password divergence."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 7,
+          "specificity": 11,
+          "risk_awareness": 14,
+          "total": 48,
+          "notes": "The plan's strongest aspect is broad coverage of both modes, rollback, permissions, secret exposure, deployment, token expiry, and several failure scenarios. Most entries remain manual 'verify' checklists without concrete setup, API requests, observation methods, or exact expected state, and many depend on invalid resources and attributes from the LLD. It expects CloudWatch token-generation logs although the proposed script emits no successful-generation log, and a 15-minute idle wait can pass using existing pooled connections without proving that new connections use refreshed credentials. It omits focused Terraform validation and Lambda tests and does not force connection-pool churn after refresh failure, the critical regression this design risks."
+        },
+        "implementation": {
+          "completeness": 6,
+          "correctness": 1,
+          "specificity": 8,
+          "risk_awareness": 3,
+          "total": 18,
+          "notes": "The patch attempts the advertised flag, proxy, task-policy, rotation, image, and container changes, but it does not implement a runnable end-to-end design. The supplied diff references a new keycloak-iam-entrypoint.sh without adding that file, indexes non-counted resources, uses an unsupported aws_db_proxy_auth resource and default_username attribute, applies merge to lists, and leaves an empty ECS secret valueFrom instead of omitting it. The connection ARN uses a cluster identifier rather than the required resource identifier, the Dockerfile runs chmod after USER keycloak, and the ECS command does not replace the image ENTRYPOINT; fallback rotation would also desynchronize the secret and database password. Independent source and git-apply verification could not be completed because all read-only shell invocations failed with a bwrap loopback RTM_NEWADDR error, but the diff's internal failures are sufficient to make it unusable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-03",
+  "skill": "swe3"
+}


### PR DESCRIPTION
Records the latest `/swe3` (single-agent) benchmark run for `qwen3.6-35b` on the `mcp-gateway-registry` dataset.

## Change

One file: `benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/mcp-gateway-registry/run-summary.json`. Per-task artifact folders remain gitignored; only the scrubbed rollup is tracked.

## Result

Mean **48.16** over 5 of 5 tasks scored, no failures.

| Task | Artifacts | Turns | Judge score |
|---|---|---|---|
| remove-faiss | 6/6 | 339 | 57.0 |
| remove-efs-from-terraform-aws-ecs | 6/6 | 67 | 56.8 |
| ssrf-hardening-outbound-url-validation | 6/6 | 12 | 53.8 |
| migrate-ecs-env-vars-to-secrets-manager | 6/6 | 100 | 39.6 |
| replace-keycloak-db-password-with-rds-iam | 6/6 | 91 | 33.6 |

Notable: every task produced all six artifacts, including `ssrf-hardening-outbound-url-validation`, which was incomplete (4/6) under the previous multi-agent run. The run used zero subagents and finished in 1h 05m against 3h 34m previously.

## Serving and scoring

- Serving: g6e.12xlarge, tensor parallel 4, 200000-token context window.
- Judge: `openai.gpt-5.6-sol` via `codex exec`, repo-grounded at ref 1.24.4, reasoning effort high.
