### PR TITLE
benchmark: re-run glm-5.2 under /swe3 on mcp-gateway-registry (mean 65.60, 4/5 complete)

### DIFF
--- a/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "glm-5.2",
+  "model_slug": "glm-5.2",
+  "agent": "claude",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 200000
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-04T20:17:00.172899Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 193735,
+      "cached_input_tokens": 153078,
+      "cache_write_input_tokens": 40647,
+      "output_tokens": 9285,
+      "reasoning_output_tokens": 7581
+    },
+    "duration_ms": 146169
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 65.6,
+  "mean_cost_usd_excl_failed": 88.25,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 52,
+      "input_tokens": 4139345,
+      "output_tokens": 23049,
+      "total_tokens": 4162394,
+      "latency_seconds": 348.7,
+      "total_cost_usd": 21.27295,
+      "result_subtype": "success",
+      "task_score": 73.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8785,
+      "generation_tokens_per_sec": 66.1,
+      "kv_cache_usage": {
+        "peak": 0.2406,
+        "mean": 0.1795
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 76,
+          "notes": "The issue identifies concrete resources, task-definition mounts, variables, outputs, scripts, and testable structural acceptance criteria. Its largest gap is treating EFS as having no consumer or valuable data without establishing that `/app/data`, `/app/logs`, and the auth configuration contain nothing requiring migration or backup. The supplied patch context corroborates symbols such as `module \"efs\"`, `mcp_gateway_efs_id`, and the three active task-definition mounts, but the final criterion that no service depends on EFS is not itself a concrete test oracle. Independent repository command verification was unavailable because every read-only shell invocation failed in the sandbox with `bwrap: loopback: Failed RTM_NEWADDR`."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 75,
+          "notes": "The LLD is implementation-oriented, naming the relevant Terraform and shell files, exact symbols, task-definition changes, script behavior, and rollout sequence. Its main weakness is the unsupported data-safety conclusion: it verifies backend-driven scope loading but does not similarly establish that mcpgw's `/app/data` or other mounted paths can be destroyed without migration, backup, or a pre-apply check. It also conflicts with the review by omitting the promised `run-scopes-init-task.sh` deprecation-header change from Step 7 and the file-change table, despite the review claiming those sections contain it. Exact line and symbol claims could be compared with the supplied diff context, but not independently verified against the checkout because repository shell access failed."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 19,
+          "risk_awareness": 15,
+          "total": 69,
+          "notes": "The review finds concrete integration failures, particularly the required `mcp_gateway_efs_id` output and the obsolete `_initialize_scopes` branch that invokes `run-scopes-init-task.sh`. Its largest deficiency is accepting the destructive no-data assumption without demanding evidence or a backup check for the actively mounted paths, while spending substantial space on a non-applicable frontend persona. The SMTS resolution incorrectly says the revised LLD's Step 7 and file table include a deprecation-header edit; those sections only list `post-deployment-setup.sh`. Claims about IAM references, CloudWatch alarms, and other repository-wide searches could not be independently verified due the sandbox command failure."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 19,
+          "risk_awareness": 15,
+          "total": 67,
+          "notes": "The plan supplies useful negative greps, a positive `SCOPES_CONFIG_PATH` oracle, Terraform validation and planning commands, and post-apply health checks. It omits shell syntax or behavioral tests for the two modified scripts and provides no pre-destruction check for data in EFS. The claim that ECS task definitions update in place is technically inaccurate because ECS task-definition changes create new revisions, and `./post-deployment-setup.sh --dry-run` may still reach the newly unconditional failure branch when no DocumentDB endpoint is detected. The commands and hard-coded example service names could not be validated against the checkout because read-only command execution failed."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 81,
+          "notes": "The patch implements the stated removal end to end: it deletes the EFS module surface, removes variables and outputs, empties auth and mcpgw volumes, changes `SCOPES_CONFIG_PATH`, and disconnects the legacy initialization path. The supplied hunks are internally consistent with the LLD and show matching original symbols such as `module.efs.access_points`, `efs_all_outbound`, and `mcp_gateway_efs_id`. The largest residual risk is destructive EFS removal without a data-preservation guard, while the summary overstates the evidence that no application data occupies the mounted paths; the retained deprecated script also remains directly executable despite being guaranteed to fail on removed outputs. I could not independently run `git apply --check` or inspect surrounding source because all repository shell operations failed in the sandbox."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 152,
+      "input_tokens": 13759166,
+      "output_tokens": 58076,
+      "total_tokens": 13817242,
+      "latency_seconds": 893.8,
+      "total_cost_usd": 70.24772999999998,
+      "result_subtype": "success",
+      "task_score": 69.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.9061,
+      "generation_tokens_per_sec": 65.0,
+      "kv_cache_usage": {
+        "peak": 0.3112,
+        "mean": 0.2014
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The issue clearly identifies the three outbound paths and provides testable criteria covering shared validation, compatibility, configuration, and deployment surfaces. The named symbols align with the submitted source context, including agent_validator._check_endpoint_reachability, agent_routes.check_agent_health, and the health service probe flow. Its largest defect is claiming that validating response.url after an automatically followed redirect closes the redirect bypass; the internal target has already been contacted by then. No independent task statement establishes requirements beyond the task identifier and repository context."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 11,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 73,
+          "notes": "The LLD is concrete about files, interfaces, status handling, configuration wiring, compatibility, rollout, IPv6-mapped addresses, and DNS rebinding. Its proposed utility and skill_service delegation closely match the existing symbols represented in the patch. The critical design error is placing redirect validation after httpx calls using follow_redirects=True, which detects an SSRF only after the protected resource has been reached and can also miss an internal intermediate hop. It also understates synchronous socket.getaddrinfo blocking in async paths and contains inconsistent guidance about whether agent_validator uses validate_outbound_url or is_safe_url."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 74,
+          "notes": "The review identifies substantive issues including IPv6-mapped IPv4 handling, DNS rebinding, redirect-site enumeration, rollout impact on private services, and configuration visibility. These findings map to concrete implementation details such as ip.ipv4_mapped and the eight follow_redirects=True sites in registry/health/service.py. Its largest miss is repeatedly endorsing post-response URL validation as closing redirect SSRF, despite the request already having followed and contacted the target. The claim that existing metrics automatically aggregate the new status is asserted without corresponding implementation evidence in the patch."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 65,
+          "notes": "The plan covers utility behavior, all three call paths, configuration overrides, compatibility, deployment wiring, rollout, and IPv6-mapped cases with specific expected values. The unit cases for schemes, private ranges, allowlists, exceptions, and skill_service delegation provide meaningful oracles. The decisive redirect test expects the metadata endpoint not to be contacted, but the designed follow_redirects=True implementation necessarily contacts it before inspecting response.url, while the proposed log check cannot prove absence of contact. Several functional steps are not executable as written, including the unspecified redirector and sentinel, and public-host unit tests depend on live DNS."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 9,
+          "specificity": 21,
+          "risk_awareness": 13,
+          "total": 61,
+          "notes": "The patch broadly implements the shared utility, direct-target guards, compatibility aliases, status value, configuration surfaces, and focused utility tests, and it enumerates all eight shown follow_redirects=True calls. Its hunks consistently target the submitted baseline symbols and the IPv6-mapped check correctly examines ipv4_mapped. The critical defect is that _is_redirect_target_safe runs only after httpx has followed redirects, so an attacker-controlled public URL can still trigger requests to metadata or private services, including intermediate redirect hops. The tests do not exercise the modified call sites or expose this defect, and implementation.md confirms that no test suite was executed while overstating the redirect bypass as fixed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 101,
+      "input_tokens": 7722187,
+      "output_tokens": 47426,
+      "total_tokens": 7769613,
+      "latency_seconds": 698.3,
+      "total_cost_usd": 39.79658499999999,
+      "result_subtype": "success",
+      "task_score": 67.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.893,
+      "generation_tokens_per_sec": 67.9,
+      "kv_cache_usage": {
+        "peak": 0.3081,
+        "mean": 0.2164
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The issue clearly scopes the ECS Terraform change, enumerates testable acceptance criteria, and names concrete integration points such as `secrets.tf`, `ecs-services.tf`, and `aws_iam_policy.ecs_secrets_access`. Its fallback, mutual-exclusion, IAM, and application-compatibility requirements are unusually specific for an issue. The largest gap is requiring secret versions for optional values without addressing AWS Secrets Manager's rejection of empty `SecretString` values, despite several variables reportedly defaulting to empty strings. No independent task statement was supplied, so requirement completeness beyond the task identifier and internally defined scope cannot be verified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 10,
+          "specificity": 24,
+          "risk_awareness": 17,
+          "total": 74,
+          "notes": "The LLD provides an implementation-ready twelve-variable inventory, exact Terraform resource shapes, container conditionals, IAM changes, configuration wiring, and rollout steps. Its critical correctness error is the explicit claim that Secrets Manager accepts an empty `SecretString`; AWS requires at least one byte, so unconditional versions such as `secret_string = var.registry_api_token` can make normal applies fail. It thoughtfully discusses Terraform-state exposure, shared IAM scope, KMS failures, rotation ownership, and PEM handling, but omits a reliable strategy for optional empty values and for redeploying ECS tasks after later secret-version updates. The claimed post-review recovery-window discussion is also absent from the LLD's stated constraints."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 64,
+          "notes": "The review identifies concrete concerns around Terraform-state exposure, shared `mcpgw` permissions, immediate secret deletion, duplicate names, and the single-string `REGISTRY_API_KEYS` contract. Its largest failure is explicitly endorsing the LLD's empty-string reasoning, thereby missing the defect most likely to prevent deployment. Several findings are declared resolved without an effective resolution: the testing plan's occurrence-count grep does not prove opposite conditional polarity, and its backend grep cannot establish externally configured state encryption. The persona structure adds breadth, but the final approval is not defensible given the missed apply-time failure and unsafe plan-inspection guidance."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 5,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 57,
+          "notes": "The plan spans formatting, validation, planning, both toggle modes, IAM/resource coverage, deployment, rollback, and runtime behavior with concrete commands and expected outcomes. Its most serious error is writing `terraform show -json` output to `/tmp/plan.json` while asserting secrets are redacted; Terraform JSON output exposes sensitive values in plaintext and uses sensitivity metadata rather than replacing values with `(sensitive value)`. The IAM assertion uses the module-local address instead of the root-plan address, the sensitive-value loop never uses its variable or fails the test, and the mutual-exclusivity grep neither identifies blocks nor asserts polarity. It also misses the empty-secret failure and proposes `env` through ECS Exec, unnecessarily displaying every migrated credential."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 6,
+          "specificity": 22,
+          "risk_awareness": 13,
+          "total": 62,
+          "notes": "The patch covers the designed surfaces end to end: twelve resource/version pairs in `secrets.tf`, complementary ECS conditionals, IAM ARNs, outputs, both variable layers, passthrough, and example configuration. The fatal defect is that every secret version is unconditional and directly assigns a possibly empty variable, while the candidate itself states that several variables default to `\"\"`; Secrets Manager rejects such versions. Because resources and versions are still created when `env_vars_secrets_manager_enabled=false`, the fallback toggle cannot avoid this provisioning failure, and later secret-version changes also lack an ECS redeployment trigger. Independent `git apply --check` and source verification could not be completed because the read-only command runner failed during sandbox setup, so the summary's applicability claim remains unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 110,
+      "input_tokens": 10969601,
+      "output_tokens": 66078,
+      "total_tokens": 11035679,
+      "latency_seconds": 937.4,
+      "total_cost_usd": 56.49995500000001,
+      "result_subtype": "success",
+      "task_score": 61.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.9237,
+      "generation_tokens_per_sec": 70.5,
+      "kv_cache_usage": {
+        "peak": 0.3291,
+        "mean": 0.215
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 61,
+          "notes": "The issue provides unusually concrete scope, exclusions, dependencies, and testable acceptance criteria across the cluster, ECS task, IAM policy, rotation resources, image, and initialization script. Its named files and symbols, including `keycloak-database.tf`, `keycloak-ecs.tf`, `keycloak_database_password`, and `aws_rds_cluster.keycloak`, correspond to the submitted baseline diff context. The largest defect is that it specifies IAM mode as default-on while explicitly deferring token refresh, so new pooled connections after the startup token expires cannot authenticate; the later artifacts silently change the default to false. It also overstates credential elimination because an RDS-managed master password remains in Secrets Manager, and reading an ECS task definition exposes a secret ARN rather than the secret value; no independent task statement was supplied to resolve these contradictions."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 8,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 65,
+          "notes": "The LLD is strongly grounded in concrete Terraform resources, ECS environment and secret wiring, ARN construction, file changes, migration concerns, and rollback steps. Its core direct-IAM design remains unsound because Keycloak retains the startup password, and RDS Proxy would not refresh the client token used when Keycloak opens a new frontend connection after 15 minutes. The proposed SQL uses `AWSAuthenticationPlugin AS 'RSA'` rather than AWS's required `'RDS'`, while the rollout applies the new ECS task before creating the IAM user and therefore creates an outage window. It also misses the new `null_resource` provider dependency and the malformed or empty DocumentDB-conditional IAM policy resources produced when the Keycloak secret references are removed."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 19,
+          "total": 71,
+          "notes": "The review identifies several real, concrete risks: token lifetime, migration-time master-password rotation, truststore behavior, task-role scoping, image dependency, initialization ordering, and dangling Terraform references. Its largest weakness is accepting default-off as resolution of the token-refresh defect even though opt-in IAM mode still fails ordinary reconnect or pool-growth behavior, and the recommended proxy alternative does not refresh client-side tokens. It does not catch the invalid `'RSA'` authentication string, the unsupported `microdnf` installation in the Keycloak UBI-micro image, or the now-empty conditional IAM policy resources. It also calls rollout ordering resolved even though the revised LLD still applies the service before creating the IAM user, and its removal of `DROP` from Keycloak's schema privileges may break future Liquibase migrations."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 60,
+          "notes": "The plan covers both feature-flag positions, Terraform planning, image contents, IAM policy shape, user creation, rollback, TLS, health, and OIDC with concrete commands and expected values. Its static-password grep cannot meet its own oracle because the patched README and tfvars comments still contain `keycloak_database_password`. The token-generation `docker run` command passes neither the required `-e` variables nor AWS credentials, and the expected plugin value conflicts with the SQL's `AWSAuthenticationPlugin` spelling and incorrect `'RSA'` auth string. Most importantly, there is no reconnect or pool-growth test after 15 minutes and no non-DocumentDB plan, so the central stale-token regression and empty IAM-resource policy can escape."
+        },
+        "implementation": {
+          "completeness": 16,
+          "correctness": 4,
+          "specificity": 18,
+          "risk_awareness": 10,
+          "total": 48,
+          "notes": "The patch broadly implements the revised design across the existing Terraform, ECS, rotation, output, documentation, Docker, Python, shell, and SQL surfaces. It is not deployable as written: the official Keycloak 25 UBI-micro final image lacks `microdnf`, and the IAM user is created with `AWSAuthenticationPlugin AS 'RSA'` instead of the required `'RDS'`. Even after those blockers, a token generated only at process startup cannot authenticate later pool connections, and the always-created rotation policy emits empty `Resource` lists when DocumentDB is disabled after the Keycloak resources are removed. The summary acknowledges token-refresh and truststore gaps but overstates end-to-end correctness; independent `git apply --check` and source verification could not be completed because the provided read-only command sandbox failed before command execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 6,
+      "num_turns": 502,
+      "input_tokens": 49821999,
+      "output_tokens": 172153,
+      "total_tokens": 49994152,
+      "latency_seconds": 2894.7,
+      "total_cost_usd": 253.41382000000002,
+      "result_subtype": "error_max_turns",
+      "task_score": 55.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.9049,
+      "generation_tokens_per_sec": 58.3,
+      "kv_cache_usage": {
+        "peak": 0.3291,
+        "mean": 0.2213
+      },
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 82,
+          "notes": "The issue clearly defines dependency removal, preserved file-backend search, repository routing, telemetry changes, scope, and non-goals. Its acceptance criteria name concrete files and observable outcomes, including `pyproject.toml`, `uv.lock`, removed settings, and backend labels. The largest gap is that no independent task statement establishes the proposed replacement algorithm or metric rename, while compatibility for existing metrics databases is deferred to a manual follow-up. Repository commands could not run because the read-only sandbox failed during setup, so claims about duplicate writes and existing helper APIs could not be independently verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 13,
+          "specificity": 19,
+          "risk_awareness": 17,
+          "total": 67,
+          "notes": "The LLD provides a concrete file map, data flow, score formula, fallback behavior, call-site conversion rule, and rollout discussion. Its largest defect is the unresolved `index_agent` contract: the LLD requires an `AgentCard`, while the review and testing plan require `card.model_dump()` and claim the ABC accepts a dictionary. It also omits an explicit telemetry-Lambda metric-field rename from Step 5 and does not fully specify enabled-entity filtering or prove that the new scoring preserves ranking behavior. Repository symbols and signatures could not be independently checked because command execution failed in the provided sandbox."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 17,
+          "total": 64,
+          "notes": "The strongest findings are the per-call-site duplicate-write audit, defensive embedding-dimension handling, and requirement to port behavioral tests rather than merely delete them. The largest defect is that finding 2.2 and its disposition assert a dictionary-based `index_agent` revision, while the submitted LLD explicitly retains an `AgentCard` signature. The review also claims the LLD enumerates the Lambda metric rename and replacement test file, although the LLD's change tables do not do so, weakening its approval verdict. Repository verification was unavailable because all read-only command attempts failed during sandbox initialization."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 12,
+          "specificity": 18,
+          "risk_awareness": 17,
+          "total": 66,
+          "notes": "The plan spans unit, compatibility, deployment, and end-to-end checks with concrete cleanup greps and expected response states. Its largest weakness is that ranking tests mention deterministic vectors without defining their values or exact score ordering, so several proposed oracles would not reliably catch a broken blend. The `index_agent(path, card.model_dump(), ...)` setup conflicts with the LLD's declared `AgentCard` interface, and the metrics checks do not explicitly assert `search_time_ms` in the telemetry Lambda schema. Commands, endpoint method, and paths could not be validated against the repository because the execution sandbox failed."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "The implementation artifact is empty, so neither `patch.diff` nor an implementation summary was submitted. There is no code change to apply or compare with the proposed design. Per the rubric, all implementation criteria therefore receive zero."
+        }
+      },
+      "is_error": true,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-04",
+  "skill": "swe3"
+}


### PR DESCRIPTION
## Summary

Re-runs **GLM-5.2** (`zai-org/GLM-5.2-FP8`) on `mcp-gateway-registry` under the Claude Code harness with the `/swe3` single-agent skill, self-hosted on vLLM.

- **Serving:** p5en.48xlarge (8xH200 141GB), TP=8, FP8, 200K context window, prefix caching enabled
- **Judge:** `openai.gpt-5.6-sol` via `codex exec`, high reasoning effort
- **Mean score:** 65.60 across 5 scored tasks (previous committed run: 61.96)

## Results

| Task | Artifacts | Turns | Prefix-cache | Cost (est $) | Judge score |
|---|---|---|---|---|---|
| remove-efs-from-terraform-aws-ecs | 6/6 | 52 | 87.8% | 21.27 | 73.6 |
| ssrf-hardening-outbound-url-validation | 6/6 | 152 | 90.6% | 70.25 | 69.8 |
| migrate-ecs-env-vars-to-secrets-manager | 6/6 | 101 | 89.3% | 39.80 | 67.8 |
| replace-keycloak-db-password-with-rds-iam | 6/6 | 110 | 92.4% | 56.50 | 61.0 |
| remove-faiss (top-up attempted) | **4/6** | 502 | 90.5% | 253.41 | 55.8 |

## `remove-faiss` did not complete

This is not a clean 5/5 sweep. The task ran 502 turns over 48.2 minutes and 49.8M input tokens, exited with `is_error: true`, and never produced `patch.diff` or `implementation.md`. Its implementation artifact scored **0**, pulling the task score to 55.8 (the four design artifacts scored 82/67/64/66). The top-up loop attempted recovery and did not succeed.

The summary reports `num_failed: 0` because the summarizer's failure convention is a *0-score task*, and this one still scored on its design artifacts. Read the `4/6` artifact count, not the failure count.

**This reproduces.** The prior committed run failed the same task the same way (251 turns, `is_error: true`, 4/6 artifacts). Same wall twice, at roughly double the turn budget -- a structural failure mode for GLM-5.2 on this task, not variance.

Cost is concentrated there: that single task is 58% of the run's 86.4M input tokens and $253 of $441. The four complete tasks average **$46.96** against the run mean of $88.25. Note the inverse relationship between turns and score -- the cheapest task (52 turns) scored highest, and 502 turns is the ceiling, so it thrashed until cut off rather than converging.

## Comparability caveat

The 61.96 -> 65.60 delta is **not** a clean model-improvement signal. The harness skill default changed to `/swe3` in e1bb0e3, and neither run summary records which skill it used, so the earlier run's orchestration cannot be pinned down from the committed data. The delta mixes orchestration and model effects.

## Judge sandbox degradation

The judge's read-only sandbox failed to initialize on several tasks (`bwrap: loopback: Failed RTM_NEWADDR`), so parts of the scoring fell back to artifact-internal consistency instead of repo-grounded verification:

| Task | Artifact notes carrying the caveat |
|---|---|
| remove-efs (top scorer, 73.6) | 4/5 |
| remove-faiss | 4/5 |
| migrate-ecs-env-vars | 1/5 |
| replace-keycloak | 1/5 |
| ssrf-hardening | 0/5 (clean) |

The highest score in the run is among the least repo-grounded. This does not invalidate the run, but 73.6 and 69.8 are not equally trustworthy and the mean carries more uncertainty than one number suggests. Worth investigating separately -- it affects any run scored on this host.

## Quality shape

GLM-5.2 was consistently strongest on the upstream design artifact (`github_issue`: 61-82) and weakest on implementation (0-81; 48 on keycloak). The judge repeatedly flagged contradictions *between* artifacts -- e.g. on `remove-faiss` the LLD specifies an `AgentCard` signature while the review and testing plan assume a dict. That is a single-agent-loop signature: `/swe3` has no fan-out, so later artifacts drifted from earlier ones with no reconciliation pass.

## Changes

- `benchmarks/swe-benchmark-data/glm-5.2/claude-code/mcp-gateway-registry/run-summary.json` -- new run data (only committable artifact; raw artifacts and `metrics.json` stay gitignored)
- `docs/harness-claude-code.md` -- regenerated via `gen_agent_report.py --harness claude-code`
- Four Claude Code charts regenerated via `plot_cost_quality.py` / `plot_quality_radar.py` (light + dark); GLM-5.2's higher score moves it onto the radar's top 4

## Verification

- Security gate (`security-check`) run on the diff: **APPROVED**. No credentials, session ids, headers, or PII in the committed summary; judge notes quote only public target-repo symbol names, never values. The `.gitignore` commit boundary is intact.
- No Python or shell changed, so Bandit has no in-scope target.