### PR TITLE
benchmark: GLM-5.2 with the pi agent on mcp-gateway-registry (5/5, 70.52)

### DIFF
--- a/benchmarks/swe-benchmark-data/glm-5.2/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/glm-5.2/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "glm-5.2",
+  "model_slug": "glm-5.2",
+  "agent": "pi",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "FP8",
+    "context_window": 300000
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-04T17:10:06.326576Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 279580,
+      "cached_input_tokens": 230966,
+      "cache_write_input_tokens": 48602,
+      "output_tokens": 8528,
+      "reasoning_output_tokens": 6851
+    },
+    "duration_ms": 152633
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 70.52,
+  "mean_cost_usd_excl_failed": null,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 46,
+      "input_tokens": 96826,
+      "output_tokens": 716,
+      "total_tokens": 2385176,
+      "latency_seconds": 648.4,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 76.6,
+      "cache_read_tokens": 2241280,
+      "cache_write_tokens": 46354,
+      "prefix_cache_hit_rate": 0.9797,
+      "generation_tokens_per_sec": 1.1,
+      "kv_cache_usage": {
+        "peak": 0.2253,
+        "mean": 0.1297
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 16,
+          "total": 81,
+          "notes": "The issue names the exact Terraform module, resources, variables, outputs, ECS mounts, script references, and testable acceptance criteria reflected in the submitted source diff. Its largest gap is treating absence of valuable EFS data and runtime dependence on `/app/logs` or `/app/data` as assumptions rather than requiring evidence or a pre-removal gate. It also calls the file system provisioned-throughput even though `efs_throughput_mode` defaults to `bursting`, and no independent task statement verifies the broader claim that all relevant state is already in S3 or DocumentDB."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 79,
+          "notes": "The LLD is unusually concrete about `storage.tf`, `ecs-services.tf`, module and root outputs, script control flow, compatibility, and the destructive state transition. The submitted source confirms the named `module.efs`, six access points, auth and mcpgw mounts, and DocumentDB/EFS branch, but the design does not establish that `/app/data` and `/app/logs` contain no required runtime state. Its pre-apply recommendation is technically weak because `aws efs describe-mount-targets` lists AWS mount-target resources, not active client mounts, and those targets would normally still be available before apply rather than pending deletion. It also omits a staged rollout or dependency mechanism to ensure old ECS tasks are drained before Terraform concurrently destroys EFS mount targets."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 19,
+          "risk_awareness": 18,
+          "total": 74,
+          "notes": "The review identifies two material concerns: irreversible EFS data loss and breakage of external consumers of the removed root outputs, both grounded in the access points and output blocks shown in the source. It also notices the orphaned scopes-init image build and explicitly prioritizes findings rather than merely approving the design. The largest omission is failure to challenge the single-apply rollout ordering between ECS replacement and EFS destruction; its recommendation to use `describe-mount-targets` to confirm zero active mounts cannot provide that assurance. The existence of external runbooks and non-DocumentDB deployment modes remains unverified, although the review appropriately flags those uncertainties."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 13,
+          "specificity": 18,
+          "risk_awareness": 16,
+          "total": 65,
+          "notes": "The plan covers static reference checks, `terraform validate`, a credentialed plan, post-apply ECS inspection, health checks, rollback limits, and both branches of `_initialize_scopes`. Several oracles are wrong: `terraform output` can retain old state outputs after a plan but before apply, and the expected three `EFS volumes removed` matches conflicts with the submitted diff, which adds four such comments in addition to the existing registry occurrences. The required destroy-plan assertions also assume an existing state containing EFS even though that deployment is listed as optional, and the missing-DocumentDB script test does not construct or isolate a concrete outputs fixture. No execution results are supplied, and the plan does not test or mitigate the ordering risk between draining old ECS tasks and deleting mount targets."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 84,
+          "notes": "The diff implements the stated end state across all principal surfaces: it deletes `storage.tf` and the EFS runner, removes both levels of outputs and module variables, strips all three mounted volumes, removes the EFS-path `SCOPES_CONFIG_PATH`, and updates the post-deployment branch and README. The target symbols and surrounding contexts are internally consistent with the baseline source presented, and retaining the separate bundled-path `SCOPES_CONFIG_PATH` is a justified distinction. The largest operational risk is that one Terraform apply has no explicit ordering to drain old auth and mcpgw tasks before EFS mount targets are destroyed, while the summary presents the deployment as a normal rolling update. The implementation also relies on the unverified premise that mounted data is dispensable and reports no actual `terraform validate` or `terraform plan`, although its summary is candid about that omission and accurately describes the patch."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 71,
+      "input_tokens": 142454,
+      "output_tokens": 1767,
+      "total_tokens": 6668176,
+      "latency_seconds": 1005.3,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 74.4,
+      "cache_read_tokens": 6462208,
+      "cache_write_tokens": 61747,
+      "prefix_cache_hit_rate": 0.9905,
+      "generation_tokens_per_sec": 1.8,
+      "kv_cache_usage": {
+        "peak": 0.3332,
+        "mean": 0.2097
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 76,
+          "notes": "The issue gives testable criteria tied to real targets such as `ecs-services.tf`, `observability.tf`, `aws_iam_policy.ecs_secrets_access`, and the Grafana role-policy maps, all of which appear in the submitted source diff. Its strongest feature is the explicit migration flag, rollback behavior, and bounded ECS-only scope. Its framing implies the migration addresses Terraform-state exposure, but the proposed `secret_string` resources still store every value in state, as the LLD later concedes. With no independent task statement, the added flag cannot be externally required, and the issue misses the default-on `\"\"` to `\"not-configured\"` compatibility change and shared-policy privilege expansion."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 81,
+          "notes": "The LLD is unusually repository-specific: its named modules, variables, output, conditional list shapes, Grafana sidecar, and IAM resource all correspond to the submitted baseline contexts and patch. It explicitly documents residual state exposure, `ignore_changes`, rollout, rollback, cost, and Grafana's broad access. The largest flaw is accepting the nonempty `not-configured` sentinel without auditing consumers, despite acknowledging that it can activate previously disabled code paths; calling resulting failures a follow-up does not make a default-on upgrade compatible. It also treats a shared ECS cluster as justification for cross-service secret access and omits ordering between secret-version creation and ECS service startup."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 80,
+          "notes": "The review identifies concrete defects rather than merely approving the design, including state persistence, sentinel semantics, Grafana lockout, `ignore_changes`, JSON preservation, and overbroad IAM. These findings are tied to real symbols such as `grafana_admin_password`, `registry_api_keys`, and `aws_kms_key.secrets`. Its largest deficiency is the unanimous nonblocking verdict: an unaudited default-on semantic change and internet-adjacent Grafana task role gaining all shared secrets warrant remediation or proof before approval. It also overlooks that expanding the shared policy broadens access for existing auth, registry, and mcpgw roles, and it does not identify the secret-version provisioning race."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 63,
+          "notes": "The plan covers both flag modes, all named credentials, IAM, KMS, live task definitions, first-apply seeding, rollback, and the `REGISTRY_API_KEYS` payload. Several commands are unusable: the implementation exports `secret_arns` rather than `migrated_secret_arns`, `terraform output -raw` cannot return that object map, and the live `describe-task-definition` command has an unterminated quote. Plan JSON cannot reliably expose module input maps such as `task_exec_iam_role_policies`, while JSON-encoded policies and container definitions containing unknown new ARNs may themselves be unknown before apply. The plaintext oracle only greps a few token patterns, and the sentinel check permits application failures as nonblocking, so the plan can miss the principal compatibility and disclosure regressions."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 72,
+          "notes": "The diff implements the described path end to end across the real Terraform integration points: 13 secret pairs, conditional container delivery, IAM resources, Grafana attachments, variables, output, and documentation. Its largest functional defect is changing every unset value from an empty string to the truthy `not-configured` sentinel under a default-enabled migration, without validating the consuming applications or requiring Grafana's password. Attaching the shared policy to Grafana's task role unnecessarily exposes every listed secret to the container, while expanding that policy also broadens existing service roles; values additionally remain in Terraform state despite the original motivation. There is no dependency ensuring secret versions exist before new tasks start, and the summary explicitly reports that Terraform formatting, validation, planning, and runtime checks were not executed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 51,
+      "input_tokens": 119202,
+      "output_tokens": 1298,
+      "total_tokens": 3866496,
+      "latency_seconds": 819.1,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 74.0,
+      "cache_read_tokens": 3687040,
+      "cache_write_tokens": 58956,
+      "prefix_cache_hit_rate": 0.9843,
+      "generation_tokens_per_sec": 1.6,
+      "kv_cache_usage": {
+        "peak": 0.2783,
+        "mean": 0.1732
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 80,
+          "notes": "The issue precisely identifies the agent-card and health-check call paths, configuration changes, compatibility expectations, and testable outcomes. Its largest flaw is prescribing automatic redirect following followed by post-response validation, which detects an unsafe redirect only after httpx has already sent the request. The submitted source hunks corroborate the named symbols, including `_check_endpoint_reachability`, `_check_single_service`, and `skill_service._is_safe_url`. No independent task statement was supplied, and repository commands failed during sandbox setup, so baseline and path claims could not be independently verified."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 13,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 75,
+          "notes": "The LLD is unusually concrete about files, interfaces, configuration defaults, status transitions, rollout, and preserving the skill-service wrapper. Its load-bearing redirect design is unsound: inspecting `response.history` and `response.url` after `follow_redirects=True` cannot prevent requests to private intermediate or final targets, despite claims that it blocks exfiltration. It does explicitly document DNS rebinding and health-path redirects as residual risks, while the submitted patch contexts support most named integration points. The claimed derivation of every health endpoint from `proxy_pass_url` and exact baseline compatibility could not be independently checked because repository reads failed."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 13,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 72,
+          "notes": "The review surfaces concrete issues involving the skill escape hatch, rollback consistency, local-development breakage, health redirects, userinfo logging, and cache handling, then records actionable resolutions. However, every reviewer accepts the incorrect premise that walking `response.history` after automatic redirects prevents mid-chain SSRF, leaving the central agent-path bypass unresolved while declaring no blockers remain. The findings reference specific symbols such as `_normalize_health_status`, `_update_tools_background`, and `assert_safe_outbound_url`, and several are reflected in the diff. Repository-specific line and behavior claims could not be independently verified due the unavailable filesystem tooling."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 14,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The plan provides broad utility, call-site, compatibility, deployment, and end-to-end coverage with concrete inputs and expected states. Its redirect test is a false security oracle because a mocked completed response with unsafe history can return \u201cblocked\u201d even though a real client already contacted the unsafe target. The plan otherwise specifies meaningful assertions such as no transport call on direct private URLs, preserved `_is_safe_url`, and rollback behavior with plausible `uv run pytest` commands. Those commands and the asserted API shapes could not be verified against the checkout because repository command execution failed."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 67,
+          "notes": "The diff coherently adds the shared validator, settings, direct URL guards, skill wrapper, operator documentation, and focused tests described by the design. The principal security defect is `httpx.get(..., follow_redirects=True)` followed by validation of `response.history`: unsafe redirect requests have already occurred, so the agent-card path remains bypassable, while health redirects are knowingly left unmitigated. Test quality is also weakened by the tautological `assert ... is False or True`, and the summary's \u201cno deviations\u201d claim conflicts with the reviewed requirement for README upgrade notes, which the patch does not modify. The patch's applicability, imports, and claimed baseline commit could not be independently confirmed because all read-only shell commands failed at sandbox initialization."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 49,
+      "input_tokens": 127324,
+      "output_tokens": 911,
+      "total_tokens": 4359250,
+      "latency_seconds": 802.2,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 66.8,
+      "cache_read_tokens": 4169664,
+      "cache_write_tokens": 61351,
+      "prefix_cache_hit_rate": 0.9855,
+      "generation_tokens_per_sec": 1.1,
+      "kv_cache_usage": {
+        "peak": 0.2962,
+        "mean": 0.1894
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 75,
+          "notes": "The issue gives concrete scope, testable flag-on and flag-off criteria, dependencies, and exclusions tied to `aws_rds_cluster.keycloak` and the ECS task definition. Its largest deficiency is accepting a startup-only token as the default despite acknowledging that new pooled connections can fail after the 15-minute token expires; a manual fallback deployment is not an operational mitigation. Submitted diff context corroborates the existing password wiring and `CKV_AWS_162` suppression. No independent task statement establishes requirements such as default-on behavior or excluding a credentials provider."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 9,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 72,
+          "notes": "The LLD is concrete about files, Terraform resources, IAM ARN construction, container lifecycle, SQL, rollback, and documentation. Its central architecture is knowingly incomplete because Keycloak reads one token at startup while the sidecar refreshes a file the JVM never rereads. The proposed HCL also contains unescaped `${RDS_PORT:-3306}` and `${TOKEN_REFRESH_SECONDS:-600}`, which Terraform treats as invalid template expressions. Source context supports the named integration points, but the claimed readiness check does not prove that fresh post-expiry database connections work."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 22,
+          "total": 80,
+          "notes": "The review identifies real lifecycle, permissions, rollout, and secret-exposure concerns, especially the unreadable token file and startup hang. Its largest error is classifying the post-expiry connection failure as an acceptable should-fix even though it defeats reliable long-running IAM authentication. It also misses the invalid Terraform interpolation, and its claim that schema-level `ALL PRIVILEGES` grants `CREATE USER` or `GRANT OPTION` is incorrect without global scope or `WITH GRANT OPTION`. Several repository-specific assertions, including the exact image UID and reboot behavior, were not demonstrated from repository evidence."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 8,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 58,
+          "notes": "The plan covers validation, both feature-flag modes, IAM policy shape, SQL, deployment, rollback, readiness, and an OIDC flow with concrete commands. The baseline comparison cannot run as written because the unpatched baseline does not declare `keycloak_database_use_iam_auth`, yet the command passes it with `-var`. Other weak oracles include `grep -A3` that cannot reach the distant password entry and a plan grep that does not prove `master_password` is wired correctly. Most importantly, no test waits beyond token expiry and forces a new pooled connection, so the known primary regression would escape."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 3,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 49,
+          "notes": "The patch touches the expected Terraform, ECS, SQL, example, and documentation surfaces, and its summary honestly discloses the missing per-connection refresh. It is not deployable as submitted because `${RDS_PORT:-3306}` and `${TOKEN_REFRESH_SECONDS:-600}` are unescaped inside an HCL string and therefore parsed as invalid Terraform interpolation expressions. Even after fixing syntax, Keycloak retains only the startup token, while the sidecar's later files are unused; refresh failures can also emit a false `refreshed` message because `chmod` and `echo` run after a failed generation. The diff context matches existing symbols such as `keycloak_container_secrets` and `aws_ecs_task_definition.keycloak`, but the claimed successful validation was explicitly not executed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 223,
+      "input_tokens": 270534,
+      "output_tokens": 901,
+      "total_tokens": 39967041,
+      "latency_seconds": 2157.7,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 60.8,
+      "cache_read_tokens": 39580288,
+      "cache_write_tokens": 115318,
+      "prefix_cache_hit_rate": 0.9971,
+      "generation_tokens_per_sec": 0.4,
+      "kv_cache_usage": {
+        "peak": 0.6269,
+        "mean": 0.3328
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 12,
+          "total": 61,
+          "notes": "The issue names concrete, relevant files such as `registry/search/service.py`, `registry/repositories/factory.py`, and `pyproject.toml`, with mostly testable removal criteria. Its largest defect is claiming preserved behavior and no dependencies while making file-backed deployments require an external DocumentDB service. The stated `/search` and `/agents/search` surfaces conflict with the patch's OpenAPI operation IDs and existing tests, which use `/api/search/semantic` and `/api/agents/discover/semantic`. With no independent task statement, the asserted mandate to route every backend through DocumentDB is not externally verifiable, and the no-FAISS grep criterion conflicts with explicitly retained documentation and test identifiers."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 64,
+          "notes": "The LLD gives unusually concrete file-level data flows and correctly distinguishes `index_agent`'s `AgentCard` argument from the old dictionary call. Its central compatibility claim is unsound: `get_search_repository()` becomes unconditionally network-backed, while startup and write paths await repository operations outside the `/search` RuntimeError handler. It also claims boot reindexing benefits from `skip_if_unchanged`, despite documenting that parameter's default as false and not passing it, and it names API routes inconsistent with the repository evidence in the patch. The file-backend migration, duplicate indexing risk, and loss of integration coverage are documented or noticed but not adequately designed around."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 18,
+          "total": 72,
+          "notes": "The review identifies several real, specific risks: the new DocumentDB requirement for file storage, rejection of legacy telemetry values, retained FAISS test names, and deletion of a large integration suite. Its largest weakness is treating documentation as resolution for a behavior regression that the issue itself says must not occur. The security claim that there are no new outbound calls contradicts the reviewed design's requirement that file-backed installations contact DocumentDB, and several parenthetical 'verified' answers provide no supporting test evidence. The review is useful and prioritized, but its approval verdict is too lenient for the unresolved deployment and compatibility failures."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 7,
+          "specificity": 17,
+          "risk_awareness": 14,
+          "total": 56,
+          "notes": "The plan covers dependency greps, factory selection, unavailable-database behavior, write/read lifecycle checks, telemetry, and deployment surfaces. However, its principal curl tests target `/search` and GET `/agents/search`, while the submitted OpenAPI diff and deleted repository tests establish POST `/api/search/semantic` and POST `/api/agents/discover/semantic`. The tag test's `>= 0` oracle cannot fail, the batch payload contains invalid `{...}` JSON, and the documentation grep conflicts with the implementation's admitted retained `docs/OBSERVABILITY-LEGACY.md` references. It also deletes rather than replaces the only broad integration suite, leaving the most consequential compatibility claim without an executable regression test."
+        },
+        "implementation": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 9,
+          "total": 51,
+          "notes": "The visible patch broadly removes the FAISS implementation, dependency, configuration, mocks, scripts, and direct imports, and reroutes concrete call sites through repository methods. The central change makes every file-backed deployment depend on DocumentDB, so startup and successful storage mutations can fail when search persistence is unavailable; the patch only demonstrates graceful handling for the read endpoint. In `registry/api/server_routes.py`, several newly converted `index_server` calls remain immediately before pre-existing DocumentDB indexing blocks, creating duplicate upserts or embedding work, while the telemetry schema unnecessarily rejects events from older registries. The patch also deletes the 1,117-line skipped integration suite without replacement, contains mechanically inaccurate documentation, and ends with an explicit truncation marker, so the claimed complete 78-file diff and apply-check cannot be verified from the submitted artifact."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-04",
+  "skill": "swe3"
+}


### PR DESCRIPTION
## Summary

Adds the run summary for **GLM-5.2-FP8** self-hosted on vLLM and driven by the **pi** coding agent over the 5-task `mcp-gateway-registry` dataset. All 5 tasks completed with the full 6/6 artifact set and were scored by the codex judge (`openai.gpt-5.6-sol`, reasoning effort high, repo-grounded).

**Mean task score: 70.52 over 5/5 scored tasks, no failures.**

| Task | Artifacts | Turns | Prefix-cache | Judge score |
|---|---|---|---|---|
| remove-efs-from-terraform-aws-ecs | 6/6 | 46 | 98.0% | 76.6 |
| migrate-ecs-env-vars-to-secrets-manager | 6/6 | 71 | 99.1% | 74.4 |
| ssrf-hardening-outbound-url-validation | 6/6 | 51 | 98.4% | 74.0 |
| replace-keycloak-db-password-with-rds-iam | 6/6 | 49 | 98.6% | 66.8 |
| remove-faiss | 6/6 | 223 | 99.7% | 60.8 |

Serving: `p5en.48xlarge` (8x H200), TP=8, FP8, 300K context window.

Scope is results only. Per-task artifacts, session logs, and the DuckDB metrics snapshot stay gitignored, matching the convention for prior runs; only the aggregate `run-summary.json` is tracked. No docs are regenerated in this PR (see Follow-ups).

## pi vs claude-code on the same model and dataset

| | pi | claude-code |
|---|---|---|
| Mean task score | **70.52** | 61.96 |
| Tasks scored / failed | 5 / 0 | 5 / 0 |
| Clean artifact sets | 5x 6/6 | 4x 6/6, `remove-faiss` 4/6 with `is_error: true` after 251 turns |
| Wall clock (total) | 90.5 min | 65.0 min |
| Total tokens | 761,933 | 50,051,636 |

pi scored higher and completed more cleanly, but it was also **slower** in wall clock, which is the opposite of the faster/cheaper pattern asserted in `docs/harness-comparison.md`. Caveat worth stating plainly: this is **one run per configuration**, so the gap is not settled. The comparison rows in `docs/harness-comparison.md` were also produced on `g6e.12xlarge` / 4x L40S / 200K, so this `p5en` / 8x H200 / 300K run is not directly comparable to them.

## Serving notes from bringing GLM-5.2 up on 8x H200

Three distinct blockers were hit before the server booted. The third is documented nowhere in the repo and is worth adding to the guide:

1. **Orphaned vLLM server holding VRAM.** A prior Devstral-2-123B server was still holding ~131 GB across GPUs 0-3 with nothing listening on :8000 and 0% GPU utilization; its own benchmark had completed days earlier. `vllm-serve.sh --stop` cleared it.
2. **vLLM custom all-reduce** raised `illegal memory access` during CUDA graph capture. Fixed with `--disable-custom-all-reduce`.
3. **FlashInfer auto-selected the `mnnvl` allreduce backend**, which needs NVSwitch multicast; multicast init had already failed on this node and the intended trtllm fallback did not engage, producing the same illegal memory access. Fixed with `export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm`. This fix is in neither `self-hosted/vllm/models/glm-5.2.md` nor `.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md`. Possibly related: this node runs driver 595.71.05 rather than the 610.43.02 the CUDA-fixes note's Section 0 aligns to.

## Known gaps in this run

- **`total_cost_usd` is `null` for every pi task**, so `mean_cost_usd_excl_failed` is `null` and the summary has no cost column. The token-based estimator did not populate for this agent path.
- **`tensor_parallel_size` and `precision` were backfilled.** These come from opt-in `--tensor-parallel-size` / `--precision` orchestrator flags that were not passed on the run. The values recorded (8, FP8) are correct for the actual launch and are pure provenance with no effect on any score. Next self-hosted run should pass the flags natively.

## Follow-ups (not in this PR)

- **`gen_agent_report.py` applies a single flat `$/hr` to every hardware-derived row** (`DEFAULT_DOLLARS_PER_HOUR = 10.49`, `benchmarks/scripts/gen_agent_report.py:46`, applied in `_row_cost()` at line 141). Each `run-summary.json` already records `instance_type`, and `self-hosted/vllm/pricing.json` already carries both `g6e.12xlarge: 10.4926` and `p5en.48xlarge: 63.296`, so the generator should look up `dollars_per_hour` per row from `instance_type`. Regenerating `docs/harness-pi.md` today would price this `p5en.48xlarge` row at $10.49/hr, understating it roughly 6x, which is why the docs are deliberately left untouched here.
- Add the `VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm` requirement to the GLM-5.2 model guide and the p5en/H200 CUDA-fixes note.

## Verification

- 5/5 tasks scored by the codex judge, `num_failed: 0`, `failed_tasks: []`.
- `run-summary.json` / `run-summary.md` generated by `scripts/summarize_run.py`, not hand-written.
- GPU time series captured for the whole run and archived to `vllm-metrics_glm-5.2_mcp-gateway-registry_20260804T175552Z.duckdb`.
- `security-check` skill run before commit: verdict **APPROVED**. Scope was the one added generated JSON file; scanned for credential-shaped values, absolute paths, URLs, and IPs with zero hits. The `token`/`password`/`secret`/`api_key` keyword matches are symbol names in judge prose about the target repo's Terraform, never values.