### PR TITLE
fix(benchmark): sum pi token usage across all turns, not just the last message

### DIFF
--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -1209,12 +1209,17 @@ def _pi_result_from_events(
     """Normalize pi's JSON-lines event stream into the claude-shaped result dict.
 
     pi ``--mode json`` emits a stream of events, not one result object. The final
-    ``agent_end`` carries the settled conversation; the last assistant message's
-    ``usage`` holds cumulative tokens, and ``stopReason`` reports why it stopped.
-    Turns are counted from ``turn_start`` events. This maps those onto the same
-    keys ``_metrics_from_result`` reads for claude (``usage.input_tokens`` etc.,
-    ``num_turns``, ``subtype``, ``is_error``, ``total_cost_usd``) so the rest of
-    the harness is agent-agnostic.
+    ``agent_end`` carries the settled conversation, and ``stopReason`` reports why
+    it stopped. Turns are counted from ``turn_start`` events.
+
+    Token usage is PER-MESSAGE, not cumulative: each assistant message carries its
+    own ``usage`` (``input``/``output``/``cacheRead``/``cacheWrite``), matching pi's
+    own ``UsageTotals`` accounting (``addUsageToTotals`` is called once per message).
+    Reading only the last message's usage undercounts a multi-turn run by ~100x
+    (a 200-turn edit run would report only the final turn's tokens), so we SUM
+    usage across every assistant message -- the same fix as sourcing claude's tokens
+    from ``modelUsage`` rather than the main-agent-only ``usage``. This maps onto the
+    keys ``_metrics_from_result`` reads for claude so the harness stays agent-agnostic.
 
     Args:
         events: The parsed JSON-lines events pi emitted, in order.
@@ -1234,32 +1239,42 @@ def _pi_result_from_events(
     if agent_end is None:
         raise RuntimeError("pi emitted no agent_end event (no parseable result)")
     messages = agent_end.get("messages") or []
-    last_assistant = next(
-        (
-            m
-            for m in reversed(messages)
-            if isinstance(m, dict) and m.get("role") == "assistant"
-        ),
-        {},
-    )
-    usage = last_assistant.get("usage") or {}
-    stop_reason = last_assistant.get("stopReason")
-    # pi's usage keys (input/output) differ from claude's (input_tokens/...);
-    # remap so _metrics_from_result reads them unchanged.
+    assistant_msgs = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "assistant"
+    ]
+    # Sum per-message usage across the whole conversation (see docstring: usage is
+    # per-message, not cumulative). stopReason comes from the LAST assistant message.
+    totals = {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "cost": 0.0}
+    for m in assistant_msgs:
+        u = m.get("usage") or {}
+        totals["input"] += u.get("input") or 0
+        totals["output"] += u.get("output") or 0
+        totals["cacheRead"] += u.get("cacheRead") or 0
+        totals["cacheWrite"] += u.get("cacheWrite") or 0
+        # Cost, when present, is per-message and additive (pi accrues it into
+        # UsageTotals.cost the same way). Shapes vary by pi version: a bare number
+        # or a {"total": ...} object -- accept both.
+        mc = u.get("cost")
+        if isinstance(mc, dict):
+            mc = mc.get("total")
+        if isinstance(mc, (int, float)):
+            totals["cost"] += mc
+    stop_reason = assistant_msgs[-1].get("stopReason") if assistant_msgs else None
+    # remap onto the keys _metrics_from_result reads for claude.
     remapped_usage: dict[str, Any] = {
-        "input_tokens": usage.get("input", 0),
-        "output_tokens": usage.get("output", 0),
+        "input_tokens": totals["input"],
+        "output_tokens": totals["output"],
     }
     # Cache tokens: against a vLLM endpoint pi reports 0 (real reuse comes from the
     # Prometheus block, so we omit them rather than record a misleading 0). Against
     # Amazon Bedrock pi DOES report native prompt-cache usage (cacheRead/cacheWrite)
     # -- pass those through under the keys _metrics_from_result expects, but only
     # when non-zero so the vLLM path stays clean.
-    if usage.get("cacheRead"):
-        remapped_usage["cache_read_input_tokens"] = usage["cacheRead"]
-    if usage.get("cacheWrite"):
-        remapped_usage["cache_creation_input_tokens"] = usage["cacheWrite"]
-    cost = (usage.get("cost") or {}).get("total")
+    if totals["cacheRead"]:
+        remapped_usage["cache_read_input_tokens"] = totals["cacheRead"]
+    if totals["cacheWrite"]:
+        remapped_usage["cache_creation_input_tokens"] = totals["cacheWrite"]
+    cost = totals["cost"] or None
     # An error retry (pi tried and gave up) or a non-"stop" terminal reason marks
     # the run failed so the harness's retry/failure logic can react.
     will_retry = agent_end.get("willRetry", False)
@@ -1331,6 +1346,13 @@ def _run_pi(cmd: list[str], env: dict[str, str], timeout: int) -> dict[str, Any]
         raise RuntimeError(
             f"pi -p output had no JSON events: {proc.stdout.strip()[:500]}"
         )
+    # Debug aid: dump the raw event stream when PI_RAW_EVENTS_DUMP is set, so the
+    # usage-summation logic can be validated against real pi output.
+    dump_path = os.environ.get("PI_RAW_EVENTS_DUMP")
+    if dump_path:
+        with open(dump_path, "w", encoding="utf-8") as fh:
+            for e in events:
+                fh.write(json.dumps(e) + "\n")
     result = _pi_result_from_events(events, elapsed)
     result["_elapsed_seconds"] = round(elapsed, 1)
     return result

--- a/benchmarks/tests/test_run_swe_headless.py
+++ b/benchmarks/tests/test_run_swe_headless.py
@@ -545,15 +545,31 @@ class BuildPiCmdTest(unittest.TestCase):
 
 def _pi_events(usage: dict, stop: str = "stop") -> list[dict]:
     """Build a minimal pi event stream ending in agent_end with the given usage."""
-    msg = {
-        "role": "assistant",
-        "content": [{"type": "text", "text": "x"}],
-        "usage": usage,
-        "stopReason": stop,
-    }
+    return _pi_events_multi([usage], stop=stop)
+
+
+def _pi_events_multi(usages: list[dict], stop: str = "stop") -> list[dict]:
+    """Build a pi event stream with one assistant message per usage dict.
+
+    pi usage is PER-MESSAGE; the last assistant message carries the terminal
+    stopReason. One turn_start per assistant message so num_turns lines up.
+    """
+    turns: list[dict] = []
+    msgs: list[dict] = [{"role": "user"}]
+    for i, usage in enumerate(usages):
+        turns.append({"type": "turn_start"})
+        msgs.append(
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "x"}],
+                "usage": usage,
+                # only the final message carries the terminal stop reason.
+                "stopReason": stop if i == len(usages) - 1 else "end_turn",
+            }
+        )
     return [
-        {"type": "turn_start"},
-        {"type": "agent_end", "messages": [{"role": "user"}, msg], "willRetry": False},
+        *turns,
+        {"type": "agent_end", "messages": msgs, "willRetry": False},
     ]
 
 
@@ -596,6 +612,69 @@ class PiResultFromEventsTest(unittest.TestCase):
         metrics = harness._metrics_from_result(result, elapsed=2.0)
         self.assertEqual(metrics["cache_read_tokens"], 1000)
         self.assertEqual(metrics["cache_creation_tokens"], 3102)
+
+    def test_sums_usage_across_all_turns_not_just_last(self) -> None:
+        # pi usage is PER-MESSAGE, not cumulative. Reading only the last message
+        # (the old bug) undercounts a multi-turn run ~100x. Every assistant
+        # message's tokens/cost must be summed; stopReason comes from the last.
+        events = _pi_events_multi(
+            [
+                {
+                    "input": 3000,
+                    "output": 300,
+                    "cacheRead": 0,
+                    "cacheWrite": 100,
+                    "cost": {"total": 0.5},
+                },
+                {
+                    "input": 2,
+                    "output": 250,
+                    "cacheRead": 90000,
+                    "cacheWrite": 40,
+                    "cost": {"total": 0.3},
+                },
+                {
+                    "input": 1,
+                    "output": 200,
+                    "cacheRead": 96000,
+                    "cacheWrite": 60,
+                    "cost": {"total": 0.2},
+                },
+            ]
+        )
+        result = harness._pi_result_from_events(events, elapsed=5.0)
+        # summed, NOT the last message's 1 / 200 / 96000 / 60.
+        self.assertEqual(result["usage"]["input_tokens"], 3003)
+        self.assertEqual(result["usage"]["output_tokens"], 750)
+        self.assertEqual(result["usage"]["cache_read_input_tokens"], 186000)
+        self.assertEqual(result["usage"]["cache_creation_input_tokens"], 200)
+        self.assertAlmostEqual(result["total_cost_usd"], 1.0)
+        self.assertEqual(result["num_turns"], 3)
+        self.assertEqual(result["subtype"], "success")
+
+    def test_accepts_bare_number_cost_shape(self) -> None:
+        # Some pi versions report usage.cost as a bare number, not {"total": ...}.
+        events = _pi_events_multi(
+            [
+                {
+                    "input": 10,
+                    "output": 5,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                    "cost": 0.4,
+                },
+                {
+                    "input": 10,
+                    "output": 5,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                    "cost": 0.6,
+                },
+            ]
+        )
+        result = harness._pi_result_from_events(events, elapsed=1.0)
+        self.assertAlmostEqual(result["total_cost_usd"], 1.0)
+        self.assertEqual(result["usage"]["output_tokens"], 10)
 
 
 class BuildSettingsArgTest(unittest.TestCase):


### PR DESCRIPTION
## Problem

`_pi_result_from_events` read token usage from **only the last assistant message**, assuming it held cumulative totals. It does not: pi's `usage` (`input`/`output`/`cacheRead`/`cacheWrite`/`cost`) is **per-message**, matching pi's own `UsageTotals` accounting (which calls `addUsageToTotals` once per assistant message). Reading the last message alone undercounts a multi-turn run by ~100x -- it captures only the final turn's tokens and cost.

## Fix

Sum `usage` across every assistant message in `agent_end.messages`. Cost is read from each message's `usage.cost` (accepting both a `{"total": ...}` object and a bare number across pi versions) and summed, replacing a read of a nonexistent `usage.cost.total` on a single message. This is the pi analog of sourcing claude tokens from `modelUsage` (summed) rather than the main-agent-only `usage`.

## Validation

Ran a real `claude-haiku-4-5` / `remove-faiss` task (86 turns) with a raw-event dump, then parsed the **identical** events both ways:

| Metric | OLD (last msg) | NEW (summed) | factor |
|---|---:|---:|---:|
| output | 1,242 | 40,147 | 32x |
| cacheRead | 96,224 | 5,962,811 | 62x |
| cost | $0.0166 | $0.9221 | 56x |
| output/turn | 14.4 | 466.8 | -- |

~14 output tokens/turn is impossible for an agent making edits; ~467/turn matches claude-code (~730/turn).

## Tests

- New multi-turn summation regression test (the blind spot that let this ship -- prior tests only exercised single-message streams).
- New bare-number cost-shape test.
- Env-gated (`PI_RAW_EVENTS_DUMP`) raw-stream dump, used to validate the fix and available for future pi diagnostics (off by default).
- Full suite: 211 pass.

## Follow-up (not in this PR)

Every pi run currently on disk carries the undercounted tokens/cost and will be re-run with the fixed harness to get correct figures. Scores, turn counts, and latency are unaffected.