### PR TITLE
benchmark: Claude Haiku 4.5 (claude-code, Bedrock) -- 5/5 tasks, mean 41.08

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,355 @@
+{
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "claude",
+  "scope": "mcp-gateway-registry",
+  "provider": "bedrock",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-04T01:06:22.563317Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 618466,
+      "cached_input_tokens": 531282,
+      "cache_write_input_tokens": 87164,
+      "output_tokens": 12056,
+      "reasoning_output_tokens": 6452
+    },
+    "duration_ms": 212118
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 41.08,
+  "mean_cost_usd_excl_failed": 0.8,
+  "tasks": [
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 60,
+      "input_tokens": 93,
+      "output_tokens": 35235,
+      "latency_seconds": 324.3,
+      "total_cost_usd": 0.8780802999999999,
+      "task_score": 44.6,
+      "cache_read_tokens": 5360023,
+      "cache_write_tokens": 132648,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 108.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 67,
+          "notes": "The issue gives concrete acceptance criteria, scope boundaries, configuration behavior, and correctly identifies `_is_safe_url()` in `registry/services/skill_service.py`. Its largest factual gap is treating agent-card fetching as conditional, although `registry/api/agent_routes.py::check_agent_health` fetches both `/.well-known/agent-card.json` and the registered agent URL. It also overlooks immediate server checks, explicit `mcp_endpoint`/`sse_endpoint` overrides, redirects, DNS rebinding, and credential forwarding. With no independent task statement, the proposed allowlist setting and new status cannot be verified as externally required."
+        },
+        "lld": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 17,
+          "risk_awareness": 8,
+          "total": 42,
+          "notes": "The LLD is concrete about real files such as `registry/health/service.py`, `registry/core/config.py`, and `registry/services/skill_service.py`, and its proposed status transition is implementation-ready. Its central codebase claim is wrong: agent URL fetching already exists, while `perform_immediate_health_check()` bypasses `_check_single_service()` and `get_endpoint_url_from_server_info()` can select an unvalidated explicit endpoint. The extraction also replaces the existing `github_extra_hosts` allowlist rather than preserving it, contradicting backward compatibility and existing tests in `tests/unit/services/test_skill_service_ssrf_allowlist.py`. Claims that blocking DNS is negligible, already performed, and safe from operational concern are unsupported, and the design does not secure redirects or credential-bearing requests."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 15,
+          "risk_awareness": 10,
+          "total": 42,
+          "notes": "The review identifies real concerns around blocking `socket.getaddrinfo()`, DNS rebinding, cache lifetime, configuration documentation, and status normalization. Its largest failure is approving the security model while asserting that health checks send no authentication; `_build_headers_for_server()` decrypts and forwards bearer, API-key, and custom headers, and multiple requests use `follow_redirects=True`. It also accepts the false claim that agent fetching is absent and misses immediate-check, explicit-endpoint, existing-test, and `github_extra_hosts` regressions. The claimed mandatory three-layer rule is not supported by `CLAUDE.md`, which requires documenting environment variables but does not state that checklist."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 5,
+          "specificity": 17,
+          "risk_awareness": 9,
+          "total": 42,
+          "notes": "The plan provides specific boolean oracles for schemes, IPv4, IPv6, metadata addresses, trusted hosts, and configuration overrides. Most integration tests target nonexistent or incorrect APIs: the repository exposes `GET /api/servers/health`, registration at `/api/servers/register`, and no submitted `/health/check-all` or per-server health route matching the commands. It omits the existing agent health fetch, immediate server checks, explicit endpoint overrides, redirects, credential leakage, and compatibility with `github_extra_hosts`; unmocked public DNS and `/var/log/registry.log` also make several checks unreliable. The proposed unit-test paths are valid conventions but no corresponding tests are included in the implementation."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 5,
+          "specificity": 13,
+          "risk_awareness": 5,
+          "total": 30,
+          "notes": "The inline patch targets source contexts present at baseline `b0fcb2db453f933da63389c0b18ccc044ee505b5` and does add a shared validator plus protection for scheduled `_check_single_service()` calls. It leaves exploitable paths intact: `perform_immediate_health_check()` calls the transport checker directly, agent health performs outbound GET/HEAD requests, explicit `mcp_endpoint` and `sse_endpoint` values supersede the validated URL, and redirects remain enabled without destination validation. Moving the functions also drops `settings.github_extra_hosts`, breaks the existing mocks and expectations in `test_skill_service_ssrf_allowlist.py`, leaves unused imports, and causes existing localhost-based `_check_single_service()` tests to be blocked before their mocked transport calls. No tests are added, and the summary's claims of no deviations and no current agent-card fetching are contradicted by both the LLD's test step and `registry/api/agent_routes.py`."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 48,
+      "input_tokens": 79,
+      "output_tokens": 19900,
+      "latency_seconds": 197.1,
+      "total_cost_usd": 0.6498471999999998,
+      "task_score": 41.8,
+      "cache_read_tokens": 4082532,
+      "cache_write_tokens": 113612,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 101.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 8,
+          "total": 47,
+          "notes": "The strongest aspect is its concrete, testable checklist covering the module resources, ECS mounts, variables, outputs, and Terraform validation. Its largest deficiency is omitting root outputs and deployment scripts while asserting that the application no longer references EFS. Repository inspection shows `ecs-services.tf:221` still sets `SCOPES_CONFIG_PATH` to `/efs/auth_config/auth_config/scopes.yml`, while `terraform/aws-ecs/outputs.tf:68` and `post-deployment-setup.sh:218` depend on EFS outputs. No independent task statement or issue #1286 content was supplied, so the broader claim that all EFS data is obsolete could not be verified."
+        },
+        "lld": {
+          "completeness": 11,
+          "correctness": 7,
+          "specificity": 16,
+          "risk_awareness": 8,
+          "total": 42,
+          "notes": "The LLD is concrete about the real module files, resource names, access points, and task-definition changes. Its critical gap is failing to design changes for the root EFS outputs, auth-server environment variable, and EFS-dependent deployment scripts. The claim that auth uses `/app/auth_server/scopes.yml` is contradicted by `ecs-services.tf:220-221`, and removing child outputs would leave `terraform/aws-ecs/outputs.tf:70-80` referencing nonexistent attributes. Assertions that MCPGW data and all EFS contents are ephemeral were not substantiated by repository evidence or a migration assessment."
+        },
+        "review": {
+          "completeness": 11,
+          "correctness": 6,
+          "specificity": 14,
+          "risk_awareness": 13,
+          "total": 44,
+          "notes": "The review usefully raises upgrade destruction, backups, logging, IAM permissions, and MCPGW persistence as concrete operational concerns. Its largest defect is declaring those concerns resolved through unsupported or contradicted checks while missing the root-output validation failure and stale EFS scripts. The no-EFS-task-IAM claim is supported by `modules/mcp-gateway/iam.tf`, but the claimed auth path check conflicts with `ecs-services.tf:221` and `run-scopes-init-task.sh` remains entirely EFS-dependent. Claims that EFS held no sensitive or persistent data and that `/app/data` is only cache could not be verified."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 5,
+          "specificity": 17,
+          "risk_awareness": 9,
+          "total": 44,
+          "notes": "The plan has concrete format, validation, plan, static-reference, output, volume, and mount-point checks with stated expected results. Its largest deficiency is that several tests cannot fail correctly, and the root plan command supplies undeclared root variables `auth_replicas`, `registry_replicas`, and `enable_autoscaling`. The grep-based ECS checks search too few lines, print success in failure branches, and the piped plan command lacks `pipefail`; it also never checks root EFS outputs, `SCOPES_CONFIG_PATH`, or deployment scripts. Terraform is not installed in the provided environment, so command execution could not be verified beyond repository-level inspection."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 4,
+          "specificity": 14,
+          "risk_awareness": 6,
+          "total": 32,
+          "notes": "The patch precisely removes the core EFS module, child outputs and variables, and the three ECS mounts, and its old blob hashes match the repository at tag `1.24.4`. Its largest defect is that deleting child outputs leaves `terraform/aws-ecs/outputs.tf:68-80` referencing `module.mcp_gateway.efs_id`, `efs_arn`, and `efs_access_points`, so root validation and planning will fail. It also leaves the auth-server `/efs` environment path and EFS-dependent `post-deployment-setup.sh` and `run-scopes-init-task.sh`, contradicting the summary's claim that all EFS infrastructure and references are removed. The summary acknowledges tests were not run, while its claims about ephemeral data, full functionality, and absence of follow-ups remain unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 61,
+      "input_tokens": 96,
+      "output_tokens": 38307,
+      "latency_seconds": 323.3,
+      "total_cost_usd": 0.8627377500000001,
+      "task_score": 41.2,
+      "cache_read_tokens": 5077280,
+      "cache_write_tokens": 130703,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 118.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 14,
+          "risk_awareness": 11,
+          "total": 49,
+          "notes": "The issue provides a clear security motivation, acceptance criteria, dependencies, and explicit exclusions. Its largest gap is the unbounded claim that all sensitive variables are covered: `ecs-services.tf` also exposes sensitive Auth0, registration webhook/gate, GitHub PAT, and private-key variables that the artifacts omit. The claim that this removes secrets from Terraform state is incorrect when `aws_secretsmanager_secret_version.secret_string` is populated from Terraform variables, and retaining input variables does not provide a runtime plaintext fallback. No independent task statement or original issue body was supplied; repository release notes verify issue `#1134` exists, but its exact intended inventory is unverifiable."
+        },
+        "lld": {
+          "completeness": 12,
+          "correctness": 7,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 46,
+          "notes": "The design names real files and correctly identifies the existing `secrets`, KMS, and IAM patterns in `terraform/aws-ecs/modules/mcp-gateway`. It omits several variables marked `sensitive = true`, incorrectly treats the registry task definition as MCPGW, and contradicts itself about whether `AUTH0_MANAGEMENT_API_TOKEN` is already migrated. Its proposed IAM list can contain empty resource strings, its task-definition fragment is not valid as shown, and it does not handle unconditional secret versions sourced from empty defaults or implement the promised fallback. It acknowledges state, regional, and rollout risks, but does not resolve rotation ownership, permanent deletion from `recovery_window_in_days = 0`, or the actual rollback mechanism."
+        },
+        "review": {
+          "completeness": 11,
+          "correctness": 6,
+          "specificity": 13,
+          "risk_awareness": 10,
+          "total": 40,
+          "notes": "The review is organized around concrete findings and assigns priorities and proposed actions. Its headline client-ID defect is fabricated because the submitted LLD already excludes client IDs, while its multi-region concern is also already an explicit non-goal. It misses the invalid Terraform shape, empty-secret failure, omitted sensitive variables, false fallback, and the fact that Terraform references already create the dependency that Circuit requests. The security approval incorrectly says secrets leave Terraform state, although Sage later partially contradicts that claim, so the verdict materially understates risk."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 5,
+          "specificity": 14,
+          "risk_awareness": 12,
+          "total": 45,
+          "notes": "The plan covers static validation, IAM, task definitions, staging deployment, health, logs, and negative behavior with concrete expected outcomes. Several central commands are unusable: repository CI initializes and validates from `terraform/aws-ecs`, `terraform plan -out=tfplan -json` is not a substitute for `terraform show -json tfplan`, and the IAM queries select `aws_iam_role_policy` although the repository defines `aws_iam_policy.ecs_secrets_access`. It also forbids task-definition replacement even though ECS task definitions are immutable, uses service and log names inconsistent with repository outputs, and its fallback and redaction checks do not prove their stated behavior. It lacks coverage for empty default values, duplicate environment/secret names, omitted sensitive variables, and feature-flag combinations; live AWS outcomes were not verifiable from the supplied evidence."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 3,
+          "specificity": 11,
+          "risk_awareness": 5,
+          "total": 26,
+          "notes": "The baseline commit and tag are correct, and the patch targets real files, symbols, KMS resources, and IAM patterns. However, both inserted `concat` sequences omit a comma before `var.enable_observability`, so the resulting HCL is invalid; the registry hunk also leaves plaintext `REGISTRY_API_TOKEN` and `ANS_API_SECRET` while adding duplicate secret entries. The patch creates five Secrets Manager secrets for six values, not six resources, leaves `AUTH0_MANAGEMENT_API_TOKEN` and at least five other explicitly sensitive plaintext values untouched, and unconditionally writes several default-empty strings to Secrets Manager. The summary falsely claims MCPGW was modified, no LLD deviations exist, all plaintext was removed, and a fallback remains; no documentation or real migration toggle implements those claims."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 49,
+      "input_tokens": 77,
+      "output_tokens": 30389,
+      "latency_seconds": 293.3,
+      "total_cost_usd": 0.7420268,
+      "task_score": 39.6,
+      "cache_read_tokens": 4318573,
+      "cache_write_tokens": 126518,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 103.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 11,
+          "total": 52,
+          "notes": "The issue clearly defines an opt-in migration, password fallback, scope boundaries, and testable outcomes. Repository evidence supports the current static-secret problem: keycloak-ecs.tf injects KC_DB_PASSWORD from Secrets Manager. Its largest defect is an incorrect IAM model: token generation is local signing, database access requires rds-db:connect on a DB-user ARN through the task role, and the issue omits database-user IAM configuration and token renewal. No independent task statement or parent issue #1303 was supplied, so requirements beyond the identifier and repository cannot be verified."
+        },
+        "lld": {
+          "completeness": 11,
+          "correctness": 4,
+          "specificity": 13,
+          "risk_awareness": 8,
+          "total": 36,
+          "notes": "The LLD is strongest where it identifies real Terraform files, the existing KC_DB variables, and the feature-flag deployment surface. Its architecture is not viable: it assigns a nonexistent rds:GenerateDBAuthToken permission to the execution role, omits rds-db:connect and AWSAuthenticationPlugin user setup, and generates only one expiring startup token. keycloak-database.tf points KC_DB_URL directly at the cluster while the proxy has iam_auth disabled, and variables.tf selects the stock Keycloak image without evidence that AWS CLI is installed. The document leaves the entrypoint mechanism unresolved, and deployed AWS behavior could not be verified without an environment."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 5,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 45,
+          "notes": "The review usefully identifies token lifetime, fallback visibility, simultaneous restarts, and operator troubleshooting as concrete concerns. Its central remediation is wrong: shortening connection lifetime forces new authentication with the same expired environment token, while token expiry does not terminate an already-authenticated connection and no SDK refresh path exists. It also endorses cluster-ARN execution-role permission and proxy passthrough despite keycloak-ecs.tf defining a separate task role and keycloak-database.tf using the cluster endpoint with proxy IAM disabled. Claimed revised-LLD sections and confirmations are absent from the submitted LLD, while latency and production behavior remain unverified."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 4,
+          "specificity": 14,
+          "risk_awareness": 9,
+          "total": 41,
+          "notes": "The plan covers both feature-flag states, failure injection, Terraform configuration, service readiness, and rollback-oriented scenarios. However, generate-db-auth-token only signs a token locally, so its nonempty-output checks prove neither IAM authorization nor database acceptance; the token is not a JWT, and the expiration test does not test expiration. The plan references nonexistent scripts and output keycloak_alb_dns_name, and its IAM deletion policy name differs from the patch's keycloak-task-exec-rds-iam-auth-policy, making the failover injection ineffective. No AWS test environment was supplied, and most RUNNING-status assertions could pass without proving that IAM authentication was used."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 2,
+          "specificity": 11,
+          "risk_awareness": 4,
+          "total": 24,
+          "notes": "The diff context matches the baseline files and correctly adds the Terraform flag and Aurora IAM-authentication setting, but it does not implement a working IAM connection path. The stock image retains kc.sh as its entrypoint, so command = [\"sh\", \"-c\", ...] is passed to kc.sh rather than launching a shell; the image is also not shown to contain AWS CLI, and exec keycloak start is not the repository's established executable. The policy uses the wrong action, resource, and execution role, while no IAM-enabled database user or renewable-token mechanism is created. The unused non-executable reference script adds dead code, and the summary's claims of exact LLD conformance and full compatibility materially overstate the patch."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 68,
+      "input_tokens": 83,
+      "output_tokens": 24082,
+      "latency_seconds": 244.8,
+      "total_cost_usd": 0.8594790000000001,
+      "task_score": 38.2,
+      "cache_read_tokens": 5742460,
+      "cache_write_tokens": 131792,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 98.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 9,
+          "specificity": 17,
+          "risk_awareness": 7,
+          "total": 48,
+          "notes": "The issue provides a clear motivation, real paths, explicit exclusions, and several testable removal criteria. Its largest omission is the supported default file backend: `Settings.storage_backend` defaults to `file`, and `get_search_repository()` selects `FaissSearchRepository` for that backend, so removal requires a compatibility or migration decision. The criterion to remove `sentence-transformers` is incorrect because `registry/embeddings/client.py` and `DocumentDBSearchRepository` use it for the default embedding provider, while unchanged relevance is not objectively defined. No independent task statement was supplied, and the asserted contents of GitHub issue #1285 could not be verified from the repository."
+        },
+        "lld": {
+          "completeness": 12,
+          "correctness": 7,
+          "specificity": 15,
+          "risk_awareness": 9,
+          "total": 43,
+          "notes": "The LLD inventories several real files and correctly revises its dependency decision to retain `sentence-transformers`. Its central design is incomplete because it neither removes nor migrates the default `file` backend, even though `registry/repositories/factory.py` still constructs `FaissSearchRepository` and `registry/core/config.py` still accepts and defaults to `file`. It also invents `DocumentDBSearchRepository.search_entities()` and imports `get_search_repository` from `interfaces`; the real repository exposes `search()` and the factory function lives in `registry/repositories/factory.py`, while `search_routes.py` already uses that interface. The rollout discussion does not address data migration, backend unavailability, or the many remaining tests and documentation references, and its claims of equivalent results and existing observability were not demonstrated."
+        },
+        "review": {
+          "completeness": 11,
+          "correctness": 8,
+          "specificity": 13,
+          "risk_awareness": 10,
+          "total": 42,
+          "notes": "The review identifies a concrete interface-signature risk, stale files, integration-test updates, and documentation follow-ups. It nevertheless declares all blockers resolved without resolving the signature and misses the decisive fact that `file` remains a supported default whose search repository imports the service being deleted. Repository inspection contradicts claims that response behavior is already verified and that FAISS data will simply be re-indexed on startup after migration; the persistent DocumentDB path normally skips startup re-indexing. Several role sections merely approve unsupported assertions such as identical relevance, improved latency, and no operational complexity."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 4,
+          "specificity": 12,
+          "risk_awareness": 10,
+          "total": 39,
+          "notes": "The plan spans dependency scans, configuration, behavior, latency, persistence, Docker, and registration workflows, and `uv run pytest tests/` is consistent with repository practice. Most functional commands target an invented `GET /search/entities` API, while `registry/main.py` mounts a JSON `POST /api/search/semantic`; the schema test also saves only `jq 'keys'` and then attempts to inspect `.servers`. The prerequisites incorrectly allow Python 3.10 despite `pyproject.toml` requiring Python 3.14, use unsupported `MONGODB_URI`, and name nonexistent `registry_servers` and `registry_agents` collections instead of the repository's `mcp_*` collections. It lacks a valid pre/post relevance oracle, file-backend compatibility coverage, database failure cases, and concrete updates for the many tests importing the deleted module."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 1,
+          "specificity": 10,
+          "risk_awareness": 1,
+          "total": 19,
+          "notes": "The patch targets real baseline files and includes valid isolated removals such as `faiss-cpu`, the two path properties, and the FAISS service itself, but it does not implement a working migration. Multiple hunks create syntax errors: `agent_routes.py` retains dangling call arguments, `server_routes.py` concatenates separate imports onto one line, and `file/search_repository.py` removes loop and return statements while leaving their bodies or arguments. It also leaves the default `file` factory path dependent on the deleted service, reverses the persistent-backend startup condition in `main.py`, and leaves numerous tests importing or patching `registry.search.service`. The summary's claims of no deviations, complete test updates, unchanged behavior, and zero regression are contradicted by the real source, and no verification was executed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-04",
+  "skill": "swe3"
+}


