### PR TITLE
benchmark: stamp skill field into committed eval.json files

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4703
     },
     "duration_ms": 163544
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5317
     },
     "duration_ms": 203897
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4297
     },
     "duration_ms": 327407
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5611
     },
     "duration_ms": 193609
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3621
     },
     "duration_ms": 349088
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe3/Hello-World/add-contributing-guide/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/claude-code/swe3/Hello-World/add-contributing-guide/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5474
     },
     "duration_ms": 88698
-  }
+  },
+  "skill": "swe3"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5405
     },
     "duration_ms": 342737
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5322
     },
     "duration_ms": 329928
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 7534
     },
     "duration_ms": 277225
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 6750
     },
     "duration_ms": 188451
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4557
     },
     "duration_ms": 268323
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 8740
     },
     "duration_ms": 228736
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4518
     },
     "duration_ms": 100664
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4888
     },
     "duration_ms": 97505
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 9160
     },
     "duration_ms": 147316
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 7078
     },
     "duration_ms": 108344
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 7966
     },
     "duration_ms": 126352
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 7470
     },
     "duration_ms": 132081
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5185
     },
     "duration_ms": 227110
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 6465
     },
     "duration_ms": 113194
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/pi/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4922
     },
     "duration_ms": 101465
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 7219
     },
     "duration_ms": 138855
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4900
     },
     "duration_ms": 136671
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 6068
     },
     "duration_ms": 195741
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 6205
     },
     "duration_ms": 112982
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 7771
     },
     "duration_ms": 112791
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4160
     },
     "duration_ms": 229044
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 8093
     },
     "duration_ms": 299434
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3119
     },
     "duration_ms": 334205
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 6050
     },
     "duration_ms": 177624
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3688
     },
     "duration_ms": 128553
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4954
     },
     "duration_ms": 91259
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4818
     },
     "duration_ms": 91989
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3940
     },
     "duration_ms": 188074
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 6036
     },
     "duration_ms": 101012
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/gemma-4-31b/pi/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4932
     },
     "duration_ms": 86941
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 6473
     },
     "duration_ms": 146600
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 4880
     },
     "duration_ms": 164590
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 996
     },
     "duration_ms": 442583
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 5958
     },
     "duration_ms": 138273
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/glm-5.2/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 4440
     },
     "duration_ms": 127272
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 5320
     },
     "duration_ms": 129064
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 4403
     },
     "duration_ms": 108066
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 5792
     },
     "duration_ms": 220975
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -46,5 +46,6 @@
       "testing.md"
     ],
     "evaluated_at": "2026-07-24T12:57:58.826398Z"
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 6949
     },
     "duration_ms": 203868
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 4000
     },
     "duration_ms": 118774
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 5125
     },
     "duration_ms": 150784
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 2126
     },
     "duration_ms": 244012
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 6620
     },
     "duration_ms": 206086
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -52,5 +52,6 @@
       "reasoning_output_tokens": 4818
     },
     "duration_ms": 143131
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3316
     },
     "duration_ms": 106012
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3254
     },
     "duration_ms": 118423
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5430
     },
     "duration_ms": 144051
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 2545
     },
     "duration_ms": 96742
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -56,5 +56,6 @@
       "testing.md"
     ],
     "evaluated_at": "2026-07-29T02:03:34.796408Z"
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -56,5 +56,6 @@
       "testing.md"
     ],
     "evaluated_at": "2026-08-01T17:04:53.196533Z"
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -56,5 +56,6 @@
       "testing.md"
     ],
     "evaluated_at": "2026-08-01T17:04:53.205580Z"
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -56,5 +56,6 @@
       "testing.md"
     ],
     "evaluated_at": "2026-08-01T17:04:53.213831Z"
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -56,5 +56,6 @@
       "testing.md"
     ],
     "evaluated_at": "2026-08-01T17:04:53.222062Z"
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-30b/pi/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -56,5 +56,6 @@
       "testing.md"
     ],
     "evaluated_at": "2026-08-01T17:04:53.230138Z"
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/Hello-World/add-contributing-guide/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/Hello-World/add-contributing-guide/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3564
     },
     "duration_ms": 110439
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5978
     },
     "duration_ms": 118295
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3699
     },
     "duration_ms": 126321
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4495
     },
     "duration_ms": 212072
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5186
     },
     "duration_ms": 148611
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/claude-code/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4389
     },
     "duration_ms": 174321
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/Hello-World/add-contributing-guide/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/Hello-World/add-contributing-guide/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 3047
     },
     "duration_ms": 162170
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4767
     },
     "duration_ms": 80304
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4412
     },
     "duration_ms": 92969
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/remove-faiss/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 5442
     },
     "duration_ms": 152512
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -60,5 +60,6 @@
       "reasoning_output_tokens": 4254
     },
     "duration_ms": 76787
-  }
+  },
+  "skill": "swe2"
 }

--- a/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3.6-35b/pi/swe2/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -53,5 +53,6 @@
       "testing.md"
     ],
     "evaluated_at": "2026-08-01T16:46:05.170658Z"
-  }
+  },
+  "skill": "swe2"
 }


### PR DESCRIPTION
## Summary

The initial skill-path migration (#93) stamped the `skill` field into `metrics.json` and `run-summary.json`, but not `eval.json`. This backfills it.

- Adds `skill` (`swe2`/`swe3`, derived from each file's path segment) to all 73 tracked `eval.json` files.
- Every committed benchmark artifact now self-identifies its skill, consistent with its sibling `metrics.json`.
- No content beyond the added field changes; verified eval/metrics skill values match per task and no `session_id`/`repo_root` leaks are present.