### PR TITLE
benchmark: Claude Sonnet 5 (claude-code, Bedrock) -- 5/5 tasks, mean 68.04

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,355 @@
+{
+  "model": "us.anthropic.claude-sonnet-5",
+  "model_slug": "claude-sonnet-5",
+  "agent": "claude",
+  "scope": "mcp-gateway-registry",
+  "provider": "bedrock",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-04T04:36:32.316795Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 549948,
+      "cached_input_tokens": 472989,
+      "cache_write_input_tokens": 76941,
+      "output_tokens": 10053,
+      "reasoning_output_tokens": 5259
+    },
+    "duration_ms": 160289
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 68.04,
+  "mean_cost_usd_excl_failed": 24.64,
+  "tasks": [
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 148,
+      "input_tokens": 296,
+      "output_tokens": 157775,
+      "latency_seconds": 1800.8,
+      "total_cost_usd": 12.240058800000003,
+      "task_score": 78.0,
+      "cache_read_tokens": 29378116,
+      "cache_write_tokens": 271804,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 87.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 84,
+          "notes": "The issue clearly identifies the two real outbound call sites, gives testable acceptance criteria, and deliberately excludes private-by-design MCP proxy URLs. Repository checks confirm `_check_endpoint_reachability`, `check_agent_health`, `_build_agent_health_urls`, and the existing `skill_service._is_safe_url` guard all exist as described. Its largest factual defect is the claimed five-minute background scan of every agent: `registry/health/service.py` checks MCP servers, while the agent health function is only an API route; the claimed ECS task-role theft through EC2 IMDS is also deployment-dependent and overstated. No independent task statement or issue #1282 content was supplied, so those external requirements could not be verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 84,
+          "notes": "The LLD is implementation-ready on the central decisions: a parameterized shared guard, separate trust domains, soft-failure behavior, explicit redirect handling, and documented DNS-rebinding residual risk. Its file and symbol references closely match the baseline, including the settings, Terraform, Compose, Helm, and health-route integration points. The largest repository-specific omission is `charts/mcpgw/reserved-env-names.txt`, which must include every chart-managed environment variable; it also incorrectly says existing tests directly import `_is_private_ip` and understates potentially blocking DNS as only a few milliseconds. Requirements attributed to the unavailable reference issue could not be independently verified."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 20,
+          "risk_awareness": 19,
+          "total": 72,
+          "notes": "The review raises concrete concerns about DNS rebinding, blocking DNS resolution, rollout visibility, redirect tests, and compatibility with existing mocks. Its consensus blocker is logically unsound: even if `fd00:ec2::254` were not classified private, the proposed explicit literal comparison would still block it, so no IMDSv6 leak depended on that classification. It also asserts the frontend can display the health `detail`, but `frontend/src/pages/Dashboard.tsx` and `AgentCard.tsx` discard successful-response detail, and it misses the Helm reserved-variable file. The external issue and claimed reference workflow were unavailable for verification."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 73,
+          "notes": "The plan provides strong unit-level oracles for blocked requests, allowlist bypass, public URLs, both agent call sites, and regression coverage for the existing skill guard. Its largest incorrect oracle is that `terraform plan` should show no diff: adding `AGENT_FETCH_HOST_ALLOWLIST` to the ECS task environment necessarily changes the task definition even when its value is empty. The successful registration response does not expose validation warnings, the proposed server cleanup uses a nonexistent `DELETE /api/servers/{path}` route, and the review-requested redirect cases are absent. No tests were executed, and task requirements beyond the submitted artifacts could not be confirmed."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 19,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 77,
+          "notes": "The patch contexts match baseline commit `b0fcb2db453f933da63389c0b18ccc044ee505b5`, and the core change correctly gates registration GETs, health GET/HEAD requests, preserves skill-service wrappers, and explicitly disables redirects. Configuration is wired through the principal deployment files, but omitting `charts/mcpgw/reserved-env-names.txt` contradicts the summary's claim that every deployment surface is covered and permits duplicate chart-managed environment entries through `extraEnv`. The added tests have meaningful no-fetch assertions and correctly retarget moved DNS mocks, but do not verify redirect arguments on health requests; DNS rebinding and unbounded blocking resolution remain acknowledged risks. The summary honestly states that tests were not run, and no independent task specification was available to validate broader expectations."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 159,
+      "input_tokens": 266,
+      "output_tokens": 100741,
+      "latency_seconds": 1219.4,
+      "total_cost_usd": 9.3122049,
+      "task_score": 76.4,
+      "cache_read_tokens": 23089723,
+      "cache_write_tokens": 232900,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 82.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 80,
+          "notes": "The issue provides unusually concrete acceptance criteria covering Terraform resources, ECS mounts, outputs, variables, CodeBuild, and post-deployment tooling. However, storage.tf defines six access points, including agents, rather than the claimed five, and docker/Dockerfile.auth places scopes.yml at /app/scopes.yml rather than the proposed registry-style /app/auth_server/scopes.yml. Its migration and file-backend exclusions expose meaningful risks, but the assertion that EFS is redundant for all relevant environments cannot be verified without deployment evidence or an independent task statement. It also overlooks the repository-wide build-config.yaml entry that continues building mcp-gateway-scopes-init."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 76,
+          "notes": "The LLD traces the real task definitions, outputs, variables, scripts, Dockerfiles, and scopes-loading flow with implementation-ready edits. Its largest gap is repository-wide integration coverage: build-config.yaml still declares mcp-gateway-scopes-init, docs/deployment-modes.md still directs operators to the deleted script, and the separate required-output validation was only found during implementation. Repository evidence also contradicts its five-access-point inventory and its claim that registry/core/config.py defaults to documentdb; that Python default is file, although the Terraform root default is documentdb. The migration and file-backend regression analysis is useful, but zero-downtime and existing-state destruction behavior remain unverified without an AWS plan."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 21,
+          "total": 77,
+          "notes": "The review identifies concrete risks around the auth image path, loss of live file-backend updates, environment-specific scopes overrides, and an unsupported zero-downtime claim. It misses the six-versus-five access-point error, the active scopes-init entry in build-config.yaml, stale operator documentation, and the required-output reference later caught by implementation. Byte's package-data concern is largely irrelevant because docker/Dockerfile.auth performs a raw COPY and .dockerignore does not exclude scopes.yml. Production use of EFS-only scope overrides remains appropriately presented as an unanswered operational question rather than a verified fact."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 16,
+          "specificity": 20,
+          "risk_awareness": 18,
+          "total": 71,
+          "notes": "The strongest test is the concrete Docker build, docker cp, non-empty check, and byte-for-byte diff for /app/scopes.yml. The fresh-stack section is labeled as a terraform plan test but runs only init and validate, while the file-backend compatibility check merely greps source and never exercises load_scopes_from_yaml or container startup. Its Terraform and stale-reference oracles are otherwise specific, but the grep scope misses build-config.yaml and documentation that still reference scopes-init. Terraform was unavailable in the supplied environment and no AWS state was provided, so the stated validate and existing-state plan outcomes could not be independently confirmed."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 20,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 78,
+          "notes": "The patch implements the core removal end to end and additionally fixes post-deployment-setup.sh's required_outputs reference to mcp_gateway_efs_id. Every target file and preimage hash matches the 1.24.4 repository, including storage.tf, ecs-services.tf, codebuild.tf, and both deleted-script contexts. The largest residual defect is that build-config.yaml still actively builds mcp-gateway-scopes-init and docs/deployment-modes.md still tells operators to invoke the deleted script, contradicting the summary's claim that the image is fully orphaned; the summary also says five access points although the deleted module contains six. The Terraform and Docker checks were not executed, so deployed-state behavior remains unverified, but the submitted diff is internally consistent with the source and removes all Terraform EFS references."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 149,
+      "input_tokens": 270,
+      "output_tokens": 105926,
+      "latency_seconds": 1246.5,
+      "total_cost_usd": 9.309698849999997,
+      "task_score": 73.6,
+      "cache_read_tokens": 22953942,
+      "cache_write_tokens": 222351,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 85.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The issue precisely identifies the thirteen variables, affected containers, fallback behavior, and testable acceptance criteria; the cited entries exist in ecs-services.tf and observability.tf. Its largest correctness gap is claiming the migration removes plaintext from Terraform state, because aws_secretsmanager_secret_version.secret_string remains stored in state. It also overlooks that ecs_secrets_access is attached to several task roles as well as execution roles, so adding all thirteen ARNs broadens runtime access beyond the stated consumers. No independent task statement was supplied, and the referenced issue #1134 could not be verified from repository evidence."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 81,
+          "notes": "The LLD is unusually well grounded: the baseline contains the named variables, existing Secrets Manager resources, task-definition blocks, and the missing Grafana execution-role attachment it identifies. Its largest design defect is the least-privilege claim: iam.tf's common ecs_secrets_access policy is attached to auth, registry, metrics, and other task roles, so each receives access to every migrated ARN. It also contradicts itself by alternately saying Grafana already has the attachment and directing Step 5 to add it, while never addressing continued secret storage in Terraform state. Claims attributed to unspecified clarifying answers are unverifiable because no independent task statement was provided."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 71,
+          "notes": "The review identifies concrete maintainability and operational risks, including map divergence, immediate secret deletion, rolling redeploys, and Grafana launch failures. Its largest miss is endorsing per-credential least privilege even though ecs_secrets_access is attached to application task roles and grants all migrated ARNs. The security recommendation that sensitive values should not appear in terraform show -json output is incorrect; Terraform JSON output exposes sensitive values and marks them separately. Several conclusions rely on unprovided clarifying answers, and the review does not catch the Terraform-state exposure."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 9,
+          "specificity": 18,
+          "risk_awareness": 15,
+          "total": 59,
+          "notes": "The plan covers enabled, disabled, empty-value, rendered-task, deployment, health, and rollback paths with concrete commands and intended oracles. Its most serious error is writing terraform show -json output to plan.json and expecting secret values to be absent; that format includes sensitive values in plaintext, so this test is inverted and creates a sensitive artifact. The resource-count setup configures only three example values while claiming exactly thirteen, its script never asserts thirteen, and the IAM filter contains `or True`, making it ineffective. It also cites nonexistent terraform/aws-ecs/versions.tf and omits repository-standard fmt, TFLint, tfsec, and Checkov checks."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 75,
+          "notes": "The patch targets real baseline files and symbols at tag 1.24.4, removes the cited plaintext entries, adds conditional per-secret resources, wires all three services, and fixes Grafana's missing execution-role attachment. Its largest defect is extending a shared policy that the repository also attaches to application task roles for auth, registry, metrics, and other services, granting them every migrated secret rather than service-specific access. The auth-server reserved-name list omits REGISTRY_API_KEYS, ANS_API_KEY, and ANS_API_SECRET, so auth_server_extra_env can still place those names in environment while the patch places them in secrets, violating the no-overlap invariant. The implementation also leaves plaintext secret_string values in Terraform state; Terraform validation was not executed, and the claimed git apply check could not be independently rerun because no standalone patch.diff file exists."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 111,
+      "input_tokens": 176,
+      "output_tokens": 169463,
+      "latency_seconds": 1882.7,
+      "total_cost_usd": 7.89164775,
+      "task_score": 60.4,
+      "cache_read_tokens": 15218645,
+      "cache_write_tokens": 208955,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 90.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 73,
+          "notes": "The issue names real integration points such as aws_rds_cluster.keycloak, keycloak_container_secrets, and the rotation Lambda, with concrete opt-in and rollback criteria. Its largest flaw is internal inconsistency: it says keycloak_database_password is unnecessary in IAM mode while also acknowledging that the retained master user still requires a password, and its security motivation overstates infrastructure removal despite retaining the secret, KMS key, proxy use, and rotation. Repository inspection confirms the cited Terraform files and the issue #1026 credential flow, but the Lambda-backed bootstrap criterion conflicts with the later local-exec implementation. No independent task statement was supplied, and issue #1303 and several AWS platform assertions could not be verified from the repository."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 63,
+          "notes": "The LLD is unusually concrete about the real cluster, task roles, direct cluster JDBC endpoint, password fallback, TLS, and least-privilege ARN construction. Its implementation path is nevertheless broken: build-config.yaml fixes the Keycloak build context at docker/keycloak, so the proposed COPY of keycloak/providers/... cannot access the new repository-root source, while no build-config change is designed. The bootstrap also assumes a VPC-connected apply host can reach Aurora, but keycloak-security-groups.tf permits port 3306 only from the ECS, proxy, and rotation-Lambda security groups, and the cited terraform-setup skill explicitly supports local laptop deployment. The Quarkus CredentialsProvider registration/version compatibility and claimed pool lifetime behavior remain unverified, and the design provides neither the referenced lifetime property nor an IAM-mode custom-image precondition."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 64,
+          "notes": "The review identifies meaningful risks including TLS, Quarkus version compatibility, database grants, bootstrap retries, least privilege, and the added Maven maintenance burden. It misses the decisive Docker build-context failure and mistakes general VPC placement for database authorization despite the security-group rules, then treats a connectivity probe as resolving the bootstrap blocker. Cipher also incorrectly characterizes credential handling as safe even though the patch passes the master password in process arguments via --password=\"$MASTER_PASSWORD\". Its provider-SPI approval and claims about the deployment host remain unsupported by repository evidence or executed builds."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 58,
+          "notes": "The plan gives specific Terraform mode checks, policy-ARN inspection, manual token authentication, absence-of-password inspection, TLS verification, and rollback oracles. It omits the critical long-lived test of opening a fresh pooled connection after token expiry and provides no automated Java/provider test, so the central refresh behavior could remain broken. Several commands are unreliable: the missing-password test also omits the separately required keycloak_admin_password, docker history cannot prove a file exists, and the public /health/ready check conflicts with the repository's management-port 9000 health check and ALB routing on port 8080. None of the live AWS, Maven, Docker, or Terraform outcomes were executed, so their expected results are unverified."
+        },
+        "implementation": {
+          "completeness": 12,
+          "correctness": 4,
+          "specificity": 19,
+          "risk_awareness": 9,
+          "total": 44,
+          "notes": "The diff targets real baseline files and symbols, and its Terraform conditionals, specific rds-db:connect ARN, TLS URL, and password-mode secret ordering fit the surrounding source. The feature cannot build through the repository's documented path because both build-config.yaml and codebuild.tf use docker/keycloak as context while the Dockerfile tries to COPY keycloak/providers/... from outside that context. The local-exec bootstrap has no matching database ingress for the apply host and exposes the master password in mysql process arguments; ECS deployment also has no dependency ensuring bootstrap and policy completion before task rollout. The Quarkus service registration and pinned dependencies were explicitly left unverified, no build or Terraform validation was run, and the summary therefore overstates an end-to-end implementation."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 6,
+      "num_turns": 802,
+      "input_tokens": 1600,
+      "output_tokens": 359532,
+      "latency_seconds": 5291.0,
+      "total_cost_usd": 84.44608170000001,
+      "task_score": 51.8,
+      "cache_read_tokens": 247848589,
+      "cache_write_tokens": 1251660,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 65.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 67,
+          "notes": "The issue provides unusually concrete scope, acceptance criteria, exclusions, and verified integration points such as registry/repositories/factory.py, registry/search/service.py, and the deprecated file backend in docs/configuration.md. Its central claim that every direct faiss_service call is duplicated by DocumentDB indexing is false for agent_routes.py::toggle_agent, whose AgentService path only updates repository state. Repointing the default file backend to DocumentDB also introduces a startup dependency that conflicts with the broad user story that search is unaffected, while numerous current references such as registry/core/schemas.py, registry/api/search_routes.py, and tests/unit/api/test_agent_routes.py are omitted from the proposed cleanup. No independent task statement establishes whether routing file-backed search to DocumentDB is required, so that architectural choice can only be judged as an internally proposed requirement."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 13,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 66,
+          "notes": "The LLD is highly specific and correctly identifies the agent-toggle gap and the file backend's new MongoDB availability requirement; the cited factory, main startup, route, and service symbols all exist. Its file inventory is materially incomplete: deleting registry/search/service.py leaves patches or assertions in tests/unit/api/test_agent_routes.py, tests/unit/api/test_server_routes.py, tests/unit/services/test_agent_batch_item_processor.py, tests/unit/repositories/test_factory_aliases.py, and other tests that the design never updates. The explanation that the FAISS toggle call kept the DocumentDB embeddings collection synchronized is technically wrong because that call only mutates the separate FAISS singleton, although the proposed new index_agent call itself is useful. It also misses current runtime and deployment references including registry/core/schemas.py::FaissMetadata, registry/servers/mcpgw.json, terraform/aws-ecs/scripts/service_mgmt.sh, and docs/design/database-abstraction-layer.md, so following the LLD would not achieve its claimed clean removal."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 14,
+          "specificity": 19,
+          "risk_awareness": 18,
+          "total": 67,
+          "notes": "The review surfaces two concrete risks rather than merely approving the design: AgentService.enable_agent/disable_agent omit search indexing, and get_documentdb_client can propagate a connection failure before DocumentDBSearchRepository.initialize enters its internal try block. It correctly verifies the relevant code in registry/services/agent_service.py, registry/api/agent_routes.py, and registry/main.py. However, it repeats the false assertion that a faiss_service call synchronized the DocumentDB collection and treats documentation as fully resolving a default-backend startup regression that remains operationally hazardous. It also approves without detecting the many unit tests and deployment scripts that still reference the deleted module, while its assertion that DocumentDB is already exercised in production is not verifiable from the repository."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 15,
+          "total": 59,
+          "notes": "The plan includes concrete negative cases, lifecycle checks, dependency checks, and a meaningful oracle for enabled-state synchronization after an agent toggle. The semantic endpoint and request fields are real, but tests/integration/test_search_integration.py is globally skipped, so merely retargeting its mocks and running the stated command would prove nothing unless that skip is removed. The server E2E uses nonexistent POST /api/servers with a JSON body instead of the repository's form-based POST /api/servers/register, and its agent registration targets an unavailable localhost endpoint despite registration performing endpoint validation. The proposed unconfigured-file-backend failure check is also unreliable because docker-compose.yml supplies and depends on the mongodb service by default, while the promised byte-for-byte ranking compatibility has no before/after oracle."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "No implementation artifact was submitted: the implementation value is empty and there is no patch.diff or implementation.md content to inspect. Consequently, none of the designed removals, test updates, dependency changes, or agent-toggle correction can be verified against the source. Patch applicability, behavioral correctness, and deviations from the LLD are therefore unassessable, requiring zero for all implementation criteria."
+        }
+      },
+      "is_error": true,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-04",
+  "skill": "swe3"
+}