### PR DESCRIPTION
Records the `/swe3` (single-agent) benchmark run for **Claude Haiku 4.5** on the `mcp-gateway-registry` dataset, via Amazon Bedrock.

## Change

One file: `benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/mcp-gateway-registry/run-summary.json`. Per-task artifact folders remain gitignored; only the scrubbed rollup is tracked.

## Folder placement

This lands in the **canonical `claude-code/`** folder, not `claude-code-swe3/`. Since #82 made `swe3` the default skill, `RunnerConfig.harness_slug` maps `swe3` to the unsuffixed `claude-code/` tree (and `swe2` to `claude-code-swe2/`). Writing to `claude-code-swe3/` would be invisible to `gen_agent_report.py` and the chart scripts, which only recognize the canonical harness slugs.

This run therefore supersedes the previous `/swe2` result (45.64) recorded at that path by #80.

## Result

Mean **41.08** over 5 of 5 tasks scored, no failures.

| Task | Artifacts | Turns | Judge score |
|---|---|---|---|
| ssrf-hardening-outbound-url-validation | 6/6 | 60 | 44.6 |
| remove-efs-from-terraform-aws-ecs | 6/6 | 48 | 41.8 |
| migrate-ecs-env-vars-to-secrets-manager | 6/6 | 61 | 41.2 |
| replace-keycloak-db-password-with-rds-iam | 6/6 | 49 | 39.6 |
| remove-faiss | 6/6 | 68 | 38.2 |

## Serving and scoring

- Provider: bedrock (Amazon Bedrock), context window None.
- Judge: `openai.gpt-5.6-sol` via `codex exec`, repo-grounded at ref 1.24.4, reasoning effort high.