### PR DESCRIPTION
Records the `/swe3` (single-agent) benchmark run for **Claude Sonnet 5** on the `mcp-gateway-registry` dataset, via Amazon Bedrock.

## Change

One file: `benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/mcp-gateway-registry/run-summary.json`. Per-task artifact folders remain gitignored; only the scrubbed rollup is tracked.

## Folder placement

This lands in the **canonical `claude-code/`** folder, not `claude-code-swe3/`. Since #82 made `swe3` the default skill, `RunnerConfig.harness_slug` maps `swe3` to the unsuffixed `claude-code/` tree (and `swe2` to `claude-code-swe2/`). Writing to `claude-code-swe3/` would be invisible to `gen_agent_report.py` and the chart scripts, which only recognize the canonical harness slugs.

This run therefore supersedes the previous `/swe2` result (76.96) recorded at that path by #80.

## Result

Mean **68.04** over 5 of 5 tasks scored, no failures.

| Task | Artifacts | Turns | Judge score |
|---|---|---|---|
| ssrf-hardening-outbound-url-validation | 6/6 | 148 | 78.0 |
| remove-efs-from-terraform-aws-ecs | 6/6 | 159 | 76.4 |
| migrate-ecs-env-vars-to-secrets-manager | 6/6 | 149 | 73.6 |
| replace-keycloak-db-password-with-rds-iam | 6/6 | 111 | 60.4 |
| remove-faiss | 4/6 | 802 | 51.8 |

## Serving and scoring

- Provider: bedrock (Amazon Bedrock), context window None.
- Judge: `openai.gpt-5.6-sol` via `codex exec`, repo-grounded at ref 1.24.4, reasoning effort high.
