### PR TITLE
benchmark: land clean swe3 runs from PRs #95, #97, #101-104 (self-hosted models)

### DIFF
--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,383 @@
+{
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "claude",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 131072
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-04T23:33:44.835870Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 258535,
+      "cached_input_tokens": 215515,
+      "cache_write_input_tokens": 43006,
+      "output_tokens": 7229,
+      "reasoning_output_tokens": 5884
+    },
+    "duration_ms": 130765
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 53.72,
+  "mean_cost_usd_excl_failed": 70.57,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 106,
+      "input_tokens": 6955183,
+      "output_tokens": 34555,
+      "total_tokens": 6989738,
+      "latency_seconds": 516.2,
+      "total_cost_usd": 35.639790000000005,
+      "result_subtype": "success",
+      "task_score": 67.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8907,
+      "generation_tokens_per_sec": 66.9,
+      "kv_cache_usage": {
+        "peak": 0.174,
+        "mean": 0.1159
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 11,
+          "total": 68,
+          "notes": "The issue inventories the relevant Terraform resources, task-definition mounts, variables, outputs, application configuration, and validation outcomes, and those paths and symbols align with the supplied patch hunks. Its acceptance criteria are mostly testable, particularly removal of the named mounts and successful Terraform validation and planning. The largest deficiency is treating destructive deletion as dependency-free and data migration as unnecessary solely because EFS is assumed unused, despite the current task definitions and SCOPES_CONFIG_PATH actively referencing it. No independent task statement or issue #1286 was supplied, so the claims that S3 and DocumentDB cover all persistence and that EFS has no data could not be verified."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 19,
+          "risk_awareness": 17,
+          "total": 70,
+          "notes": "The LLD provides a concrete file-by-file removal plan matching the supplied module.efs references, ECS volumes, variables, and outputs, and it considers deployment, rollback, and data-loss risk. It incorrectly describes the scopes_loader.py fallback as the absolute EFS path when the shown code resolves repository-relative auth_server/auth_config/scopes.yml; removing that fallback is therefore not justified by EFS removal. The proposed single patch also cannot implement its own first deployment phase of disabling mounts while retaining EFS, and reverting later would recreate an empty file system unless a valid AWS Backup recovery point exists. CloudTrail EFS API events do not establish absence of NFS file activity, an AWS EFS secure-deletion feature is not identified, and repository-specific IAM, alarm, documentation, and persistent-storage claims remain unverified."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 13,
+          "specificity": 16,
+          "risk_awareness": 18,
+          "total": 65,
+          "notes": "The SRE and backend sections identify the most important hazards: destructive data loss, task-update ordering, hidden writers, backup, and rollback. The review nevertheless closes every concern based largely on assumptions, including a claim that no file-based configuration was found even though the supplied Terraform sets SCOPES_CONFIG_PATH to an EFS-mounted scopes file and mounts /app/data and /app/logs. Its proposed CloudTrail audit cannot detect ordinary NFS reads and writes, and the referenced EFS secure-deletion feature is unsupported. Recommendations are actionable at a high level, but the approving verdict is not defensible until actual EFS metrics, contents, consumers, and a realizable two-stage rollout are verified."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 12,
+          "specificity": 15,
+          "risk_awareness": 17,
+          "total": 63,
+          "notes": "The plan spans Terraform validation, staging deployment, service behavior, security, monitoring, performance, and rollback, with useful expected plan changes and service-state oracles. Many cases are not executable as written: terraform plan lacks backend, credentials, and variable-file details; the existing scopes-loader test suite and health endpoints are not named; and MCPGW persistence is qualified with \"if applicable\" rather than a defined state oracle. CloudTrail cannot prove absence of NFS access, AWS EFS secure deletion is not a concrete operation, alarm-name searches do not prove metric cleanup, and recreating EFS does not restore its prior data. The plan also omits a precise source-wide reference scan and a regression test for the repository-relative scopes fallback removed by the patch."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 71,
+          "notes": "The patch coherently removes the supplied EFS module, both ECS volume configurations and mount points, the EFS-backed environment variable, module variables, and root and child outputs. Its clearest defect is deleting the repository-relative auth_server/auth_config/scopes.yml fallback merely because its comment says EFS; that code does not reference the /efs mount and may be an independent compatibility path. Documentation required by the issue is explicitly left unchanged, and a single Terraform apply may destroy mount targets concurrently with replacement task deployment despite the summary prescribing a staged rollout. Repository command execution failed in the read-only harness, so patch applicability, Terraform validation, and source-wide absence of remaining EFS references could not be independently verified; the summary also overstates rollback because recreated EFS is empty without a tested backup recovery path."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 211,
+      "input_tokens": 14006362,
+      "output_tokens": 93156,
+      "total_tokens": 14099518,
+      "latency_seconds": 1317.3,
+      "total_cost_usd": 72.36070999999997,
+      "result_subtype": "success",
+      "task_score": 60.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8839,
+      "generation_tokens_per_sec": 70.7,
+      "kv_cache_usage": {
+        "peak": 0.1763,
+        "mean": 0.1216
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 21,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 76,
+          "notes": "The strongest aspect is its clear scope across agent, server, CLI, configuration, compatibility, and tests, with explicit non-goals. The named files and symbols, including `skill_service.py`, `check_agent_health`, and `_check_server_endpoint_transport_aware`, correspond to the submitted source diff. Its largest deficiency is limited treatment of redirect-based SSRF, DNS rebinding, blocking DNS calls, sensitive URL logging, and migration for currently reachable private services. No independent task statement was supplied, so issue number `#1282`, release history, and requirements beyond the task identifier could not be independently verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 13,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 64,
+          "notes": "The LLD is unusually concrete about files, call sites, exception behavior, configuration merging, and utility implementation. Its integration points align with the diff, including `registry/api/agent_routes.py`, `registry/health/service.py`, and the existing skill-service helpers. The largest flaw is that validation and HTTP connection perform separate DNS resolutions, leaving DNS rebinding possible, while redirect destinations may be checked only after a request has occurred. It also inconsistently uses `SSRF_TRUSTED_HOSTS` and `SSRF_ALLOWED_HOSTS`, leaves exception inheritance open, and claims backward compatibility without a pre-deployment allowlist migration."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 9,
+          "specificity": 17,
+          "risk_awareness": 16,
+          "total": 57,
+          "notes": "The review's strongest finding is the genuine DNS rebinding gap, supplemented by useful concerns about URL logging, configuration validation, and operational status distinctions. Its headline critical IPv6 finding is contradicted by the reviewed LLD, whose `is_private_ip` design already uses IPv6-aware `ipaddress` properties plus `fc00::/7` and `2001:db8::/32` checks. It also claims metrics and docstrings are missing despite explicit LLD sections for both, and discusses a CLI fallback import that the LLD does not propose. The review misses the concrete `requests` redirect bypass and ultimately prioritizes already-addressed findings above the unresolved rebinding defect."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 7,
+          "specificity": 17,
+          "risk_awareness": 15,
+          "total": 57,
+          "notes": "The strongest aspect is the broad matrix of private ranges, IPv6 cases, configuration combinations, negative paths, and explicit expected values. Several proposed tests do not match the source: they instantiate `HealthCheckService` although the patch shows `HealthMonitoringService`, and call `_check_server_endpoint_transport_aware` without the `server_info` consumed by that method. The API test expects a top-level `error`, while the implementation raises `HTTPException(detail=str(e))`, and snippets also omit imports such as `socket` and `AsyncMock`. The plan lacks redirect and DNS-rebinding tests, contains timing assertions that are inherently flaky, and provides no verified repository test command."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 7,
+          "total": 46,
+          "notes": "The patch is focused and reaches the principal source symbols, extracting the utility and adding checks to agent, server, CLI, and skill paths. Its largest security defect is that `requests.get` follows redirects by default after validating only the initial CLI URL, while all clients remain vulnerable to DNS rebinding between `getaddrinfo` and connection establishment. The patch adds no tests and omits the existing allowlist-test update identified by the LLD despite deleting `_trusted_domains`, `_is_private_ip`, and `_is_safe_url`. The summary overstates consistency: the API emits a FastAPI `detail` string rather than the designed structured error, and server health returns a different status text than the testing plan expects."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 423,
+      "input_tokens": 29157979,
+      "output_tokens": 147431,
+      "total_tokens": 29305410,
+      "latency_seconds": 2258.4,
+      "total_cost_usd": 149.47566999999998,
+      "result_subtype": "success",
+      "task_score": 51.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8811,
+      "generation_tokens_per_sec": 62.3,
+      "kv_cache_usage": {
+        "peak": 0.1791,
+        "mean": 0.1101
+      },
+      "agent_invocations": 2,
+      "topped_up_artifacts": [
+        "patch.diff",
+        "implementation.md"
+      ],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 19,
+          "risk_awareness": 15,
+          "total": 67,
+          "notes": "The issue gives a concrete removal inventory and testable criteria covering pyproject.toml, registry/search/service.py, the file search repository, configuration, tests, and documentation. Those components and the file-versus-MongoDB factory split are supported by the submitted source diff. Its largest weakness is the unresolved core behavior for file-backed users, while simultaneously claiming end users are unaffected and search remains identical. No independent task statement establishes DocumentDB equivalence or permits removal of the broader file storage backend, so those claims remain unverified."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 16,
+          "risk_awareness": 13,
+          "total": 53,
+          "notes": "The LLD is grounded in real symbols including get_search_repository(), MONGODB_BACKENDS, Settings, and the startup search initialization, and it provides a phased file-level plan. It does not map all direct FaissService callers to the SearchRepositoryBase interface, leaving a load-bearing integration decision unresolved. The default backend remains an open choice, migration scripting is conditional, and the proposed partial rollback cannot work after deleting both the FAISS repository and service. It recognizes migration, local-development, latency, and rollout risks, but its caching, pooling, migration, and fallback guidance is largely speculative and not implementation-ready."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 15,
+          "risk_awareness": 17,
+          "total": 57,
+          "notes": "The review correctly prioritizes migration disruption, local development, database outages, documentation, and performance regression. It provides actionable recommendations such as configuration errors, MongoDB-backed development setup, and connectivity health checks. It misses the LLD's invalid rollback, unresolved backend default, non-search consequences of rejecting storage_backend=\"file\", and the repository interface mismatch later exposed by the patch. Claims that DocumentDB is production-proven, imposes no new operational burden, and preserves API behavior are unsupported, making the final assertion that all critical issues are addressed unjustified."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 13,
+          "risk_awareness": 18,
+          "total": 59,
+          "notes": "The plan spans unit, integration, migration, failure, performance, Docker, and dependency checks, including relevant existing paths such as tests/unit/core/test_config.py and tests/integration/test_search_integration.py. Most cases lack concrete fixtures, commands, and exact result oracles; phrases such as results being identical or correct would not reliably detect ranking or indexing regressions. It also proposes unverified scripts, tools, environments, migration behavior, and a FAISS baseline without establishing their repository support. Its strongest aspect is broad risk coverage, but it fails to require removal of stale imports such as the implementation's remaining registry.api.search_routes.faiss_service patch targets."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 1,
+          "specificity": 11,
+          "risk_awareness": 3,
+          "total": 22,
+          "notes": "The patch removes the dependency, FAISS service, file search repository, configuration properties, and factory branch, so it implements part of the proposed removal. It is syntactically invalid in registry/api/server_routes.py because it deletes the opening add_or_update_service call while leaving its arguments and closing parenthesis. Calls added in agent_routes.py and agent_batch_item_processor.py use add_or_update_entity, while the repository abstraction shown in the deleted wrapper exposes index_entity, and integration tests still patch the deleted registry.api.search_routes.faiss_service symbol. The summary admits remaining FAISS tests, documentation, and deployment scripts, while uv.lock and several acceptance-criteria areas are omitted; an independent git apply check could not be run because the command sandbox failed before execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 90,
+      "input_tokens": 5940812,
+      "output_tokens": 39419,
+      "total_tokens": 5980231,
+      "latency_seconds": 562.8,
+      "total_cost_usd": 30.689535000000006,
+      "result_subtype": "success",
+      "task_score": 47.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8781,
+      "generation_tokens_per_sec": 70.0,
+      "kv_cache_usage": {
+        "peak": 0.1758,
+        "mean": 0.119
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 16,
+          "risk_awareness": 13,
+          "total": 56,
+          "notes": "The issue clearly states the credential-rotation problem, ECS scope, non-goals, and mostly observable acceptance criteria. Its largest defect is contradictory and technically incorrect acceptance criteria: it requires removing the password while retaining password fallback, and names nonexistent `rds:GenerateDBAuthToken` authorization on the execution role rather than `rds-db:connect` on the task role. It also leaves RDS Proxy as either configured or removed and omits IAM database-user provisioning and token lifecycle behavior. No independent task statement was supplied, and the claimed issue references and ECS-only constraint could not be verified."
+        },
+        "lld": {
+          "completeness": 13,
+          "correctness": 5,
+          "specificity": 14,
+          "risk_awareness": 14,
+          "total": 46,
+          "notes": "The LLD names the principal Terraform and container files and recognizes token expiry, fallback, secret migration, observability, and rollout concerns. The central design remains undecided between an unverified `useAwsIam=true` mode and a wrapper whose exported password cannot be refreshed inside the already-running Keycloak process. Its proposed policy uses nonexistent `rds:GenerateDBAuthToken` and cluster ARNs instead of an `rds-db:connect` DB-user ARN, while setting `master_password = null` without managed master credentials and never provisioning a MySQL user with `AWSAuthenticationPlugin`. Claims about Connector/J native IAM support and RDS Proxy handling reauthentication are unsupported, so the detailed steps would require substantial redesign."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 9,
+          "specificity": 14,
+          "risk_awareness": 17,
+          "total": 55,
+          "notes": "The review correctly identifies native-driver support and token refresh as blockers and raises useful migration, least-privilege, token exposure, and rollback risks. Its largest deficiency is declaring those blockers resolved merely because verification and several possible strategies were listed, despite the LLD still having no viable committed authentication mechanism. It misses the invalid IAM action and resource ARN, absent database-user plugin configuration, invalid fresh-cluster password handling, and falsely states that token generation is a CloudTrail-recorded API call. Multi-region failover and load-balancer canary recommendations are not grounded in supplied repository or task evidence."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 5,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 46,
+          "notes": "The plan spans Terraform, direct database connectivity, password fallback, ECS readiness, login, expiry, performance, security, and rollback, with useful concrete oracles such as `SELECT 1`. Several tests are not executable or do not prove their claims: the token is not a JWT, an ECS role normally cannot be assumed by the operator, and `list-attached-role-policies` cannot inspect the inline `aws_iam_role_policy` changed by the patch. The expiry test deploys no stated workload, supplies CloudWatch start time in seconds rather than milliseconds, and treats absence of matching logs as proof of successful refresh. Hard-coded clone paths, role names, secret names, ALB names, and public health endpoints could not be verified against the repository."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 2,
+          "specificity": 17,
+          "risk_awareness": 7,
+          "total": 34,
+          "notes": "The patch concretely touches the expected Terraform variables, cluster, proxy, ECS policy, image, and wrapper surfaces, but it omits IAM-enabled MySQL user provisioning, rotation cleanup, and working long-lived credential delivery. The Docker build is likely to fail because `COPY` creates a root-owned script after `USER keycloak` and the following `chmod` runs unprivileged; even if built, changing ECS `command` passes the wrapper path to the existing `kc.sh` entrypoint instead of executing it. Authentication remains nonfunctional because the policy uses the wrong action and ARN, `master_password = null` cannot bootstrap a fresh cluster, and a background subshell cannot update Keycloak's environment for new pooled connections. The summary materially overclaims least privilege, CloudTrail auditing, compatibility, and token refresh; independent `git apply --check` and source inspection were unavailable because every read-only shell command failed with a sandbox `RTM_NEWADDR` error."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 179,
+      "input_tokens": 12375581,
+      "output_tokens": 113074,
+      "total_tokens": 12488655,
+      "latency_seconds": 1534.5,
+      "total_cost_usd": 64.70475500000003,
+      "result_subtype": "success",
+      "task_score": 42.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8751,
+      "generation_tokens_per_sec": 73.7,
+      "kv_cache_usage": {
+        "peak": 0.1789,
+        "mean": 0.1272
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 13,
+          "risk_awareness": 8,
+          "total": 43,
+          "notes": "The issue names affected services, defines exclusions, and gives acceptance criteria for Secrets Manager and IAM integration. Its central security claim is incorrect because Terraform-managed aws_secretsmanager_secret_version.secret_string values remain in Terraform state, and retaining plaintext task-definition environment entries preserves the original exposure. The proposed fallback is also unsound: ECS resolves secrets before container startup, so failure to retrieve one prevents the application from falling back to a duplicate plaintext variable. No independent task statement was supplied, and Issue #1134 could not be verified from the available evidence."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 6,
+          "specificity": 13,
+          "risk_awareness": 11,
+          "total": 44,
+          "notes": "The LLD names concrete Terraform files, variables, ECS containers, secret resources, and IAM integration points reflected in the submitted diff. Its load-bearing migration model is wrong: ECS injects Secrets Manager values at task initialization, so application retries, dual reads, and runtime fallback cannot recover from secret retrieval failure. The Grafana design crosses the separate observability module boundary without defining inputs or outputs, while terraform output -json cannot extract arbitrary input-variable values for the proposed migration. Risk coverage is broad but often speculative or invalid, including unimplemented EventBridge behavior and a cost calculation where 100 calls per minute would cost about $21.90 monthly at the stated rate, not $0.22."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 13,
+          "risk_awareness": 15,
+          "total": 49,
+          "notes": "The review correctly identifies that ECS tasks need replacement after secret rotation and that the existing KMS role-name wildcard is broad. It misses the more fundamental defects that Terraform secret versions still store values in state and that ECS startup failure cannot trigger application-level environment fallback. Several recommendations are technically weak: explicit depends_on is unnecessary where resource references already create dependencies, and terraform output cannot generally recover input variables. The final READY FOR IMPLEMENTATION verdict is unsupported because the appended LLD text describes scripts, alarms, replication, and restart automation without actually specifying or implementing them."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 10,
+          "risk_awareness": 14,
+          "total": 46,
+          "notes": "The plan spans Terraform, IAM, deployment, rollback, security, and performance, and includes several measurable thresholds. Most cases remain labels rather than executable tests with exact setup, actions, commands, and expected resource values; even terraform validate lacks a working directory and initialization procedure. BC-02 and the suggested secret-deletion fallback test assert impossible behavior because ECS must retrieve referenced secrets before starting the container, while runtime refresh and caching tests do not match ECS environment injection. Checkov, Terratest, Postman, workspace behavior, compliance requirements, and the 99.9% target are not established by repository or task evidence, and allowing only 90% of cases to pass could accept critical failures."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 4,
+          "specificity": 12,
+          "risk_awareness": 5,
+          "total": 29,
+          "notes": "The patch concretely adds secret resources, IAM ARNs, and ECS secret entries across three Terraform files, but it does not implement the claimed secure migration end to end. Every new secret value is still supplied through Terraform secret_string, plaintext environment entries are retained, and ECS cannot provide the summary's fallback when secret initialization fails. It grants and injects registry-only webhook, gate, and GitHub values into auth-server, injects Auth0 and Grafana values into registry, and never wires the Grafana secret into terraform/aws-ecs/modules/observability/main.tf; the wildcard KMS patterns are also not specific roles as claimed. No tests, documentation, migration script, rotation restart, or real rollback mechanism are included, and independent git apply or source validation was unavailable because repository command execution failed in the provided read-only environment."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-04",
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 16,
+      "risk_awareness": 11,
+      "total": 55,
+      "notes": "The issue clearly identifies the exposure paths, affected secret classes, IAM work, and explicit exclusions. Its largest flaw is the unsupported fallback requirement: ECS resolves task-definition secrets before container startup, so an unavailable secret prevents the application from performing an environment fallback. The proposed aws_secretsmanager_secret_version resources also retain supplied plaintext in Terraform state, contradicting a primary motivation. No independent task statement establishes the exact required inventory or migration behavior."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 6,
+      "specificity": 16,
+      "risk_awareness": 14,
+      "total": 50,
+      "notes": "The LLD names concrete Terraform files, variables, resources, IAM integration, and rollout phases. Its core design is unsound because ECS injection cannot provide the described runtime fallback, rotation is not observed until tasks restart, and secret_string values remain in Terraform state. The proposed SecretRetrievalFailure AWS/ECS metric is not a native ECS metric, while recovery_window_in_days = 0 permits immediate deletion rather than protecting recovery. Repository execution failed before inspection, so claimed source line numbers and existing-pattern assertions could not be independently verified."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 14,
+      "total": 51,
+      "notes": "The review surfaces actionable concerns around extra-variable classification, IAM policy size, state migration, monitoring, and fallback testing. It misses the fundamental impossibility of application fallback after ECS secret retrieval failure and does not challenge continued plaintext storage in Terraform state. It incorrectly says a zero-day recovery window prevents accidental deletion and treats rotation as a blocker despite the issue explicitly excluding automatic rotation. Several findings also describe monitoring or keyword classification as current after the LLD claims those sections were revised."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 4,
+      "specificity": 15,
+      "risk_awareness": 12,
+      "total": 45,
+      "notes": "The plan spans provisioning, compatibility, IAM, audit, rollback, rotation, and performance with concrete intended outcomes. Many procedures cannot establish those outcomes: describe-tasks does not expose task-definition secrets, updating only a secret description does not make it missing, and Secrets Manager rejects an empty SecretString. terraform output -raw cannot read the migrated_secrets map, the IAM test uses the operator identity rather than the ECS execution role, and the rotation check reuses a stale task ARN. Hardcoded service names, log groups, module targets, ECS Exec availability, and the temporary checkout path were not verified against the repository."
+    },
+    "implementation": {
+      "completeness": 8,
+      "correctness": 3,
+      "specificity": 12,
+      "risk_awareness": 7,
+      "total": 30,
+      "notes": "The unified diff concretely adds secret resources, task-definition references, IAM ARNs, and explicit sensitive-extra inputs, while the summary acknowledges partial scope. It does not implement the design end to end: only REGISTRY_API_TOKEN and REGISTRY_API_KEYS are removed from plaintext blocks, while added federation, ANS, GitHub, registration, Grafana, and mcpgw resources are not consistently removed from or injected into their consumers, and no fallback exists. The sensitive extra-env variables feed for_each keys and unsafely keyed cross-service maps, and outputs derived from sensitive variables omit sensitive = true, making the claim that terraform validate passes implausible. Repository inspection and git apply --check were unavailable because the read-only executor failed before running commands, so patch applicability and surrounding symbols could not be independently confirmed."
+    }
+  },
+  "task_score": 46.2,
+  "verdict": "The submission identifies the right security domain but its fallback model is infeasible and the partial Terraform patch is internally inconsistent and likely fails validation.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T14:05:30.701725Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 219340,
+      "cached_input_tokens": 178518,
+      "cache_write_input_tokens": 40810,
+      "output_tokens": 7399,
+      "reasoning_output_tokens": 5648
+    },
+    "duration_ms": 132670
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,290 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 42.6,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 9791776,
+    "output_tokens": 41734,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 9833510,
+    "total_cost_usd": 50.00222999999998,
+    "latency_seconds": 980.8,
+    "num_turns": 81,
+    "generation_tokens_per_sec": 42.6,
+    "prefix_cache_hit_rate": 0.8422,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 9791776,
+  "output_tokens": 41734,
+  "latency_seconds": 980.8,
+  "num_turns": 81,
+  "total_cost_usd": 50.00222999999998,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T13:40:13.106182Z",
+  "run_ended_at": "2026-08-05T13:56:34.605378Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 9791776,
+    "output_tokens": 41734,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 9833510,
+    "total_cost_usd": 50.00222999999998,
+    "latency_seconds": 980.8,
+    "num_turns": 81,
+    "generation_tokens_per_sec": 42.6,
+    "prefix_cache_hit_rate": 0.8422,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8422,
+      "prompt_tokens_cached_rate": 0.8422
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 41734,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 8246784,
+      "vllm:prefix_cache_queries_total": 9791776,
+      "vllm:prompt_tokens_by_source_total": 9791776,
+      "vllm:prompt_tokens_cached_total": 8246784,
+      "vllm:prompt_tokens_total": 9791776,
+      "vllm:request_success_total": 81,
+      "vllm:tool_call_parser_invocations_total": 41734
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 81,
+        "sum": 977.1661,
+        "mean": 12.063779
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 41653,
+        "sum": 648.9934,
+        "mean": 0.015581
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 41734,
+        "sum": 1586726,
+        "mean": 38.019984
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 81,
+        "sum": 648.9934,
+        "mean": 8.012264
+      },
+      "vllm:request_generation_tokens": {
+        "count": 81,
+        "sum": 41734,
+        "mean": 515.234568
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 81,
+        "sum": 966.7702,
+        "mean": 11.935435
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 81,
+        "sum": 41734,
+        "mean": 515.234568
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 81,
+        "sum": 1296000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 81,
+        "sum": 81,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 81,
+        "sum": 1544992,
+        "mean": 19073.975309
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 81,
+        "sum": 317.7768,
+        "mean": 3.923171
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 81,
+        "sum": 9791776,
+        "mean": 120886.123457
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 81,
+        "sum": 0.1313,
+        "mean": 0.00162
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 81,
+        "sum": 1.2664,
+        "mean": 0.015634
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 81,
+        "sum": 328.2223,
+        "mean": 4.052127
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1306,
+          "mean": 0.0938,
+          "samples": 976
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9805,
+          "samples": 976
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 976
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 16,
+        "risk_awareness": 11,
+        "total": 55,
+        "notes": "The issue clearly identifies the exposure paths, affected secret classes, IAM work, and explicit exclusions. Its largest flaw is the unsupported fallback requirement: ECS resolves task-definition secrets before container startup, so an unavailable secret prevents the application from performing an environment fallback. The proposed aws_secretsmanager_secret_version resources also retain supplied plaintext in Terraform state, contradicting a primary motivation. No independent task statement establishes the exact required inventory or migration behavior."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 6,
+        "specificity": 16,
+        "risk_awareness": 14,
+        "total": 50,
+        "notes": "The LLD names concrete Terraform files, variables, resources, IAM integration, and rollout phases. Its core design is unsound because ECS injection cannot provide the described runtime fallback, rotation is not observed until tasks restart, and secret_string values remain in Terraform state. The proposed SecretRetrievalFailure AWS/ECS metric is not a native ECS metric, while recovery_window_in_days = 0 permits immediate deletion rather than protecting recovery. Repository execution failed before inspection, so claimed source line numbers and existing-pattern assertions could not be independently verified."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 14,
+        "total": 51,
+        "notes": "The review surfaces actionable concerns around extra-variable classification, IAM policy size, state migration, monitoring, and fallback testing. It misses the fundamental impossibility of application fallback after ECS secret retrieval failure and does not challenge continued plaintext storage in Terraform state. It incorrectly says a zero-day recovery window prevents accidental deletion and treats rotation as a blocker despite the issue explicitly excluding automatic rotation. Several findings also describe monitoring or keyword classification as current after the LLD claims those sections were revised."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 4,
+        "specificity": 15,
+        "risk_awareness": 12,
+        "total": 45,
+        "notes": "The plan spans provisioning, compatibility, IAM, audit, rollback, rotation, and performance with concrete intended outcomes. Many procedures cannot establish those outcomes: describe-tasks does not expose task-definition secrets, updating only a secret description does not make it missing, and Secrets Manager rejects an empty SecretString. terraform output -raw cannot read the migrated_secrets map, the IAM test uses the operator identity rather than the ECS execution role, and the rotation check reuses a stale task ARN. Hardcoded service names, log groups, module targets, ECS Exec availability, and the temporary checkout path were not verified against the repository."
+      },
+      "implementation": {
+        "completeness": 8,
+        "correctness": 3,
+        "specificity": 12,
+        "risk_awareness": 7,
+        "total": 30,
+        "notes": "The unified diff concretely adds secret resources, task-definition references, IAM ARNs, and explicit sensitive-extra inputs, while the summary acknowledges partial scope. It does not implement the design end to end: only REGISTRY_API_TOKEN and REGISTRY_API_KEYS are removed from plaintext blocks, while added federation, ANS, GitHub, registration, Grafana, and mcpgw resources are not consistently removed from or injected into their consumers, and no fallback exists. The sensitive extra-env variables feed for_each keys and unsafely keyed cross-service maps, and outputs derived from sensitive variables omit sensitive = true, making the claim that terraform validate passes implausible. Repository inspection and git apply --check were unavailable because the read-only executor failed before running commands, so patch applicability and surrounding symbols could not be independently confirmed."
+      }
+    },
+    "task_score": 46.2,
+    "verdict": "The submission identifies the right security domain but its fallback model is infeasible and the partial Terraform patch is internally inconsistent and likely fails validation.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T14:05:30.701725Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 219340,
+        "cached_input_tokens": 178518,
+        "cache_write_input_tokens": 40810,
+        "output_tokens": 7399,
+        "reasoning_output_tokens": 5648
+      },
+      "duration_ms": 132670
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 13,
+      "total": 72,
+      "notes": "The issue provides concrete, testable acceptance criteria covering the EFS module, variables, ECS volumes, outputs, scripts, validation, and planning. Its named paths and symbols agree with the submitted diff, including `storage.tf`, `efs_throughput_mode`, and both output layers. The largest gap is weak treatment of the destructive upgrade: existing EFS data, service restarts, output compatibility, and rollback are largely dismissed as unnecessary. With no independent task statement or application evidence, the assertion that S3 and DocumentDB have fully replaced EFS remains unverified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 71,
+      "notes": "The LLD is highly specific about modules, files, volume names, access points, outputs, and the intended `SCOPES_CONFIG_PATH`, and most of those details match the diff's baseline context. Its largest deficiency is leaving deployment-script behavior optional even though the scripts are identified as EFS-dependent integration points. It also quotes the old scopes path as `/efs/auth_config/scopes.yml`, while the actual diff context contains `/efs/auth_config/auth_config/scopes.yml`, and it inconsistently calls the removal backward-compatible before acknowledging it is breaking. The rollout recognizes destruction and service replacement, but provides no reliable data recovery or validated fallback, and the claimed DocumentDB/S3 behavior is not established by repository evidence."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 18,
+      "risk_awareness": 19,
+      "total": 69,
+      "notes": "The review's strongest work is identifying concrete risks around the unverified scopes path, EFS-dependent scripts, state transitions, service restarts, monitoring, and runtime testing. Its verdict is not defensible: it reports zero blockers and says all blocking issues are resolved while the critical path and script questions remain unanswered. Several recommendations are speculative or technically weak, including manual state cleanup, an invented conditional `storage_backend` precondition, and account-wide AWS checks that could include unrelated resources. Claims that IAM permissions are removed and DocumentDB provides the required storage and audit behavior are not tied to identified source or configuration."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 7,
+      "specificity": 14,
+      "risk_awareness": 12,
+      "total": 49,
+      "notes": "The plan spans static configuration checks, fresh and existing deployments, ECS runtime behavior, APIs, storage, and rollback, with useful grep checks for the removed Terraform symbols. However, several central tests do not execute what they claim: `test-old.tfvars` is invoked as a shell command, the mock state is never supplied to Terraform, and the existing-state test merely creates an unrelated output file and prints instructions. The hard-coded repository path, targeted plans without required deployment inputs, account-wide EFS counts, and unverified endpoint and log assertions make much of the plan non-reproducible. Its rollback recreates an empty EFS rather than recovering destroyed data, and cleanup omits destroying workspace resources before deleting the workspace."
+    },
+    "implementation": {
+      "completeness": 16,
+      "correctness": 15,
+      "specificity": 19,
+      "risk_awareness": 11,
+      "total": 61,
+      "notes": "The patch directly removes the EFS module, child variables, task-definition mounts and volumes, and module and root outputs, while updating the auth scopes path in the relevant ECS service. The largest defect is that it knowingly leaves `run-scopes-init-task.sh` and `post-deployment-setup.sh` unchanged despite the issue requiring them to be updated or marked obsolete and the design identifying them as deployment integration points. The diff is focused and internally consistent in the Terraform files, but the new `/app/auth_server/scopes.yml` path and MCPGW behavior without `/app/data` are not validated. The summary overstates completion and functionality, reports no LLD deviations, and offers a rollback that cannot restore deleted EFS data; it also explicitly states that verification tests were not executed."
+    }
+  },
+  "task_score": 64.4,
+  "verdict": "The submission has a solid core Terraform removal, but leaves known EFS-dependent deployment scripts unresolved and relies on a largely non-executable testing plan.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T14:07:15.150628Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 147069,
+      "cached_input_tokens": 116549,
+      "cache_write_input_tokens": 30510,
+      "output_tokens": 6181,
+      "reasoning_output_tokens": 4658
+    },
+    "duration_ms": 104437
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,289 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 33.9,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5048259,
+    "output_tokens": 19515,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5067774,
+    "total_cost_usd": 25.72917,
+    "latency_seconds": 575.2,
+    "num_turns": 40,
+    "generation_tokens_per_sec": 33.9,
+    "prefix_cache_hit_rate": 0.7676,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5048259,
+  "output_tokens": 19515,
+  "latency_seconds": 575.2,
+  "num_turns": 40,
+  "total_cost_usd": 25.72917,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T13:19:05.344997Z",
+  "run_ended_at": "2026-08-05T13:28:41.375297Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5048259,
+    "output_tokens": 19515,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5067774,
+    "total_cost_usd": 25.72917,
+    "latency_seconds": 575.2,
+    "num_turns": 40,
+    "generation_tokens_per_sec": 33.9,
+    "prefix_cache_hit_rate": 0.7676,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.7676,
+      "prompt_tokens_cached_rate": 0.7676
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 19515,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 3875088,
+      "vllm:prefix_cache_queries_total": 5048259,
+      "vllm:prompt_tokens_by_source_total": 5048259,
+      "vllm:prompt_tokens_cached_total": 3875088,
+      "vllm:prompt_tokens_total": 5048259,
+      "vllm:request_success_total": 40,
+      "vllm:tool_call_parser_invocations_total": 19515
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 40,
+        "sum": 573.0647,
+        "mean": 14.326617
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 19475,
+        "sum": 314.1679,
+        "mean": 0.016132
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 19515,
+        "sum": 1192686,
+        "mean": 61.116372
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 40,
+        "sum": 314.1679,
+        "mean": 7.854197
+      },
+      "vllm:request_generation_tokens": {
+        "count": 40,
+        "sum": 19515,
+        "mean": 487.875
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 40,
+        "sum": 567.8905,
+        "mean": 14.197262
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 40,
+        "sum": 19515,
+        "mean": 487.875
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 40,
+        "sum": 640000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 40,
+        "sum": 40,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 40,
+        "sum": 1173171,
+        "mean": 29329.275
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 40,
+        "sum": 253.7226,
+        "mean": 6.343065
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 40,
+        "sum": 5048259,
+        "mean": 126206.475
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 40,
+        "sum": 0.0636,
+        "mean": 0.001589
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 40,
+        "sum": 0.6318,
+        "mean": 0.015795
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 40,
+        "sum": 258.9201,
+        "mean": 6.473002
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1415,
+          "mean": 0.1021,
+          "samples": 573
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9756,
+          "samples": 573
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 573
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 13,
+        "total": 72,
+        "notes": "The issue provides concrete, testable acceptance criteria covering the EFS module, variables, ECS volumes, outputs, scripts, validation, and planning. Its named paths and symbols agree with the submitted diff, including `storage.tf`, `efs_throughput_mode`, and both output layers. The largest gap is weak treatment of the destructive upgrade: existing EFS data, service restarts, output compatibility, and rollback are largely dismissed as unnecessary. With no independent task statement or application evidence, the assertion that S3 and DocumentDB have fully replaced EFS remains unverified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 71,
+        "notes": "The LLD is highly specific about modules, files, volume names, access points, outputs, and the intended `SCOPES_CONFIG_PATH`, and most of those details match the diff's baseline context. Its largest deficiency is leaving deployment-script behavior optional even though the scripts are identified as EFS-dependent integration points. It also quotes the old scopes path as `/efs/auth_config/scopes.yml`, while the actual diff context contains `/efs/auth_config/auth_config/scopes.yml`, and it inconsistently calls the removal backward-compatible before acknowledging it is breaking. The rollout recognizes destruction and service replacement, but provides no reliable data recovery or validated fallback, and the claimed DocumentDB/S3 behavior is not established by repository evidence."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 18,
+        "risk_awareness": 19,
+        "total": 69,
+        "notes": "The review's strongest work is identifying concrete risks around the unverified scopes path, EFS-dependent scripts, state transitions, service restarts, monitoring, and runtime testing. Its verdict is not defensible: it reports zero blockers and says all blocking issues are resolved while the critical path and script questions remain unanswered. Several recommendations are speculative or technically weak, including manual state cleanup, an invented conditional `storage_backend` precondition, and account-wide AWS checks that could include unrelated resources. Claims that IAM permissions are removed and DocumentDB provides the required storage and audit behavior are not tied to identified source or configuration."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 7,
+        "specificity": 14,
+        "risk_awareness": 12,
+        "total": 49,
+        "notes": "The plan spans static configuration checks, fresh and existing deployments, ECS runtime behavior, APIs, storage, and rollback, with useful grep checks for the removed Terraform symbols. However, several central tests do not execute what they claim: `test-old.tfvars` is invoked as a shell command, the mock state is never supplied to Terraform, and the existing-state test merely creates an unrelated output file and prints instructions. The hard-coded repository path, targeted plans without required deployment inputs, account-wide EFS counts, and unverified endpoint and log assertions make much of the plan non-reproducible. Its rollback recreates an empty EFS rather than recovering destroyed data, and cleanup omits destroying workspace resources before deleting the workspace."
+      },
+      "implementation": {
+        "completeness": 16,
+        "correctness": 15,
+        "specificity": 19,
+        "risk_awareness": 11,
+        "total": 61,
+        "notes": "The patch directly removes the EFS module, child variables, task-definition mounts and volumes, and module and root outputs, while updating the auth scopes path in the relevant ECS service. The largest defect is that it knowingly leaves `run-scopes-init-task.sh` and `post-deployment-setup.sh` unchanged despite the issue requiring them to be updated or marked obsolete and the design identifying them as deployment integration points. The diff is focused and internally consistent in the Terraform files, but the new `/app/auth_server/scopes.yml` path and MCPGW behavior without `/app/data` are not validated. The summary overstates completion and functionality, reports no LLD deviations, and offers a rollback that cannot restore deleted EFS data; it also explicitly states that verification tests were not executed."
+      }
+    },
+    "task_score": 64.4,
+    "verdict": "The submission has a solid core Terraform removal, but leaves known EFS-dependent deployment scripts unresolved and relies on a largely non-executable testing plan.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T14:07:15.150628Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 147069,
+        "cached_input_tokens": 116549,
+        "cache_write_input_tokens": 30510,
+        "output_tokens": 6181,
+        "reasoning_output_tokens": 4658
+      },
+      "duration_ms": 104437
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 19,
+      "risk_awareness": 10,
+      "total": 59,
+      "notes": "The issue provides measurable acceptance criteria and names FAISS files and Settings properties represented in the supplied diff. Its central deficiency is contradictory scope: file-backend removal is out of scope, yet the criteria permit its removal and promise unchanged behavior while the proposed factory error disables it. The existing documentation excerpt still describes three supported storage backends, making the claimed absence of breaking changes untenable for file-backend users. No independent task statement was supplied, and the deployment and related-issue claims could not be verified."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 11,
+      "specificity": 18,
+      "risk_awareness": 10,
+      "total": 55,
+      "notes": "The LLD gives concrete changes for get_search_repository, Settings.faiss_index_path, lifespan initialization, dependencies, tests, and documentation that correspond to the supplied source context. Its chosen design makes STORAGE_BACKEND=file fail during search-repository creation despite declaring file-backend removal a non-goal and repeatedly claiming no breaking changes. It also relies on an unsupported assertion that no production deployment uses FAISS and leaves migration, lockfile handling, reference cleanup, and rollback underdeveloped. Repository command execution failed in the provided sandbox, so endpoint, infrastructure, and global-reference claims could not be independently verified."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 11,
+      "specificity": 15,
+      "risk_awareness": 16,
+      "total": 57,
+      "notes": "The review usefully identifies the need for a factory error test, explicit migration guidance, and checks for operational references. Its largest failure is approving the design without resolving the contradiction between preserving the file backend and making application startup fail for that configuration. The resolution section claims a security section, test summary, Docker-size goal, and rollout migration instructions were added, but those changes are not present as described in the submitted LLD. Claims about CVEs, dashboards, backups, frontend flags, and complete file identification remain unverified."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 12,
+      "total": 51,
+      "notes": "The plan spans API, factory-error, dependency, Docker, integration, and end-to-end coverage and includes several concrete expected states. Several procedures are not reliable: the compatibility loop has malformed `jq ... done` syntax, curl checks omit `--fail`, and the rollback test incorrectly expects dependency installation to fail because FAISS is not already installed. Hard-coded search results lack deterministic fixture setup, image-size comparison has no baseline, and several assertions only check response shape or command execution rather than promised equivalence. The submitted patch adds no replacement automated factory test, and the documented endpoint and registration commands could not be independently verified against the repository."
+    },
+    "implementation": {
+      "completeness": 14,
+      "correctness": 2,
+      "specificity": 14,
+      "risk_awareness": 4,
+      "total": 34,
+      "notes": "The patch removes the principal FAISS service, wrapper, tests, dependency declaration, configuration properties, and related documentation references, broadly following the proposed file list. It is not mergeable as shown: after removing the `else:` in registry/main.py, the retained agent-state comment and statements remain over-indented, producing an `IndentationError`. The factory intentionally rejects the file backend while docs/configuration.md still presents that backend as supported, and no regression test is added for this new startup failure. The summary materially misreports deletion counts, claims zero breaking changes despite requiring migration, and reports verification results as facts even though verification was not executed; patch applicability and remaining repository-wide references could not be independently checked because repository commands failed in the sandbox."
+    }
+  },
+  "task_score": 51.2,
+  "verdict": "The submission is detailed and mostly identifies the intended FAISS surface, but contradictory compatibility claims, unreliable tests, and a syntax-broken implementation make it unsafe to merge.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T14:08:59.305748Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 266240,
+      "cached_input_tokens": 211019,
+      "cache_write_input_tokens": 55211,
+      "output_tokens": 5830,
+      "reasoning_output_tokens": 4352
+    },
+    "duration_ms": 104141
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,290 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 33.8,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5876679,
+    "output_tokens": 21674,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5898353,
+    "total_cost_usd": 29.925245000000004,
+    "latency_seconds": 640.4,
+    "num_turns": 52,
+    "generation_tokens_per_sec": 33.8,
+    "prefix_cache_hit_rate": 0.788,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5876679,
+  "output_tokens": 21674,
+  "latency_seconds": 640.4,
+  "num_turns": 52,
+  "total_cost_usd": 29.925245000000004,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T13:08:22.745817Z",
+  "run_ended_at": "2026-08-05T13:19:03.726920Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5876679,
+    "output_tokens": 21674,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5898353,
+    "total_cost_usd": 29.925245000000004,
+    "latency_seconds": 640.4,
+    "num_turns": 52,
+    "generation_tokens_per_sec": 33.8,
+    "prefix_cache_hit_rate": 0.788,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.788,
+      "prompt_tokens_cached_rate": 0.788
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 21674,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 4630816,
+      "vllm:prefix_cache_queries_total": 5876679,
+      "vllm:prompt_tokens_by_source_total": 5876679,
+      "vllm:prompt_tokens_cached_total": 4630816,
+      "vllm:prompt_tokens_total": 5876679,
+      "vllm:request_success_total": 45,
+      "vllm:tool_call_parser_invocations_total": 21674
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 45,
+        "sum": 638.2702,
+        "mean": 14.183782
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 21629,
+        "sum": 355.2339,
+        "mean": 0.016424
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 21674,
+        "sum": 1267537,
+        "mean": 58.481914
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 45,
+        "sum": 355.2339,
+        "mean": 7.894088
+      },
+      "vllm:request_generation_tokens": {
+        "count": 45,
+        "sum": 21674,
+        "mean": 481.644444
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 45,
+        "sum": 632.2117,
+        "mean": 14.04915
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 45,
+        "sum": 21674,
+        "mean": 481.644444
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 45,
+        "sum": 720000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 45,
+        "sum": 45,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 45,
+        "sum": 1245863,
+        "mean": 27685.844444
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 45,
+        "sum": 276.9778,
+        "mean": 6.155062
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 45,
+        "sum": 5876679,
+        "mean": 130592.866667
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 45,
+        "sum": 0.0707,
+        "mean": 0.001571
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 45,
+        "sum": 0.7159,
+        "mean": 0.015909
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 45,
+        "sum": 283.0607,
+        "mean": 6.290237
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1536,
+          "mean": 0.1121,
+          "samples": 638
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9859,
+          "samples": 638
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 1.0,
+          "mean": 0.0016,
+          "samples": 638
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 19,
+        "risk_awareness": 10,
+        "total": 59,
+        "notes": "The issue provides measurable acceptance criteria and names FAISS files and Settings properties represented in the supplied diff. Its central deficiency is contradictory scope: file-backend removal is out of scope, yet the criteria permit its removal and promise unchanged behavior while the proposed factory error disables it. The existing documentation excerpt still describes three supported storage backends, making the claimed absence of breaking changes untenable for file-backend users. No independent task statement was supplied, and the deployment and related-issue claims could not be verified."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 11,
+        "specificity": 18,
+        "risk_awareness": 10,
+        "total": 55,
+        "notes": "The LLD gives concrete changes for get_search_repository, Settings.faiss_index_path, lifespan initialization, dependencies, tests, and documentation that correspond to the supplied source context. Its chosen design makes STORAGE_BACKEND=file fail during search-repository creation despite declaring file-backend removal a non-goal and repeatedly claiming no breaking changes. It also relies on an unsupported assertion that no production deployment uses FAISS and leaves migration, lockfile handling, reference cleanup, and rollback underdeveloped. Repository command execution failed in the provided sandbox, so endpoint, infrastructure, and global-reference claims could not be independently verified."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 11,
+        "specificity": 15,
+        "risk_awareness": 16,
+        "total": 57,
+        "notes": "The review usefully identifies the need for a factory error test, explicit migration guidance, and checks for operational references. Its largest failure is approving the design without resolving the contradiction between preserving the file backend and making application startup fail for that configuration. The resolution section claims a security section, test summary, Docker-size goal, and rollout migration instructions were added, but those changes are not present as described in the submitted LLD. Claims about CVEs, dashboards, backups, frontend flags, and complete file identification remain unverified."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 12,
+        "total": 51,
+        "notes": "The plan spans API, factory-error, dependency, Docker, integration, and end-to-end coverage and includes several concrete expected states. Several procedures are not reliable: the compatibility loop has malformed `jq ... done` syntax, curl checks omit `--fail`, and the rollback test incorrectly expects dependency installation to fail because FAISS is not already installed. Hard-coded search results lack deterministic fixture setup, image-size comparison has no baseline, and several assertions only check response shape or command execution rather than promised equivalence. The submitted patch adds no replacement automated factory test, and the documented endpoint and registration commands could not be independently verified against the repository."
+      },
+      "implementation": {
+        "completeness": 14,
+        "correctness": 2,
+        "specificity": 14,
+        "risk_awareness": 4,
+        "total": 34,
+        "notes": "The patch removes the principal FAISS service, wrapper, tests, dependency declaration, configuration properties, and related documentation references, broadly following the proposed file list. It is not mergeable as shown: after removing the `else:` in registry/main.py, the retained agent-state comment and statements remain over-indented, producing an `IndentationError`. The factory intentionally rejects the file backend while docs/configuration.md still presents that backend as supported, and no regression test is added for this new startup failure. The summary materially misreports deletion counts, claims zero breaking changes despite requiring migration, and reports verification results as facts even though verification was not executed; patch applicability and remaining repository-wide references could not be independently checked because repository commands failed in the sandbox."
+      }
+    },
+    "task_score": 51.2,
+    "verdict": "The submission is detailed and mostly identifies the intended FAISS surface, but contradictory compatibility claims, unreliable tests, and a syntax-broken implementation make it unsafe to merge.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T14:08:59.305748Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 266240,
+        "cached_input_tokens": 211019,
+        "cache_write_input_tokens": 55211,
+        "output_tokens": 5830,
+        "reasoning_output_tokens": 4352
+      },
+      "duration_ms": 104141
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 7,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 49,
+      "notes": "The issue's strongest aspect is its explicit opt-in scope, non-goals, and acceptance checks covering the cluster, proxy, task role, documentation, and password compatibility. Its largest deficiency is promising automatic IAM token rotation and password fallback without specifying a Keycloak-compatible token generation and refresh mechanism; `KC_DB_IAM_AUTH_ENABLED` is not a standard Keycloak database option, and a proxy configured with `iam_auth = \"REQUIRED\"` will reject password authentication. The submitted source context shows `aws_db_proxy.keycloak` using `SECRETS` and the task consuming `KC_DB_PASSWORD`, so replacing client authentication requires more than infrastructure toggles. No independent task statement or issue history verifies references #1303 and #1026, and `GenerateDBAuthToken` is not an IAM action; authorization uses `rds-db:connect` while token creation is local SigV4 signing."
+    },
+    "lld": {
+      "completeness": 8,
+      "correctness": 4,
+      "specificity": 10,
+      "risk_awareness": 9,
+      "total": 31,
+      "notes": "The LLD is strongest where it identifies concrete Terraform files, existing resources, an opt-in default, and a staged rollout. Its load-bearing design is infeasible: it assumes Keycloak and its MySQL driver will interpret `KC_DB_IAM_AUTH_ENABLED`, generate and renew tokens, emit custom authentication logs and metrics, and fall back automatically, but it adds no driver, token provider, wrapper, or startup logic implementing any of those behaviors. The proposed proxy configuration sets IAM to `REQUIRED` when enabled while retaining `KC_DB_PASSWORD`, which creates mutually exclusive modes rather than the documented runtime fallback. Exact engine-version and existing-pattern claims could not be independently verified, while the unresolved token lifecycle, TLS configuration, database-user requirements, and wildcard `dbuser:*/...` scope leave major security and operational decisions open."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 6,
+      "specificity": 12,
+      "risk_awareness": 12,
+      "total": 40,
+      "notes": "The review's strongest contribution is identifying the precise questions the LLD needed to answer, including driver requirements, token renewal, fallback behavior, TLS, pooling, rollback, and failover. Its largest failure is declaring zero blockers and later claiming all findings were resolved even though the LLD still contains no mechanism that generates an IAM token or refreshes credentials for new pooled connections. The resolution that the MySQL driver handles expiration automatically is unsupported, and the recommendation to audit `GenerateDBAuthToken` through CloudTrail is technically inaccurate because token generation is local signing rather than an AWS API call. Several real risks are named, but they are treated as documentation improvements instead of correctness blockers, and claimed TLS, audit, rollback, and fallback resolutions are not present as implementable changes."
+    },
+    "testing": {
+      "completeness": 9,
+      "correctness": 4,
+      "specificity": 12,
+      "risk_awareness": 10,
+      "total": 35,
+      "notes": "The plan's strongest aspect is its broad coverage of Terraform validation, disabled-mode compatibility, deployment inspection, rollback, and attempted end-to-end checks with stated outcomes. Its largest deficiency is that most checks inspect text or hypothetical output rather than proving that Keycloak can generate a fresh IAM token, connect through the proxy, and create another physical connection after token expiry. Concrete defects include a hard-coded temporary repository path, a targeted plan that expects an untargeted IAM policy, nonexistent implementation log messages, and use of `aws logs get-log-events --log-stream-name-prefix`, which is not a valid invocation for that command. The fallback test would revoke the only IAM authorization while the proxy remains `REQUIRED`, so its expected uninterrupted password fallback is false; AWS deployment results and performance thresholds were also not executed or otherwise substantiated."
+    },
+    "implementation": {
+      "completeness": 4,
+      "correctness": 2,
+      "specificity": 11,
+      "risk_awareness": 3,
+      "total": 20,
+      "notes": "The patch is focused and does add a false-by-default Terraform variable, cluster and proxy IAM settings, and an `rds-db:connect` task-role policy. It does not implement the essential client behavior: `KC_DB_IAM_AUTH_ENABLED` is not consumed by standard Keycloak, no IAM token is placed in the JDBC password path, and no refresh provider exists, so enabling `iam_auth = \"REQUIRED\"` leaves Keycloak sending its static `KC_DB_PASSWORD` to a proxy that requires IAM authentication. The always-created policy uses `dbuser:*/${var.keycloak_database_username}`, while the summary inaccurately calls this least privilege and claims working fallback, automatic rotation, TLS enforcement, CloudTrail token-generation events, and complete implementation. The hunks are internally plausible against the submitted resource context, but command-level applicability to the stated baseline could not be independently verified because repository shell access failed in the provided environment."
+    }
+  },
+  "task_score": 35.0,
+  "verdict": "The artifacts are detailed and well scoped, but the design and patch omit any Keycloak-compatible IAM token generation and refresh path, so enabling the feature would likely break database connectivity rather than replace password authentication.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T14:11:10.930080Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 175438,
+      "cached_input_tokens": 144614,
+      "cache_write_input_tokens": 30812,
+      "output_tokens": 7327,
+      "reasoning_output_tokens": 5243
+    },
+    "duration_ms": 131612
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,290 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 56.3,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3046068,
+    "output_tokens": 22568,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 3068636,
+    "total_cost_usd": 15.794539999999996,
+    "latency_seconds": 400.8,
+    "num_turns": 43,
+    "generation_tokens_per_sec": 56.3,
+    "prefix_cache_hit_rate": 0.8448,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 3046068,
+  "output_tokens": 22568,
+  "latency_seconds": 400.8,
+  "num_turns": 43,
+  "total_cost_usd": 15.794539999999996,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T13:56:36.203280Z",
+  "run_ended_at": "2026-08-05T14:03:17.565320Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3046068,
+    "output_tokens": 22568,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 3068636,
+    "total_cost_usd": 15.794539999999996,
+    "latency_seconds": 400.8,
+    "num_turns": 43,
+    "generation_tokens_per_sec": 56.3,
+    "prefix_cache_hit_rate": 0.8448,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8448,
+      "prompt_tokens_cached_rate": 0.8448
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 22568,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 2573264,
+      "vllm:prefix_cache_queries_total": 3046068,
+      "vllm:prompt_tokens_by_source_total": 3046068,
+      "vllm:prompt_tokens_cached_total": 2573264,
+      "vllm:prompt_tokens_total": 3046068,
+      "vllm:request_success_total": 43,
+      "vllm:tool_call_parser_invocations_total": 22568
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 43,
+        "sum": 396.9578,
+        "mean": 9.231577
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 22525,
+        "sum": 319.2322,
+        "mean": 0.014172
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 22568,
+        "sum": 495372,
+        "mean": 21.950195
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 43,
+        "sum": 319.2322,
+        "mean": 7.424004
+      },
+      "vllm:request_generation_tokens": {
+        "count": 43,
+        "sum": 22568,
+        "mean": 524.837209
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 43,
+        "sum": 393.3213,
+        "mean": 9.147008
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 43,
+        "sum": 22568,
+        "mean": 524.837209
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 43,
+        "sum": 688000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 43,
+        "sum": 43,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 43,
+        "sum": 472804,
+        "mean": 10995.44186
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 43,
+        "sum": 74.0892,
+        "mean": 1.723004
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 43,
+        "sum": 3046068,
+        "mean": 70838.790698
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 43,
+        "sum": 0.0653,
+        "mean": 0.001519
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 43,
+        "sum": 0.6094,
+        "mean": 0.014171
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 43,
+        "sum": 77.7452,
+        "mean": 1.808027
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0762,
+          "mean": 0.0581,
+          "samples": 399
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9749,
+          "samples": 399
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 399
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 7,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 49,
+        "notes": "The issue's strongest aspect is its explicit opt-in scope, non-goals, and acceptance checks covering the cluster, proxy, task role, documentation, and password compatibility. Its largest deficiency is promising automatic IAM token rotation and password fallback without specifying a Keycloak-compatible token generation and refresh mechanism; `KC_DB_IAM_AUTH_ENABLED` is not a standard Keycloak database option, and a proxy configured with `iam_auth = \"REQUIRED\"` will reject password authentication. The submitted source context shows `aws_db_proxy.keycloak` using `SECRETS` and the task consuming `KC_DB_PASSWORD`, so replacing client authentication requires more than infrastructure toggles. No independent task statement or issue history verifies references #1303 and #1026, and `GenerateDBAuthToken` is not an IAM action; authorization uses `rds-db:connect` while token creation is local SigV4 signing."
+      },
+      "lld": {
+        "completeness": 8,
+        "correctness": 4,
+        "specificity": 10,
+        "risk_awareness": 9,
+        "total": 31,
+        "notes": "The LLD is strongest where it identifies concrete Terraform files, existing resources, an opt-in default, and a staged rollout. Its load-bearing design is infeasible: it assumes Keycloak and its MySQL driver will interpret `KC_DB_IAM_AUTH_ENABLED`, generate and renew tokens, emit custom authentication logs and metrics, and fall back automatically, but it adds no driver, token provider, wrapper, or startup logic implementing any of those behaviors. The proposed proxy configuration sets IAM to `REQUIRED` when enabled while retaining `KC_DB_PASSWORD`, which creates mutually exclusive modes rather than the documented runtime fallback. Exact engine-version and existing-pattern claims could not be independently verified, while the unresolved token lifecycle, TLS configuration, database-user requirements, and wildcard `dbuser:*/...` scope leave major security and operational decisions open."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 6,
+        "specificity": 12,
+        "risk_awareness": 12,
+        "total": 40,
+        "notes": "The review's strongest contribution is identifying the precise questions the LLD needed to answer, including driver requirements, token renewal, fallback behavior, TLS, pooling, rollback, and failover. Its largest failure is declaring zero blockers and later claiming all findings were resolved even though the LLD still contains no mechanism that generates an IAM token or refreshes credentials for new pooled connections. The resolution that the MySQL driver handles expiration automatically is unsupported, and the recommendation to audit `GenerateDBAuthToken` through CloudTrail is technically inaccurate because token generation is local signing rather than an AWS API call. Several real risks are named, but they are treated as documentation improvements instead of correctness blockers, and claimed TLS, audit, rollback, and fallback resolutions are not present as implementable changes."
+      },
+      "testing": {
+        "completeness": 9,
+        "correctness": 4,
+        "specificity": 12,
+        "risk_awareness": 10,
+        "total": 35,
+        "notes": "The plan's strongest aspect is its broad coverage of Terraform validation, disabled-mode compatibility, deployment inspection, rollback, and attempted end-to-end checks with stated outcomes. Its largest deficiency is that most checks inspect text or hypothetical output rather than proving that Keycloak can generate a fresh IAM token, connect through the proxy, and create another physical connection after token expiry. Concrete defects include a hard-coded temporary repository path, a targeted plan that expects an untargeted IAM policy, nonexistent implementation log messages, and use of `aws logs get-log-events --log-stream-name-prefix`, which is not a valid invocation for that command. The fallback test would revoke the only IAM authorization while the proxy remains `REQUIRED`, so its expected uninterrupted password fallback is false; AWS deployment results and performance thresholds were also not executed or otherwise substantiated."
+      },
+      "implementation": {
+        "completeness": 4,
+        "correctness": 2,
+        "specificity": 11,
+        "risk_awareness": 3,
+        "total": 20,
+        "notes": "The patch is focused and does add a false-by-default Terraform variable, cluster and proxy IAM settings, and an `rds-db:connect` task-role policy. It does not implement the essential client behavior: `KC_DB_IAM_AUTH_ENABLED` is not consumed by standard Keycloak, no IAM token is placed in the JDBC password path, and no refresh provider exists, so enabling `iam_auth = \"REQUIRED\"` leaves Keycloak sending its static `KC_DB_PASSWORD` to a proxy that requires IAM authentication. The always-created policy uses `dbuser:*/${var.keycloak_database_username}`, while the summary inaccurately calls this least privilege and claims working fallback, automatic rotation, TLS enforcement, CloudTrail token-generation events, and complete implementation. The hunks are internally plausible against the submitted resource context, but command-level applicability to the stated baseline could not be independently verified because repository shell access failed in the provided environment."
+      }
+    },
+    "task_score": 35.0,
+    "verdict": "The artifacts are detailed and well scoped, but the design and patch omit any Keycloak-compatible IAM token generation and refresh path, so enabling the feature would likely break database connectivity rather than replace password authentication.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T14:11:10.930080Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 175438,
+        "cached_input_tokens": 144614,
+        "cache_write_input_tokens": 30812,
+        "output_tokens": 7327,
+        "reasoning_output_tokens": 5243
+      },
+      "duration_ms": 131612
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "claude",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T14:05:30.701725Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 219340,
+      "cached_input_tokens": 178518,
+      "cache_write_input_tokens": 40810,
+      "output_tokens": 7399,
+      "reasoning_output_tokens": 5648
+    },
+    "duration_ms": 132670
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 49.52,
+  "mean_cost_usd_excl_failed": 28.77,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 40,
+      "input_tokens": 5048259,
+      "output_tokens": 19515,
+      "total_tokens": 5067774,
+      "latency_seconds": 575.2,
+      "total_cost_usd": 25.72917,
+      "result_subtype": "success",
+      "task_score": 64.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.7676,
+      "generation_tokens_per_sec": 33.9,
+      "kv_cache_usage": {
+        "peak": 0.1415,
+        "mean": 0.1021
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 13,
+          "total": 72,
+          "notes": "The issue provides concrete, testable acceptance criteria covering the EFS module, variables, ECS volumes, outputs, scripts, validation, and planning. Its named paths and symbols agree with the submitted diff, including `storage.tf`, `efs_throughput_mode`, and both output layers. The largest gap is weak treatment of the destructive upgrade: existing EFS data, service restarts, output compatibility, and rollback are largely dismissed as unnecessary. With no independent task statement or application evidence, the assertion that S3 and DocumentDB have fully replaced EFS remains unverified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 71,
+          "notes": "The LLD is highly specific about modules, files, volume names, access points, outputs, and the intended `SCOPES_CONFIG_PATH`, and most of those details match the diff's baseline context. Its largest deficiency is leaving deployment-script behavior optional even though the scripts are identified as EFS-dependent integration points. It also quotes the old scopes path as `/efs/auth_config/scopes.yml`, while the actual diff context contains `/efs/auth_config/auth_config/scopes.yml`, and it inconsistently calls the removal backward-compatible before acknowledging it is breaking. The rollout recognizes destruction and service replacement, but provides no reliable data recovery or validated fallback, and the claimed DocumentDB/S3 behavior is not established by repository evidence."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 19,
+          "total": 69,
+          "notes": "The review's strongest work is identifying concrete risks around the unverified scopes path, EFS-dependent scripts, state transitions, service restarts, monitoring, and runtime testing. Its verdict is not defensible: it reports zero blockers and says all blocking issues are resolved while the critical path and script questions remain unanswered. Several recommendations are speculative or technically weak, including manual state cleanup, an invented conditional `storage_backend` precondition, and account-wide AWS checks that could include unrelated resources. Claims that IAM permissions are removed and DocumentDB provides the required storage and audit behavior are not tied to identified source or configuration."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 7,
+          "specificity": 14,
+          "risk_awareness": 12,
+          "total": 49,
+          "notes": "The plan spans static configuration checks, fresh and existing deployments, ECS runtime behavior, APIs, storage, and rollback, with useful grep checks for the removed Terraform symbols. However, several central tests do not execute what they claim: `test-old.tfvars` is invoked as a shell command, the mock state is never supplied to Terraform, and the existing-state test merely creates an unrelated output file and prints instructions. The hard-coded repository path, targeted plans without required deployment inputs, account-wide EFS counts, and unverified endpoint and log assertions make much of the plan non-reproducible. Its rollback recreates an empty EFS rather than recovering destroyed data, and cleanup omits destroying workspace resources before deleting the workspace."
+        },
+        "implementation": {
+          "completeness": 16,
+          "correctness": 15,
+          "specificity": 19,
+          "risk_awareness": 11,
+          "total": 61,
+          "notes": "The patch directly removes the EFS module, child variables, task-definition mounts and volumes, and module and root outputs, while updating the auth scopes path in the relevant ECS service. The largest defect is that it knowingly leaves `run-scopes-init-task.sh` and `post-deployment-setup.sh` unchanged despite the issue requiring them to be updated or marked obsolete and the design identifying them as deployment integration points. The diff is focused and internally consistent in the Terraform files, but the new `/app/auth_server/scopes.yml` path and MCPGW behavior without `/app/data` are not validated. The summary overstates completion and functionality, reports no LLD deviations, and offers a rollback that cannot restore deleted EFS data; it also explicitly states that verification tests were not executed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 52,
+      "input_tokens": 5876679,
+      "output_tokens": 21674,
+      "total_tokens": 5898353,
+      "latency_seconds": 640.4,
+      "total_cost_usd": 29.925245000000004,
+      "result_subtype": "success",
+      "task_score": 51.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.788,
+      "generation_tokens_per_sec": 33.8,
+      "kv_cache_usage": {
+        "peak": 0.1536,
+        "mean": 0.1121
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 19,
+          "risk_awareness": 10,
+          "total": 59,
+          "notes": "The issue provides measurable acceptance criteria and names FAISS files and Settings properties represented in the supplied diff. Its central deficiency is contradictory scope: file-backend removal is out of scope, yet the criteria permit its removal and promise unchanged behavior while the proposed factory error disables it. The existing documentation excerpt still describes three supported storage backends, making the claimed absence of breaking changes untenable for file-backend users. No independent task statement was supplied, and the deployment and related-issue claims could not be verified."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 18,
+          "risk_awareness": 10,
+          "total": 55,
+          "notes": "The LLD gives concrete changes for get_search_repository, Settings.faiss_index_path, lifespan initialization, dependencies, tests, and documentation that correspond to the supplied source context. Its chosen design makes STORAGE_BACKEND=file fail during search-repository creation despite declaring file-backend removal a non-goal and repeatedly claiming no breaking changes. It also relies on an unsupported assertion that no production deployment uses FAISS and leaves migration, lockfile handling, reference cleanup, and rollback underdeveloped. Repository command execution failed in the provided sandbox, so endpoint, infrastructure, and global-reference claims could not be independently verified."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 15,
+          "risk_awareness": 16,
+          "total": 57,
+          "notes": "The review usefully identifies the need for a factory error test, explicit migration guidance, and checks for operational references. Its largest failure is approving the design without resolving the contradiction between preserving the file backend and making application startup fail for that configuration. The resolution section claims a security section, test summary, Docker-size goal, and rollout migration instructions were added, but those changes are not present as described in the submitted LLD. Claims about CVEs, dashboards, backups, frontend flags, and complete file identification remain unverified."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 51,
+          "notes": "The plan spans API, factory-error, dependency, Docker, integration, and end-to-end coverage and includes several concrete expected states. Several procedures are not reliable: the compatibility loop has malformed `jq ... done` syntax, curl checks omit `--fail`, and the rollback test incorrectly expects dependency installation to fail because FAISS is not already installed. Hard-coded search results lack deterministic fixture setup, image-size comparison has no baseline, and several assertions only check response shape or command execution rather than promised equivalence. The submitted patch adds no replacement automated factory test, and the documented endpoint and registration commands could not be independently verified against the repository."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 2,
+          "specificity": 14,
+          "risk_awareness": 4,
+          "total": 34,
+          "notes": "The patch removes the principal FAISS service, wrapper, tests, dependency declaration, configuration properties, and related documentation references, broadly following the proposed file list. It is not mergeable as shown: after removing the `else:` in registry/main.py, the retained agent-state comment and statements remain over-indented, producing an `IndentationError`. The factory intentionally rejects the file backend while docs/configuration.md still presents that backend as supported, and no regression test is added for this new startup failure. The summary materially misreports deletion counts, claims zero breaking changes despite requiring migration, and reports verification results as facts even though verification was not executed; patch applicability and remaining repository-wide references could not be independently checked because repository commands failed in the sandbox."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 52,
+      "input_tokens": 4304594,
+      "output_tokens": 34200,
+      "total_tokens": 4338794,
+      "latency_seconds": 687.6,
+      "total_cost_usd": 22.377970000000005,
+      "result_subtype": "success",
+      "task_score": 50.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8071,
+      "generation_tokens_per_sec": 49.7,
+      "kv_cache_usage": {
+        "peak": 0.1475,
+        "mean": 0.0919
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 73,
+          "notes": "The issue clearly scopes agent-card fetching, agent health checks, and server health checks, with testable blocking and allowlist requirements. Its references to `_is_safe_url`, `skill_service.py`, and `settings.github_extra_hosts` agree with the submitted source context. The largest gap is the undefined compatibility policy: blocking health checks for existing private registrations conflicts with saying they continue to work unless migration or grandfathering behavior is specified. No independent task statement was supplied, so issue references and the exact compatibility obligation remain unverifiable, while redirect and DNS-rebinding risks are omitted."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 13,
+          "total": 60,
+          "notes": "The design names concrete integration points including `check_agent_health`, `_check_server_endpoint_transport_aware`, `_validate_agent_url`, and the existing skill validation helpers. Its central security flaw is a validation-to-request race: `_is_safe_url` resolves an address, but the subsequent `httpx` request still uses the hostname and can resolve again. Redirect handling, synchronous DNS inside asynchronous paths, and the promised compatibility behavior are not resolved. Claims that deployment files already expose the setting and that validation costs only 1-5 ms are unsupported by supplied evidence."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 13,
+          "specificity": 17,
+          "risk_awareness": 19,
+          "total": 65,
+          "notes": "The security review correctly identifies DNS rebinding as a concrete flaw in the LLD's check-then-fetch design. Its proposed resolution is incomplete and internally inconsistent: callers are told to reuse resolved IPs without explaining HTTP host and TLS handling, while DNS caching is proposed both without a real TTL and despite its security implications. Path traversal and CSP are largely unrelated to this SSRF boundary, while redirects and the unresolved existing-registration policy receive insufficient attention. The role-based reviews provide actionable observations, but several approvals and performance recommendations are unsupported by measurements or repository evidence."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 6,
+          "specificity": 14,
+          "risk_awareness": 11,
+          "total": 44,
+          "notes": "The plan covers private, loopback, link-local, metadata, allowlist, health-check, and compatibility scenarios with many explicit inputs. Its E2E setup is not executable as described: it starts a loopback server that should be blocked, creates the card at the wrong location, and then tests `example.com` instead of that server. `docker exec -e` does not reconfigure the running registry, and an expected result of \"400 (or 200 with unhealthy status)\" is not a meaningful oracle. DNS rebinding remains a placeholder, redirect and mixed-address DNS cases are absent, and several authentication, endpoint, Terraform, Helm, and container commands are not established by the supplied source."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 1,
+          "specificity": 5,
+          "risk_awareness": 2,
+          "total": 12,
+          "notes": "The patch targets the intended existing functions but does not implement the design end to end. It imports `registry.utils.url_validation` from four files without including the claimed new module, and it includes none of the claimed unit or integration tests. `_validate_agent_url` changes from `bool` to a tuple without any caller updates, while validation there does not demonstrate protection before the agent-card fetch. DNS pinning is also false because health requests continue using `base_url` or `proxy_pass_url` and never consume resolved IPs; the summary's test, benchmark, compatibility, and deployment-ready claims therefore substantially overstate the patch."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 81,
+      "input_tokens": 9791776,
+      "output_tokens": 41734,
+      "total_tokens": 9833510,
+      "latency_seconds": 980.8,
+      "total_cost_usd": 50.00222999999998,
+      "result_subtype": "success",
+      "task_score": 46.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8422,
+      "generation_tokens_per_sec": 42.6,
+      "kv_cache_usage": {
+        "peak": 0.1306,
+        "mean": 0.0938
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 16,
+          "risk_awareness": 11,
+          "total": 55,
+          "notes": "The issue clearly identifies the exposure paths, affected secret classes, IAM work, and explicit exclusions. Its largest flaw is the unsupported fallback requirement: ECS resolves task-definition secrets before container startup, so an unavailable secret prevents the application from performing an environment fallback. The proposed aws_secretsmanager_secret_version resources also retain supplied plaintext in Terraform state, contradicting a primary motivation. No independent task statement establishes the exact required inventory or migration behavior."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 6,
+          "specificity": 16,
+          "risk_awareness": 14,
+          "total": 50,
+          "notes": "The LLD names concrete Terraform files, variables, resources, IAM integration, and rollout phases. Its core design is unsound because ECS injection cannot provide the described runtime fallback, rotation is not observed until tasks restart, and secret_string values remain in Terraform state. The proposed SecretRetrievalFailure AWS/ECS metric is not a native ECS metric, while recovery_window_in_days = 0 permits immediate deletion rather than protecting recovery. Repository execution failed before inspection, so claimed source line numbers and existing-pattern assertions could not be independently verified."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 14,
+          "total": 51,
+          "notes": "The review surfaces actionable concerns around extra-variable classification, IAM policy size, state migration, monitoring, and fallback testing. It misses the fundamental impossibility of application fallback after ECS secret retrieval failure and does not challenge continued plaintext storage in Terraform state. It incorrectly says a zero-day recovery window prevents accidental deletion and treats rotation as a blocker despite the issue explicitly excluding automatic rotation. Several findings also describe monitoring or keyword classification as current after the LLD claims those sections were revised."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 4,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 45,
+          "notes": "The plan spans provisioning, compatibility, IAM, audit, rollback, rotation, and performance with concrete intended outcomes. Many procedures cannot establish those outcomes: describe-tasks does not expose task-definition secrets, updating only a secret description does not make it missing, and Secrets Manager rejects an empty SecretString. terraform output -raw cannot read the migrated_secrets map, the IAM test uses the operator identity rather than the ECS execution role, and the rotation check reuses a stale task ARN. Hardcoded service names, log groups, module targets, ECS Exec availability, and the temporary checkout path were not verified against the repository."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 3,
+          "specificity": 12,
+          "risk_awareness": 7,
+          "total": 30,
+          "notes": "The unified diff concretely adds secret resources, task-definition references, IAM ARNs, and explicit sensitive-extra inputs, while the summary acknowledges partial scope. It does not implement the design end to end: only REGISTRY_API_TOKEN and REGISTRY_API_KEYS are removed from plaintext blocks, while added federation, ANS, GitHub, registration, Grafana, and mcpgw resources are not consistently removed from or injected into their consumers, and no fallback exists. The sensitive extra-env variables feed for_each keys and unsafely keyed cross-service maps, and outputs derived from sensitive variables omit sensitive = true, making the claim that terraform validate passes implausible. Repository inspection and git apply --check were unavailable because the read-only executor failed before running commands, so patch applicability and surrounding symbols could not be independently confirmed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 43,
+      "input_tokens": 3046068,
+      "output_tokens": 22568,
+      "total_tokens": 3068636,
+      "latency_seconds": 400.8,
+      "total_cost_usd": 15.794539999999996,
+      "result_subtype": "success",
+      "task_score": 35.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8448,
+      "generation_tokens_per_sec": 56.3,
+      "kv_cache_usage": {
+        "peak": 0.0762,
+        "mean": 0.0581
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 49,
+          "notes": "The issue's strongest aspect is its explicit opt-in scope, non-goals, and acceptance checks covering the cluster, proxy, task role, documentation, and password compatibility. Its largest deficiency is promising automatic IAM token rotation and password fallback without specifying a Keycloak-compatible token generation and refresh mechanism; `KC_DB_IAM_AUTH_ENABLED` is not a standard Keycloak database option, and a proxy configured with `iam_auth = \"REQUIRED\"` will reject password authentication. The submitted source context shows `aws_db_proxy.keycloak` using `SECRETS` and the task consuming `KC_DB_PASSWORD`, so replacing client authentication requires more than infrastructure toggles. No independent task statement or issue history verifies references #1303 and #1026, and `GenerateDBAuthToken` is not an IAM action; authorization uses `rds-db:connect` while token creation is local SigV4 signing."
+        },
+        "lld": {
+          "completeness": 8,
+          "correctness": 4,
+          "specificity": 10,
+          "risk_awareness": 9,
+          "total": 31,
+          "notes": "The LLD is strongest where it identifies concrete Terraform files, existing resources, an opt-in default, and a staged rollout. Its load-bearing design is infeasible: it assumes Keycloak and its MySQL driver will interpret `KC_DB_IAM_AUTH_ENABLED`, generate and renew tokens, emit custom authentication logs and metrics, and fall back automatically, but it adds no driver, token provider, wrapper, or startup logic implementing any of those behaviors. The proposed proxy configuration sets IAM to `REQUIRED` when enabled while retaining `KC_DB_PASSWORD`, which creates mutually exclusive modes rather than the documented runtime fallback. Exact engine-version and existing-pattern claims could not be independently verified, while the unresolved token lifecycle, TLS configuration, database-user requirements, and wildcard `dbuser:*/...` scope leave major security and operational decisions open."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 6,
+          "specificity": 12,
+          "risk_awareness": 12,
+          "total": 40,
+          "notes": "The review's strongest contribution is identifying the precise questions the LLD needed to answer, including driver requirements, token renewal, fallback behavior, TLS, pooling, rollback, and failover. Its largest failure is declaring zero blockers and later claiming all findings were resolved even though the LLD still contains no mechanism that generates an IAM token or refreshes credentials for new pooled connections. The resolution that the MySQL driver handles expiration automatically is unsupported, and the recommendation to audit `GenerateDBAuthToken` through CloudTrail is technically inaccurate because token generation is local signing rather than an AWS API call. Several real risks are named, but they are treated as documentation improvements instead of correctness blockers, and claimed TLS, audit, rollback, and fallback resolutions are not present as implementable changes."
+        },
+        "testing": {
+          "completeness": 9,
+          "correctness": 4,
+          "specificity": 12,
+          "risk_awareness": 10,
+          "total": 35,
+          "notes": "The plan's strongest aspect is its broad coverage of Terraform validation, disabled-mode compatibility, deployment inspection, rollback, and attempted end-to-end checks with stated outcomes. Its largest deficiency is that most checks inspect text or hypothetical output rather than proving that Keycloak can generate a fresh IAM token, connect through the proxy, and create another physical connection after token expiry. Concrete defects include a hard-coded temporary repository path, a targeted plan that expects an untargeted IAM policy, nonexistent implementation log messages, and use of `aws logs get-log-events --log-stream-name-prefix`, which is not a valid invocation for that command. The fallback test would revoke the only IAM authorization while the proxy remains `REQUIRED`, so its expected uninterrupted password fallback is false; AWS deployment results and performance thresholds were also not executed or otherwise substantiated."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 2,
+          "specificity": 11,
+          "risk_awareness": 3,
+          "total": 20,
+          "notes": "The patch is focused and does add a false-by-default Terraform variable, cluster and proxy IAM settings, and an `rds-db:connect` task-role policy. It does not implement the essential client behavior: `KC_DB_IAM_AUTH_ENABLED` is not consumed by standard Keycloak, no IAM token is placed in the JDBC password path, and no refresh provider exists, so enabling `iam_auth = \"REQUIRED\"` leaves Keycloak sending its static `KC_DB_PASSWORD` to a proxy that requires IAM authentication. The always-created policy uses `dbuser:*/${var.keycloak_database_username}`, while the summary inaccurately calls this least privilege and claims working fallback, automatic rotation, TLS enforcement, CloudTrail token-generation events, and complete implementation. The hunks are internally plausible against the submitted resource context, but command-level applicability to the stated baseline could not be independently verified because repository shell access failed in the provided environment."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-05"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 73,
+      "notes": "The issue clearly scopes agent-card fetching, agent health checks, and server health checks, with testable blocking and allowlist requirements. Its references to `_is_safe_url`, `skill_service.py`, and `settings.github_extra_hosts` agree with the submitted source context. The largest gap is the undefined compatibility policy: blocking health checks for existing private registrations conflicts with saying they continue to work unless migration or grandfathering behavior is specified. No independent task statement was supplied, so issue references and the exact compatibility obligation remain unverifiable, while redirect and DNS-rebinding risks are omitted."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 11,
+      "specificity": 19,
+      "risk_awareness": 13,
+      "total": 60,
+      "notes": "The design names concrete integration points including `check_agent_health`, `_check_server_endpoint_transport_aware`, `_validate_agent_url`, and the existing skill validation helpers. Its central security flaw is a validation-to-request race: `_is_safe_url` resolves an address, but the subsequent `httpx` request still uses the hostname and can resolve again. Redirect handling, synchronous DNS inside asynchronous paths, and the promised compatibility behavior are not resolved. Claims that deployment files already expose the setting and that validation costs only 1-5 ms are unsupported by supplied evidence."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 13,
+      "specificity": 17,
+      "risk_awareness": 19,
+      "total": 65,
+      "notes": "The security review correctly identifies DNS rebinding as a concrete flaw in the LLD's check-then-fetch design. Its proposed resolution is incomplete and internally inconsistent: callers are told to reuse resolved IPs without explaining HTTP host and TLS handling, while DNS caching is proposed both without a real TTL and despite its security implications. Path traversal and CSP are largely unrelated to this SSRF boundary, while redirects and the unresolved existing-registration policy receive insufficient attention. The role-based reviews provide actionable observations, but several approvals and performance recommendations are unsupported by measurements or repository evidence."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 6,
+      "specificity": 14,
+      "risk_awareness": 11,
+      "total": 44,
+      "notes": "The plan covers private, loopback, link-local, metadata, allowlist, health-check, and compatibility scenarios with many explicit inputs. Its E2E setup is not executable as described: it starts a loopback server that should be blocked, creates the card at the wrong location, and then tests `example.com` instead of that server. `docker exec -e` does not reconfigure the running registry, and an expected result of \"400 (or 200 with unhealthy status)\" is not a meaningful oracle. DNS rebinding remains a placeholder, redirect and mixed-address DNS cases are absent, and several authentication, endpoint, Terraform, Helm, and container commands are not established by the supplied source."
+    },
+    "implementation": {
+      "completeness": 4,
+      "correctness": 1,
+      "specificity": 5,
+      "risk_awareness": 2,
+      "total": 12,
+      "notes": "The patch targets the intended existing functions but does not implement the design end to end. It imports `registry.utils.url_validation` from four files without including the claimed new module, and it includes none of the claimed unit or integration tests. `_validate_agent_url` changes from `bool` to a tuple without any caller updates, while validation there does not demonstrate protection before the agent-card fetch. DNS pinning is also false because health requests continue using `base_url` or `proxy_pass_url` and never consume resolved IPs; the summary's test, benchmark, compatibility, and deployment-ready claims therefore substantially overstate the patch."
+    }
+  },
+  "task_score": 50.8,
+  "verdict": "The design artifacts identify the right SSRF surfaces, but unresolved request-time DNS behavior and a fundamentally incomplete, internally incompatible patch prevent this submission from being deployable.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T14:13:27.998499Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 249867,
+      "cached_input_tokens": 215048,
+      "cache_write_input_tokens": 34803,
+      "output_tokens": 6098,
+      "reasoning_output_tokens": 4390
+    },
+    "duration_ms": 137057
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,289 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 49.7,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4304594,
+    "output_tokens": 34200,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4338794,
+    "total_cost_usd": 22.377970000000005,
+    "latency_seconds": 687.6,
+    "num_turns": 52,
+    "generation_tokens_per_sec": 49.7,
+    "prefix_cache_hit_rate": 0.8071,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4304594,
+  "output_tokens": 34200,
+  "latency_seconds": 687.6,
+  "num_turns": 52,
+  "total_cost_usd": 22.377970000000005,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T13:28:43.106142Z",
+  "run_ended_at": "2026-08-05T13:40:11.340970Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4304594,
+    "output_tokens": 34200,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4338794,
+    "total_cost_usd": 22.377970000000005,
+    "latency_seconds": 687.6,
+    "num_turns": 52,
+    "generation_tokens_per_sec": 49.7,
+    "prefix_cache_hit_rate": 0.8071,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8071,
+      "prompt_tokens_cached_rate": 0.8071
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 34200,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 3474256,
+      "vllm:prefix_cache_queries_total": 4304594,
+      "vllm:prompt_tokens_by_source_total": 4304594,
+      "vllm:prompt_tokens_cached_total": 3474256,
+      "vllm:prompt_tokens_total": 4304594,
+      "vllm:request_success_total": 52,
+      "vllm:tool_call_parser_invocations_total": 34200
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 52,
+        "sum": 685.4175,
+        "mean": 13.181106
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 34148,
+        "sum": 523.6225,
+        "mean": 0.015334
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 34200,
+        "sum": 864538,
+        "mean": 25.278889
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 52,
+        "sum": 523.6225,
+        "mean": 10.069663
+      },
+      "vllm:request_generation_tokens": {
+        "count": 52,
+        "sum": 34200,
+        "mean": 657.692308
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 52,
+        "sum": 680.5575,
+        "mean": 13.087645
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 52,
+        "sum": 34200,
+        "mean": 657.692308
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 52,
+        "sum": 832000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 52,
+        "sum": 52,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 52,
+        "sum": 830338,
+        "mean": 15968.038462
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 52,
+        "sum": 156.9351,
+        "mean": 3.017982
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 52,
+        "sum": 4304594,
+        "mean": 82780.653846
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 52,
+        "sum": 0.0825,
+        "mean": 0.001586
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 52,
+        "sum": 0.7551,
+        "mean": 0.014521
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 52,
+        "sum": 161.8195,
+        "mean": 3.111914
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1475,
+          "mean": 0.0919,
+          "samples": 685
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9825,
+          "samples": 685
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 685
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 73,
+        "notes": "The issue clearly scopes agent-card fetching, agent health checks, and server health checks, with testable blocking and allowlist requirements. Its references to `_is_safe_url`, `skill_service.py`, and `settings.github_extra_hosts` agree with the submitted source context. The largest gap is the undefined compatibility policy: blocking health checks for existing private registrations conflicts with saying they continue to work unless migration or grandfathering behavior is specified. No independent task statement was supplied, so issue references and the exact compatibility obligation remain unverifiable, while redirect and DNS-rebinding risks are omitted."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 11,
+        "specificity": 19,
+        "risk_awareness": 13,
+        "total": 60,
+        "notes": "The design names concrete integration points including `check_agent_health`, `_check_server_endpoint_transport_aware`, `_validate_agent_url`, and the existing skill validation helpers. Its central security flaw is a validation-to-request race: `_is_safe_url` resolves an address, but the subsequent `httpx` request still uses the hostname and can resolve again. Redirect handling, synchronous DNS inside asynchronous paths, and the promised compatibility behavior are not resolved. Claims that deployment files already expose the setting and that validation costs only 1-5 ms are unsupported by supplied evidence."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 13,
+        "specificity": 17,
+        "risk_awareness": 19,
+        "total": 65,
+        "notes": "The security review correctly identifies DNS rebinding as a concrete flaw in the LLD's check-then-fetch design. Its proposed resolution is incomplete and internally inconsistent: callers are told to reuse resolved IPs without explaining HTTP host and TLS handling, while DNS caching is proposed both without a real TTL and despite its security implications. Path traversal and CSP are largely unrelated to this SSRF boundary, while redirects and the unresolved existing-registration policy receive insufficient attention. The role-based reviews provide actionable observations, but several approvals and performance recommendations are unsupported by measurements or repository evidence."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 6,
+        "specificity": 14,
+        "risk_awareness": 11,
+        "total": 44,
+        "notes": "The plan covers private, loopback, link-local, metadata, allowlist, health-check, and compatibility scenarios with many explicit inputs. Its E2E setup is not executable as described: it starts a loopback server that should be blocked, creates the card at the wrong location, and then tests `example.com` instead of that server. `docker exec -e` does not reconfigure the running registry, and an expected result of \"400 (or 200 with unhealthy status)\" is not a meaningful oracle. DNS rebinding remains a placeholder, redirect and mixed-address DNS cases are absent, and several authentication, endpoint, Terraform, Helm, and container commands are not established by the supplied source."
+      },
+      "implementation": {
+        "completeness": 4,
+        "correctness": 1,
+        "specificity": 5,
+        "risk_awareness": 2,
+        "total": 12,
+        "notes": "The patch targets the intended existing functions but does not implement the design end to end. It imports `registry.utils.url_validation` from four files without including the claimed new module, and it includes none of the claimed unit or integration tests. `_validate_agent_url` changes from `bool` to a tuple without any caller updates, while validation there does not demonstrate protection before the agent-card fetch. DNS pinning is also false because health requests continue using `base_url` or `proxy_pass_url` and never consume resolved IPs; the summary's test, benchmark, compatibility, and deployment-ready claims therefore substantially overstate the patch."
+      }
+    },
+    "task_score": 50.8,
+    "verdict": "The design artifacts identify the right SSRF surfaces, but unresolved request-time DNS behavior and a fundamentally incomplete, internally incompatible patch prevent this submission from being deployable.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T14:13:27.998499Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 249867,
+        "cached_input_tokens": 215048,
+        "cache_write_input_tokens": 34803,
+        "output_tokens": 6098,
+        "reasoning_output_tokens": 4390
+      },
+      "duration_ms": 137057
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 19,
+      "risk_awareness": 14,
+      "total": 61,
+      "notes": "The issue clearly enumerates affected services, eight registry secrets, three auth-server secrets, scope, exclusions, and acceptance criteria. Its file and variable assumptions are consistent with the submitted patch's Terraform modules and symbols. The largest defect is the proposed fallback: ECS resolves task-definition secrets before container startup and does not fall back to a same-named plaintext environment entry when retrieval fails; retaining those entries also preserves the state and task-definition exposure the issue claims to solve. With no independent task statement and unavailable repository reads, the #1134 linkage, MCPGW migration status, and claimed need for config-loader changes could not be verified."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 6,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 50,
+      "notes": "The LLD is concrete about `ecs-services.tf`, `iam.tf`, `secrets.tf`, the execution-role policy, secret ARNs, and rollout phases. Its central error-handling decision is invalid because ECS task startup fails when a referenced secret cannot be fetched, while the proposed object-or-null expressions can put null entries into the ECS `secrets` array. It also creates secret versions unconditionally from variables treated elsewhere as optional, continues placing plaintext values in Terraform state, and leaves rotation, monitoring, cleanup timing, and state remediation unresolved. Claims that all secrets already have rotation enabled and that critical monitoring or rollback details were added are contradicted by the supplied snippets and later implementation's rotation skips."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 8,
+      "specificity": 17,
+      "risk_awareness": 18,
+      "total": 59,
+      "notes": "The strongest part of the review is its identification of real risks around Terraform state, absent rotation, expiration, monitoring, restart coordination, rollback, and prolonged plaintext fallback. It nevertheless misses the design's decisive runtime flaw: ECS cannot use the plaintext entry as fallback after secret resolution fails, and it does not catch unconditional empty secret versions or nullable ECS list elements. The resolution section falsely says the LLD gained rotation resources, CloudWatch alarms, state cleanup, deployment ordering, and a detailed rollback even though those changes are absent from the submitted LLD. Several role-based approvals therefore endorse unsupported claims such as transparent fallback and completed least-privilege handling."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 4,
+      "specificity": 16,
+      "risk_awareness": 12,
+      "total": 49,
+      "notes": "The plan spans Terraform, IAM, task definitions, rotation, rollback, service behavior, and negative scenarios with concrete expected counts. Major tests are nonfunctional: Test 8 never removes IAM access and uses ECS service `ACTIVE` as its oracle, while denied secret access would prevent new tasks from starting rather than exercise fallback. Other concrete defects include nonexistent `get-secret-value` encryption fields, hard-coded IAM policy version `v1`, unsupported `aws ecs execute-command --c`, a rollback command that does not select the previous revision, and commands that print secret values. Secret ARN outputs, literal service names, CloudTrail log-group layout, and the three proposed health endpoints are not established by the diff and could not be verified against the repository."
+    },
+    "implementation": {
+      "completeness": 13,
+      "correctness": 3,
+      "specificity": 18,
+      "risk_awareness": 7,
+      "total": 41,
+      "notes": "The patch concretely adds eight secret resources, IAM ARNs, and task-definition references in the three Terraform files named by the design, but direct repository inspection and `git apply --check` were unavailable because every read-only shell command failed before execution with a bwrap loopback error. Each secret version is unconditional while task references are guarded by `var != \"\"`, so empty optional inputs can fail secret creation, and false conditions can serialize null entries into ECS secret lists. The claimed fallback is not implemented because ECS must resolve referenced secrets before startup, while preserving same-named plaintext environment entries continues exposing values in task definitions and Terraform state. The summary also overstates completion: the diff contains no documentation, alarms, rotation configuration, state cleanup, or tests, despite claiming exact LLD compliance, comprehensive monitoring, and no sensitive state data."
+    }
+  },
+  "task_score": 52.0,
+  "verdict": "The artifacts are concrete and broad but the implementation rests on a nonexistent ECS fallback mechanism and introduces optional-secret deployment failures while leaving plaintext exposure intact.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T12:48:21.103393Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 251982,
+      "cached_input_tokens": 212453,
+      "cache_write_input_tokens": 39515,
+      "output_tokens": 9742,
+      "reasoning_output_tokens": 8019
+    },
+    "duration_ms": 159307
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 70.2,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2480142,
+    "output_tokens": 39772,
+    "cache_read_tokens": 2434096,
+    "cache_write_tokens": 46046,
+    "total_tokens": 5000056,
+    "total_cost_usd": null,
+    "latency_seconds": 566.9,
+    "num_turns": 48,
+    "generation_tokens_per_sec": 70.2,
+    "prefix_cache_hit_rate": 0.9814,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2480142,
+  "output_tokens": 39772,
+  "latency_seconds": 566.9,
+  "num_turns": 48,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T12:30:05.141506Z",
+  "run_ended_at": "2026-08-05T12:39:42.618766Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2480142,
+    "output_tokens": 39772,
+    "cache_read_tokens": 2434096,
+    "cache_write_tokens": 46046,
+    "total_tokens": 5000056,
+    "total_cost_usd": null,
+    "latency_seconds": 566.9,
+    "num_turns": 48,
+    "generation_tokens_per_sec": 70.2,
+    "prefix_cache_hit_rate": 0.9814,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9814,
+      "prompt_tokens_cached_rate": 0.9814
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 39772,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 2434096,
+      "vllm:prefix_cache_queries_total": 2480142,
+      "vllm:prompt_tokens_by_source_total": 2480142,
+      "vllm:prompt_tokens_cached_total": 2434096,
+      "vllm:prompt_tokens_total": 2480142,
+      "vllm:request_success_total": 48,
+      "vllm:tool_call_parser_invocations_total": 39772
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 48,
+        "sum": 558.9517,
+        "mean": 11.644827
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 39724,
+        "sum": 548.3951,
+        "mean": 0.013805
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 39772,
+        "sum": 85818,
+        "mean": 2.157749
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 48,
+        "sum": 548.3951,
+        "mean": 11.424899
+      },
+      "vllm:request_generation_tokens": {
+        "count": 48,
+        "sum": 39772,
+        "mean": 828.583333
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 48,
+        "sum": 556.0971,
+        "mean": 11.585356
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 48,
+        "sum": 39772,
+        "mean": 828.583333
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 48,
+        "sum": 768000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 48,
+        "sum": 48,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 48,
+        "sum": 46046,
+        "mean": 959.291667
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 48,
+        "sum": 7.702,
+        "mean": 0.160457
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 48,
+        "sum": 2480142,
+        "mean": 51669.625
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 48,
+        "sum": 0.0743,
+        "mean": 0.001547
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 48,
+        "sum": 0.6521,
+        "mean": 0.013584
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 48,
+        "sum": 10.5728,
+        "mean": 0.220266
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0725,
+          "mean": 0.052,
+          "samples": 564
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9823,
+          "samples": 564
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 564
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 19,
+        "risk_awareness": 14,
+        "total": 61,
+        "notes": "The issue clearly enumerates affected services, eight registry secrets, three auth-server secrets, scope, exclusions, and acceptance criteria. Its file and variable assumptions are consistent with the submitted patch's Terraform modules and symbols. The largest defect is the proposed fallback: ECS resolves task-definition secrets before container startup and does not fall back to a same-named plaintext environment entry when retrieval fails; retaining those entries also preserves the state and task-definition exposure the issue claims to solve. With no independent task statement and unavailable repository reads, the #1134 linkage, MCPGW migration status, and claimed need for config-loader changes could not be verified."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 6,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 50,
+        "notes": "The LLD is concrete about `ecs-services.tf`, `iam.tf`, `secrets.tf`, the execution-role policy, secret ARNs, and rollout phases. Its central error-handling decision is invalid because ECS task startup fails when a referenced secret cannot be fetched, while the proposed object-or-null expressions can put null entries into the ECS `secrets` array. It also creates secret versions unconditionally from variables treated elsewhere as optional, continues placing plaintext values in Terraform state, and leaves rotation, monitoring, cleanup timing, and state remediation unresolved. Claims that all secrets already have rotation enabled and that critical monitoring or rollback details were added are contradicted by the supplied snippets and later implementation's rotation skips."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 8,
+        "specificity": 17,
+        "risk_awareness": 18,
+        "total": 59,
+        "notes": "The strongest part of the review is its identification of real risks around Terraform state, absent rotation, expiration, monitoring, restart coordination, rollback, and prolonged plaintext fallback. It nevertheless misses the design's decisive runtime flaw: ECS cannot use the plaintext entry as fallback after secret resolution fails, and it does not catch unconditional empty secret versions or nullable ECS list elements. The resolution section falsely says the LLD gained rotation resources, CloudWatch alarms, state cleanup, deployment ordering, and a detailed rollback even though those changes are absent from the submitted LLD. Several role-based approvals therefore endorse unsupported claims such as transparent fallback and completed least-privilege handling."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 4,
+        "specificity": 16,
+        "risk_awareness": 12,
+        "total": 49,
+        "notes": "The plan spans Terraform, IAM, task definitions, rotation, rollback, service behavior, and negative scenarios with concrete expected counts. Major tests are nonfunctional: Test 8 never removes IAM access and uses ECS service `ACTIVE` as its oracle, while denied secret access would prevent new tasks from starting rather than exercise fallback. Other concrete defects include nonexistent `get-secret-value` encryption fields, hard-coded IAM policy version `v1`, unsupported `aws ecs execute-command --c`, a rollback command that does not select the previous revision, and commands that print secret values. Secret ARN outputs, literal service names, CloudTrail log-group layout, and the three proposed health endpoints are not established by the diff and could not be verified against the repository."
+      },
+      "implementation": {
+        "completeness": 13,
+        "correctness": 3,
+        "specificity": 18,
+        "risk_awareness": 7,
+        "total": 41,
+        "notes": "The patch concretely adds eight secret resources, IAM ARNs, and task-definition references in the three Terraform files named by the design, but direct repository inspection and `git apply --check` were unavailable because every read-only shell command failed before execution with a bwrap loopback error. Each secret version is unconditional while task references are guarded by `var != \"\"`, so empty optional inputs can fail secret creation, and false conditions can serialize null entries into ECS secret lists. The claimed fallback is not implemented because ECS must resolve referenced secrets before startup, while preserving same-named plaintext environment entries continues exposing values in task definitions and Terraform state. The summary also overstates completion: the diff contains no documentation, alarms, rotation configuration, state cleanup, or tests, despite claiming exact LLD compliance, comprehensive monitoring, and no sensitive state data."
+      }
+    },
+    "task_score": 52.0,
+    "verdict": "The artifacts are concrete and broad but the implementation rests on a nonexistent ECS fallback mechanism and introduces optional-secret deployment failures while leaving plaintext exposure intact.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T12:48:21.103393Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 251982,
+        "cached_input_tokens": 212453,
+        "cache_write_input_tokens": 39515,
+        "output_tokens": 9742,
+        "reasoning_output_tokens": 8019
+      },
+      "duration_ms": 159307
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 19,
+      "risk_awareness": 10,
+      "total": 63,
+      "notes": "The issue identifies concrete files, variables, outputs, mounts, and acceptance checks that correspond to symbols shown in the submitted diff. Its strongest aspect is the explicit scope boundary around Terraform and data migration. Its largest deficiency is treating ephemeral logs, configuration, and MCPGW data as having no functional impact while providing no evidence that DocumentDB/S3 replaces every EFS use. No independent task statement or application evidence verifies the central persistence claim, and destructive upgrade behavior is underexplained."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 10,
+      "specificity": 18,
+      "risk_awareness": 9,
+      "total": 53,
+      "notes": "The LLD gives concrete file-level changes and names the actual `module.efs`, output, volume, and `SCOPES_CONFIG_PATH` integration points visible in the patch. Its largest flaw is leaving the key volume decision as remove-or-replace while later selecting an empty mount at `/app/auth_server`, which can obscure the bundled `scopes.yml` it expects there. The rollback guidance does not account for Terraform destroying the existing file system, and reverting state or code cannot recover deleted EFS data. Claims of no data loss and complete S3/DocumentDB coverage are not established by the supplied evidence."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 11,
+      "total": 48,
+      "notes": "The review usefully raises container-image, directory, state, documentation, and observability concerns rather than only approving the component list. However, it incorrectly says the LLD omitted the exact `SCOPES_CONFIG_PATH` change even though the LLD specifies it, and its recommendation to run `terraform state rm` would orphan live EFS resources instead of deleting them. It also misses the conflict between mounting an empty volume at `/app/auth_server` and expecting an image-bundled file at that path. Assertions that no other dependencies exist and the change is low risk are not demonstrated from repository evidence."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 6,
+      "specificity": 13,
+      "risk_awareness": 11,
+      "total": 47,
+      "notes": "The plan covers validation, upgrade deployment, service health, authentication, registration, restart persistence, cost, and rollback, with several concrete expected states. Its central `terraform plan | grep -i efs` oracle is wrong for an existing deployment because the successful removal plan should contain EFS resources marked for destruction, and it also demands all other resources remain unchanged despite expected task-definition updates. The baseline/post-change saved-plan performance sequence can mutate state and make the second plan stale, while rollback never reapplies the previous Terraform configuration. The endpoint paths and three workflow scripts are placeholders not shown to exist, so the most important functional tests are not executable as written."
+    },
+    "implementation": {
+      "completeness": 10,
+      "correctness": 2,
+      "specificity": 15,
+      "risk_awareness": 5,
+      "total": 32,
+      "notes": "The patch attempts all principal removals across the EFS module, variables, outputs, and ECS volumes, and the summary precisely enumerates those intended edits. The implementation is unusable as submitted: the root `outputs.tf` hunk has inconsistent unified-diff line counts, while the module output hunk leaves a dangling `sensitive = false` and closing brace after deleting `output \"efs_access_points\"`. Mounting an empty volume over `/app/auth_server` also conflicts with the summary's requirement that `scopes.yml` be bundled at that location, and the suggested `terraform state rm module.mcp_gateway.module.efs` would orphan AWS resources. The claimed validation command runs `terraform validate` against individual `.tf` paths rather than an initialized module directory, so the reported successful validation is not credible."
+    }
+  },
+  "task_score": 48.6,
+  "verdict": "The submission identifies the intended EFS surface well, but unsafe migration advice, non-executable tests, and a malformed, syntactically broken patch prevent it from being implementation-ready.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T13:55:20.867992Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 169407,
+      "cached_input_tokens": 139782,
+      "cache_write_input_tokens": 29611,
+      "output_tokens": 7653,
+      "reasoning_output_tokens": 5865
+    },
+    "duration_ms": 141900
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,291 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 2,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 68.3,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3310562,
+    "output_tokens": 16360,
+    "cache_read_tokens": 3258480,
+    "cache_write_tokens": 52082,
+    "total_tokens": 6637484,
+    "total_cost_usd": 0,
+    "latency_seconds": 239.4,
+    "num_turns": 62,
+    "generation_tokens_per_sec": 68.3,
+    "prefix_cache_hit_rate": 0.9843,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 3310562,
+  "output_tokens": 16360,
+  "latency_seconds": 239.4,
+  "num_turns": 62,
+  "total_cost_usd": 0,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T12:10:11.685734Z",
+  "run_ended_at": "2026-08-05T12:14:12.383140Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3310562,
+    "output_tokens": 16360,
+    "cache_read_tokens": 3258480,
+    "cache_write_tokens": 52082,
+    "total_tokens": 6637484,
+    "total_cost_usd": 0,
+    "latency_seconds": 239.4,
+    "num_turns": 62,
+    "generation_tokens_per_sec": 68.3,
+    "prefix_cache_hit_rate": 0.9843,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9843,
+      "prompt_tokens_cached_rate": 0.9843
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 16360,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 3258480,
+      "vllm:prefix_cache_queries_total": 3310562,
+      "vllm:prompt_tokens_by_source_total": 3310562,
+      "vllm:prompt_tokens_cached_total": 3258480,
+      "vllm:prompt_tokens_total": 3310562,
+      "vllm:request_success_total": 62,
+      "vllm:tool_call_parser_invocations_total": 16360
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 62,
+        "sum": 237.3157,
+        "mean": 3.827672
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 16298,
+        "sum": 225.0045,
+        "mean": 0.013806
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 16360,
+        "sum": 68442,
+        "mean": 4.183496
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 62,
+        "sum": 225.0045,
+        "mean": 3.629105
+      },
+      "vllm:request_generation_tokens": {
+        "count": 62,
+        "sum": 16360,
+        "mean": 263.870968
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 62,
+        "sum": 233.7954,
+        "mean": 3.770893
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 62,
+        "sum": 16360,
+        "mean": 263.870968
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 62,
+        "sum": 992000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 62,
+        "sum": 62,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 62,
+        "sum": 52082,
+        "mean": 840.032258
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 62,
+        "sum": 8.7909,
+        "mean": 0.141788
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 62,
+        "sum": 3310562,
+        "mean": 53396.16129
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 62,
+        "sum": 0.0912,
+        "mean": 0.001471
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 62,
+        "sum": 0.8459,
+        "mean": 0.013643
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 62,
+        "sum": 12.3335,
+        "mean": 0.198927
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0626,
+          "mean": 0.0504,
+          "samples": 239
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9707,
+          "samples": 239
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 239
+        }
+      }
+    }
+  },
+  "cache_read_tokens": 3258480,
+  "cache_creation_tokens": 52082,
+  "agent_invocations": 2,
+  "topped_up_artifacts": [],
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 19,
+        "risk_awareness": 10,
+        "total": 63,
+        "notes": "The issue identifies concrete files, variables, outputs, mounts, and acceptance checks that correspond to symbols shown in the submitted diff. Its strongest aspect is the explicit scope boundary around Terraform and data migration. Its largest deficiency is treating ephemeral logs, configuration, and MCPGW data as having no functional impact while providing no evidence that DocumentDB/S3 replaces every EFS use. No independent task statement or application evidence verifies the central persistence claim, and destructive upgrade behavior is underexplained."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 10,
+        "specificity": 18,
+        "risk_awareness": 9,
+        "total": 53,
+        "notes": "The LLD gives concrete file-level changes and names the actual `module.efs`, output, volume, and `SCOPES_CONFIG_PATH` integration points visible in the patch. Its largest flaw is leaving the key volume decision as remove-or-replace while later selecting an empty mount at `/app/auth_server`, which can obscure the bundled `scopes.yml` it expects there. The rollback guidance does not account for Terraform destroying the existing file system, and reverting state or code cannot recover deleted EFS data. Claims of no data loss and complete S3/DocumentDB coverage are not established by the supplied evidence."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 11,
+        "total": 48,
+        "notes": "The review usefully raises container-image, directory, state, documentation, and observability concerns rather than only approving the component list. However, it incorrectly says the LLD omitted the exact `SCOPES_CONFIG_PATH` change even though the LLD specifies it, and its recommendation to run `terraform state rm` would orphan live EFS resources instead of deleting them. It also misses the conflict between mounting an empty volume at `/app/auth_server` and expecting an image-bundled file at that path. Assertions that no other dependencies exist and the change is low risk are not demonstrated from repository evidence."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 6,
+        "specificity": 13,
+        "risk_awareness": 11,
+        "total": 47,
+        "notes": "The plan covers validation, upgrade deployment, service health, authentication, registration, restart persistence, cost, and rollback, with several concrete expected states. Its central `terraform plan | grep -i efs` oracle is wrong for an existing deployment because the successful removal plan should contain EFS resources marked for destruction, and it also demands all other resources remain unchanged despite expected task-definition updates. The baseline/post-change saved-plan performance sequence can mutate state and make the second plan stale, while rollback never reapplies the previous Terraform configuration. The endpoint paths and three workflow scripts are placeholders not shown to exist, so the most important functional tests are not executable as written."
+      },
+      "implementation": {
+        "completeness": 10,
+        "correctness": 2,
+        "specificity": 15,
+        "risk_awareness": 5,
+        "total": 32,
+        "notes": "The patch attempts all principal removals across the EFS module, variables, outputs, and ECS volumes, and the summary precisely enumerates those intended edits. The implementation is unusable as submitted: the root `outputs.tf` hunk has inconsistent unified-diff line counts, while the module output hunk leaves a dangling `sensitive = false` and closing brace after deleting `output \"efs_access_points\"`. Mounting an empty volume over `/app/auth_server` also conflicts with the summary's requirement that `scopes.yml` be bundled at that location, and the suggested `terraform state rm module.mcp_gateway.module.efs` would orphan AWS resources. The claimed validation command runs `terraform validate` against individual `.tf` paths rather than an initialized module directory, so the reported successful validation is not credible."
+      }
+    },
+    "task_score": 48.6,
+    "verdict": "The submission identifies the intended EFS surface well, but unsafe migration advice, non-executable tests, and a malformed, syntactically broken patch prevent it from being implementation-ready.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T13:55:20.867992Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 169407,
+        "cached_input_tokens": 139782,
+        "cache_write_input_tokens": 29611,
+        "output_tokens": 7653,
+        "reasoning_output_tokens": 5865
+      },
+      "duration_ms": 141900
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 11,
+      "specificity": 16,
+      "risk_awareness": 8,
+      "total": 50,
+      "notes": "The issue clearly identifies dependency, configuration, test, documentation, and Docker surfaces, with several directly testable removal criteria. Its central deficiency is promising unchanged behavior while requiring DocumentDB for file-backed deployments without defining migration or unavailable-database behavior. The factory preimage selects DocumentDB only for MONGODB_BACKENDS and FaissSearchRepository otherwise, so the proposal materially changes an existing deployment mode. No independent task statement establishes the replacement architecture, and claims of mature feature parity and issue #1285 could not be verified."
+    },
+    "lld": {
+      "completeness": 12,
+      "correctness": 6,
+      "specificity": 14,
+      "risk_awareness": 9,
+      "total": 41,
+      "notes": "The LLD names relevant files and accurately identifies the FAISS dependency, configuration properties, service, repository, and factory integration points shown by the baseline context. Its proposed FileSearchRepository imports `.documentdb.search_repository` from inside `registry.repositories.file`, which resolves to a nonexistent child package rather than the sibling `..documentdb` package. The factory simultaneously bypasses that wrapper entirely, while migration, file-only operation, and failure behavior remain unresolved despite the backward-compatibility claim. Assertions about comprehensive fallbacks, unchanged observability, and superior scaling are not tied to verified APIs or rollout checks."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 14,
+      "specificity": 16,
+      "risk_awareness": 18,
+      "total": 64,
+      "notes": "The review's strongest contribution is identifying the two load-bearing risks: file deployments without DocumentDB and loss of existing FAISS-backed search state. Those concerns are supported by the existing backend-conditional factory and the proposed deletion of persisted-index handling. Its resolutions remain indecisive, and the proposed migration script and `registry.cli migrate-search` command have no repository evidence and conflict with removing the FAISS dependency needed to read old indexes. It also misses the incorrect relative import, dead file repository design, and unchanged production FAISS callers, making the 4.2/5 verdict too favorable."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 6,
+      "specificity": 10,
+      "risk_awareness": 14,
+      "total": 45,
+      "notes": "The plan broadly covers search, indexing lifecycle, database failure, Docker, compatibility, performance, rollback, and observability. Its unit-test example patches `registry.repositories.file.search_repository.DocumentDBSearchRepository`, but the proposed implementation only imports that symbol locally inside `__init__`, so the patch target does not exist. The E2E commands use `/api/v1/servers` while the repository test preimage explicitly documents registration at `/api/servers/register`; the CLI command and several named test files are likewise unverified. Many assertions lack fixed fixtures or objective result oracles, although the unavailable-database and update/delete scenarios target relevant risks."
+    },
+    "implementation": {
+      "completeness": 6,
+      "correctness": 3,
+      "specificity": 11,
+      "risk_awareness": 7,
+      "total": 27,
+      "notes": "The patch removes the declared dependency, configuration properties, FAISS service, and conditional factory branch, addressing the mechanical portion of removal. It deletes `registry/search/service.py` without modifying production server routes, while the existing test preimage explicitly patches the lazily imported `registry.search.service.faiss_service` for registration and toggle workflows, demonstrating an unhandled caller. The new file repository also has the invalid `.documentdb` import, is bypassed by the factory, leaves `rebuild_index` as a no-op, and is tested through a nonexistent module-level patch target. The summary admits incomplete tests, documentation, migration, and fallback work yet still claims complete preservation and graceful degradation; independent `git apply --check` execution was unavailable."
+    }
+  },
+  "task_score": 45.4,
+  "verdict": "The submission recognizes the main migration risks, but its implementation is incomplete and contains fatal integration and import errors that prevent a credible FAISS removal.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T12:50:46.277509Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 296835,
+      "cached_input_tokens": 253019,
+      "cache_write_input_tokens": 43802,
+      "output_tokens": 7551,
+      "reasoning_output_tokens": 6268
+    },
+    "duration_ms": 145154
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 64.8,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 6413120,
+    "output_tokens": 26961,
+    "cache_read_tokens": 6335664,
+    "cache_write_tokens": 77456,
+    "total_tokens": 12853201,
+    "total_cost_usd": null,
+    "latency_seconds": 415.8,
+    "num_turns": 92,
+    "generation_tokens_per_sec": 64.8,
+    "prefix_cache_hit_rate": 0.9879,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 6413120,
+  "output_tokens": 26961,
+  "latency_seconds": 415.8,
+  "num_turns": 92,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T11:58:36.080016Z",
+  "run_ended_at": "2026-08-05T12:05:35.044951Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 6413120,
+    "output_tokens": 26961,
+    "cache_read_tokens": 6335664,
+    "cache_write_tokens": 77456,
+    "total_tokens": 12853201,
+    "total_cost_usd": null,
+    "latency_seconds": 415.8,
+    "num_turns": 92,
+    "generation_tokens_per_sec": 64.8,
+    "prefix_cache_hit_rate": 0.9879,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9879,
+      "prompt_tokens_cached_rate": 0.9879
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 26961,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 6335664,
+      "vllm:prefix_cache_queries_total": 6413120,
+      "vllm:prompt_tokens_by_source_total": 6413120,
+      "vllm:prompt_tokens_cached_total": 6335664,
+      "vllm:prompt_tokens_total": 6413120,
+      "vllm:request_success_total": 92,
+      "vllm:tool_call_parser_invocations_total": 26961
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 92,
+        "sum": 410.8216,
+        "mean": 4.465452
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 26869,
+        "sum": 387.2934,
+        "mean": 0.014414
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 26961,
+        "sum": 104417,
+        "mean": 3.87289
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 92,
+        "sum": 387.2934,
+        "mean": 4.20971
+      },
+      "vllm:request_generation_tokens": {
+        "count": 92,
+        "sum": 26961,
+        "mean": 293.054348
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 92,
+        "sum": 402.6199,
+        "mean": 4.376303
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 92,
+        "sum": 26961,
+        "mean": 293.054348
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 92,
+        "sum": 1472000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 92,
+        "sum": 92,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 92,
+        "sum": 77456,
+        "mean": 841.913043
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 92,
+        "sum": 15.3265,
+        "mean": 0.166593
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 92,
+        "sum": 6413120,
+        "mean": 69707.826087
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 92,
+        "sum": 0.1367,
+        "mean": 0.001486
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 92,
+        "sum": 1.2981,
+        "mean": 0.01411
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 92,
+        "sum": 23.5688,
+        "mean": 0.256182
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0888,
+          "mean": 0.0679,
+          "samples": 414
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9589,
+          "samples": 414
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 414
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 11,
+        "specificity": 16,
+        "risk_awareness": 8,
+        "total": 50,
+        "notes": "The issue clearly identifies dependency, configuration, test, documentation, and Docker surfaces, with several directly testable removal criteria. Its central deficiency is promising unchanged behavior while requiring DocumentDB for file-backed deployments without defining migration or unavailable-database behavior. The factory preimage selects DocumentDB only for MONGODB_BACKENDS and FaissSearchRepository otherwise, so the proposal materially changes an existing deployment mode. No independent task statement establishes the replacement architecture, and claims of mature feature parity and issue #1285 could not be verified."
+      },
+      "lld": {
+        "completeness": 12,
+        "correctness": 6,
+        "specificity": 14,
+        "risk_awareness": 9,
+        "total": 41,
+        "notes": "The LLD names relevant files and accurately identifies the FAISS dependency, configuration properties, service, repository, and factory integration points shown by the baseline context. Its proposed FileSearchRepository imports `.documentdb.search_repository` from inside `registry.repositories.file`, which resolves to a nonexistent child package rather than the sibling `..documentdb` package. The factory simultaneously bypasses that wrapper entirely, while migration, file-only operation, and failure behavior remain unresolved despite the backward-compatibility claim. Assertions about comprehensive fallbacks, unchanged observability, and superior scaling are not tied to verified APIs or rollout checks."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 14,
+        "specificity": 16,
+        "risk_awareness": 18,
+        "total": 64,
+        "notes": "The review's strongest contribution is identifying the two load-bearing risks: file deployments without DocumentDB and loss of existing FAISS-backed search state. Those concerns are supported by the existing backend-conditional factory and the proposed deletion of persisted-index handling. Its resolutions remain indecisive, and the proposed migration script and `registry.cli migrate-search` command have no repository evidence and conflict with removing the FAISS dependency needed to read old indexes. It also misses the incorrect relative import, dead file repository design, and unchanged production FAISS callers, making the 4.2/5 verdict too favorable."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 6,
+        "specificity": 10,
+        "risk_awareness": 14,
+        "total": 45,
+        "notes": "The plan broadly covers search, indexing lifecycle, database failure, Docker, compatibility, performance, rollback, and observability. Its unit-test example patches `registry.repositories.file.search_repository.DocumentDBSearchRepository`, but the proposed implementation only imports that symbol locally inside `__init__`, so the patch target does not exist. The E2E commands use `/api/v1/servers` while the repository test preimage explicitly documents registration at `/api/servers/register`; the CLI command and several named test files are likewise unverified. Many assertions lack fixed fixtures or objective result oracles, although the unavailable-database and update/delete scenarios target relevant risks."
+      },
+      "implementation": {
+        "completeness": 6,
+        "correctness": 3,
+        "specificity": 11,
+        "risk_awareness": 7,
+        "total": 27,
+        "notes": "The patch removes the declared dependency, configuration properties, FAISS service, and conditional factory branch, addressing the mechanical portion of removal. It deletes `registry/search/service.py` without modifying production server routes, while the existing test preimage explicitly patches the lazily imported `registry.search.service.faiss_service` for registration and toggle workflows, demonstrating an unhandled caller. The new file repository also has the invalid `.documentdb` import, is bypassed by the factory, leaves `rebuild_index` as a no-op, and is tested through a nonexistent module-level patch target. The summary admits incomplete tests, documentation, migration, and fallback work yet still claims complete preservation and graceful degradation; independent `git apply --check` execution was unavailable."
+      }
+    },
+    "task_score": 45.4,
+    "verdict": "The submission recognizes the main migration risks, but its implementation is incomplete and contains fatal integration and import errors that prevent a credible FAISS removal.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T12:50:46.277509Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 296835,
+        "cached_input_tokens": 253019,
+        "cache_write_input_tokens": 43802,
+        "output_tokens": 7551,
+        "reasoning_output_tokens": 6268
+      },
+      "duration_ms": 145154
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 15,
+      "risk_awareness": 11,
+      "total": 51,
+      "notes": "The issue clearly scopes the change to AWS ECS and Aurora, excludes Helm/EKS and version upgrades, and supplies concrete acceptance criteria. Its largest defect is the contradiction between removing static credentials entirely and retaining password authentication as a default-enabled fallback. It also assumes Keycloak can generate and consume IAM tokens without specifying a datasource extension, IAM-enabled MySQL user, TLS settings, or token renewal behavior. No independent task statement exists, and repository execution failed before source reads, so claims about the current rotation Lambda and deployment topology could not be independently verified."
+    },
+    "lld": {
+      "completeness": 9,
+      "correctness": 4,
+      "specificity": 8,
+      "risk_awareness": 11,
+      "total": 32,
+      "notes": "The LLD names plausible Terraform files, gives a correctly shaped rds-db:connect ARN, and discusses rollout, rollback, pooling, and fallback risks. The load-bearing Keycloak integration remains a placeholder, while KC_DB_IAM_AUTH_ENABLED and KC_DB_IAM_AUTH_FALLBACK_ENABLED are not standard Keycloak settings and therefore do nothing by themselves. Aurora IAM authentication is enabled through the cluster's iam_database_authentication_enabled property, not an aurora_enable_iam_auth parameter, and aws_rds_cluster_iam_auth is not a Terraform AWS resource. The design also omits executable MySQL user provisioning, TLS configuration, token generation integration, and metric emitters; repository-specific compatibility could not be independently checked because source commands failed."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 10,
+      "specificity": 14,
+      "risk_awareness": 16,
+      "total": 54,
+      "notes": "The review finds the most important design flaw: stock Keycloak's MySQL datasource does not natively regenerate RDS IAM tokens, and it connects that gap to pooling, expiration, and startup failure. It nevertheless approves the design with high confidence without selecting or validating an implementable integration mechanism. Its illustrative wrapper is not tied to this repository or Keycloak's Agroal configuration, and suggestions that Secrets Manager generates IAM tokens or that token duration can be chosen between 15 and 60 minutes are technically unsound. It also misses the invalid Terraform resources and parameters, IAM-enabled database-user setup, TLS requirements, and the contradiction between credential removal and fallback."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 4,
+      "specificity": 8,
+      "risk_awareness": 12,
+      "total": 35,
+      "notes": "The plan spans both authentication modes, fallback, expiration, load, security, regression, and post-deployment checks. Its largest weakness is that the examples do not establish that IAM authentication was used rather than the unchanged password path. The Docker test exposes no port, provides no IAM token or database user, and relies on unsupported Keycloak environment variables; the API test fails to extract access_token and treats Keycloak's empty successful user-creation response as failure. The pytest modules, JMeter plan, staging module, Keycloak 25 image, and CI paths were not grounded in verifiable repository files, and several proposed assertions merely prove process health."
+    },
+    "implementation": {
+      "completeness": 4,
+      "correctness": 2,
+      "specificity": 6,
+      "risk_awareness": 6,
+      "total": 18,
+      "notes": "The patch adds two flags, two environment variables, and a narrowly scoped rds-db:connect policy in the stated Terraform files. It does not implement IAM authentication: it uses the wrong Aurora enablement mechanism, adds no IAM-authenticated MySQL user or Keycloak datasource extension, and explicitly retains master_password = var.keycloak_database_password. The summary's Java wrapper, metrics, alarms, documentation, and validation logic are absent from the diff, and its sample token generator incorrectly calls an STS GenerateDBAuthToken API that does not exist. Defaults enable the incomplete path immediately and the claimed fallback has no code; independent source-context and git apply checks were unavailable because the read-only executor failed before running commands."
+    }
+  },
+  "task_score": 38.0,
+  "verdict": "The submission recognizes the central Keycloak integration problem but ships a nonfunctional Terraform-only patch that neither enables Aurora IAM authentication correctly nor makes Keycloak use IAM tokens.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T13:57:40.996141Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 205475,
+      "cached_input_tokens": 173901,
+      "cache_write_input_tokens": 31560,
+      "output_tokens": 7458,
+      "reasoning_output_tokens": 5828
+    },
+    "duration_ms": 136594
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,292 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 0,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 61.9,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2071752,
+    "output_tokens": 4727,
+    "cache_read_tokens": 2015616,
+    "cache_write_tokens": 56136,
+    "total_tokens": 4148231,
+    "total_cost_usd": 0,
+    "latency_seconds": 76.4,
+    "num_turns": 45,
+    "generation_tokens_per_sec": 61.9,
+    "prefix_cache_hit_rate": 0.9729,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2071752,
+  "output_tokens": 4727,
+  "latency_seconds": 76.4,
+  "num_turns": 45,
+  "total_cost_usd": 0,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T12:44:24.734075Z",
+  "run_ended_at": "2026-08-05T12:45:41.204427Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2071752,
+    "output_tokens": 4727,
+    "cache_read_tokens": 2015616,
+    "cache_write_tokens": 56136,
+    "total_tokens": 4148231,
+    "total_cost_usd": 0,
+    "latency_seconds": 76.4,
+    "num_turns": 45,
+    "generation_tokens_per_sec": 61.9,
+    "prefix_cache_hit_rate": 0.9729,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9729,
+      "prompt_tokens_cached_rate": 0.9729
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 4727,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 2015616,
+      "vllm:prefix_cache_queries_total": 2071752,
+      "vllm:prompt_tokens_by_source_total": 2071752,
+      "vllm:prompt_tokens_cached_total": 2015616,
+      "vllm:prompt_tokens_total": 2071752,
+      "vllm:request_success_total": 45,
+      "vllm:tool_call_parser_invocations_total": 4727
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 45,
+        "sum": 74.9527,
+        "mean": 1.665616
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 4682,
+        "sum": 63.6788,
+        "mean": 0.013601
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 4727,
+        "sum": 60863,
+        "mean": 12.875608
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 45,
+        "sum": 63.6788,
+        "mean": 1.415085
+      },
+      "vllm:request_generation_tokens": {
+        "count": 45,
+        "sum": 4727,
+        "mean": 105.044444
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 45,
+        "sum": 72.7759,
+        "mean": 1.617242
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 45,
+        "sum": 4727,
+        "mean": 105.044444
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 45,
+        "sum": 720000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 45,
+        "sum": 45,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 45,
+        "sum": 56136,
+        "mean": 1247.466667
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 45,
+        "sum": 9.0971,
+        "mean": 0.202157
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 45,
+        "sum": 2071752,
+        "mean": 46038.933333
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 45,
+        "sum": 0.0616,
+        "mean": 0.001368
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 45,
+        "sum": 0.6046,
+        "mean": 0.013435
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 45,
+        "sum": 11.2891,
+        "mean": 0.250868
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.056,
+          "mean": 0.0405,
+          "samples": 77
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8961,
+          "samples": 77
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 77
+        }
+      }
+    }
+  },
+  "cache_read_tokens": 2015616,
+  "cache_creation_tokens": 56136,
+  "agent_invocations": 2,
+  "topped_up_artifacts": [],
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 15,
+        "risk_awareness": 11,
+        "total": 51,
+        "notes": "The issue clearly scopes the change to AWS ECS and Aurora, excludes Helm/EKS and version upgrades, and supplies concrete acceptance criteria. Its largest defect is the contradiction between removing static credentials entirely and retaining password authentication as a default-enabled fallback. It also assumes Keycloak can generate and consume IAM tokens without specifying a datasource extension, IAM-enabled MySQL user, TLS settings, or token renewal behavior. No independent task statement exists, and repository execution failed before source reads, so claims about the current rotation Lambda and deployment topology could not be independently verified."
+      },
+      "lld": {
+        "completeness": 9,
+        "correctness": 4,
+        "specificity": 8,
+        "risk_awareness": 11,
+        "total": 32,
+        "notes": "The LLD names plausible Terraform files, gives a correctly shaped rds-db:connect ARN, and discusses rollout, rollback, pooling, and fallback risks. The load-bearing Keycloak integration remains a placeholder, while KC_DB_IAM_AUTH_ENABLED and KC_DB_IAM_AUTH_FALLBACK_ENABLED are not standard Keycloak settings and therefore do nothing by themselves. Aurora IAM authentication is enabled through the cluster's iam_database_authentication_enabled property, not an aurora_enable_iam_auth parameter, and aws_rds_cluster_iam_auth is not a Terraform AWS resource. The design also omits executable MySQL user provisioning, TLS configuration, token generation integration, and metric emitters; repository-specific compatibility could not be independently checked because source commands failed."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 10,
+        "specificity": 14,
+        "risk_awareness": 16,
+        "total": 54,
+        "notes": "The review finds the most important design flaw: stock Keycloak's MySQL datasource does not natively regenerate RDS IAM tokens, and it connects that gap to pooling, expiration, and startup failure. It nevertheless approves the design with high confidence without selecting or validating an implementable integration mechanism. Its illustrative wrapper is not tied to this repository or Keycloak's Agroal configuration, and suggestions that Secrets Manager generates IAM tokens or that token duration can be chosen between 15 and 60 minutes are technically unsound. It also misses the invalid Terraform resources and parameters, IAM-enabled database-user setup, TLS requirements, and the contradiction between credential removal and fallback."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 4,
+        "specificity": 8,
+        "risk_awareness": 12,
+        "total": 35,
+        "notes": "The plan spans both authentication modes, fallback, expiration, load, security, regression, and post-deployment checks. Its largest weakness is that the examples do not establish that IAM authentication was used rather than the unchanged password path. The Docker test exposes no port, provides no IAM token or database user, and relies on unsupported Keycloak environment variables; the API test fails to extract access_token and treats Keycloak's empty successful user-creation response as failure. The pytest modules, JMeter plan, staging module, Keycloak 25 image, and CI paths were not grounded in verifiable repository files, and several proposed assertions merely prove process health."
+      },
+      "implementation": {
+        "completeness": 4,
+        "correctness": 2,
+        "specificity": 6,
+        "risk_awareness": 6,
+        "total": 18,
+        "notes": "The patch adds two flags, two environment variables, and a narrowly scoped rds-db:connect policy in the stated Terraform files. It does not implement IAM authentication: it uses the wrong Aurora enablement mechanism, adds no IAM-authenticated MySQL user or Keycloak datasource extension, and explicitly retains master_password = var.keycloak_database_password. The summary's Java wrapper, metrics, alarms, documentation, and validation logic are absent from the diff, and its sample token generator incorrectly calls an STS GenerateDBAuthToken API that does not exist. Defaults enable the incomplete path immediately and the claimed fallback has no code; independent source-context and git apply checks were unavailable because the read-only executor failed before running commands."
+      }
+    },
+    "task_score": 38.0,
+    "verdict": "The submission recognizes the central Keycloak integration problem but ships a nonfunctional Terraform-only patch that neither enables Aurora IAM authentication correctly nor makes Keycloak use IAM tokens.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T13:57:40.996141Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 205475,
+        "cached_input_tokens": 173901,
+        "cache_write_input_tokens": 31560,
+        "output_tokens": 7458,
+        "reasoning_output_tokens": 5828
+      },
+      "duration_ms": 136594
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "pi",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T12:48:21.103393Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 251982,
+      "cached_input_tokens": 212453,
+      "cache_write_input_tokens": 39515,
+      "output_tokens": 9742,
+      "reasoning_output_tokens": 8019
+    },
+    "duration_ms": 159307
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 47.64,
+  "mean_cost_usd_excl_failed": 0.0,
+  "tasks": [
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 71,
+      "input_tokens": 4398084,
+      "output_tokens": 31496,
+      "total_tokens": 8827664,
+      "latency_seconds": 473.5,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 54.2,
+      "cache_read_tokens": 4327440,
+      "cache_write_tokens": 70644,
+      "prefix_cache_hit_rate": 0.9839,
+      "generation_tokens_per_sec": 66.5,
+      "kv_cache_usage": {
+        "peak": 0.0865,
+        "mean": 0.067
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 18,
+          "risk_awareness": 16,
+          "total": 71,
+          "notes": "The issue clearly identifies the exposed outbound operations, names `registry/utils/agent_validator.py`, `registry/health/service.py`, and the existing skill-service guard, and supplies testable extraction and integration criteria. The submitted source hunks support those named symbols and show that `_is_safe_url` previously lived in `registry/services/skill_service.py`. Its largest gap is that backward compatibility is asserted without defining migration behavior for existing private endpoints or the existing `github_extra_hosts` trust configuration, and it omits redirect and DNS-rebinding behavior from acceptance criteria. No independent task statement was supplied, so broader requirement coverage beyond the identifier and internally consistent artifacts cannot be verified."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 14,
+          "total": 55,
+          "notes": "The LLD is concrete about files, functions, configuration fields, IPv6 handling, logging, and failure-closed behavior. Its central redirect design is incorrect: both examples use `follow_redirects=True` and validate only `response.url`, after every redirect request, including a potentially internal request, has already occurred. It also proposes process-global `socket.setdefaulttimeout`, does not prevent DNS rebinding between validation and connection, and replaces the skill service's `github_extra_hosts` merge with `ssrf_allowlist`, contradicting its compatibility claim. The rollout is generic and documentation changes are omitted, while independent repository inspection was unavailable because read-only shell commands failed before execution in the provided sandbox."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 16,
+          "risk_awareness": 16,
+          "total": 57,
+          "notes": "The review surfaces specific and relevant concerns about redirects, DNS latency, IPv6, and inconsistent error contracts, with prioritized consequences and proposed actions. Its largest defect is declaring the findings resolved even though final-URL validation after automatic redirects cannot prevent SSRF and the proposed DNS timeout mechanism is process-global and unreliable for `getaddrinfo`. It also misses the regression caused by dropping `settings.github_extra_hosts`, the validation-to-connect DNS rebinding window, and blocking synchronous DNS inside the asynchronous health service. The multiple reviewer personas add limited evidence, and claims of compatibility and acceptable operational characteristics could not be independently validated."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 13,
+          "total": 51,
+          "notes": "The plan provides useful exact oracles for schemes, private IPv4 and IPv6 addresses, metadata IPs, allowlists, and DNS failures. Its most important omission is an integration test proving that no request is sent to an unsafe redirect target; unit-testing `validate_redirect_url` would pass while the implementation remains exploitable because `httpx` follows the redirect first. Several tests are placeholders rather than executable cases, including the health and skill compatibility checks, while `MockDNSServer.start` is empty and is not connected to `socket.getaddrinfo`; public-domain tests are also network-dependent. The proposed registration routes, expected 422 response, Terraform paths, and `uv` commands could not be independently checked against the repository due the unavailable shell."
+        },
+        "implementation": {
+          "completeness": 12,
+          "correctness": 5,
+          "specificity": 14,
+          "risk_awareness": 6,
+          "total": 37,
+          "notes": "The patch adds direct pre-request checks at the named agent and health integration points, centralizes the original validator, adds configuration, and includes focused utility tests. The core redirect protection is ineffective because `follow_redirects=True` performs unsafe intermediate requests before `validate_redirect_url` examines only the final URL, and separate DNS resolution leaves a rebinding window. On successful validation with an original default timeout of `None`, the conditional `finally` fails to restore the global socket timeout; additionally, skill validation stops honoring `github_extra_hosts`, no integration or documentation changes are included, and the summary's CIDR and backward-compatibility claims are false. The patch contexts are internally coherent, but `git apply --check` and independent source verification could not run because every shell invocation failed with `bwrap: loopback: Failed RTM_NEWADDR`."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 48,
+      "input_tokens": 2480142,
+      "output_tokens": 39772,
+      "total_tokens": 5000056,
+      "latency_seconds": 566.9,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 52.0,
+      "cache_read_tokens": 2434096,
+      "cache_write_tokens": 46046,
+      "prefix_cache_hit_rate": 0.9814,
+      "generation_tokens_per_sec": 70.2,
+      "kv_cache_usage": {
+        "peak": 0.0725,
+        "mean": 0.052
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 61,
+          "notes": "The issue clearly enumerates affected services, eight registry secrets, three auth-server secrets, scope, exclusions, and acceptance criteria. Its file and variable assumptions are consistent with the submitted patch's Terraform modules and symbols. The largest defect is the proposed fallback: ECS resolves task-definition secrets before container startup and does not fall back to a same-named plaintext environment entry when retrieval fails; retaining those entries also preserves the state and task-definition exposure the issue claims to solve. With no independent task statement and unavailable repository reads, the #1134 linkage, MCPGW migration status, and claimed need for config-loader changes could not be verified."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 6,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 50,
+          "notes": "The LLD is concrete about `ecs-services.tf`, `iam.tf`, `secrets.tf`, the execution-role policy, secret ARNs, and rollout phases. Its central error-handling decision is invalid because ECS task startup fails when a referenced secret cannot be fetched, while the proposed object-or-null expressions can put null entries into the ECS `secrets` array. It also creates secret versions unconditionally from variables treated elsewhere as optional, continues placing plaintext values in Terraform state, and leaves rotation, monitoring, cleanup timing, and state remediation unresolved. Claims that all secrets already have rotation enabled and that critical monitoring or rollback details were added are contradicted by the supplied snippets and later implementation's rotation skips."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 18,
+          "total": 59,
+          "notes": "The strongest part of the review is its identification of real risks around Terraform state, absent rotation, expiration, monitoring, restart coordination, rollback, and prolonged plaintext fallback. It nevertheless misses the design's decisive runtime flaw: ECS cannot use the plaintext entry as fallback after secret resolution fails, and it does not catch unconditional empty secret versions or nullable ECS list elements. The resolution section falsely says the LLD gained rotation resources, CloudWatch alarms, state cleanup, deployment ordering, and a detailed rollback even though those changes are absent from the submitted LLD. Several role-based approvals therefore endorse unsupported claims such as transparent fallback and completed least-privilege handling."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 4,
+          "specificity": 16,
+          "risk_awareness": 12,
+          "total": 49,
+          "notes": "The plan spans Terraform, IAM, task definitions, rotation, rollback, service behavior, and negative scenarios with concrete expected counts. Major tests are nonfunctional: Test 8 never removes IAM access and uses ECS service `ACTIVE` as its oracle, while denied secret access would prevent new tasks from starting rather than exercise fallback. Other concrete defects include nonexistent `get-secret-value` encryption fields, hard-coded IAM policy version `v1`, unsupported `aws ecs execute-command --c`, a rollback command that does not select the previous revision, and commands that print secret values. Secret ARN outputs, literal service names, CloudTrail log-group layout, and the three proposed health endpoints are not established by the diff and could not be verified against the repository."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 3,
+          "specificity": 18,
+          "risk_awareness": 7,
+          "total": 41,
+          "notes": "The patch concretely adds eight secret resources, IAM ARNs, and task-definition references in the three Terraform files named by the design, but direct repository inspection and `git apply --check` were unavailable because every read-only shell command failed before execution with a bwrap loopback error. Each secret version is unconditional while task references are guarded by `var != \"\"`, so empty optional inputs can fail secret creation, and false conditions can serialize null entries into ECS secret lists. The claimed fallback is not implemented because ECS must resolve referenced secrets before startup, while preserving same-named plaintext environment entries continues exposing values in task definitions and Terraform state. The summary also overstates completion: the diff contains no documentation, alarms, rotation configuration, state cleanup, or tests, despite claiming exact LLD compliance, comprehensive monitoring, and no sensitive state data."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 62,
+      "input_tokens": 3310562,
+      "output_tokens": 16360,
+      "total_tokens": 6637484,
+      "latency_seconds": 239.4,
+      "total_cost_usd": 0,
+      "result_subtype": "success",
+      "task_score": 48.6,
+      "cache_read_tokens": 3258480,
+      "cache_write_tokens": 52082,
+      "prefix_cache_hit_rate": 0.9843,
+      "generation_tokens_per_sec": 68.3,
+      "kv_cache_usage": {
+        "peak": 0.0626,
+        "mean": 0.0504
+      },
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 19,
+          "risk_awareness": 10,
+          "total": 63,
+          "notes": "The issue identifies concrete files, variables, outputs, mounts, and acceptance checks that correspond to symbols shown in the submitted diff. Its strongest aspect is the explicit scope boundary around Terraform and data migration. Its largest deficiency is treating ephemeral logs, configuration, and MCPGW data as having no functional impact while providing no evidence that DocumentDB/S3 replaces every EFS use. No independent task statement or application evidence verifies the central persistence claim, and destructive upgrade behavior is underexplained."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 9,
+          "total": 53,
+          "notes": "The LLD gives concrete file-level changes and names the actual `module.efs`, output, volume, and `SCOPES_CONFIG_PATH` integration points visible in the patch. Its largest flaw is leaving the key volume decision as remove-or-replace while later selecting an empty mount at `/app/auth_server`, which can obscure the bundled `scopes.yml` it expects there. The rollback guidance does not account for Terraform destroying the existing file system, and reverting state or code cannot recover deleted EFS data. Claims of no data loss and complete S3/DocumentDB coverage are not established by the supplied evidence."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 48,
+          "notes": "The review usefully raises container-image, directory, state, documentation, and observability concerns rather than only approving the component list. However, it incorrectly says the LLD omitted the exact `SCOPES_CONFIG_PATH` change even though the LLD specifies it, and its recommendation to run `terraform state rm` would orphan live EFS resources instead of deleting them. It also misses the conflict between mounting an empty volume at `/app/auth_server` and expecting an image-bundled file at that path. Assertions that no other dependencies exist and the change is low risk are not demonstrated from repository evidence."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 6,
+          "specificity": 13,
+          "risk_awareness": 11,
+          "total": 47,
+          "notes": "The plan covers validation, upgrade deployment, service health, authentication, registration, restart persistence, cost, and rollback, with several concrete expected states. Its central `terraform plan | grep -i efs` oracle is wrong for an existing deployment because the successful removal plan should contain EFS resources marked for destruction, and it also demands all other resources remain unchanged despite expected task-definition updates. The baseline/post-change saved-plan performance sequence can mutate state and make the second plan stale, while rollback never reapplies the previous Terraform configuration. The endpoint paths and three workflow scripts are placeholders not shown to exist, so the most important functional tests are not executable as written."
+        },
+        "implementation": {
+          "completeness": 10,
+          "correctness": 2,
+          "specificity": 15,
+          "risk_awareness": 5,
+          "total": 32,
+          "notes": "The patch attempts all principal removals across the EFS module, variables, outputs, and ECS volumes, and the summary precisely enumerates those intended edits. The implementation is unusable as submitted: the root `outputs.tf` hunk has inconsistent unified-diff line counts, while the module output hunk leaves a dangling `sensitive = false` and closing brace after deleting `output \"efs_access_points\"`. Mounting an empty volume over `/app/auth_server` also conflicts with the summary's requirement that `scopes.yml` be bundled at that location, and the suggested `terraform state rm module.mcp_gateway.module.efs` would orphan AWS resources. The claimed validation command runs `terraform validate` against individual `.tf` paths rather than an initialized module directory, so the reported successful validation is not credible."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 92,
+      "input_tokens": 6413120,
+      "output_tokens": 26961,
+      "total_tokens": 12853201,
+      "latency_seconds": 415.8,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 45.4,
+      "cache_read_tokens": 6335664,
+      "cache_write_tokens": 77456,
+      "prefix_cache_hit_rate": 0.9879,
+      "generation_tokens_per_sec": 64.8,
+      "kv_cache_usage": {
+        "peak": 0.0888,
+        "mean": 0.0679
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 16,
+          "risk_awareness": 8,
+          "total": 50,
+          "notes": "The issue clearly identifies dependency, configuration, test, documentation, and Docker surfaces, with several directly testable removal criteria. Its central deficiency is promising unchanged behavior while requiring DocumentDB for file-backed deployments without defining migration or unavailable-database behavior. The factory preimage selects DocumentDB only for MONGODB_BACKENDS and FaissSearchRepository otherwise, so the proposal materially changes an existing deployment mode. No independent task statement establishes the replacement architecture, and claims of mature feature parity and issue #1285 could not be verified."
+        },
+        "lld": {
+          "completeness": 12,
+          "correctness": 6,
+          "specificity": 14,
+          "risk_awareness": 9,
+          "total": 41,
+          "notes": "The LLD names relevant files and accurately identifies the FAISS dependency, configuration properties, service, repository, and factory integration points shown by the baseline context. Its proposed FileSearchRepository imports `.documentdb.search_repository` from inside `registry.repositories.file`, which resolves to a nonexistent child package rather than the sibling `..documentdb` package. The factory simultaneously bypasses that wrapper entirely, while migration, file-only operation, and failure behavior remain unresolved despite the backward-compatibility claim. Assertions about comprehensive fallbacks, unchanged observability, and superior scaling are not tied to verified APIs or rollout checks."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 14,
+          "specificity": 16,
+          "risk_awareness": 18,
+          "total": 64,
+          "notes": "The review's strongest contribution is identifying the two load-bearing risks: file deployments without DocumentDB and loss of existing FAISS-backed search state. Those concerns are supported by the existing backend-conditional factory and the proposed deletion of persisted-index handling. Its resolutions remain indecisive, and the proposed migration script and `registry.cli migrate-search` command have no repository evidence and conflict with removing the FAISS dependency needed to read old indexes. It also misses the incorrect relative import, dead file repository design, and unchanged production FAISS callers, making the 4.2/5 verdict too favorable."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 6,
+          "specificity": 10,
+          "risk_awareness": 14,
+          "total": 45,
+          "notes": "The plan broadly covers search, indexing lifecycle, database failure, Docker, compatibility, performance, rollback, and observability. Its unit-test example patches `registry.repositories.file.search_repository.DocumentDBSearchRepository`, but the proposed implementation only imports that symbol locally inside `__init__`, so the patch target does not exist. The E2E commands use `/api/v1/servers` while the repository test preimage explicitly documents registration at `/api/servers/register`; the CLI command and several named test files are likewise unverified. Many assertions lack fixed fixtures or objective result oracles, although the unavailable-database and update/delete scenarios target relevant risks."
+        },
+        "implementation": {
+          "completeness": 6,
+          "correctness": 3,
+          "specificity": 11,
+          "risk_awareness": 7,
+          "total": 27,
+          "notes": "The patch removes the declared dependency, configuration properties, FAISS service, and conditional factory branch, addressing the mechanical portion of removal. It deletes `registry/search/service.py` without modifying production server routes, while the existing test preimage explicitly patches the lazily imported `registry.search.service.faiss_service` for registration and toggle workflows, demonstrating an unhandled caller. The new file repository also has the invalid `.documentdb` import, is bypassed by the factory, leaves `rebuild_index` as a no-op, and is tested through a nonexistent module-level patch target. The summary admits incomplete tests, documentation, migration, and fallback work yet still claims complete preservation and graceful degradation; independent `git apply --check` execution was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 45,
+      "input_tokens": 2071752,
+      "output_tokens": 4727,
+      "total_tokens": 4148231,
+      "latency_seconds": 76.4,
+      "total_cost_usd": 0,
+      "result_subtype": "success",
+      "task_score": 38.0,
+      "cache_read_tokens": 2015616,
+      "cache_write_tokens": 56136,
+      "prefix_cache_hit_rate": 0.9729,
+      "generation_tokens_per_sec": 61.9,
+      "kv_cache_usage": {
+        "peak": 0.056,
+        "mean": 0.0405
+      },
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 51,
+          "notes": "The issue clearly scopes the change to AWS ECS and Aurora, excludes Helm/EKS and version upgrades, and supplies concrete acceptance criteria. Its largest defect is the contradiction between removing static credentials entirely and retaining password authentication as a default-enabled fallback. It also assumes Keycloak can generate and consume IAM tokens without specifying a datasource extension, IAM-enabled MySQL user, TLS settings, or token renewal behavior. No independent task statement exists, and repository execution failed before source reads, so claims about the current rotation Lambda and deployment topology could not be independently verified."
+        },
+        "lld": {
+          "completeness": 9,
+          "correctness": 4,
+          "specificity": 8,
+          "risk_awareness": 11,
+          "total": 32,
+          "notes": "The LLD names plausible Terraform files, gives a correctly shaped rds-db:connect ARN, and discusses rollout, rollback, pooling, and fallback risks. The load-bearing Keycloak integration remains a placeholder, while KC_DB_IAM_AUTH_ENABLED and KC_DB_IAM_AUTH_FALLBACK_ENABLED are not standard Keycloak settings and therefore do nothing by themselves. Aurora IAM authentication is enabled through the cluster's iam_database_authentication_enabled property, not an aurora_enable_iam_auth parameter, and aws_rds_cluster_iam_auth is not a Terraform AWS resource. The design also omits executable MySQL user provisioning, TLS configuration, token generation integration, and metric emitters; repository-specific compatibility could not be independently checked because source commands failed."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 14,
+          "risk_awareness": 16,
+          "total": 54,
+          "notes": "The review finds the most important design flaw: stock Keycloak's MySQL datasource does not natively regenerate RDS IAM tokens, and it connects that gap to pooling, expiration, and startup failure. It nevertheless approves the design with high confidence without selecting or validating an implementable integration mechanism. Its illustrative wrapper is not tied to this repository or Keycloak's Agroal configuration, and suggestions that Secrets Manager generates IAM tokens or that token duration can be chosen between 15 and 60 minutes are technically unsound. It also misses the invalid Terraform resources and parameters, IAM-enabled database-user setup, TLS requirements, and the contradiction between credential removal and fallback."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 4,
+          "specificity": 8,
+          "risk_awareness": 12,
+          "total": 35,
+          "notes": "The plan spans both authentication modes, fallback, expiration, load, security, regression, and post-deployment checks. Its largest weakness is that the examples do not establish that IAM authentication was used rather than the unchanged password path. The Docker test exposes no port, provides no IAM token or database user, and relies on unsupported Keycloak environment variables; the API test fails to extract access_token and treats Keycloak's empty successful user-creation response as failure. The pytest modules, JMeter plan, staging module, Keycloak 25 image, and CI paths were not grounded in verifiable repository files, and several proposed assertions merely prove process health."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 2,
+          "specificity": 6,
+          "risk_awareness": 6,
+          "total": 18,
+          "notes": "The patch adds two flags, two environment variables, and a narrowly scoped rds-db:connect policy in the stated Terraform files. It does not implement IAM authentication: it uses the wrong Aurora enablement mechanism, adds no IAM-authenticated MySQL user or Keycloak datasource extension, and explicitly retains master_password = var.keycloak_database_password. The summary's Java wrapper, metrics, alarms, documentation, and validation logic are absent from the diff, and its sample token generator incorrectly calls an STS GenerateDBAuthToken API that does not exist. Defaults enable the incomplete path immediately and the claimed fallback has no code; independent source-context and git apply checks were unavailable because the read-only executor failed before running commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-05"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "devstral-2-123b",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 18,
+      "risk_awareness": 16,
+      "total": 71,
+      "notes": "The issue clearly identifies the exposed outbound operations, names `registry/utils/agent_validator.py`, `registry/health/service.py`, and the existing skill-service guard, and supplies testable extraction and integration criteria. The submitted source hunks support those named symbols and show that `_is_safe_url` previously lived in `registry/services/skill_service.py`. Its largest gap is that backward compatibility is asserted without defining migration behavior for existing private endpoints or the existing `github_extra_hosts` trust configuration, and it omits redirect and DNS-rebinding behavior from acceptance criteria. No independent task statement was supplied, so broader requirement coverage beyond the identifier and internally consistent artifacts cannot be verified."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 8,
+      "specificity": 17,
+      "risk_awareness": 14,
+      "total": 55,
+      "notes": "The LLD is concrete about files, functions, configuration fields, IPv6 handling, logging, and failure-closed behavior. Its central redirect design is incorrect: both examples use `follow_redirects=True` and validate only `response.url`, after every redirect request, including a potentially internal request, has already occurred. It also proposes process-global `socket.setdefaulttimeout`, does not prevent DNS rebinding between validation and connection, and replaces the skill service's `github_extra_hosts` merge with `ssrf_allowlist`, contradicting its compatibility claim. The rollout is generic and documentation changes are omitted, while independent repository inspection was unavailable because read-only shell commands failed before execution in the provided sandbox."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 16,
+      "risk_awareness": 16,
+      "total": 57,
+      "notes": "The review surfaces specific and relevant concerns about redirects, DNS latency, IPv6, and inconsistent error contracts, with prioritized consequences and proposed actions. Its largest defect is declaring the findings resolved even though final-URL validation after automatic redirects cannot prevent SSRF and the proposed DNS timeout mechanism is process-global and unreliable for `getaddrinfo`. It also misses the regression caused by dropping `settings.github_extra_hosts`, the validation-to-connect DNS rebinding window, and blocking synchronous DNS inside the asynchronous health service. The multiple reviewer personas add limited evidence, and claims of compatibility and acceptable operational characteristics could not be independently validated."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 13,
+      "total": 51,
+      "notes": "The plan provides useful exact oracles for schemes, private IPv4 and IPv6 addresses, metadata IPs, allowlists, and DNS failures. Its most important omission is an integration test proving that no request is sent to an unsafe redirect target; unit-testing `validate_redirect_url` would pass while the implementation remains exploitable because `httpx` follows the redirect first. Several tests are placeholders rather than executable cases, including the health and skill compatibility checks, while `MockDNSServer.start` is empty and is not connected to `socket.getaddrinfo`; public-domain tests are also network-dependent. The proposed registration routes, expected 422 response, Terraform paths, and `uv` commands could not be independently checked against the repository due the unavailable shell."
+    },
+    "implementation": {
+      "completeness": 12,
+      "correctness": 5,
+      "specificity": 14,
+      "risk_awareness": 6,
+      "total": 37,
+      "notes": "The patch adds direct pre-request checks at the named agent and health integration points, centralizes the original validator, adds configuration, and includes focused utility tests. The core redirect protection is ineffective because `follow_redirects=True` performs unsafe intermediate requests before `validate_redirect_url` examines only the final URL, and separate DNS resolution leaves a rebinding window. On successful validation with an original default timeout of `None`, the conditional `finally` fails to restore the global socket timeout; additionally, skill validation stops honoring `github_extra_hosts`, no integration or documentation changes are included, and the summary's CIDR and backward-compatibility claims are false. The patch contexts are internally coherent, but `git apply --check` and independent source verification could not run because every shell invocation failed with `bwrap: loopback: Failed RTM_NEWADDR`."
+    }
+  },
+  "task_score": 54.2,
+  "verdict": "The submission has useful repository-specific framing, but its post-request redirect validation leaves the principal SSRF bypass open and the implementation introduces compatibility and global-timeout regressions.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T12:52:55.198536Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 239103,
+      "cached_input_tokens": 203381,
+      "cache_write_input_tokens": 35708,
+      "output_tokens": 6590,
+      "reasoning_output_tokens": 4961
+    },
+    "duration_ms": 128902
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/devstral-2-123b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "devstral-2-123b",
+  "model_slug": "devstral-2-123b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 262144
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 66.5,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4398084,
+    "output_tokens": 31496,
+    "cache_read_tokens": 4327440,
+    "cache_write_tokens": 70644,
+    "total_tokens": 8827664,
+    "total_cost_usd": null,
+    "latency_seconds": 473.5,
+    "num_turns": 71,
+    "generation_tokens_per_sec": 66.5,
+    "prefix_cache_hit_rate": 0.9839,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4398084,
+  "output_tokens": 31496,
+  "latency_seconds": 473.5,
+  "num_turns": 71,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T12:14:14.023950Z",
+  "run_ended_at": "2026-08-05T12:22:11.063726Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4398084,
+    "output_tokens": 31496,
+    "cache_read_tokens": 4327440,
+    "cache_write_tokens": 70644,
+    "total_tokens": 8827664,
+    "total_cost_usd": null,
+    "latency_seconds": 473.5,
+    "num_turns": 71,
+    "generation_tokens_per_sec": 66.5,
+    "prefix_cache_hit_rate": 0.9839,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9839,
+      "prompt_tokens_cached_rate": 0.9839
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 31496,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 4327440,
+      "vllm:prefix_cache_queries_total": 4398084,
+      "vllm:prompt_tokens_by_source_total": 4398084,
+      "vllm:prompt_tokens_cached_total": 4327440,
+      "vllm:prompt_tokens_total": 4398084,
+      "vllm:request_success_total": 71,
+      "vllm:tool_call_parser_invocations_total": 31496
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 71,
+        "sum": 468.6734,
+        "mean": 6.601033
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 31425,
+        "sum": 450.4725,
+        "mean": 0.014335
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 31496,
+        "sum": 102140,
+        "mean": 3.242951
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 71,
+        "sum": 450.4725,
+        "mean": 6.344683
+      },
+      "vllm:request_generation_tokens": {
+        "count": 71,
+        "sum": 31496,
+        "mean": 443.605634
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 71,
+        "sum": 464.0446,
+        "mean": 6.535839
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 71,
+        "sum": 31496,
+        "mean": 443.605634
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 71,
+        "sum": 1136000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 71,
+        "sum": 71,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 71,
+        "sum": 70644,
+        "mean": 994.985915
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 71,
+        "sum": 13.5721,
+        "mean": 0.191156
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 71,
+        "sum": 4398084,
+        "mean": 61944.84507
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 71,
+        "sum": 0.1037,
+        "mean": 0.001461
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 71,
+        "sum": 0.9869,
+        "mean": 0.0139
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 71,
+        "sum": 18.2248,
+        "mean": 0.256687
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0865,
+          "mean": 0.067,
+          "samples": 473
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9831,
+          "samples": 473
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 473
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "devstral-2-123b",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 18,
+        "risk_awareness": 16,
+        "total": 71,
+        "notes": "The issue clearly identifies the exposed outbound operations, names `registry/utils/agent_validator.py`, `registry/health/service.py`, and the existing skill-service guard, and supplies testable extraction and integration criteria. The submitted source hunks support those named symbols and show that `_is_safe_url` previously lived in `registry/services/skill_service.py`. Its largest gap is that backward compatibility is asserted without defining migration behavior for existing private endpoints or the existing `github_extra_hosts` trust configuration, and it omits redirect and DNS-rebinding behavior from acceptance criteria. No independent task statement was supplied, so broader requirement coverage beyond the identifier and internally consistent artifacts cannot be verified."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 8,
+        "specificity": 17,
+        "risk_awareness": 14,
+        "total": 55,
+        "notes": "The LLD is concrete about files, functions, configuration fields, IPv6 handling, logging, and failure-closed behavior. Its central redirect design is incorrect: both examples use `follow_redirects=True` and validate only `response.url`, after every redirect request, including a potentially internal request, has already occurred. It also proposes process-global `socket.setdefaulttimeout`, does not prevent DNS rebinding between validation and connection, and replaces the skill service's `github_extra_hosts` merge with `ssrf_allowlist`, contradicting its compatibility claim. The rollout is generic and documentation changes are omitted, while independent repository inspection was unavailable because read-only shell commands failed before execution in the provided sandbox."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 16,
+        "risk_awareness": 16,
+        "total": 57,
+        "notes": "The review surfaces specific and relevant concerns about redirects, DNS latency, IPv6, and inconsistent error contracts, with prioritized consequences and proposed actions. Its largest defect is declaring the findings resolved even though final-URL validation after automatic redirects cannot prevent SSRF and the proposed DNS timeout mechanism is process-global and unreliable for `getaddrinfo`. It also misses the regression caused by dropping `settings.github_extra_hosts`, the validation-to-connect DNS rebinding window, and blocking synchronous DNS inside the asynchronous health service. The multiple reviewer personas add limited evidence, and claims of compatibility and acceptable operational characteristics could not be independently validated."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 13,
+        "total": 51,
+        "notes": "The plan provides useful exact oracles for schemes, private IPv4 and IPv6 addresses, metadata IPs, allowlists, and DNS failures. Its most important omission is an integration test proving that no request is sent to an unsafe redirect target; unit-testing `validate_redirect_url` would pass while the implementation remains exploitable because `httpx` follows the redirect first. Several tests are placeholders rather than executable cases, including the health and skill compatibility checks, while `MockDNSServer.start` is empty and is not connected to `socket.getaddrinfo`; public-domain tests are also network-dependent. The proposed registration routes, expected 422 response, Terraform paths, and `uv` commands could not be independently checked against the repository due the unavailable shell."
+      },
+      "implementation": {
+        "completeness": 12,
+        "correctness": 5,
+        "specificity": 14,
+        "risk_awareness": 6,
+        "total": 37,
+        "notes": "The patch adds direct pre-request checks at the named agent and health integration points, centralizes the original validator, adds configuration, and includes focused utility tests. The core redirect protection is ineffective because `follow_redirects=True` performs unsafe intermediate requests before `validate_redirect_url` examines only the final URL, and separate DNS resolution leaves a rebinding window. On successful validation with an original default timeout of `None`, the conditional `finally` fails to restore the global socket timeout; additionally, skill validation stops honoring `github_extra_hosts`, no integration or documentation changes are included, and the summary's CIDR and backward-compatibility claims are false. The patch contexts are internally coherent, but `git apply --check` and independent source verification could not run because every shell invocation failed with `bwrap: loopback: Failed RTM_NEWADDR`."
+      }
+    },
+    "task_score": 54.2,
+    "verdict": "The submission has useful repository-specific framing, but its post-request redirect validation leaves the principal SSRF bypass open and the implementation introduces compatibility and global-timeout regressions.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T12:52:55.198536Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 239103,
+        "cached_input_tokens": 203381,
+        "cache_write_input_tokens": 35708,
+        "output_tokens": 6590,
+        "reasoning_output_tokens": 4961
+      },
+      "duration_ms": 128902
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "kimi-k2.7-code",
+  "model_slug": "kimi-k2.7-code",
+  "agent": "claude",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 131072
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-04T22:43:36.207975Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 153155,
+      "cached_input_tokens": 125191,
+      "cache_write_input_tokens": 27952,
+      "output_tokens": 8998,
+      "reasoning_output_tokens": 6496
+    },
+    "duration_ms": 143622
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 55.44,
+  "mean_cost_usd_excl_failed": 59.34,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 101,
+      "input_tokens": 5091053,
+      "output_tokens": 34089,
+      "total_tokens": 5125142,
+      "latency_seconds": 431.1,
+      "total_cost_usd": 26.30748999999999,
+      "result_subtype": "success",
+      "task_score": 64.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.9178,
+      "generation_tokens_per_sec": 79.1,
+      "kv_cache_usage": {
+        "peak": 0.126,
+        "mean": 0.0921
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 9,
+          "total": 67,
+          "notes": "The issue provides concrete paths, integration points, and testable acceptance criteria covering Terraform resources, ECS mounts, scripts, and CodeBuild. Its largest gap is operational: deleting the EFS module will destroy existing filesystems and data, but no migration, backup, rollout, or rollback requirement is included. The submitted diff confirms named symbols such as `module.efs`, `mcp_gateway_efs_id`, and `SCOPES_CONFIG_PATH`; however, the claim that `terraform plan` needs no AWS credentials conflicts with the testing artifact's acknowledgment of provider data-source evaluation. No independent task statement was supplied, so the asserted S3/DocumentDB persistence requirement cannot be verified beyond the artifacts themselves."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 16,
+          "specificity": 21,
+          "risk_awareness": 10,
+          "total": 66,
+          "notes": "The LLD is implementation-oriented and identifies nearly every changed file, symbol, and replacement value, including `/app/scopes.yml` and the DocumentDB-only script branch. Its largest deficiency is treating destructive EFS removal as already migrated without specifying data verification, backup, staged rollout, or recovery, while also leaving related scope-init build assets unaddressed. The patch contradicts several repository descriptions: existing mount paths are `/app/logs` and `/app/data`, not `/var/log/mcp-logs` and `/data`, and `storage.tf` contains six access points but the LLD names only five. Claims that all prior mounted data is already handled by S3/DocumentDB and that the image path is valid were not independently demonstrated by tests."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 17,
+          "specificity": 19,
+          "risk_awareness": 12,
+          "total": 64,
+          "notes": "The review identifies real dependency failures around `module.efs`, removed outputs, the post-deployment required-output list, and the auth image path, and it adds a concrete least-privilege README change. Its largest weakness is that every perspective quickly approves the design without challenging the destructive state transition, validating data migration, or identifying orphaned scope-init build artifacts. Assertions such as no secrets residing on EFS and no other billable resources depending on it are unsupported by the submitted evidence, while the diff does confirm the cited `efs_all_outbound` rule and ECR build wiring. The review also does not resolve the cross-artifact disagreement over whether planning requires AWS credentials."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 15,
+          "risk_awareness": 15,
+          "total": 58,
+          "notes": "The plan spans formatting, validation, plan inspection, shell behavior, container startup, security, cost, and an optional deployed smoke test. Several central checks are not executable or have weak oracles: Terraform plan JSON exposes root outputs under `planned_values.outputs`, not `.outputs`, the task-definition query selects by resource `name` rather than module address and never asserts nonempty results, and the MCPGW check has no command. Sourcing `post-deployment-setup.sh --dry-run` runs the script rather than isolating `_validate_terraform_outputs`, while the DocumentDB test permits mere code inspection instead of a concrete invocation. The existing-deployment section recognizes destruction but provides no backup, migration, state-diff, or rollback validation, and the candidate reports that Terraform commands were not actually run."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 19,
+          "specificity": 20,
+          "risk_awareness": 10,
+          "total": 67,
+          "notes": "The patch implements the issue's principal path end to end: it deletes `storage.tf`, removes module and root outputs and variables, clears auth/MCPGW mounts, updates `SCOPES_CONFIG_PATH`, removes the EFS fallback, and cleans CodeBuild and README wiring. The largest limitation is operational safety: applying the deletion to existing state destroys EFS and access points without migration checks, backup safeguards, or rollback guidance, and related assets such as the referenced `build-and-push-scopes-init.sh` and `docker/Dockerfile.scopes-init` are not removed. The implementation summary is factually inaccurate about the six deleted access points, naming `registry_data`, `metrics_data`, and `grafana_data` where the patch actually contains `servers`, `models`, and `agents`. The diff contexts are internally coherent, but independent repository inspection and `git apply --check` could not be completed because the read-only command runner failed before execution, and Terraform validation was also explicitly not performed by the candidate."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 92,
+      "input_tokens": 3695985,
+      "output_tokens": 48422,
+      "total_tokens": 3744407,
+      "latency_seconds": 597.4,
+      "total_cost_usd": 19.690475,
+      "result_subtype": "success",
+      "task_score": 57.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8646,
+      "generation_tokens_per_sec": 81.1,
+      "kv_cache_usage": {
+        "peak": 0.1257,
+        "mean": 0.0957
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 9,
+          "specificity": 22,
+          "risk_awareness": 12,
+          "total": 62,
+          "notes": "The issue concretely enumerates 13 values, affected Terraform files and services, exclusions, and observable acceptance criteria. Its central fallback claim is incorrect: an empty or unavailable ECS secret does not fall back to a duplicate plaintext environment entry after secret precedence applies. Moreover, unconditional secret versions initialized from optional empty variables conflict with Secrets Manager's nonempty value requirement, undermining the new-deployment criteria. No independent task statement was supplied, and the referenced issue and PR history could not be verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 7,
+          "specificity": 22,
+          "risk_awareness": 9,
+          "total": 56,
+          "notes": "The LLD gives decision-ready resource names, container mappings, IAM changes, lifecycle behavior, and observability gating. It incorrectly treats empty Secrets Manager values as valid fallback inputs, although the proposed secret-version resources cannot reliably create empty versions and ECS will not substitute the legacy value. Attaching the shared `ecs_secrets_access` policy to both Grafana roles also exposes all listed application secrets to Grafana, contradicting least privilege. The asserted KMS role-name compatibility and application configuration coverage could not be independently verified because repository command execution was unavailable."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 48,
+          "notes": "The review identifies one real residual risk: retaining plaintext environment entries leaves credentials in Terraform state and ECS task definitions. All five personas nevertheless approve the false fallback behavior and miss the likely apply failure for optional empty secret values. The compliance verdict also calls the design least-privilege even though the patch attaches a policy covering every application secret to Grafana's task and execution roles. Its KMS wildcard and Pydantic coverage assertions were not backed by verifiable repository evidence."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 11,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 67,
+          "notes": "The plan covers formatting, validation, plan inspection, task definitions, IAM denial, runtime precedence, upgrades, health, and feature-level regressions with concrete commands and oracles. The empty-secret scenario tests behavior that the implementation cannot provide, so it would fail during secret creation or task initialization rather than prove fallback. The IAM command hard-codes policy version `v1`, which is not generally the default version after an update, and the workspace plan follows an initialization performed with `-backend=false`. It also omits a least-privilege negative test proving Grafana cannot read unrelated secrets and prints a credential directly through ECS Exec."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 7,
+          "specificity": 20,
+          "risk_awareness": 8,
+          "total": 54,
+          "notes": "The patch consistently adds all 13 declared secret resources, container references, IAM resources, and Grafana role attachments described by the LLD. Unconditional `aws_secretsmanager_secret_version` resources make deployments with default empty optional credentials fail, while duplicate secret names do not provide the claimed runtime fallback. Retaining every plaintext environment entry preserves the original exposure, and granting Grafana the shared policy permits access to unrelated Keycloak, registry, and federation secrets. The summary discloses that Terraform formatting was not run, and repository execution was unavailable to independently confirm `git apply --check` or validation."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 173,
+      "input_tokens": 8333112,
+      "output_tokens": 92763,
+      "total_tokens": 8425875,
+      "latency_seconds": 1158.9,
+      "total_cost_usd": 43.98463499999998,
+      "result_subtype": "success",
+      "task_score": 56.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.9076,
+      "generation_tokens_per_sec": 80.0,
+      "kv_cache_usage": {
+        "peak": 0.145,
+        "mean": 0.0946
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 13,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 70,
+          "notes": "The issue provides concrete scope, non-goals, feature defaults, fallback behavior, and testable Terraform, ECS, image, and documentation criteria. Its central design is inconsistent: the proxy uses the managed master-user secret while Keycloak connects as keycloak_iam, and rds-db:connect through a proxy must target the proxy resource rather than aws_rds_cluster.keycloak.cluster_resource_id. It acknowledges bootstrap and fallback but omits the destructive default-true upgrade sequence, proxy-user credential mapping, TLS enforcement, and image readiness. No independent task statement was supplied, and the referenced issue #1303 could not be verified from the repository evidence."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 6,
+          "specificity": 22,
+          "risk_awareness": 10,
+          "total": 57,
+          "notes": "The LLD is repository-specific and names the real Terraform files and resources, including aws_db_proxy.keycloak, aws_rds_cluster.keycloak, rotation resources, and the ECS task definition. The IAM path is not viable because SECRETS proxy authentication is configured with the master-user secret while the client uses keycloak_iam, and the task policy grants the cluster DB-user ARN instead of the proxy DB-user ARN. Password fallback is also malformed because a valueFrom object is placed in ECS environment rather than secrets, while the conditional rotation policy can emit an RDSAccess statement with Resource = []. The rollback section overlooks those failures, the default-image compatibility problem, migration ordering, TLS, and potentially destructive secret removal."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 7,
+          "specificity": 18,
+          "risk_awareness": 10,
+          "total": 51,
+          "notes": "The review catches genuine issues around KC_DB_DRIVER, Docker entrypoint command composition, counted Terraform resources, bootstrap work, and the default-true upgrade risk. It incorrectly says the password validation rejects a supplied password in IAM mode, although var.keycloak_rds_iam_auth_enabled makes the condition unconditionally true in that mode. It approves the design without finding the proxy secret/username mismatch, wrong proxy authorization ARN, invalid fallback ECS environment shape, empty IAM Resource list, or unavailable curl in the Keycloak image. Claims that the issue explicitly preserves require_tls = false and that the LLD consistently uses [0] in depends_on are contradicted by the submitted artifacts."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 56,
+          "notes": "The plan covers both feature states, rendered resource expectations, image construction, documentation, least privilege, compatibility, and an optional live deployment. Terraform validate does not exercise values from terraform.tfvars, so the two proposed validation runs neither test the flag branches nor the short-password rejection. The plan gives no concrete terraform plan command or fixture, does not actually assert JAR presence, references an unrelated clone path, and searches for a variable name rather than the password value. Most importantly, static checks miss the invalid ECS valueFrom placement and proxy IAM identity model, while the proposed token-expiry rotation is not an available operation."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 4,
+          "specificity": 21,
+          "risk_awareness": 6,
+          "total": 48,
+          "notes": "The patch is broad and uses existing files and symbols such as keycloak-database.tf, keycloak_container_env, aws_iam_role.rotation_lambda, and the Keycloak 25 Dockerfile. Both modes have critical failures: password mode puts KC_DB_USERNAME valueFrom under environment, while IAM mode uses a master-user proxy secret for keycloak_iam and grants rds-db:connect against the cluster resource ID instead of the proxy ID. Default DocumentDB deployments can also produce an IAM statement with Resource = [], and RUN curl is unlikely to work in the minimal Keycloak image. The summary therefore overstates end-to-end implementation and validation; terraform validate would not detect these AWS API, ECS schema, image-build, or database authentication failures."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 117,
+      "input_tokens": 5372509,
+      "output_tokens": 44511,
+      "total_tokens": 5417020,
+      "latency_seconds": 569.1,
+      "total_cost_usd": 27.97532000000001,
+      "result_subtype": "success",
+      "task_score": 54.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.9134,
+      "generation_tokens_per_sec": 78.2,
+      "kv_cache_usage": {
+        "peak": 0.1355,
+        "mean": 0.0889
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 75,
+          "notes": "The issue identifies three concrete outbound paths and gives testable outcomes, including a 400 response for agent health checks and an unhealthy server status. Its submitted diff context is internally consistent with the named `_is_safe_url`, `_check_endpoint_reachability`, `check_agent_health`, and health-service symbols. The largest deficiency is calling the existing pre-resolution check sufficient while omitting redirect handling and DNS rebinding between validation and connection. No independent task statement establishes whether other outbound paths are in scope, and the issue states no explicit non-goals."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 64,
+          "notes": "The LLD commits to concrete files, interfaces, caller-specific failure behavior, configuration precedence, and documentation changes. Its core design does not bind the validated DNS result to the HTTP connection or define redirect validation, leaving major SSRF bypasses unresolved. The submitted code context shows async route and health-service callers, so synchronous `socket.getaddrinfo` can block the event loop; its proposed caller warnings also log raw URLs despite the credential-redaction requirement. Repository-wide coverage of every user-controlled outbound request could not be independently verified."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 9,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 47,
+          "notes": "The review usefully identifies credential leakage, allowlist tradeoffs, DNS failure behavior, and configuration documentation as concrete concerns. Its largest error is asserting that checking every result from an initial `getaddrinfo` closes DNS rebinding, although the HTTP client performs a separate resolution when connecting. The submitted patch shows async callers and raw URL interpolation in their warning logs, contradicting the review's claims that blocking resolution is fine and credential stripping is addressed solely inside the helper. It also misses redirect validation and consequently approves a materially incomplete security design."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 19,
+          "risk_awareness": 15,
+          "total": 64,
+          "notes": "The plan supplies concrete inputs, expected values, status codes, log assertions, compatibility cases, and checks that blocked requests produce no outbound I/O. Its largest gap is the absence of redirect-to-private-address and DNS rebinding tests, which are critical for the proposed validation architecture. It also tests redaction only in the helper while the submitted caller changes log raw URLs, and it inconsistently uses `check_reachability` where the issue describes `verify_endpoint`. Public-host tests depend on live DNS, cached allowlist state is not explicitly reset, and no repository-specific pytest command is provided."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 1,
+          "specificity": 12,
+          "risk_awareness": 6,
+          "total": 23,
+          "notes": "The patch adds concrete guards at the named caller locations, but it does not contain either advertised added file: `registry/utils/url_safety.py` or `tests/unit/test_url_safety.py`. Because existing helpers are removed and multiple modules import the absent replacement, the submitted change would fail at import time rather than implement the design. The summary's claims of 16 passing tests, clean application, and no LLD deviations are therefore contradicted by the actual diff; direct worktree command verification was unavailable because read-only shell invocations failed before execution. Independently, caller warnings expose raw credential-bearing URLs, and the checks still do not address redirects or validation-to-connection DNS rebinding."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 6,
+      "num_turns": 502,
+      "input_tokens": 35005563,
+      "output_tokens": 149560,
+      "total_tokens": 35155123,
+      "latency_seconds": 1994.0,
+      "total_cost_usd": 178.76681500000007,
+      "result_subtype": "error_max_turns",
+      "task_score": 44.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.9416,
+      "generation_tokens_per_sec": 72.4,
+      "kv_cache_usage": {
+        "peak": 0.128,
+        "mean": 0.0845
+      },
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 68,
+          "notes": "The issue provides a detailed inventory, explicit preservation requirements, and testable dependency and reference-removal criteria. Its largest defect is an internal contradiction: it promises continued search for every supported backend while directing the file backend to DocumentDB, and the LLD later admits file deployments lose local search. The conflict is concrete in the goal, factory requirement, and acceptance criterion 3. No independent task statement was supplied, and repository paths and symbols could not be independently verified because read-only shell execution failed in the provided environment."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 58,
+          "notes": "The LLD maps numerous files, lifecycle operations, dependency changes, and old-to-new repository calls. Its central design is unsound against its own requirements: it always returns DocumentDBSearchRepository but simultaneously acknowledges that file storage loses local search, without removing file support or defining a compatible replacement. The metrics change is labeled breaking but lacks an existing-database migration or compatibility strategy, while operational choices such as replacing or removing verify_faiss_metadata remain unresolved. Exact factory code, method signatures, and listed files could not be independently verified because repository command execution was unavailable."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 16,
+          "risk_awareness": 11,
+          "total": 50,
+          "notes": "The review identifies the most relevant pressure points, including loss of file-backed search, manual FAISS persistence, infrastructure references, and the metrics rename. Its largest deficiency is that it notices the critical file-backend incompatibility and dismisses it using an unsupported claim that the project is moving away from file storage, despite the issue requiring all supported backends to keep working. Finding 1 and the unconditional no-blockers conclusion demonstrate that the review preserves rather than resolves this contradiction, and it also misses migration of existing metrics databases. Claims about all call sites and infrastructure files could not be independently verified from source because repository inspection commands failed."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 12,
+          "risk_awareness": 9,
+          "total": 46,
+          "notes": "The plan spans unit, static, functional, deployment, telemetry, metrics, and documentation checks. It does not test the highest-risk requirement: startup and search across every supported backend, especially file storage, because its only startup scenario uses mongodb-ce. Several functional oracles are non-deterministic, such as expecting relevant results or behavior as before, and there is no test for upgrading an existing metrics database from faiss_search_time_ms. The asserted POST endpoint, DocumentDB test directory, and plain pytest commands could not be verified against the repository because shell-based inspection was unavailable."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "No implementation was submitted; the implementation artifact is an empty string and contains neither patch.diff nor implementation.md content. Consequently, none of the proposed dependency, factory, route, metrics, documentation, or test changes can be evaluated as implemented. There is no patch to apply or compare with the real source. All implementation criteria therefore receive zero as required."
+        }
+      },
+      "is_error": true,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-04"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 16,
+      "correctness": 12,
+      "specificity": 15,
+      "risk_awareness": 12,
+      "total": 55,
+      "notes": "The issue clearly states the security motivation, non-goals, dependencies, and a useful acceptance checklist. Its largest defect is the contradictory fallback requirement: the submitted patch selects Secrets Manager when a variable is nonempty and retains the environment entry only when that same value is empty, which is not a usable plaintext fallback. Creating secret versions from Terraform variables also leaves values in state, so the proposed solution does not fully address a central stated risk. No independent task statement was supplied, and the claims about all sensitive variables, the existing KMS key, and issue 1134 could not be independently established."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 18,
+      "risk_awareness": 12,
+      "total": 53,
+      "notes": "The LLD is strongest in naming the nine variables, Terraform files, ECS injection flow, IAM integration, and phased rollout. Its central migration decision is unsound because the proposed fallback injects the same variable only when it is empty, with no mode flag, legacy value, or external secret ARN. Its examples are internally inconsistent: the resource is initially uncounted while later references use index `[0]`, and the implementation summary contradicts the planned variable additions by saying those variables already existed. It acknowledges state exposure and rotation limitations, but leaves rollback, fallback removal, and rotation-triggered ECS redeployment unresolved."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 9,
+      "specificity": 14,
+      "risk_awareness": 15,
+      "total": 51,
+      "notes": "The review usefully identifies persistent Terraform-state exposure, long-lived plaintext fallback risk, rotation documentation, and the absence of an operator runbook. Its largest failure is declaring no blockers while missing that the fallback cannot preserve a nonempty legacy value and that the LLD's conditional collection shapes are not valid Terraform designs. Calling immediate deletion via `recovery_window_in_days = 0` a security strength is questionable, and recommendations such as generic `min_length` validation and custom Secrets Manager encryption context are not implementation-ready Terraform guidance. Claims about the existing KMS policy and current policy size are asserted without repository evidence in the artifacts."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 5,
+      "specificity": 15,
+      "risk_awareness": 10,
+      "total": 45,
+      "notes": "The plan covers plan/apply behavior, task definitions, IAM, mixed configurations, API checks, and security observations with concrete expected secret names. Several commands are unusable: `aws ecs describe-task-definitions` is not an AWS CLI operation, and `get-role-policy` cannot inspect the managed `aws_iam_policy.ecs_secrets_access` resource. The rollback depends on an unimplemented `use_secrets_manager` variable, the sensitivity grep checks only one variable without failing the run, and the ECS exec test prints a secret-bearing environment variable. The existence of `prod.tfvars`, `dev.tfvars`, the named CloudFormation stack, and the proposed federation endpoint is not established."
+    },
+    "implementation": {
+      "completeness": 11,
+      "correctness": 2,
+      "specificity": 17,
+      "risk_awareness": 3,
+      "total": 33,
+      "notes": "The patch attempts all nine named migrations across `ecs-services.tf`, `iam.tf`, and `secrets.tf`, but omits the documentation required by the issue. It is not Terraform-valid: expressions such as `condition ? { name = ..., valueFrom = ... } : []` mix object and tuple result types, while the IAM list similarly mixes ARN strings with empty lists. The environment lists also emit `null` entries, and the alleged fallback exposes only an empty value; immediate secret destruction and `ignore_changes` further create recovery and rotation risks. Repository command execution was unavailable, so mechanical applicability to the stated baseline could not be confirmed, but these defects are present directly in the submitted diff and contradict the summary's claim of complete, deviation-free implementation."
+    }
+  },
+  "task_score": 47.4,
+  "verdict": "The submission is detailed and repository-shaped, but its migration model is logically broken and the implementation contains Terraform type errors that prevent a valid plan.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T17:32:32.109572Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 169945,
+      "cached_input_tokens": 140130,
+      "cache_write_input_tokens": 29803,
+      "output_tokens": 8103,
+      "reasoning_output_tokens": 6405
+    },
+    "duration_ms": 141202
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,291 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 97.9,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5966971,
+    "output_tokens": 25865,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5992836,
+    "total_cost_usd": 30.481479999999998,
+    "latency_seconds": 264.1,
+    "num_turns": 65,
+    "generation_tokens_per_sec": 97.9,
+    "prefix_cache_hit_rate": 0.8729,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5966971,
+  "output_tokens": 25865,
+  "latency_seconds": 264.1,
+  "num_turns": 65,
+  "total_cost_usd": 30.481479999999998,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "thinking_tokens_estimate": 789,
+  "run_started_at": "2026-08-05T17:21:18.386882Z",
+  "run_ended_at": "2026-08-05T17:25:43.059981Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5966971,
+    "output_tokens": 25865,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5992836,
+    "total_cost_usd": 30.481479999999998,
+    "latency_seconds": 264.1,
+    "num_turns": 65,
+    "generation_tokens_per_sec": 97.9,
+    "prefix_cache_hit_rate": 0.8729,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8729,
+      "prompt_tokens_cached_rate": 0.8729
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 25865,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 5208560,
+      "vllm:prefix_cache_queries_total": 5966971,
+      "vllm:prompt_tokens_by_source_total": 5966971,
+      "vllm:prompt_tokens_cached_total": 5208560,
+      "vllm:prompt_tokens_total": 5966971,
+      "vllm:request_success_total": 62,
+      "vllm:tool_call_parser_invocations_total": 22406
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 62,
+        "sum": 261.6822,
+        "mean": 4.220681
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 25803,
+        "sum": 203.5529,
+        "mean": 0.007889
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 25865,
+        "sum": 784276,
+        "mean": 30.321902
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 62,
+        "sum": 203.5529,
+        "mean": 3.283111
+      },
+      "vllm:request_generation_tokens": {
+        "count": 62,
+        "sum": 25865,
+        "mean": 417.177419
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 62,
+        "sum": 249.0784,
+        "mean": 4.017394
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 62,
+        "sum": 25865,
+        "mean": 417.177419
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 62,
+        "sum": 992000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 62,
+        "sum": 62,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 62,
+        "sum": 758411,
+        "mean": 12232.435484
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 62,
+        "sum": 45.5256,
+        "mean": 0.734283
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 62,
+        "sum": 5966971,
+        "mean": 96241.467742
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 62,
+        "sum": 0.0008,
+        "mean": 1.2e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 62,
+        "sum": 0.4933,
+        "mean": 0.007956
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 62,
+        "sum": 58.1521,
+        "mean": 0.937937
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1014,
+          "mean": 0.0688,
+          "samples": 263
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9163,
+          "samples": 263
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 263
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 16,
+        "correctness": 12,
+        "specificity": 15,
+        "risk_awareness": 12,
+        "total": 55,
+        "notes": "The issue clearly states the security motivation, non-goals, dependencies, and a useful acceptance checklist. Its largest defect is the contradictory fallback requirement: the submitted patch selects Secrets Manager when a variable is nonempty and retains the environment entry only when that same value is empty, which is not a usable plaintext fallback. Creating secret versions from Terraform variables also leaves values in state, so the proposed solution does not fully address a central stated risk. No independent task statement was supplied, and the claims about all sensitive variables, the existing KMS key, and issue 1134 could not be independently established."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 18,
+        "risk_awareness": 12,
+        "total": 53,
+        "notes": "The LLD is strongest in naming the nine variables, Terraform files, ECS injection flow, IAM integration, and phased rollout. Its central migration decision is unsound because the proposed fallback injects the same variable only when it is empty, with no mode flag, legacy value, or external secret ARN. Its examples are internally inconsistent: the resource is initially uncounted while later references use index `[0]`, and the implementation summary contradicts the planned variable additions by saying those variables already existed. It acknowledges state exposure and rotation limitations, but leaves rollback, fallback removal, and rotation-triggered ECS redeployment unresolved."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 9,
+        "specificity": 14,
+        "risk_awareness": 15,
+        "total": 51,
+        "notes": "The review usefully identifies persistent Terraform-state exposure, long-lived plaintext fallback risk, rotation documentation, and the absence of an operator runbook. Its largest failure is declaring no blockers while missing that the fallback cannot preserve a nonempty legacy value and that the LLD's conditional collection shapes are not valid Terraform designs. Calling immediate deletion via `recovery_window_in_days = 0` a security strength is questionable, and recommendations such as generic `min_length` validation and custom Secrets Manager encryption context are not implementation-ready Terraform guidance. Claims about the existing KMS policy and current policy size are asserted without repository evidence in the artifacts."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 5,
+        "specificity": 15,
+        "risk_awareness": 10,
+        "total": 45,
+        "notes": "The plan covers plan/apply behavior, task definitions, IAM, mixed configurations, API checks, and security observations with concrete expected secret names. Several commands are unusable: `aws ecs describe-task-definitions` is not an AWS CLI operation, and `get-role-policy` cannot inspect the managed `aws_iam_policy.ecs_secrets_access` resource. The rollback depends on an unimplemented `use_secrets_manager` variable, the sensitivity grep checks only one variable without failing the run, and the ECS exec test prints a secret-bearing environment variable. The existence of `prod.tfvars`, `dev.tfvars`, the named CloudFormation stack, and the proposed federation endpoint is not established."
+      },
+      "implementation": {
+        "completeness": 11,
+        "correctness": 2,
+        "specificity": 17,
+        "risk_awareness": 3,
+        "total": 33,
+        "notes": "The patch attempts all nine named migrations across `ecs-services.tf`, `iam.tf`, and `secrets.tf`, but omits the documentation required by the issue. It is not Terraform-valid: expressions such as `condition ? { name = ..., valueFrom = ... } : []` mix object and tuple result types, while the IAM list similarly mixes ARN strings with empty lists. The environment lists also emit `null` entries, and the alleged fallback exposes only an empty value; immediate secret destruction and `ignore_changes` further create recovery and rotation risks. Repository command execution was unavailable, so mechanical applicability to the stated baseline could not be confirmed, but these defects are present directly in the submitted diff and contradict the summary's claim of complete, deviation-free implementation."
+      }
+    },
+    "task_score": 47.4,
+    "verdict": "The submission is detailed and repository-shaped, but its migration model is logically broken and the implementation contains Terraform type errors that prevent a valid plan.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T17:32:32.109572Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 169945,
+        "cached_input_tokens": 140130,
+        "cache_write_input_tokens": 29803,
+        "output_tokens": 8103,
+        "reasoning_output_tokens": 6405
+      },
+      "duration_ms": 141202
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 11,
+      "total": 67,
+      "notes": "The issue gives concrete acceptance criteria naming the relevant Terraform modules, outputs, variables, and scripts, all of which correspond to targets shown in the submitted source diff. Its largest gap is that it excludes application dependencies without specifying replacement behavior for scopes configuration, log mounts, or other paths currently backed by EFS. The existing outputs and script references demonstrate that removing EFS affects callers, making the claim of no dependencies too strong. No independent task statement or runtime evidence establishes that EFS was never populated or that S3 and DocumentDB already cover every persistence requirement."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 15,
+      "specificity": 18,
+      "risk_awareness": 12,
+      "total": 62,
+      "notes": "The LLD is grounded in actual paths and accurately inventories the EFS module, six access points, task volumes, outputs, variables, and scripts represented in the baseline. Its largest deficiency is leaving critical behavior as \"remove or update,\" particularly the scopes initialization flow and replacement for SCOPES_CONFIG_PATH, while declaring no open questions. It correctly requires removal of corresponding container mountPoints, a requirement later missed by the implementation. The rollout lacks state backup, data verification, external-output compatibility, and a viable rollback after destructive EFS removal, while its DocumentDB and S3 migration claims remain unverified."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 15,
+      "specificity": 16,
+      "risk_awareness": 18,
+      "total": 64,
+      "notes": "The review identifies several change-specific risks, including orphaned container mountPoints, lingering module references, output compatibility, NFS rules, and destructive data loss. Its largest weakness is assigning no blockers despite unresolved replacement semantics and checks that are necessary for a deployable task definition. The warning about removing container-side mountPoints is materially correct: the implementation retains the mcp-logs sourceVolume reference after replacing the module volume map with an empty map. Much of the multi-role presentation is repetitive, and recommendations such as graceful handling of missing EFS outputs conflict with the cleaner requirement to remove obsolete EFS-dependent flows."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 10,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 50,
+      "notes": "The plan provides concrete validate, plan, grep, and bash syntax commands with explicit exit-code or text oracles; bash -n would catch the implementation's extra closing brace. Its stated seven-resource destruction oracle is incorrect because storage.tf defines six access points including mcpgw_data, while the list includes only five and also omits module-created mount targets and security-group resources. The /efs grep cannot detect a sourceVolume that references an undefined task volume, so the retained mcp-logs mount could pass this plan without any ECS task-registration or service smoke test. It also excludes shell scripts from the broad EFS-reference check and dismisses backward compatibility despite removing public Terraform outputs."
+    },
+    "implementation": {
+      "completeness": 11,
+      "correctness": 5,
+      "specificity": 14,
+      "risk_awareness": 4,
+      "total": 34,
+      "notes": "The patch removes the main EFS module, related variables and outputs, and the explicit EFS volume configurations across the expected files. It is not deployable as submitted: post-deployment-setup.sh adds a new function-closing brace immediately before the existing one, producing a shell syntax error, and ecs-services.tf retains the mcp-logs mountPoint while setting volume to an empty map. run-scopes-init-task.sh exits successfully mid-script but leaves its remaining EFS task code unreachable, while the new local scopes path and automatic DocumentDB initialization claims are not validated. The summary's claims of exact LLD compliance and no follow-ups therefore overstate the change; independent git apply checking was unavailable in the provided execution environment."
+    }
+  },
+  "task_score": 55.4,
+  "verdict": "The artifacts provide a useful removal inventory, but unresolved persistence behavior and a patch containing both a shell syntax error and an invalid ECS volume reference make the submission unsafe to merge.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T17:34:39.353214Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 138843,
+      "cached_input_tokens": 111353,
+      "cache_write_input_tokens": 27478,
+      "output_tokens": 6824,
+      "reasoning_output_tokens": 5316
+    },
+    "duration_ms": 127232
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,290 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 89.5,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 9726111,
+    "output_tokens": 24343,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 9750454,
+    "total_cost_usd": 49.239129999999996,
+    "latency_seconds": 272.0,
+    "num_turns": 124,
+    "generation_tokens_per_sec": 89.5,
+    "prefix_cache_hit_rate": 0.8841,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 9726111,
+  "output_tokens": 24343,
+  "latency_seconds": 272.0,
+  "num_turns": 124,
+  "total_cost_usd": 49.239129999999996,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "thinking_tokens_estimate": 529,
+  "run_started_at": "2026-08-05T17:12:31.550052Z",
+  "run_ended_at": "2026-08-05T17:17:04.112044Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 9726111,
+    "output_tokens": 24343,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 9750454,
+    "total_cost_usd": 49.239129999999996,
+    "latency_seconds": 272.0,
+    "num_turns": 124,
+    "generation_tokens_per_sec": 89.5,
+    "prefix_cache_hit_rate": 0.8841,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8841,
+      "prompt_tokens_cached_rate": 0.8841
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 24343,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 8599200,
+      "vllm:prefix_cache_queries_total": 9726111,
+      "vllm:prompt_tokens_by_source_total": 9726111,
+      "vllm:prompt_tokens_cached_total": 8599200,
+      "vllm:prompt_tokens_total": 9726111,
+      "vllm:request_success_total": 123,
+      "vllm:tool_call_parser_invocations_total": 20913
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 123,
+        "sum": 265.5018,
+        "mean": 2.158551
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 24220,
+        "sum": 182.8217,
+        "mean": 0.007548
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 24343,
+        "sum": 1151254,
+        "mean": 47.293021
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 123,
+        "sum": 182.8217,
+        "mean": 1.486355
+      },
+      "vllm:request_generation_tokens": {
+        "count": 123,
+        "sum": 24343,
+        "mean": 197.910569
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 123,
+        "sum": 245.0476,
+        "mean": 1.992257
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 123,
+        "sum": 24343,
+        "mean": 197.910569
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 123,
+        "sum": 1968000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 123,
+        "sum": 123,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 123,
+        "sum": 1126911,
+        "mean": 9161.878049
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 123,
+        "sum": 62.2259,
+        "mean": 0.505902
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 123,
+        "sum": 9726111,
+        "mean": 79074.073171
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 123,
+        "sum": 0.0012,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 123,
+        "sum": 0.9354,
+        "mean": 0.007605
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 123,
+        "sum": 82.7192,
+        "mean": 0.672514
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0878,
+          "mean": 0.0541,
+          "samples": 271
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8782,
+          "samples": 271
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 271
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 11,
+        "total": 67,
+        "notes": "The issue gives concrete acceptance criteria naming the relevant Terraform modules, outputs, variables, and scripts, all of which correspond to targets shown in the submitted source diff. Its largest gap is that it excludes application dependencies without specifying replacement behavior for scopes configuration, log mounts, or other paths currently backed by EFS. The existing outputs and script references demonstrate that removing EFS affects callers, making the claim of no dependencies too strong. No independent task statement or runtime evidence establishes that EFS was never populated or that S3 and DocumentDB already cover every persistence requirement."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 15,
+        "specificity": 18,
+        "risk_awareness": 12,
+        "total": 62,
+        "notes": "The LLD is grounded in actual paths and accurately inventories the EFS module, six access points, task volumes, outputs, variables, and scripts represented in the baseline. Its largest deficiency is leaving critical behavior as \"remove or update,\" particularly the scopes initialization flow and replacement for SCOPES_CONFIG_PATH, while declaring no open questions. It correctly requires removal of corresponding container mountPoints, a requirement later missed by the implementation. The rollout lacks state backup, data verification, external-output compatibility, and a viable rollback after destructive EFS removal, while its DocumentDB and S3 migration claims remain unverified."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 15,
+        "specificity": 16,
+        "risk_awareness": 18,
+        "total": 64,
+        "notes": "The review identifies several change-specific risks, including orphaned container mountPoints, lingering module references, output compatibility, NFS rules, and destructive data loss. Its largest weakness is assigning no blockers despite unresolved replacement semantics and checks that are necessary for a deployable task definition. The warning about removing container-side mountPoints is materially correct: the implementation retains the mcp-logs sourceVolume reference after replacing the module volume map with an empty map. Much of the multi-role presentation is repetitive, and recommendations such as graceful handling of missing EFS outputs conflict with the cleaner requirement to remove obsolete EFS-dependent flows."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 10,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 50,
+        "notes": "The plan provides concrete validate, plan, grep, and bash syntax commands with explicit exit-code or text oracles; bash -n would catch the implementation's extra closing brace. Its stated seven-resource destruction oracle is incorrect because storage.tf defines six access points including mcpgw_data, while the list includes only five and also omits module-created mount targets and security-group resources. The /efs grep cannot detect a sourceVolume that references an undefined task volume, so the retained mcp-logs mount could pass this plan without any ECS task-registration or service smoke test. It also excludes shell scripts from the broad EFS-reference check and dismisses backward compatibility despite removing public Terraform outputs."
+      },
+      "implementation": {
+        "completeness": 11,
+        "correctness": 5,
+        "specificity": 14,
+        "risk_awareness": 4,
+        "total": 34,
+        "notes": "The patch removes the main EFS module, related variables and outputs, and the explicit EFS volume configurations across the expected files. It is not deployable as submitted: post-deployment-setup.sh adds a new function-closing brace immediately before the existing one, producing a shell syntax error, and ecs-services.tf retains the mcp-logs mountPoint while setting volume to an empty map. run-scopes-init-task.sh exits successfully mid-script but leaves its remaining EFS task code unreachable, while the new local scopes path and automatic DocumentDB initialization claims are not validated. The summary's claims of exact LLD compliance and no follow-ups therefore overstate the change; independent git apply checking was unavailable in the provided execution environment."
+      }
+    },
+    "task_score": 55.4,
+    "verdict": "The artifacts provide a useful removal inventory, but unresolved persistence behavior and a patch containing both a shell syntax error and an invalid ECS volume reference make the submission unsafe to merge.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T17:34:39.353214Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 138843,
+        "cached_input_tokens": 111353,
+        "cache_write_input_tokens": 27478,
+        "output_tokens": 6824,
+        "reasoning_output_tokens": 5316
+      },
+      "duration_ms": 127232
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 19,
+      "risk_awareness": 9,
+      "total": 59,
+      "notes": "The issue provides concrete file-level acceptance criteria and explicit non-goals. The submitted diff corroborates the existence of pyproject.toml, registry/core/config.py, registry/search/service.py, and the file search repository. Its largest contradiction is promising unchanged search while explicitly replacing semantic FAISS behavior with keyword-only search for file deployments. No independent task statement establishes the equivalence or obsolescence claims, and the issue omits startup reindexing, persisted-index migration, and measurable compatibility criteria."
+    },
+    "lld": {
+      "completeness": 13,
+      "correctness": 12,
+      "specificity": 17,
+      "risk_awareness": 9,
+      "total": 51,
+      "notes": "The LLD is grounded in concrete repository paths, the SearchRepositoryBase abstraction, the repository factory, and the two backend implementations. Its method list and file plan are specific, but it does not define result-field compatibility, tool-result behavior, ranking semantics, or how existing file-backed entities populate the new in-memory index after restart. Error handling is reduced to handling missing metadata, while persistence, concurrent updates, memory bounds, and recovery are left undecided. The rollout plan is only a testing sequence and supplies neither rollback nor a fallback when the replacement repository is empty or incompatible."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 10,
+      "specificity": 14,
+      "risk_awareness": 14,
+      "total": 51,
+      "notes": "The strongest review content identifies the in-memory repository's non-persistence, memory growth, direct FaissService consumers, and need for replacement tests. It then declares those concerns resolved even though the submitted LLD contains no startup rebuild mechanism or concrete memory limit, and its claimed small-deployment resolution is absent from the design. It misses the loss of tool results and response metadata visible when comparing the new repository with the deleted FaissService.search_mixed implementation. The final no-blockers verdict is therefore not supported by its own critical findings."
+    },
+    "testing": {
+      "completeness": 12,
+      "correctness": 7,
+      "specificity": 12,
+      "risk_awareness": 8,
+      "total": 39,
+      "notes": "The plan spans API, compatibility, dependency, Docker, configuration, and end-to-end surfaces. Most shell checks are observational rather than assertions: jq length and select succeed with zero matches, the tag test never verifies returned tags, and the deletion check incorrectly expects the entire server result list to be empty. The repository snippet only checks isinstance and performs one index call, with no search, ranking, filtering, removal, or result-shape oracle. It omits the highest-risk cases: restart hydration, existing file data, tool results, agent input compatibility, and dedicated tests for FileSearchRepository."
+    },
+    "implementation": {
+      "completeness": 8,
+      "correctness": 5,
+      "specificity": 12,
+      "risk_awareness": 3,
+      "total": 28,
+      "notes": "The patch concretely removes the declared dependency, configuration properties, FAISS service, mocks, and old tests, and introduces FileSearchRepository. Its initialize method only flips a boolean while _entities starts empty, so existing file-backed registrations are unsearchable after restart unless another undocumented path reindexes them. Its search method never populates tools, skills, or virtual_servers and always returns empty matching_tools, while index_agent changes the former dictionary input to AgentCard without replacement coverage. Documentation still names FaissSearchRepository, service_index.faiss, and the deleted service under mechanical text such as \"vector search search,\" so the summary's no-deviation claim is false; a shell sandbox failure prevented an independent git apply check."
+    }
+  },
+  "task_score": 45.6,
+  "verdict": "The submission is repository-aware and concrete, but it does not preserve file-backed search across restarts or maintain the existing search result contract, and its tests would not catch those regressions.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T17:36:46.781400Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 338582,
+      "cached_input_tokens": 279996,
+      "cache_write_input_tokens": 58574,
+      "output_tokens": 7035,
+      "reasoning_output_tokens": 5428
+    },
+    "duration_ms": 127415
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,291 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 74.1,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 9821325,
+    "output_tokens": 21383,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 9842708,
+    "total_cost_usd": 49.64119999999998,
+    "latency_seconds": 288.7,
+    "num_turns": 83,
+    "generation_tokens_per_sec": 74.1,
+    "prefix_cache_hit_rate": 0.8778,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 9821325,
+  "output_tokens": 21383,
+  "latency_seconds": 288.7,
+  "num_turns": 83,
+  "total_cost_usd": 49.64119999999998,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "thinking_tokens_estimate": 593,
+  "run_started_at": "2026-08-05T17:07:39.776148Z",
+  "run_ended_at": "2026-08-05T17:12:29.030438Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 9821325,
+    "output_tokens": 21383,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 9842708,
+    "total_cost_usd": 49.64119999999998,
+    "latency_seconds": 288.7,
+    "num_turns": 83,
+    "generation_tokens_per_sec": 74.1,
+    "prefix_cache_hit_rate": 0.8778,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8778,
+      "prompt_tokens_cached_rate": 0.8778
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 21383,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 8620944,
+      "vllm:prefix_cache_queries_total": 9821325,
+      "vllm:prompt_tokens_by_source_total": 9821325,
+      "vllm:prompt_tokens_cached_total": 8620944,
+      "vllm:prompt_tokens_total": 9821325,
+      "vllm:request_success_total": 83,
+      "vllm:tool_call_parser_invocations_total": 17870
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 83,
+        "sum": 282.8743,
+        "mean": 3.408124
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 21300,
+        "sum": 179.3468,
+        "mean": 0.00842
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 21383,
+        "sum": 1221764,
+        "mean": 57.137165
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 83,
+        "sum": 179.3468,
+        "mean": 2.160805
+      },
+      "vllm:request_generation_tokens": {
+        "count": 83,
+        "sum": 21383,
+        "mean": 257.626506
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 83,
+        "sum": 262.1932,
+        "mean": 3.158954
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 83,
+        "sum": 21383,
+        "mean": 257.626506
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 83,
+        "sum": 1328000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 83,
+        "sum": 83,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 83,
+        "sum": 1200381,
+        "mean": 14462.421687
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 83,
+        "sum": 82.8464,
+        "mean": 0.998149
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 83,
+        "sum": 9821325,
+        "mean": 118329.216867
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 83,
+        "sum": 0.0008,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 83,
+        "sum": 0.6975,
+        "mean": 0.008404
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 83,
+        "sum": 103.5618,
+        "mean": 1.247732
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.122,
+          "mean": 0.0828,
+          "samples": 288
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.875,
+          "samples": 288
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 288
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 19,
+        "risk_awareness": 9,
+        "total": 59,
+        "notes": "The issue provides concrete file-level acceptance criteria and explicit non-goals. The submitted diff corroborates the existence of pyproject.toml, registry/core/config.py, registry/search/service.py, and the file search repository. Its largest contradiction is promising unchanged search while explicitly replacing semantic FAISS behavior with keyword-only search for file deployments. No independent task statement establishes the equivalence or obsolescence claims, and the issue omits startup reindexing, persisted-index migration, and measurable compatibility criteria."
+      },
+      "lld": {
+        "completeness": 13,
+        "correctness": 12,
+        "specificity": 17,
+        "risk_awareness": 9,
+        "total": 51,
+        "notes": "The LLD is grounded in concrete repository paths, the SearchRepositoryBase abstraction, the repository factory, and the two backend implementations. Its method list and file plan are specific, but it does not define result-field compatibility, tool-result behavior, ranking semantics, or how existing file-backed entities populate the new in-memory index after restart. Error handling is reduced to handling missing metadata, while persistence, concurrent updates, memory bounds, and recovery are left undecided. The rollout plan is only a testing sequence and supplies neither rollback nor a fallback when the replacement repository is empty or incompatible."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 10,
+        "specificity": 14,
+        "risk_awareness": 14,
+        "total": 51,
+        "notes": "The strongest review content identifies the in-memory repository's non-persistence, memory growth, direct FaissService consumers, and need for replacement tests. It then declares those concerns resolved even though the submitted LLD contains no startup rebuild mechanism or concrete memory limit, and its claimed small-deployment resolution is absent from the design. It misses the loss of tool results and response metadata visible when comparing the new repository with the deleted FaissService.search_mixed implementation. The final no-blockers verdict is therefore not supported by its own critical findings."
+      },
+      "testing": {
+        "completeness": 12,
+        "correctness": 7,
+        "specificity": 12,
+        "risk_awareness": 8,
+        "total": 39,
+        "notes": "The plan spans API, compatibility, dependency, Docker, configuration, and end-to-end surfaces. Most shell checks are observational rather than assertions: jq length and select succeed with zero matches, the tag test never verifies returned tags, and the deletion check incorrectly expects the entire server result list to be empty. The repository snippet only checks isinstance and performs one index call, with no search, ranking, filtering, removal, or result-shape oracle. It omits the highest-risk cases: restart hydration, existing file data, tool results, agent input compatibility, and dedicated tests for FileSearchRepository."
+      },
+      "implementation": {
+        "completeness": 8,
+        "correctness": 5,
+        "specificity": 12,
+        "risk_awareness": 3,
+        "total": 28,
+        "notes": "The patch concretely removes the declared dependency, configuration properties, FAISS service, mocks, and old tests, and introduces FileSearchRepository. Its initialize method only flips a boolean while _entities starts empty, so existing file-backed registrations are unsearchable after restart unless another undocumented path reindexes them. Its search method never populates tools, skills, or virtual_servers and always returns empty matching_tools, while index_agent changes the former dictionary input to AgentCard without replacement coverage. Documentation still names FaissSearchRepository, service_index.faiss, and the deleted service under mechanical text such as \"vector search search,\" so the summary's no-deviation claim is false; a shell sandbox failure prevented an independent git apply check."
+      }
+    },
+    "task_score": 45.6,
+    "verdict": "The submission is repository-aware and concrete, but it does not preserve file-backed search across restarts or maintain the existing search result contract, and its tests would not catch those regressions.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T17:36:46.781400Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 338582,
+        "cached_input_tokens": 279996,
+        "cache_write_input_tokens": 58574,
+        "output_tokens": 7035,
+        "reasoning_output_tokens": 5428
+      },
+      "duration_ms": 127415
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 16,
+      "correctness": 9,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 52,
+      "notes": "The issue clearly identifies the current Secrets Manager password flow, affected Aurora, proxy, and ECS components, a feature flag, and useful non-goals. Its largest defect is technical: IAM tokens are locally signed credentials, not automatically rotated through `rds:GenerateDBAuthToken`, and their generation is not the CloudTrail audit trail claimed here. The existing `keycloak-database.tf` and `keycloak-ecs.tf` contexts confirm proxy secret authentication and injection of `KC_DB_PASSWORD`, but the criteria also contradict themselves by requiring no Keycloak configuration changes while changing its database authentication configuration. No independent task statement establishes the asserted zero-downtime fallback or audit requirements."
+    },
+    "lld": {
+      "completeness": 13,
+      "correctness": 4,
+      "specificity": 16,
+      "risk_awareness": 9,
+      "total": 42,
+      "notes": "The LLD names real Terraform resources and files and provides concrete variables, rollout phases, and container changes. Its critical authentication design is invalid: clients need `rds-db:connect` on a database-user ARN, not `rds:GenerateDBAuthToken` on `aws_rds_cluster.keycloak.arn`, and a token generated only at startup cannot authenticate new pooled connections after expiry. The source contexts confirm `aws_db_proxy.keycloak`, `aws_rds_cluster.keycloak`, the Keycloak task role, and container secret locals, but the document repeatedly changes between native proxy handling, an init container, and a custom entrypoint without resolving refresh or fallback behavior. CloudTrail token-generation observability, automatic proxy token refresh, and the proposed custom-image build path are unsupported or unverifiable, while TLS, image validation, and failure recovery remain incomplete."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 16,
+      "risk_awareness": 15,
+      "total": 54,
+      "notes": "The review usefully identifies that Keycloak cannot generate IAM credentials natively, that proxy `REQUIRED` mode creates a lockout risk, and that rollback secrets must remain available. It nevertheless endorses the invalid `rds:GenerateDBAuthToken` cluster-ARN policy, even claiming the LLD used a wildcard although its sample already uses `aws_rds_cluster.keycloak.arn`; another reviewer then calls that ARN appropriate. It also misses the decisive 15-minute startup-token expiry problem and does not challenge the proposed Docker build or Terraform integration. The concrete recommendations are useful, but an approval-with-changes verdict is not defensible while the review itself labels the unresolved client authentication mechanism critical."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 4,
+      "specificity": 15,
+      "risk_awareness": 10,
+      "total": 43,
+      "notes": "The plan spans Terraform, image construction, compatibility, deployment inspection, end-to-end health, and rollback. Several core commands and oracles are wrong: an RDS token is a presigned URL rather than a JWT beginning with `keycloak/`, `describe-db-proxy` and `describe-db-log-file-credits` are not valid AWS CLI commands, and token generation is not observable as the claimed CloudTrail API event. The image inspection invokes `cat` through the custom Keycloak entrypoint, while the API assertion accepts every status below 500, including authentication failures and curl's `000`, so broken behavior can pass. It lacks the most important longevity test for opening new connections after token expiry, denied `rds-db:connect`, malformed JDBC URLs, and an enabled flag with no custom image."
+    },
+    "implementation": {
+      "completeness": 8,
+      "correctness": 2,
+      "specificity": 13,
+      "risk_awareness": 4,
+      "total": 27,
+      "notes": "The patch touches the real cluster, proxy, task definition, variables, examples, and image surfaces, but it does not produce a usable end-to-end implementation. In `keycloak-ecs.tf`, `keycloak_image` is placed as an unsupported `aws_ecs_task_definition` argument while the container references undefined `local.keycloak_image`, so Terraform validation fails even with the feature disabled; the IAM action and cluster ARN are also invalid for database login. The Dockerfile attempts `microdnf` in the minimal Keycloak image, uses `unzip` without installing it, and chmods a root-owned copied script after switching to `USER keycloak`; even a successful image would retain one startup token indefinitely. The summary falsely reports no deviations or follow-ups despite omitting the LLD's fallback and production guardrail, silently selecting the stock image when IAM is enabled without an IAM image URI, and providing no token-refresh mechanism."
+    }
+  },
+  "task_score": 43.6,
+  "verdict": "The artifacts identify the correct infrastructure area but rely on an invalid IAM permission model and deliver a patch that cannot validate, build, or sustain authenticated database connections.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T17:39:33.040217Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 217556,
+      "cached_input_tokens": 188081,
+      "cache_write_input_tokens": 29459,
+      "output_tokens": 8402,
+      "reasoning_output_tokens": 6447
+    },
+    "duration_ms": 166247
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,291 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 97.0,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 6934724,
+    "output_tokens": 25438,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 6960162,
+    "total_cost_usd": 35.309569999999994,
+    "latency_seconds": 262.2,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 97.0,
+    "prefix_cache_hit_rate": 0.8788,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 6934724,
+  "output_tokens": 25438,
+  "latency_seconds": 262.2,
+  "num_turns": 80,
+  "total_cost_usd": 35.309569999999994,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "thinking_tokens_estimate": 496,
+  "run_started_at": "2026-08-05T17:25:47.659814Z",
+  "run_ended_at": "2026-08-05T17:30:10.457203Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 6934724,
+    "output_tokens": 25438,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 6960162,
+    "total_cost_usd": 35.309569999999994,
+    "latency_seconds": 262.2,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 97.0,
+    "prefix_cache_hit_rate": 0.8788,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8788,
+      "prompt_tokens_cached_rate": 0.8788
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 25438,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 6094032,
+      "vllm:prefix_cache_queries_total": 6934724,
+      "vllm:prompt_tokens_by_source_total": 6934724,
+      "vllm:prompt_tokens_cached_total": 6094032,
+      "vllm:prompt_tokens_total": 6934724,
+      "vllm:request_success_total": 80,
+      "vllm:tool_call_parser_invocations_total": 22747
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 80,
+        "sum": 258.4729,
+        "mean": 3.230912
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 25358,
+        "sum": 195.5966,
+        "mean": 0.007713
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 25438,
+        "sum": 866130,
+        "mean": 34.048667
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 80,
+        "sum": 195.5966,
+        "mean": 2.444958
+      },
+      "vllm:request_generation_tokens": {
+        "count": 80,
+        "sum": 25438,
+        "mean": 317.975
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 80,
+        "sum": 243.7121,
+        "mean": 3.046402
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 80,
+        "sum": 25438,
+        "mean": 317.975
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 80,
+        "sum": 1280000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 80,
+        "sum": 80,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 80,
+        "sum": 840692,
+        "mean": 10508.65
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 80,
+        "sum": 48.1155,
+        "mean": 0.601444
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 80,
+        "sum": 6934724,
+        "mean": 86684.05
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 80,
+        "sum": 0.0009,
+        "mean": 1.1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 80,
+        "sum": 0.6214,
+        "mean": 0.007767
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 80,
+        "sum": 62.9073,
+        "mean": 0.786341
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0941,
+          "mean": 0.0606,
+          "samples": 262
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8893,
+          "samples": 262
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 262
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 16,
+        "correctness": 9,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 52,
+        "notes": "The issue clearly identifies the current Secrets Manager password flow, affected Aurora, proxy, and ECS components, a feature flag, and useful non-goals. Its largest defect is technical: IAM tokens are locally signed credentials, not automatically rotated through `rds:GenerateDBAuthToken`, and their generation is not the CloudTrail audit trail claimed here. The existing `keycloak-database.tf` and `keycloak-ecs.tf` contexts confirm proxy secret authentication and injection of `KC_DB_PASSWORD`, but the criteria also contradict themselves by requiring no Keycloak configuration changes while changing its database authentication configuration. No independent task statement establishes the asserted zero-downtime fallback or audit requirements."
+      },
+      "lld": {
+        "completeness": 13,
+        "correctness": 4,
+        "specificity": 16,
+        "risk_awareness": 9,
+        "total": 42,
+        "notes": "The LLD names real Terraform resources and files and provides concrete variables, rollout phases, and container changes. Its critical authentication design is invalid: clients need `rds-db:connect` on a database-user ARN, not `rds:GenerateDBAuthToken` on `aws_rds_cluster.keycloak.arn`, and a token generated only at startup cannot authenticate new pooled connections after expiry. The source contexts confirm `aws_db_proxy.keycloak`, `aws_rds_cluster.keycloak`, the Keycloak task role, and container secret locals, but the document repeatedly changes between native proxy handling, an init container, and a custom entrypoint without resolving refresh or fallback behavior. CloudTrail token-generation observability, automatic proxy token refresh, and the proposed custom-image build path are unsupported or unverifiable, while TLS, image validation, and failure recovery remain incomplete."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 16,
+        "risk_awareness": 15,
+        "total": 54,
+        "notes": "The review usefully identifies that Keycloak cannot generate IAM credentials natively, that proxy `REQUIRED` mode creates a lockout risk, and that rollback secrets must remain available. It nevertheless endorses the invalid `rds:GenerateDBAuthToken` cluster-ARN policy, even claiming the LLD used a wildcard although its sample already uses `aws_rds_cluster.keycloak.arn`; another reviewer then calls that ARN appropriate. It also misses the decisive 15-minute startup-token expiry problem and does not challenge the proposed Docker build or Terraform integration. The concrete recommendations are useful, but an approval-with-changes verdict is not defensible while the review itself labels the unresolved client authentication mechanism critical."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 4,
+        "specificity": 15,
+        "risk_awareness": 10,
+        "total": 43,
+        "notes": "The plan spans Terraform, image construction, compatibility, deployment inspection, end-to-end health, and rollback. Several core commands and oracles are wrong: an RDS token is a presigned URL rather than a JWT beginning with `keycloak/`, `describe-db-proxy` and `describe-db-log-file-credits` are not valid AWS CLI commands, and token generation is not observable as the claimed CloudTrail API event. The image inspection invokes `cat` through the custom Keycloak entrypoint, while the API assertion accepts every status below 500, including authentication failures and curl's `000`, so broken behavior can pass. It lacks the most important longevity test for opening new connections after token expiry, denied `rds-db:connect`, malformed JDBC URLs, and an enabled flag with no custom image."
+      },
+      "implementation": {
+        "completeness": 8,
+        "correctness": 2,
+        "specificity": 13,
+        "risk_awareness": 4,
+        "total": 27,
+        "notes": "The patch touches the real cluster, proxy, task definition, variables, examples, and image surfaces, but it does not produce a usable end-to-end implementation. In `keycloak-ecs.tf`, `keycloak_image` is placed as an unsupported `aws_ecs_task_definition` argument while the container references undefined `local.keycloak_image`, so Terraform validation fails even with the feature disabled; the IAM action and cluster ARN are also invalid for database login. The Dockerfile attempts `microdnf` in the minimal Keycloak image, uses `unzip` without installing it, and chmods a root-owned copied script after switching to `USER keycloak`; even a successful image would retain one startup token indefinitely. The summary falsely reports no deviations or follow-ups despite omitting the LLD's fallback and production guardrail, silently selecting the stock image when IAM is enabled without an IAM image URI, and providing no token-refresh mechanism."
+      }
+    },
+    "task_score": 43.6,
+    "verdict": "The artifacts identify the correct infrastructure area but rely on an invalid IAM permission model and deliver a patch that cannot validate, build, or sustain authenticated database connections.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T17:39:33.040217Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 217556,
+        "cached_input_tokens": 188081,
+        "cache_write_input_tokens": 29459,
+        "output_tokens": 8402,
+        "reasoning_output_tokens": 6447
+      },
+      "duration_ms": 166247
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "claude",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T17:32:32.109572Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 169945,
+      "cached_input_tokens": 140130,
+      "cache_write_input_tokens": 29803,
+      "output_tokens": 8103,
+      "reasoning_output_tokens": 6405
+    },
+    "duration_ms": 141202
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 48.36,
+  "mean_cost_usd_excl_failed": 39.51,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 124,
+      "input_tokens": 9726111,
+      "output_tokens": 24343,
+      "total_tokens": 9750454,
+      "latency_seconds": 272.0,
+      "total_cost_usd": 49.239129999999996,
+      "result_subtype": "success",
+      "task_score": 55.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8841,
+      "generation_tokens_per_sec": 89.5,
+      "kv_cache_usage": {
+        "peak": 0.0878,
+        "mean": 0.0541
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 11,
+          "total": 67,
+          "notes": "The issue gives concrete acceptance criteria naming the relevant Terraform modules, outputs, variables, and scripts, all of which correspond to targets shown in the submitted source diff. Its largest gap is that it excludes application dependencies without specifying replacement behavior for scopes configuration, log mounts, or other paths currently backed by EFS. The existing outputs and script references demonstrate that removing EFS affects callers, making the claim of no dependencies too strong. No independent task statement or runtime evidence establishes that EFS was never populated or that S3 and DocumentDB already cover every persistence requirement."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 15,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 62,
+          "notes": "The LLD is grounded in actual paths and accurately inventories the EFS module, six access points, task volumes, outputs, variables, and scripts represented in the baseline. Its largest deficiency is leaving critical behavior as \"remove or update,\" particularly the scopes initialization flow and replacement for SCOPES_CONFIG_PATH, while declaring no open questions. It correctly requires removal of corresponding container mountPoints, a requirement later missed by the implementation. The rollout lacks state backup, data verification, external-output compatibility, and a viable rollback after destructive EFS removal, while its DocumentDB and S3 migration claims remain unverified."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 15,
+          "specificity": 16,
+          "risk_awareness": 18,
+          "total": 64,
+          "notes": "The review identifies several change-specific risks, including orphaned container mountPoints, lingering module references, output compatibility, NFS rules, and destructive data loss. Its largest weakness is assigning no blockers despite unresolved replacement semantics and checks that are necessary for a deployable task definition. The warning about removing container-side mountPoints is materially correct: the implementation retains the mcp-logs sourceVolume reference after replacing the module volume map with an empty map. Much of the multi-role presentation is repetitive, and recommendations such as graceful handling of missing EFS outputs conflict with the cleaner requirement to remove obsolete EFS-dependent flows."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 10,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 50,
+          "notes": "The plan provides concrete validate, plan, grep, and bash syntax commands with explicit exit-code or text oracles; bash -n would catch the implementation's extra closing brace. Its stated seven-resource destruction oracle is incorrect because storage.tf defines six access points including mcpgw_data, while the list includes only five and also omits module-created mount targets and security-group resources. The /efs grep cannot detect a sourceVolume that references an undefined task volume, so the retained mcp-logs mount could pass this plan without any ECS task-registration or service smoke test. It also excludes shell scripts from the broad EFS-reference check and dismisses backward compatibility despite removing public Terraform outputs."
+        },
+        "implementation": {
+          "completeness": 11,
+          "correctness": 5,
+          "specificity": 14,
+          "risk_awareness": 4,
+          "total": 34,
+          "notes": "The patch removes the main EFS module, related variables and outputs, and the explicit EFS volume configurations across the expected files. It is not deployable as submitted: post-deployment-setup.sh adds a new function-closing brace immediately before the existing one, producing a shell syntax error, and ecs-services.tf retains the mcp-logs mountPoint while setting volume to an empty map. run-scopes-init-task.sh exits successfully mid-script but leaves its remaining EFS task code unreachable, while the new local scopes path and automatic DocumentDB initialization claims are not validated. The summary's claims of exact LLD compliance and no follow-ups therefore overstate the change; independent git apply checking was unavailable in the provided execution environment."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 68,
+      "input_tokens": 6460028,
+      "output_tokens": 23404,
+      "total_tokens": 6483432,
+      "latency_seconds": 250.3,
+      "total_cost_usd": 32.885239999999996,
+      "result_subtype": "success",
+      "task_score": 49.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8825,
+      "generation_tokens_per_sec": 93.5,
+      "kv_cache_usage": {
+        "peak": 0.0994,
+        "mean": 0.0729
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 16,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 70,
+          "notes": "The issue identifies three concrete outbound-fetch paths, names _check_endpoint_reachability and proxy_pass_url, and supplies mostly testable acceptance criteria and explicit non-goals. Its largest inconsistency is declaring skill-service modification out of scope while requiring the existing private function to be extracted, and centralization alone cannot make future fetches automatically inherit protection. The named symbols are corroborated by the submitted patch contexts, but redirect handling and compatibility for already-registered internal services are omitted. No independent task statement was supplied, so broader requirement coverage cannot be verified."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 10,
+          "total": 51,
+          "notes": "The LLD is concrete about registry/core/config.py, registry/utils/agent_validator.py, registry/api/agent_routes.py, registry/health/service.py, configuration, and expected failure behavior. Its critical technical error is enabling automatic redirects and validating response.url afterward, when the unsafe redirected request has already occurred. It also calls the change an extraction without planning any skill_service.py modification, leaves server-health redirect behavior undefined, and understates synchronous DNS latency in async paths. The rollout does not address existing internal endpoints that become unhealthy under an initially empty allowlist, while DNS rebinding is at least explicitly identified as excluded."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 16,
+          "risk_awareness": 13,
+          "total": 52,
+          "notes": "The review raises concrete concerns about synchronous DNS, inconsistent errors, operational visibility, deployment configuration, tests, and redirects. Its largest defect is marking redirect validation resolved even though the LLD checks the final URL only after following and issuing the redirect request, which does not prevent SSRF. It also accepts unsupported claims that the utility automatically protects future fetches and that existing behavior remains intact, without challenging the absent skill_service.py migration. The recommendations are actionable, but the role-based repetition adds little and misses the compatibility and status-contract risks."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 10,
+          "total": 46,
+          "notes": "The plan provides concrete private, loopback, metadata, invalid-URL, allowlist, registration, health, and compatibility cases. The unit tests depend on live DNS instead of mocking getaddrinfo, and internal.example.com returning false would not prove private-address detection if it merely fails resolution. Redirect validation is labeled required but has no setup, action, or oracle, while several curl checks accept either success or an unrelated validation failure and therefore could pass with broken SSRF behavior. Agent-health and server-health setup remains largely hypothetical, and the asserted API payloads, routes, and /var/log/registry.log location could not be independently verified."
+        },
+        "implementation": {
+          "completeness": 12,
+          "correctness": 1,
+          "specificity": 14,
+          "risk_awareness": 3,
+          "total": 30,
+          "notes": "The patch targets the named configuration, agent validation, agent health, and server health locations, but never edits skill_service.py, so it copies rather than extracts the existing guard and does not centralize skill behavior. In agent_routes.py the HEAD fallback introduces a nested try while retained status-handling lines remain at the try statement's indentation with no matching except or finally, making the module syntactically invalid; the retained logic also risks marking an unsafe redirect healthy. Both agent redirect checks use follow_redirects=True and inspect response.url only after the redirected request has occurred, and server health has no redirect validation at all. The summary incorrectly claims exact LLD conformance and no follow-ups; direct source and git-apply verification were unavailable because repository command execution failed in the read-only sandbox."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 65,
+      "input_tokens": 5966971,
+      "output_tokens": 25865,
+      "total_tokens": 5992836,
+      "latency_seconds": 264.1,
+      "total_cost_usd": 30.481479999999998,
+      "result_subtype": "success",
+      "task_score": 47.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8729,
+      "generation_tokens_per_sec": 97.9,
+      "kv_cache_usage": {
+        "peak": 0.1014,
+        "mean": 0.0688
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 12,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 55,
+          "notes": "The issue clearly states the security motivation, non-goals, dependencies, and a useful acceptance checklist. Its largest defect is the contradictory fallback requirement: the submitted patch selects Secrets Manager when a variable is nonempty and retains the environment entry only when that same value is empty, which is not a usable plaintext fallback. Creating secret versions from Terraform variables also leaves values in state, so the proposed solution does not fully address a central stated risk. No independent task statement was supplied, and the claims about all sensitive variables, the existing KMS key, and issue 1134 could not be independently established."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 53,
+          "notes": "The LLD is strongest in naming the nine variables, Terraform files, ECS injection flow, IAM integration, and phased rollout. Its central migration decision is unsound because the proposed fallback injects the same variable only when it is empty, with no mode flag, legacy value, or external secret ARN. Its examples are internally inconsistent: the resource is initially uncounted while later references use index `[0]`, and the implementation summary contradicts the planned variable additions by saying those variables already existed. It acknowledges state exposure and rotation limitations, but leaves rollback, fallback removal, and rotation-triggered ECS redeployment unresolved."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 9,
+          "specificity": 14,
+          "risk_awareness": 15,
+          "total": 51,
+          "notes": "The review usefully identifies persistent Terraform-state exposure, long-lived plaintext fallback risk, rotation documentation, and the absence of an operator runbook. Its largest failure is declaring no blockers while missing that the fallback cannot preserve a nonempty legacy value and that the LLD's conditional collection shapes are not valid Terraform designs. Calling immediate deletion via `recovery_window_in_days = 0` a security strength is questionable, and recommendations such as generic `min_length` validation and custom Secrets Manager encryption context are not implementation-ready Terraform guidance. Claims about the existing KMS policy and current policy size are asserted without repository evidence in the artifacts."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 5,
+          "specificity": 15,
+          "risk_awareness": 10,
+          "total": 45,
+          "notes": "The plan covers plan/apply behavior, task definitions, IAM, mixed configurations, API checks, and security observations with concrete expected secret names. Several commands are unusable: `aws ecs describe-task-definitions` is not an AWS CLI operation, and `get-role-policy` cannot inspect the managed `aws_iam_policy.ecs_secrets_access` resource. The rollback depends on an unimplemented `use_secrets_manager` variable, the sensitivity grep checks only one variable without failing the run, and the ECS exec test prints a secret-bearing environment variable. The existence of `prod.tfvars`, `dev.tfvars`, the named CloudFormation stack, and the proposed federation endpoint is not established."
+        },
+        "implementation": {
+          "completeness": 11,
+          "correctness": 2,
+          "specificity": 17,
+          "risk_awareness": 3,
+          "total": 33,
+          "notes": "The patch attempts all nine named migrations across `ecs-services.tf`, `iam.tf`, and `secrets.tf`, but omits the documentation required by the issue. It is not Terraform-valid: expressions such as `condition ? { name = ..., valueFrom = ... } : []` mix object and tuple result types, while the IAM list similarly mixes ARN strings with empty lists. The environment lists also emit `null` entries, and the alleged fallback exposes only an empty value; immediate secret destruction and `ignore_changes` further create recovery and rotation risks. Repository command execution was unavailable, so mechanical applicability to the stated baseline could not be confirmed, but these defects are present directly in the submitted diff and contradict the summary's claim of complete, deviation-free implementation."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 83,
+      "input_tokens": 9821325,
+      "output_tokens": 21383,
+      "total_tokens": 9842708,
+      "latency_seconds": 288.7,
+      "total_cost_usd": 49.64119999999998,
+      "result_subtype": "success",
+      "task_score": 45.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8778,
+      "generation_tokens_per_sec": 74.1,
+      "kv_cache_usage": {
+        "peak": 0.122,
+        "mean": 0.0828
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 19,
+          "risk_awareness": 9,
+          "total": 59,
+          "notes": "The issue provides concrete file-level acceptance criteria and explicit non-goals. The submitted diff corroborates the existence of pyproject.toml, registry/core/config.py, registry/search/service.py, and the file search repository. Its largest contradiction is promising unchanged search while explicitly replacing semantic FAISS behavior with keyword-only search for file deployments. No independent task statement establishes the equivalence or obsolescence claims, and the issue omits startup reindexing, persisted-index migration, and measurable compatibility criteria."
+        },
+        "lld": {
+          "completeness": 13,
+          "correctness": 12,
+          "specificity": 17,
+          "risk_awareness": 9,
+          "total": 51,
+          "notes": "The LLD is grounded in concrete repository paths, the SearchRepositoryBase abstraction, the repository factory, and the two backend implementations. Its method list and file plan are specific, but it does not define result-field compatibility, tool-result behavior, ranking semantics, or how existing file-backed entities populate the new in-memory index after restart. Error handling is reduced to handling missing metadata, while persistence, concurrent updates, memory bounds, and recovery are left undecided. The rollout plan is only a testing sequence and supplies neither rollback nor a fallback when the replacement repository is empty or incompatible."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 10,
+          "specificity": 14,
+          "risk_awareness": 14,
+          "total": 51,
+          "notes": "The strongest review content identifies the in-memory repository's non-persistence, memory growth, direct FaissService consumers, and need for replacement tests. It then declares those concerns resolved even though the submitted LLD contains no startup rebuild mechanism or concrete memory limit, and its claimed small-deployment resolution is absent from the design. It misses the loss of tool results and response metadata visible when comparing the new repository with the deleted FaissService.search_mixed implementation. The final no-blockers verdict is therefore not supported by its own critical findings."
+        },
+        "testing": {
+          "completeness": 12,
+          "correctness": 7,
+          "specificity": 12,
+          "risk_awareness": 8,
+          "total": 39,
+          "notes": "The plan spans API, compatibility, dependency, Docker, configuration, and end-to-end surfaces. Most shell checks are observational rather than assertions: jq length and select succeed with zero matches, the tag test never verifies returned tags, and the deletion check incorrectly expects the entire server result list to be empty. The repository snippet only checks isinstance and performs one index call, with no search, ranking, filtering, removal, or result-shape oracle. It omits the highest-risk cases: restart hydration, existing file data, tool results, agent input compatibility, and dedicated tests for FileSearchRepository."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 5,
+          "specificity": 12,
+          "risk_awareness": 3,
+          "total": 28,
+          "notes": "The patch concretely removes the declared dependency, configuration properties, FAISS service, mocks, and old tests, and introduces FileSearchRepository. Its initialize method only flips a boolean while _entities starts empty, so existing file-backed registrations are unsearchable after restart unless another undocumented path reindexes them. Its search method never populates tools, skills, or virtual_servers and always returns empty matching_tools, while index_agent changes the former dictionary input to AgentCard without replacement coverage. Documentation still names FaissSearchRepository, service_index.faiss, and the deleted service under mechanical text such as \"vector search search,\" so the summary's no-deviation claim is false; a shell sandbox failure prevented an independent git apply check."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 80,
+      "input_tokens": 6934724,
+      "output_tokens": 25438,
+      "total_tokens": 6960162,
+      "latency_seconds": 262.2,
+      "total_cost_usd": 35.309569999999994,
+      "result_subtype": "success",
+      "task_score": 43.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8788,
+      "generation_tokens_per_sec": 97.0,
+      "kv_cache_usage": {
+        "peak": 0.0941,
+        "mean": 0.0606
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 52,
+          "notes": "The issue clearly identifies the current Secrets Manager password flow, affected Aurora, proxy, and ECS components, a feature flag, and useful non-goals. Its largest defect is technical: IAM tokens are locally signed credentials, not automatically rotated through `rds:GenerateDBAuthToken`, and their generation is not the CloudTrail audit trail claimed here. The existing `keycloak-database.tf` and `keycloak-ecs.tf` contexts confirm proxy secret authentication and injection of `KC_DB_PASSWORD`, but the criteria also contradict themselves by requiring no Keycloak configuration changes while changing its database authentication configuration. No independent task statement establishes the asserted zero-downtime fallback or audit requirements."
+        },
+        "lld": {
+          "completeness": 13,
+          "correctness": 4,
+          "specificity": 16,
+          "risk_awareness": 9,
+          "total": 42,
+          "notes": "The LLD names real Terraform resources and files and provides concrete variables, rollout phases, and container changes. Its critical authentication design is invalid: clients need `rds-db:connect` on a database-user ARN, not `rds:GenerateDBAuthToken` on `aws_rds_cluster.keycloak.arn`, and a token generated only at startup cannot authenticate new pooled connections after expiry. The source contexts confirm `aws_db_proxy.keycloak`, `aws_rds_cluster.keycloak`, the Keycloak task role, and container secret locals, but the document repeatedly changes between native proxy handling, an init container, and a custom entrypoint without resolving refresh or fallback behavior. CloudTrail token-generation observability, automatic proxy token refresh, and the proposed custom-image build path are unsupported or unverifiable, while TLS, image validation, and failure recovery remain incomplete."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 16,
+          "risk_awareness": 15,
+          "total": 54,
+          "notes": "The review usefully identifies that Keycloak cannot generate IAM credentials natively, that proxy `REQUIRED` mode creates a lockout risk, and that rollback secrets must remain available. It nevertheless endorses the invalid `rds:GenerateDBAuthToken` cluster-ARN policy, even claiming the LLD used a wildcard although its sample already uses `aws_rds_cluster.keycloak.arn`; another reviewer then calls that ARN appropriate. It also misses the decisive 15-minute startup-token expiry problem and does not challenge the proposed Docker build or Terraform integration. The concrete recommendations are useful, but an approval-with-changes verdict is not defensible while the review itself labels the unresolved client authentication mechanism critical."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 4,
+          "specificity": 15,
+          "risk_awareness": 10,
+          "total": 43,
+          "notes": "The plan spans Terraform, image construction, compatibility, deployment inspection, end-to-end health, and rollback. Several core commands and oracles are wrong: an RDS token is a presigned URL rather than a JWT beginning with `keycloak/`, `describe-db-proxy` and `describe-db-log-file-credits` are not valid AWS CLI commands, and token generation is not observable as the claimed CloudTrail API event. The image inspection invokes `cat` through the custom Keycloak entrypoint, while the API assertion accepts every status below 500, including authentication failures and curl's `000`, so broken behavior can pass. It lacks the most important longevity test for opening new connections after token expiry, denied `rds-db:connect`, malformed JDBC URLs, and an enabled flag with no custom image."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 2,
+          "specificity": 13,
+          "risk_awareness": 4,
+          "total": 27,
+          "notes": "The patch touches the real cluster, proxy, task definition, variables, examples, and image surfaces, but it does not produce a usable end-to-end implementation. In `keycloak-ecs.tf`, `keycloak_image` is placed as an unsupported `aws_ecs_task_definition` argument while the container references undefined `local.keycloak_image`, so Terraform validation fails even with the feature disabled; the IAM action and cluster ARN are also invalid for database login. The Dockerfile attempts `microdnf` in the minimal Keycloak image, uses `unzip` without installing it, and chmods a root-owned copied script after switching to `USER keycloak`; even a successful image would retain one startup token indefinitely. The summary falsely reports no deviations or follow-ups despite omitting the LLD's fallback and production guardrail, silently selecting the stock image when IAM is enabled without an IAM image URI, and providing no token-refresh mechanism."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-05"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 16,
+      "specificity": 20,
+      "risk_awareness": 15,
+      "total": 70,
+      "notes": "The issue identifies three concrete outbound-fetch paths, names _check_endpoint_reachability and proxy_pass_url, and supplies mostly testable acceptance criteria and explicit non-goals. Its largest inconsistency is declaring skill-service modification out of scope while requiring the existing private function to be extracted, and centralization alone cannot make future fetches automatically inherit protection. The named symbols are corroborated by the submitted patch contexts, but redirect handling and compatibility for already-registered internal services are omitted. No independent task statement was supplied, so broader requirement coverage cannot be verified."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 18,
+      "risk_awareness": 10,
+      "total": 51,
+      "notes": "The LLD is concrete about registry/core/config.py, registry/utils/agent_validator.py, registry/api/agent_routes.py, registry/health/service.py, configuration, and expected failure behavior. Its critical technical error is enabling automatic redirects and validating response.url afterward, when the unsafe redirected request has already occurred. It also calls the change an extraction without planning any skill_service.py modification, leaves server-health redirect behavior undefined, and understates synchronous DNS latency in async paths. The rollout does not address existing internal endpoints that become unhealthy under an initially empty allowlist, while DNS rebinding is at least explicitly identified as excluded."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 9,
+      "specificity": 16,
+      "risk_awareness": 13,
+      "total": 52,
+      "notes": "The review raises concrete concerns about synchronous DNS, inconsistent errors, operational visibility, deployment configuration, tests, and redirects. Its largest defect is marking redirect validation resolved even though the LLD checks the final URL only after following and issuing the redirect request, which does not prevent SSRF. It also accepts unsupported claims that the utility automatically protects future fetches and that existing behavior remains intact, without challenging the absent skill_service.py migration. The recommendations are actionable, but the role-based repetition adds little and misses the compatibility and status-contract risks."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 10,
+      "total": 46,
+      "notes": "The plan provides concrete private, loopback, metadata, invalid-URL, allowlist, registration, health, and compatibility cases. The unit tests depend on live DNS instead of mocking getaddrinfo, and internal.example.com returning false would not prove private-address detection if it merely fails resolution. Redirect validation is labeled required but has no setup, action, or oracle, while several curl checks accept either success or an unrelated validation failure and therefore could pass with broken SSRF behavior. Agent-health and server-health setup remains largely hypothetical, and the asserted API payloads, routes, and /var/log/registry.log location could not be independently verified."
+    },
+    "implementation": {
+      "completeness": 12,
+      "correctness": 1,
+      "specificity": 14,
+      "risk_awareness": 3,
+      "total": 30,
+      "notes": "The patch targets the named configuration, agent validation, agent health, and server health locations, but never edits skill_service.py, so it copies rather than extracts the existing guard and does not centralize skill behavior. In agent_routes.py the HEAD fallback introduces a nested try while retained status-handling lines remain at the try statement's indentation with no matching except or finally, making the module syntactically invalid; the retained logic also risks marking an unsafe redirect healthy. Both agent redirect checks use follow_redirects=True and inspect response.url only after the redirected request has occurred, and server health has no redirect validation at all. The summary incorrectly claims exact LLD conformance and no follow-ups; direct source and git-apply verification were unavailable because repository command execution failed in the read-only sandbox."
+    }
+  },
+  "task_score": 49.8,
+  "verdict": "The submission is repository-specific and broadly scoped, but its implementation is unusable due to malformed control flow and its redirect strategy validates only after the SSRF-capable request has already happened.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T17:41:20.835736Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 131231,
+      "cached_input_tokens": 103138,
+      "cache_write_input_tokens": 28083,
+      "output_tokens": 6091,
+      "reasoning_output_tokens": 4639
+    },
+    "duration_ms": 107784
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,290 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 93.5,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 6460028,
+    "output_tokens": 23404,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 6483432,
+    "total_cost_usd": 32.885239999999996,
+    "latency_seconds": 250.3,
+    "num_turns": 68,
+    "generation_tokens_per_sec": 93.5,
+    "prefix_cache_hit_rate": 0.8825,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 6460028,
+  "output_tokens": 23404,
+  "latency_seconds": 250.3,
+  "num_turns": 68,
+  "total_cost_usd": 32.885239999999996,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "thinking_tokens_estimate": 507,
+  "run_started_at": "2026-08-05T17:17:05.759475Z",
+  "run_ended_at": "2026-08-05T17:21:16.643308Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 6460028,
+    "output_tokens": 23404,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 6483432,
+    "total_cost_usd": 32.885239999999996,
+    "latency_seconds": 250.3,
+    "num_turns": 68,
+    "generation_tokens_per_sec": 93.5,
+    "prefix_cache_hit_rate": 0.8825,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8825,
+      "prompt_tokens_cached_rate": 0.8825
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 23404,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 5701216,
+      "vllm:prefix_cache_queries_total": 6460028,
+      "vllm:prompt_tokens_by_source_total": 6460028,
+      "vllm:prompt_tokens_cached_total": 5701216,
+      "vllm:prompt_tokens_total": 6460028,
+      "vllm:request_success_total": 68,
+      "vllm:tool_call_parser_invocations_total": 20856
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 68,
+        "sum": 245.7782,
+        "mean": 3.614386
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 23336,
+        "sum": 185.9281,
+        "mean": 0.007967
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 23404,
+        "sum": 782216,
+        "mean": 33.422321
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 68,
+        "sum": 185.9281,
+        "mean": 2.734236
+      },
+      "vllm:request_generation_tokens": {
+        "count": 68,
+        "sum": 23404,
+        "mean": 344.176471
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 68,
+        "sum": 231.6941,
+        "mean": 3.407267
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 68,
+        "sum": 23404,
+        "mean": 344.176471
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 68,
+        "sum": 1088000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 68,
+        "sum": 68,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 68,
+        "sum": 758812,
+        "mean": 11159.0
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 68,
+        "sum": 45.7661,
+        "mean": 0.67303
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 68,
+        "sum": 6460028,
+        "mean": 95000.411765
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 68,
+        "sum": 0.0007,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 68,
+        "sum": 0.5392,
+        "mean": 0.007929
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 68,
+        "sum": 59.8756,
+        "mean": 0.880524
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0994,
+          "mean": 0.0729,
+          "samples": 250
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.92,
+          "samples": 250
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 250
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 16,
+        "specificity": 20,
+        "risk_awareness": 15,
+        "total": 70,
+        "notes": "The issue identifies three concrete outbound-fetch paths, names _check_endpoint_reachability and proxy_pass_url, and supplies mostly testable acceptance criteria and explicit non-goals. Its largest inconsistency is declaring skill-service modification out of scope while requiring the existing private function to be extracted, and centralization alone cannot make future fetches automatically inherit protection. The named symbols are corroborated by the submitted patch contexts, but redirect handling and compatibility for already-registered internal services are omitted. No independent task statement was supplied, so broader requirement coverage cannot be verified."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 18,
+        "risk_awareness": 10,
+        "total": 51,
+        "notes": "The LLD is concrete about registry/core/config.py, registry/utils/agent_validator.py, registry/api/agent_routes.py, registry/health/service.py, configuration, and expected failure behavior. Its critical technical error is enabling automatic redirects and validating response.url afterward, when the unsafe redirected request has already occurred. It also calls the change an extraction without planning any skill_service.py modification, leaves server-health redirect behavior undefined, and understates synchronous DNS latency in async paths. The rollout does not address existing internal endpoints that become unhealthy under an initially empty allowlist, while DNS rebinding is at least explicitly identified as excluded."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 9,
+        "specificity": 16,
+        "risk_awareness": 13,
+        "total": 52,
+        "notes": "The review raises concrete concerns about synchronous DNS, inconsistent errors, operational visibility, deployment configuration, tests, and redirects. Its largest defect is marking redirect validation resolved even though the LLD checks the final URL only after following and issuing the redirect request, which does not prevent SSRF. It also accepts unsupported claims that the utility automatically protects future fetches and that existing behavior remains intact, without challenging the absent skill_service.py migration. The recommendations are actionable, but the role-based repetition adds little and misses the compatibility and status-contract risks."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 10,
+        "total": 46,
+        "notes": "The plan provides concrete private, loopback, metadata, invalid-URL, allowlist, registration, health, and compatibility cases. The unit tests depend on live DNS instead of mocking getaddrinfo, and internal.example.com returning false would not prove private-address detection if it merely fails resolution. Redirect validation is labeled required but has no setup, action, or oracle, while several curl checks accept either success or an unrelated validation failure and therefore could pass with broken SSRF behavior. Agent-health and server-health setup remains largely hypothetical, and the asserted API payloads, routes, and /var/log/registry.log location could not be independently verified."
+      },
+      "implementation": {
+        "completeness": 12,
+        "correctness": 1,
+        "specificity": 14,
+        "risk_awareness": 3,
+        "total": 30,
+        "notes": "The patch targets the named configuration, agent validation, agent health, and server health locations, but never edits skill_service.py, so it copies rather than extracts the existing guard and does not centralize skill behavior. In agent_routes.py the HEAD fallback introduces a nested try while retained status-handling lines remain at the try statement's indentation with no matching except or finally, making the module syntactically invalid; the retained logic also risks marking an unsafe redirect healthy. Both agent redirect checks use follow_redirects=True and inspect response.url only after the redirected request has occurred, and server health has no redirect validation at all. The summary incorrectly claims exact LLD conformance and no follow-ups; direct source and git-apply verification were unavailable because repository command execution failed in the read-only sandbox."
+      }
+    },
+    "task_score": 49.8,
+    "verdict": "The submission is repository-specific and broadly scoped, but its implementation is unusable due to malformed control flow and its redirect strategy validates only after the SSRF-capable request has already happened.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T17:41:20.835736Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 131231,
+        "cached_input_tokens": 103138,
+        "cache_write_input_tokens": 28083,
+        "output_tokens": 6091,
+        "reasoning_output_tokens": 4639
+      },
+      "duration_ms": 107784
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 16,
+      "correctness": 8,
+      "specificity": 14,
+      "risk_awareness": 13,
+      "total": 51,
+      "notes": "The issue clearly identifies the security objective, affected ECS and IAM surfaces, exclusions, and several testable outcomes. Its largest defect is the proposed same-name plaintext fallback: ECS secret resolution occurs before container startup, so plaintext cannot rescue a task whose secret retrieval fails, and the LLD itself says the two sources cannot be mixed for one name. Creating `aws_secretsmanager_secret_version` resources from Terraform variables also retains secret values in Terraform state, contradicting the stated state-exposure benefit. No independent task statement was supplied, so the exact secret inventory and cited issue `#1026` could not be verified as requirements."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 7,
+      "specificity": 18,
+      "risk_awareness": 12,
+      "total": 53,
+      "notes": "The design is concrete about the target files, twelve variables, Secrets Manager resources, ECS `valueFrom` entries, and IAM integration, with those paths and symbols also represented in the submitted diff. Its central migration decision is internally contradictory: it states that the same variable cannot appear in both `environment` and `secrets`, then prescribes exactly that as the fallback strategy without defining precedence or a deployable phased configuration. The proposed `secret_string = var.*` resources leave values in Terraform state, while the observability section incorrectly implies the migration removes that exposure and guarantees logs contain no secrets. Rollout, rollback, optional-value handling, and service-specific secret placement remain unresolved, and claims about existing issue numbers and MongoDB dual-write behavior could not be independently verified."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 9,
+      "specificity": 17,
+      "risk_awareness": 17,
+      "total": 59,
+      "notes": "The review surfaces useful concrete risks, including optional empty secrets, startup failure from IAM errors, multiline private-key handling, lingering tfvars values, and the need for migration sequencing. It misses the design's fatal fallback contradiction and incorrectly treats `sensitive = true` as sufficient mitigation even though Terraform still stores sensitive values in state. Its resolution section claims the LLD gained migration commands, tfvars cleanup, and complete variable definitions, but those changes are absent from the submitted LLD. The patch does implement the recommended `jsonencode` private-key representation, while the broad KMS-policy claim and need for resource imports were not substantiated by the available artifacts."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 5,
+      "specificity": 15,
+      "risk_awareness": 12,
+      "total": 48,
+      "notes": "The plan covers Terraform validation, deployed task definitions, IAM, application behavior, security inspection, compatibility, and rollback with concrete intended oracles. Several commands are unusable: a saved plan cannot be applied with a new `-var-file`, `terraform apply -var \"rollback=true\" ...` is invented and syntactically incomplete, and grepping the binary plan file does not count resources reliably. `aws logs filter-log-events` normally succeeds with an empty event list, so the proposed secret-leak commands report failure even when no leak exists, and the fallback test never simulates failed secret retrieval. Task-family names, role and policy names, API endpoints, backend settings, and the `rollback` variable are asserted without repository evidence."
+    },
+    "implementation": {
+      "completeness": 13,
+      "correctness": 3,
+      "specificity": 17,
+      "risk_awareness": 7,
+      "total": 40,
+      "notes": "The patch concretely covers secret resources, ECS references, IAM ARNs, conditional Auth0 handling, and JSON extraction for the GitHub private key across the three stated Terraform files. However, the auth-service `secrets = concat(...)` edit inserts `var.auth0_enabled ? [` before the original base list is closed and replaces that closing `],` with the conditional's `] : [],`, leaving the outer list unclosed; Terraform validation should therefore fail. Even after fixing syntax, same-name plaintext entries do not provide fallback when ECS cannot retrieve a secret, Terraform still records each `secret_string`, and `ignore_changes` prevents later variable updates from rotating those values. The summary's claim of no LLD deviation and successful migration is consequently false, and a repository-side apply check could not be completed because the provided command sandbox failed before executing Git."
+    }
+  },
+  "task_score": 50.2,
+  "verdict": "The submission identifies the right Terraform integration surfaces but is undermined by an invalid patch and a migration strategy that neither removes secrets from state nor provides the claimed runtime fallback.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T18:14:59.503983Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 231467,
+      "cached_input_tokens": 197477,
+      "cache_write_input_tokens": 33974,
+      "output_tokens": 7507,
+      "reasoning_output_tokens": 5289
+    },
+    "duration_ms": 150543
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 132.5,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2611810,
+    "output_tokens": 22787,
+    "cache_read_tokens": 2560928,
+    "cache_write_tokens": 50882,
+    "total_tokens": 5246407,
+    "total_cost_usd": null,
+    "latency_seconds": 172.0,
+    "num_turns": 54,
+    "generation_tokens_per_sec": 132.5,
+    "prefix_cache_hit_rate": 0.9805,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2611810,
+  "output_tokens": 22787,
+  "latency_seconds": 172.0,
+  "num_turns": 54,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T18:07:07.876212Z",
+  "run_ended_at": "2026-08-05T18:10:01.452666Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2611810,
+    "output_tokens": 22787,
+    "cache_read_tokens": 2560928,
+    "cache_write_tokens": 50882,
+    "total_tokens": 5246407,
+    "total_cost_usd": null,
+    "latency_seconds": 172.0,
+    "num_turns": 54,
+    "generation_tokens_per_sec": 132.5,
+    "prefix_cache_hit_rate": 0.9805,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9805,
+      "prompt_tokens_cached_rate": 0.9805
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 22787,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 2560928,
+      "vllm:prefix_cache_queries_total": 2611810,
+      "vllm:prompt_tokens_by_source_total": 2611810,
+      "vllm:prompt_tokens_cached_total": 2560928,
+      "vllm:prompt_tokens_total": 2611810,
+      "vllm:request_success_total": 54,
+      "vllm:tool_call_parser_invocations_total": 19386
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 54,
+        "sum": 169.6392,
+        "mean": 3.141466
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 22733,
+        "sum": 159.5951,
+        "mean": 0.00702
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 22787,
+        "sum": 73669,
+        "mean": 3.23294
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 54,
+        "sum": 159.5951,
+        "mean": 2.955465
+      },
+      "vllm:request_generation_tokens": {
+        "count": 54,
+        "sum": 22787,
+        "mean": 421.981481
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 54,
+        "sum": 163.6596,
+        "mean": 3.030734
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 54,
+        "sum": 22787,
+        "mean": 421.981481
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 54,
+        "sum": 864000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 54,
+        "sum": 54,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 54,
+        "sum": 50882,
+        "mean": 942.259259
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 54,
+        "sum": 4.0645,
+        "mean": 0.075269
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 54,
+        "sum": 2611810,
+        "mean": 48366.851852
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 54,
+        "sum": 0.0005,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 54,
+        "sum": 0.3761,
+        "mean": 0.006964
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 54,
+        "sum": 10.0564,
+        "mean": 0.18623
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0598,
+          "mean": 0.0415,
+          "samples": 172
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9535,
+          "samples": 172
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 172
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 16,
+        "correctness": 8,
+        "specificity": 14,
+        "risk_awareness": 13,
+        "total": 51,
+        "notes": "The issue clearly identifies the security objective, affected ECS and IAM surfaces, exclusions, and several testable outcomes. Its largest defect is the proposed same-name plaintext fallback: ECS secret resolution occurs before container startup, so plaintext cannot rescue a task whose secret retrieval fails, and the LLD itself says the two sources cannot be mixed for one name. Creating `aws_secretsmanager_secret_version` resources from Terraform variables also retains secret values in Terraform state, contradicting the stated state-exposure benefit. No independent task statement was supplied, so the exact secret inventory and cited issue `#1026` could not be verified as requirements."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 7,
+        "specificity": 18,
+        "risk_awareness": 12,
+        "total": 53,
+        "notes": "The design is concrete about the target files, twelve variables, Secrets Manager resources, ECS `valueFrom` entries, and IAM integration, with those paths and symbols also represented in the submitted diff. Its central migration decision is internally contradictory: it states that the same variable cannot appear in both `environment` and `secrets`, then prescribes exactly that as the fallback strategy without defining precedence or a deployable phased configuration. The proposed `secret_string = var.*` resources leave values in Terraform state, while the observability section incorrectly implies the migration removes that exposure and guarantees logs contain no secrets. Rollout, rollback, optional-value handling, and service-specific secret placement remain unresolved, and claims about existing issue numbers and MongoDB dual-write behavior could not be independently verified."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 9,
+        "specificity": 17,
+        "risk_awareness": 17,
+        "total": 59,
+        "notes": "The review surfaces useful concrete risks, including optional empty secrets, startup failure from IAM errors, multiline private-key handling, lingering tfvars values, and the need for migration sequencing. It misses the design's fatal fallback contradiction and incorrectly treats `sensitive = true` as sufficient mitigation even though Terraform still stores sensitive values in state. Its resolution section claims the LLD gained migration commands, tfvars cleanup, and complete variable definitions, but those changes are absent from the submitted LLD. The patch does implement the recommended `jsonencode` private-key representation, while the broad KMS-policy claim and need for resource imports were not substantiated by the available artifacts."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 5,
+        "specificity": 15,
+        "risk_awareness": 12,
+        "total": 48,
+        "notes": "The plan covers Terraform validation, deployed task definitions, IAM, application behavior, security inspection, compatibility, and rollback with concrete intended oracles. Several commands are unusable: a saved plan cannot be applied with a new `-var-file`, `terraform apply -var \"rollback=true\" ...` is invented and syntactically incomplete, and grepping the binary plan file does not count resources reliably. `aws logs filter-log-events` normally succeeds with an empty event list, so the proposed secret-leak commands report failure even when no leak exists, and the fallback test never simulates failed secret retrieval. Task-family names, role and policy names, API endpoints, backend settings, and the `rollback` variable are asserted without repository evidence."
+      },
+      "implementation": {
+        "completeness": 13,
+        "correctness": 3,
+        "specificity": 17,
+        "risk_awareness": 7,
+        "total": 40,
+        "notes": "The patch concretely covers secret resources, ECS references, IAM ARNs, conditional Auth0 handling, and JSON extraction for the GitHub private key across the three stated Terraform files. However, the auth-service `secrets = concat(...)` edit inserts `var.auth0_enabled ? [` before the original base list is closed and replaces that closing `],` with the conditional's `] : [],`, leaving the outer list unclosed; Terraform validation should therefore fail. Even after fixing syntax, same-name plaintext entries do not provide fallback when ECS cannot retrieve a secret, Terraform still records each `secret_string`, and `ignore_changes` prevents later variable updates from rotating those values. The summary's claim of no LLD deviation and successful migration is consequently false, and a repository-side apply check could not be completed because the provided command sandbox failed before executing Git."
+      }
+    },
+    "task_score": 50.2,
+    "verdict": "The submission identifies the right Terraform integration surfaces but is undermined by an invalid patch and a migration strategy that neither removes secrets from state nor provides the claimed runtime fallback.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T18:14:59.503983Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 231467,
+        "cached_input_tokens": 197477,
+        "cache_write_input_tokens": 33974,
+        "output_tokens": 7507,
+        "reasoning_output_tokens": 5289
+      },
+      "duration_ms": 150543
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 17,
+      "specificity": 20,
+      "risk_awareness": 8,
+      "total": 62,
+      "notes": "The issue provides testable criteria naming `storage.tf`, `ecs-services.tf`, both output layers, and the two actual EFS variables shown in the patch. It correctly scopes removal of the file system, mount targets, security group, task volumes, variables, and outputs. Its largest deficiency is treating destructive infrastructure removal as dependency-free while omitting migration confirmation, backup, rollback, downstream output consumers, and the required `SCOPES_CONFIG_PATH` replacement. No independent task statement or evidence verifies the premise that all EFS data has migrated to S3 and DocumentDB."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 15,
+      "specificity": 18,
+      "risk_awareness": 10,
+      "total": 58,
+      "notes": "The LLD is well grounded in real symbols such as `module.efs`, `efs_all_outbound`, the auth and mcpgw mount names, and the module and root outputs. It precisely identifies most target files and service-level removals. However, deleting the auth-config mount leaves `SCOPES_CONFIG_PATH` invalid unless another location is chosen, and the LLD never makes that load-bearing decision even though the implementation changes it. It also incorrectly predicts a removal-only plan despite ECS task-definition replacement, and provides no concrete state, backup, consumer-compatibility, or rollback treatment."
+    },
+    "review": {
+      "completeness": 12,
+      "correctness": 11,
+      "specificity": 13,
+      "risk_awareness": 12,
+      "total": 48,
+      "notes": "The review identifies two relevant concerns: dangling `module.efs` references and destruction of potentially remaining EFS data, while also correcting the missing `terraform init` step. Its data-loss concern is dismissed using the unverified migration assertion rather than requiring evidence or a backup gate. Claims of no breaking changes and comprehensive coverage overlook removed Terraform outputs, ECS task replacement, and the undocumented `SCOPES_CONFIG_PATH` change. The role-based approvals are otherwise largely generic, and the stated confirmation that migration is complete cannot be verified from the supplied evidence."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 7,
+      "specificity": 16,
+      "risk_awareness": 10,
+      "total": 46,
+      "notes": "The plan includes validation, planning, static reference checks, and post-deployment checks with concrete commands and expected outcomes. However, its hard-coded `/tmp/swe-clone-remove-efs-from-terraform-aws-ecs/...` paths do not match the submitted repository path, and a fresh plan without the deployed state cannot demonstrate EFS destruction. The assertion that the plan contains no additions is also wrong because changed ECS task definitions require replacement, while several grep checks merely print output or even return success after printing `FAIL`. It omits verification that `/app/auth_server/scopes.yml` exists and works, and incorrectly declares compatibility testing inapplicable despite removal of public outputs and variables."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 12,
+      "total": 71,
+      "notes": "The patch implements the main removal end to end: it deletes the 182-line EFS module, removes auth and mcpgw mounts and volumes, and removes both EFS variables plus module and root outputs. Its changes are tightly scoped and use the repository's existing empty `mountPoints` and `volume` conventions. The largest unresolved correctness risk is the untested substitution of `/app/auth_server/scopes.yml`, whose presence in the built image is not established by the submitted patch. The summary correctly admits validation and planning were not executed, but its claim of no LLD deviation is false and it omits the destructive state transition and downstream output compatibility impact."
+    }
+  },
+  "task_score": 57.0,
+  "verdict": "The submission contains a strong, focused implementation, but the surrounding design and verification artifacts understate destructive rollout and compatibility risks and include an invalid plan oracle.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T18:16:51.513241Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 106927,
+      "cached_input_tokens": 84405,
+      "cache_write_input_tokens": 22512,
+      "output_tokens": 6600,
+      "reasoning_output_tokens": 5148
+    },
+    "duration_ms": 111998
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 117.1,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2780184,
+    "output_tokens": 12507,
+    "cache_read_tokens": 2725216,
+    "cache_write_tokens": 54968,
+    "total_tokens": 5572875,
+    "total_cost_usd": null,
+    "latency_seconds": 106.8,
+    "num_turns": 54,
+    "generation_tokens_per_sec": 117.1,
+    "prefix_cache_hit_rate": 0.9802,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2780184,
+  "output_tokens": 12507,
+  "latency_seconds": 106.8,
+  "num_turns": 54,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T18:03:08.952247Z",
+  "run_ended_at": "2026-08-05T18:04:56.165758Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2780184,
+    "output_tokens": 12507,
+    "cache_read_tokens": 2725216,
+    "cache_write_tokens": 54968,
+    "total_tokens": 5572875,
+    "total_cost_usd": null,
+    "latency_seconds": 106.8,
+    "num_turns": 54,
+    "generation_tokens_per_sec": 117.1,
+    "prefix_cache_hit_rate": 0.9802,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9802,
+      "prompt_tokens_cached_rate": 0.9802
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 12507,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 2725216,
+      "vllm:prefix_cache_queries_total": 2780184,
+      "vllm:prompt_tokens_by_source_total": 2780184,
+      "vllm:prompt_tokens_cached_total": 2725216,
+      "vllm:prompt_tokens_total": 2780184,
+      "vllm:request_success_total": 54,
+      "vllm:tool_call_parser_invocations_total": 10747
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 54,
+        "sum": 98.0554,
+        "mean": 1.81584
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 12453,
+        "sum": 88.0302,
+        "mean": 0.007069
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 12507,
+        "sum": 67475,
+        "mean": 5.394979
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 54,
+        "sum": 88.0302,
+        "mean": 1.630188
+      },
+      "vllm:request_generation_tokens": {
+        "count": 54,
+        "sum": 12507,
+        "mean": 231.611111
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 54,
+        "sum": 91.9677,
+        "mean": 1.703105
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 54,
+        "sum": 12507,
+        "mean": 231.611111
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 54,
+        "sum": 864000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 54,
+        "sum": 54,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 54,
+        "sum": 54968,
+        "mean": 1017.925926
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 54,
+        "sum": 3.9375,
+        "mean": 0.072917
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 54,
+        "sum": 2780184,
+        "mean": 51484.888889
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 54,
+        "sum": 0.0005,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 54,
+        "sum": 0.38,
+        "mean": 0.007038
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 54,
+        "sum": 10.0372,
+        "mean": 0.185874
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0578,
+          "mean": 0.0385,
+          "samples": 107
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8505,
+          "samples": 107
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 107
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 17,
+        "specificity": 20,
+        "risk_awareness": 8,
+        "total": 62,
+        "notes": "The issue provides testable criteria naming `storage.tf`, `ecs-services.tf`, both output layers, and the two actual EFS variables shown in the patch. It correctly scopes removal of the file system, mount targets, security group, task volumes, variables, and outputs. Its largest deficiency is treating destructive infrastructure removal as dependency-free while omitting migration confirmation, backup, rollback, downstream output consumers, and the required `SCOPES_CONFIG_PATH` replacement. No independent task statement or evidence verifies the premise that all EFS data has migrated to S3 and DocumentDB."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 15,
+        "specificity": 18,
+        "risk_awareness": 10,
+        "total": 58,
+        "notes": "The LLD is well grounded in real symbols such as `module.efs`, `efs_all_outbound`, the auth and mcpgw mount names, and the module and root outputs. It precisely identifies most target files and service-level removals. However, deleting the auth-config mount leaves `SCOPES_CONFIG_PATH` invalid unless another location is chosen, and the LLD never makes that load-bearing decision even though the implementation changes it. It also incorrectly predicts a removal-only plan despite ECS task-definition replacement, and provides no concrete state, backup, consumer-compatibility, or rollback treatment."
+      },
+      "review": {
+        "completeness": 12,
+        "correctness": 11,
+        "specificity": 13,
+        "risk_awareness": 12,
+        "total": 48,
+        "notes": "The review identifies two relevant concerns: dangling `module.efs` references and destruction of potentially remaining EFS data, while also correcting the missing `terraform init` step. Its data-loss concern is dismissed using the unverified migration assertion rather than requiring evidence or a backup gate. Claims of no breaking changes and comprehensive coverage overlook removed Terraform outputs, ECS task replacement, and the undocumented `SCOPES_CONFIG_PATH` change. The role-based approvals are otherwise largely generic, and the stated confirmation that migration is complete cannot be verified from the supplied evidence."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 7,
+        "specificity": 16,
+        "risk_awareness": 10,
+        "total": 46,
+        "notes": "The plan includes validation, planning, static reference checks, and post-deployment checks with concrete commands and expected outcomes. However, its hard-coded `/tmp/swe-clone-remove-efs-from-terraform-aws-ecs/...` paths do not match the submitted repository path, and a fresh plan without the deployed state cannot demonstrate EFS destruction. The assertion that the plan contains no additions is also wrong because changed ECS task definitions require replacement, while several grep checks merely print output or even return success after printing `FAIL`. It omits verification that `/app/auth_server/scopes.yml` exists and works, and incorrectly declares compatibility testing inapplicable despite removal of public outputs and variables."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 12,
+        "total": 71,
+        "notes": "The patch implements the main removal end to end: it deletes the 182-line EFS module, removes auth and mcpgw mounts and volumes, and removes both EFS variables plus module and root outputs. Its changes are tightly scoped and use the repository's existing empty `mountPoints` and `volume` conventions. The largest unresolved correctness risk is the untested substitution of `/app/auth_server/scopes.yml`, whose presence in the built image is not established by the submitted patch. The summary correctly admits validation and planning were not executed, but its claim of no LLD deviation is false and it omits the destructive state transition and downstream output compatibility impact."
+      }
+    },
+    "task_score": 57.0,
+    "verdict": "The submission contains a strong, focused implementation, but the surrounding design and verification artifacts understate destructive rollout and compatibility risks and include an invalid plan oracle.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T18:16:51.513241Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 106927,
+        "cached_input_tokens": 84405,
+        "cache_write_input_tokens": 22512,
+        "output_tokens": 6600,
+        "reasoning_output_tokens": 5148
+      },
+      "duration_ms": 111998
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 14,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 6,
+      "total": 43,
+      "notes": "The issue concretely names the dependency, service, configuration, tests, Docker metadata, and documentation as removal surfaces. Its largest deficiency is treating DocumentDB as an equivalent drop-in for file-backed search without specifying provisioning, migration, availability, or failure behavior. The submitted factory context shows DocumentDB was selected only for MONGODB_BACKENDS while file storage used FaissSearchRepository, contradicting the implied existing mixed-backend support. With no independent task statement, the claims that FAISS is obsolete and DocumentDB replacement is required or behaviorally equivalent remain unverified."
+    },
+    "lld": {
+      "completeness": 10,
+      "correctness": 6,
+      "specificity": 13,
+      "risk_awareness": 5,
+      "total": 34,
+      "notes": "The LLD names concrete files, interfaces, factory behavior, and deletion steps. Its target architecture depends on an unspecified embedded or external DocumentDB for file storage, but it never selects, configures, provisions, or operates either option. The pre-change factory shown in the diff deliberately confines DocumentDBSearchRepository to MONGODB_BACKENDS, while the LLD supplies no data migration, reindex, Docker Compose, or connection-lifecycle design for changing that boundary. Its compatibility, existing mixed-backend support, and route-call claims could not be independently established, and the rollout plan lacks validation and rollback decisions."
+    },
+    "review": {
+      "completeness": 12,
+      "correctness": 6,
+      "specificity": 11,
+      "risk_awareness": 11,
+      "total": 40,
+      "notes": "The review identifies the central availability question for file-backed deployments and also raises response parity, latency, TLS, and data-exposure concerns. It then resolves the blocking infrastructure issue by merely asserting that embedded MongoDB or an existing Compose service will be used and declares no blocking findings. The submitted patch contains no embedded database, Compose update, search health check, or fallback, while the original factory branch indicates this is a new backend dependency. It also misses the removed batch indexing calls, deleted-service test references, migration or rebuild requirements, and rollback behavior."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 7,
+      "specificity": 10,
+      "risk_awareness": 6,
+      "total": 34,
+      "notes": "The plan spans registration, search, response shape, dependency removal, Docker build, empty results, and both proposed storage modes. Many steps remain manual or subjective, including \"Restart service,\" relevance judgments, and verification that results are returned correctly, while the submitted evidence does not establish the stated API paths, payloads, or Python 3.14 prerequisite. The response assertion accepts any one result key, and the grep-based E2E checks print FAIL through an OR branch without necessarily producing a failing command status. It omits concrete tests for update and deletion consistency, DocumentDB unavailability, migration or reindexing, and the known remaining imports of the deleted FAISS fixture."
+    },
+    "implementation": {
+      "completeness": 6,
+      "correctness": 3,
+      "specificity": 13,
+      "risk_awareness": 2,
+      "total": 24,
+      "notes": "The patch concretely removes faiss-cpu, FAISS configuration properties, the service implementation, and its dedicated tests, and the summary candidly lists some unfinished work. However, agent_batch_item_processor.py deletes the actual registration and deletion indexing calls and leaves comments claiming those actions, causing stale search state. The factory now always constructs DocumentDBSearchRepository and bypasses the newly added FileSearchRepository, despite the original code selecting DocumentDB only for MONGODB_BACKENDS. The patch adds no replacement tests, retains a FaissSearchRepository alias, omits LLD-identified route changes, and admits API tests still reference the deleted fixture, so its claims of complete removal and preserved behavior are unsupported."
+    }
+  },
+  "task_score": 35.0,
+  "verdict": "The submission identifies many relevant FAISS surfaces, but its unresolved DocumentDB dependency and implementation that removes indexing without replacing it make the proposed change incomplete and behaviorally unsafe.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T18:18:45.940101Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 286590,
+      "cached_input_tokens": 237323,
+      "cache_write_input_tokens": 49255,
+      "output_tokens": 5515,
+      "reasoning_output_tokens": 3961
+    },
+    "duration_ms": 114413
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 117.5,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 12109832,
+    "output_tokens": 30363,
+    "cache_read_tokens": 12045040,
+    "cache_write_tokens": 64792,
+    "total_tokens": 24250027,
+    "total_cost_usd": null,
+    "latency_seconds": 258.4,
+    "num_turns": 191,
+    "generation_tokens_per_sec": 117.5,
+    "prefix_cache_hit_rate": 0.9946,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 12109832,
+  "output_tokens": 30363,
+  "latency_seconds": 258.4,
+  "num_turns": 191,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T17:58:43.811929Z",
+  "run_ended_at": "2026-08-05T18:03:03.074873Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 12109832,
+    "output_tokens": 30363,
+    "cache_read_tokens": 12045040,
+    "cache_write_tokens": 64792,
+    "total_tokens": 24250027,
+    "total_cost_usd": null,
+    "latency_seconds": 258.4,
+    "num_turns": 191,
+    "generation_tokens_per_sec": 117.5,
+    "prefix_cache_hit_rate": 0.9946,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9946,
+      "prompt_tokens_cached_rate": 0.9946
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 30363,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 12045040,
+      "vllm:prefix_cache_queries_total": 12109832,
+      "vllm:prompt_tokens_by_source_total": 12109832,
+      "vllm:prompt_tokens_cached_total": 12045040,
+      "vllm:prompt_tokens_total": 12109832,
+      "vllm:request_success_total": 191,
+      "vllm:tool_call_parser_invocations_total": 24954
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 191,
+        "sum": 253.7056,
+        "mean": 1.328301
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 30172,
+        "sum": 218.73,
+        "mean": 0.007249
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 30363,
+        "sum": 95155,
+        "mean": 3.133913
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 191,
+        "sum": 218.73,
+        "mean": 1.145183
+      },
+      "vllm:request_generation_tokens": {
+        "count": 191,
+        "sum": 30363,
+        "mean": 158.968586
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 191,
+        "sum": 227.861,
+        "mean": 1.19299
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 191,
+        "sum": 30363,
+        "mean": 158.968586
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 191,
+        "sum": 3056000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 191,
+        "sum": 191,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 191,
+        "sum": 64792,
+        "mean": 339.225131
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 191,
+        "sum": 9.131,
+        "mean": 0.047806
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 191,
+        "sum": 12109832,
+        "mean": 63402.26178
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 191,
+        "sum": 0.0018,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 191,
+        "sum": 1.3908,
+        "mean": 0.007282
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 191,
+        "sum": 35.0292,
+        "mean": 0.183399
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0781,
+          "mean": 0.0456,
+          "samples": 258
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8566,
+          "samples": 258
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 258
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 14,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 6,
+        "total": 43,
+        "notes": "The issue concretely names the dependency, service, configuration, tests, Docker metadata, and documentation as removal surfaces. Its largest deficiency is treating DocumentDB as an equivalent drop-in for file-backed search without specifying provisioning, migration, availability, or failure behavior. The submitted factory context shows DocumentDB was selected only for MONGODB_BACKENDS while file storage used FaissSearchRepository, contradicting the implied existing mixed-backend support. With no independent task statement, the claims that FAISS is obsolete and DocumentDB replacement is required or behaviorally equivalent remain unverified."
+      },
+      "lld": {
+        "completeness": 10,
+        "correctness": 6,
+        "specificity": 13,
+        "risk_awareness": 5,
+        "total": 34,
+        "notes": "The LLD names concrete files, interfaces, factory behavior, and deletion steps. Its target architecture depends on an unspecified embedded or external DocumentDB for file storage, but it never selects, configures, provisions, or operates either option. The pre-change factory shown in the diff deliberately confines DocumentDBSearchRepository to MONGODB_BACKENDS, while the LLD supplies no data migration, reindex, Docker Compose, or connection-lifecycle design for changing that boundary. Its compatibility, existing mixed-backend support, and route-call claims could not be independently established, and the rollout plan lacks validation and rollback decisions."
+      },
+      "review": {
+        "completeness": 12,
+        "correctness": 6,
+        "specificity": 11,
+        "risk_awareness": 11,
+        "total": 40,
+        "notes": "The review identifies the central availability question for file-backed deployments and also raises response parity, latency, TLS, and data-exposure concerns. It then resolves the blocking infrastructure issue by merely asserting that embedded MongoDB or an existing Compose service will be used and declares no blocking findings. The submitted patch contains no embedded database, Compose update, search health check, or fallback, while the original factory branch indicates this is a new backend dependency. It also misses the removed batch indexing calls, deleted-service test references, migration or rebuild requirements, and rollback behavior."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 7,
+        "specificity": 10,
+        "risk_awareness": 6,
+        "total": 34,
+        "notes": "The plan spans registration, search, response shape, dependency removal, Docker build, empty results, and both proposed storage modes. Many steps remain manual or subjective, including \"Restart service,\" relevance judgments, and verification that results are returned correctly, while the submitted evidence does not establish the stated API paths, payloads, or Python 3.14 prerequisite. The response assertion accepts any one result key, and the grep-based E2E checks print FAIL through an OR branch without necessarily producing a failing command status. It omits concrete tests for update and deletion consistency, DocumentDB unavailability, migration or reindexing, and the known remaining imports of the deleted FAISS fixture."
+      },
+      "implementation": {
+        "completeness": 6,
+        "correctness": 3,
+        "specificity": 13,
+        "risk_awareness": 2,
+        "total": 24,
+        "notes": "The patch concretely removes faiss-cpu, FAISS configuration properties, the service implementation, and its dedicated tests, and the summary candidly lists some unfinished work. However, agent_batch_item_processor.py deletes the actual registration and deletion indexing calls and leaves comments claiming those actions, causing stale search state. The factory now always constructs DocumentDBSearchRepository and bypasses the newly added FileSearchRepository, despite the original code selecting DocumentDB only for MONGODB_BACKENDS. The patch adds no replacement tests, retains a FaissSearchRepository alias, omits LLD-identified route changes, and admits API tests still reference the deleted fixture, so its claims of complete removal and preserved behavior are unsupported."
+      }
+    },
+    "task_score": 35.0,
+    "verdict": "The submission identifies many relevant FAISS surfaces, but its unresolved DocumentDB dependency and implementation that removes indexing without replacing it make the proposed change incomplete and behaviorally unsafe.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T18:18:45.940101Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 286590,
+        "cached_input_tokens": 237323,
+        "cache_write_input_tokens": 49255,
+        "output_tokens": 5515,
+        "reasoning_output_tokens": 3961
+      },
+      "duration_ms": 114413
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 14,
+      "correctness": 8,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 49,
+      "notes": "The issue provides concrete scope, non-goals, a named feature flag, and acceptance criteria covering both authentication modes. Its central authorization requirement is incorrect: generating a token is local request signing, while database access requires `rds-db:connect` against a DB-user resource ARN, not `rds:GenerateDBAuthToken` against a cluster. It also calls the change self-contained despite requiring database-principal provisioning and potentially a different JDBC driver, and it makes the migration-prone IAM mode the default. The submitted diff context supports the stated existing `master_password` and `KC_DB_PASSWORD` configuration, but no independent task statement was supplied and repository reads could not be completed because the read-only shell consistently failed during sandbox setup."
+    },
+    "lld": {
+      "completeness": 9,
+      "correctness": 2,
+      "specificity": 13,
+      "risk_awareness": 7,
+      "total": 31,
+      "notes": "The LLD names concrete Terraform files, resources, variables, and conditional configuration, which makes its intended change boundary clear. Its load-bearing design is technically invalid: `master_password = \"\"` is not a viable Aurora master credential, the IAM action and resource are wrong, a stock MySQL Connector/J does not gain token generation from `iam=1`, and a `SECRETS` proxy auth block cannot be converted by supplying an empty secret ARN. Database-user creation is left as an open deployment consideration, uses the questionable `AWSAUTH` syntax rather than Aurora MySQL's `AWSAuthenticationPlugin`, and the rollout does not mitigate making this incomplete path the default. Exact repository integration and provider-version compatibility could not be independently verified because repository shell access failed, although the submitted patch context contains the named files and symbols."
+    },
+    "review": {
+      "completeness": 8,
+      "correctness": 3,
+      "specificity": 12,
+      "risk_awareness": 7,
+      "total": 30,
+      "notes": "The review usefully identifies database-user provisioning, fallback behavior, rollback testing, and removal of the obsolete Checkov suppression. It nevertheless explicitly endorses the two most serious false claims: that `iam=1` is native Keycloak/MySQL behavior and that `rds:GenerateDBAuthToken` scoped to the cluster ARN is correct. It misses the invalid empty Aurora master password and proxy secret, the absent token-refresh implementation, and the dangerous default-on migration, then labels all remaining findings non-blocking. Repository-specific assertions such as the role separation and Checkov location were visible in submitted diff context but could not be independently checked because read-only repository commands failed."
+    },
+    "testing": {
+      "completeness": 12,
+      "correctness": 5,
+      "specificity": 14,
+      "risk_awareness": 10,
+      "total": 41,
+      "notes": "The plan covers both flag settings, deployment, health, proxy connectivity, and rollback with reasonably concrete expected states. Several tests cannot work against the submitted patch: a missing password cannot be rejected because the variable defaults to an empty string without validation, `keycloak_db_auth_mode` is not implemented, and the AWS CLI command is `describe-db-proxies`, not `describe-db-proxy`. It also omits the critical token-expiry and pooled-connection renewal case, does not prove static credentials are absent, uses unverified hard-coded resource names, and its realm test never captures or asserts the HTTP 201 status. The exact required Terraform inputs and deployed naming conventions could not be verified because repository shell access was unavailable."
+    },
+    "implementation": {
+      "completeness": 5,
+      "correctness": 1,
+      "specificity": 12,
+      "risk_awareness": 4,
+      "total": 22,
+      "notes": "The patch is narrowly scoped to the four declared Terraform files and implements the proposed flag and conditional task configuration. It cannot deliver IAM authentication: it sets an invalid empty Aurora master password and proxy secret ARN, grants the nonexistent `rds:GenerateDBAuthToken` action on the wrong resource type instead of `rds-db:connect` on a DB-user ARN, and assumes unsupported token generation from `iam=1`. The required IAM-enabled database user and JDBC capability are absent while IAM is enabled by default, so a fresh or upgraded deployment is likely to fail before Keycloak starts; retaining the username secret also does not substantiate the summary's claim that static database credential infrastructure was eliminated. The summary acknowledges the unimplemented database migration and unexecuted verification but still claims exact completion; patch applicability and surrounding source could not be independently checked because every read-only shell invocation failed during sandbox setup."
+    }
+  },
+  "task_score": 34.6,
+  "verdict": "The artifacts are concrete but built around an invalid AWS/JDBC authentication design, leaving the implementation unable to establish a working Keycloak database connection.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T18:21:00.246024Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 147421,
+      "cached_input_tokens": 121129,
+      "cache_write_input_tokens": 26280,
+      "output_tokens": 7572,
+      "reasoning_output_tokens": 5378
+    },
+    "duration_ms": 134295
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 139.0,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1881348,
+    "output_tokens": 19973,
+    "cache_read_tokens": 1847696,
+    "cache_write_tokens": 33652,
+    "total_tokens": 3782669,
+    "total_cost_usd": null,
+    "latency_seconds": 143.7,
+    "num_turns": 51,
+    "generation_tokens_per_sec": 139.0,
+    "prefix_cache_hit_rate": 0.9821,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 1881348,
+  "output_tokens": 19973,
+  "latency_seconds": 143.7,
+  "num_turns": 51,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T18:10:03.173895Z",
+  "run_ended_at": "2026-08-05T18:12:28.464494Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1881348,
+    "output_tokens": 19973,
+    "cache_read_tokens": 1847696,
+    "cache_write_tokens": 33652,
+    "total_tokens": 3782669,
+    "total_cost_usd": null,
+    "latency_seconds": 143.7,
+    "num_turns": 51,
+    "generation_tokens_per_sec": 139.0,
+    "prefix_cache_hit_rate": 0.9821,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9821,
+      "prompt_tokens_cached_rate": 0.9821
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 19973,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 1847696,
+      "vllm:prefix_cache_queries_total": 1881348,
+      "vllm:prompt_tokens_by_source_total": 1881348,
+      "vllm:prompt_tokens_cached_total": 1847696,
+      "vllm:prompt_tokens_total": 1881348,
+      "vllm:request_success_total": 51,
+      "vllm:tool_call_parser_invocations_total": 17438
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 51,
+        "sum": 141.441,
+        "mean": 2.773354
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 19922,
+        "sum": 134.4398,
+        "mean": 0.006748
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 19973,
+        "sum": 53625,
+        "mean": 2.684875
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 51,
+        "sum": 134.4398,
+        "mean": 2.636074
+      },
+      "vllm:request_generation_tokens": {
+        "count": 51,
+        "sum": 19973,
+        "mean": 391.627451
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 51,
+        "sum": 137.2247,
+        "mean": 2.690681
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 51,
+        "sum": 19973,
+        "mean": 391.627451
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 51,
+        "sum": 816000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 51,
+        "sum": 51,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 51,
+        "sum": 33652,
+        "mean": 659.843137
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 51,
+        "sum": 2.785,
+        "mean": 0.054607
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 51,
+        "sum": 1881348,
+        "mean": 36889.176471
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 51,
+        "sum": 0.0004,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 51,
+        "sum": 0.3435,
+        "mean": 0.006735
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 51,
+        "sum": 7.0107,
+        "mean": 0.137465
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0455,
+          "mean": 0.0292,
+          "samples": 144
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9097,
+          "samples": 144
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 144
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 14,
+        "correctness": 8,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 49,
+        "notes": "The issue provides concrete scope, non-goals, a named feature flag, and acceptance criteria covering both authentication modes. Its central authorization requirement is incorrect: generating a token is local request signing, while database access requires `rds-db:connect` against a DB-user resource ARN, not `rds:GenerateDBAuthToken` against a cluster. It also calls the change self-contained despite requiring database-principal provisioning and potentially a different JDBC driver, and it makes the migration-prone IAM mode the default. The submitted diff context supports the stated existing `master_password` and `KC_DB_PASSWORD` configuration, but no independent task statement was supplied and repository reads could not be completed because the read-only shell consistently failed during sandbox setup."
+      },
+      "lld": {
+        "completeness": 9,
+        "correctness": 2,
+        "specificity": 13,
+        "risk_awareness": 7,
+        "total": 31,
+        "notes": "The LLD names concrete Terraform files, resources, variables, and conditional configuration, which makes its intended change boundary clear. Its load-bearing design is technically invalid: `master_password = \"\"` is not a viable Aurora master credential, the IAM action and resource are wrong, a stock MySQL Connector/J does not gain token generation from `iam=1`, and a `SECRETS` proxy auth block cannot be converted by supplying an empty secret ARN. Database-user creation is left as an open deployment consideration, uses the questionable `AWSAUTH` syntax rather than Aurora MySQL's `AWSAuthenticationPlugin`, and the rollout does not mitigate making this incomplete path the default. Exact repository integration and provider-version compatibility could not be independently verified because repository shell access failed, although the submitted patch context contains the named files and symbols."
+      },
+      "review": {
+        "completeness": 8,
+        "correctness": 3,
+        "specificity": 12,
+        "risk_awareness": 7,
+        "total": 30,
+        "notes": "The review usefully identifies database-user provisioning, fallback behavior, rollback testing, and removal of the obsolete Checkov suppression. It nevertheless explicitly endorses the two most serious false claims: that `iam=1` is native Keycloak/MySQL behavior and that `rds:GenerateDBAuthToken` scoped to the cluster ARN is correct. It misses the invalid empty Aurora master password and proxy secret, the absent token-refresh implementation, and the dangerous default-on migration, then labels all remaining findings non-blocking. Repository-specific assertions such as the role separation and Checkov location were visible in submitted diff context but could not be independently checked because read-only repository commands failed."
+      },
+      "testing": {
+        "completeness": 12,
+        "correctness": 5,
+        "specificity": 14,
+        "risk_awareness": 10,
+        "total": 41,
+        "notes": "The plan covers both flag settings, deployment, health, proxy connectivity, and rollback with reasonably concrete expected states. Several tests cannot work against the submitted patch: a missing password cannot be rejected because the variable defaults to an empty string without validation, `keycloak_db_auth_mode` is not implemented, and the AWS CLI command is `describe-db-proxies`, not `describe-db-proxy`. It also omits the critical token-expiry and pooled-connection renewal case, does not prove static credentials are absent, uses unverified hard-coded resource names, and its realm test never captures or asserts the HTTP 201 status. The exact required Terraform inputs and deployed naming conventions could not be verified because repository shell access was unavailable."
+      },
+      "implementation": {
+        "completeness": 5,
+        "correctness": 1,
+        "specificity": 12,
+        "risk_awareness": 4,
+        "total": 22,
+        "notes": "The patch is narrowly scoped to the four declared Terraform files and implements the proposed flag and conditional task configuration. It cannot deliver IAM authentication: it sets an invalid empty Aurora master password and proxy secret ARN, grants the nonexistent `rds:GenerateDBAuthToken` action on the wrong resource type instead of `rds-db:connect` on a DB-user ARN, and assumes unsupported token generation from `iam=1`. The required IAM-enabled database user and JDBC capability are absent while IAM is enabled by default, so a fresh or upgraded deployment is likely to fail before Keycloak starts; retaining the username secret also does not substantiate the summary's claim that static database credential infrastructure was eliminated. The summary acknowledges the unimplemented database migration and unexecuted verification but still claims exact completion; patch applicability and surrounding source could not be independently checked because every read-only shell invocation failed during sandbox setup."
+      }
+    },
+    "task_score": 34.6,
+    "verdict": "The artifacts are concrete but built around an invalid AWS/JDBC authentication design, leaving the implementation unable to establish a working Keycloak database connection.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T18:21:00.246024Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 147421,
+        "cached_input_tokens": 121129,
+        "cache_write_input_tokens": 26280,
+        "output_tokens": 7572,
+        "reasoning_output_tokens": 5378
+      },
+      "duration_ms": 134295
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "pi",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T18:14:59.503983Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 231467,
+      "cached_input_tokens": 197477,
+      "cache_write_input_tokens": 33974,
+      "output_tokens": 7507,
+      "reasoning_output_tokens": 5289
+    },
+    "duration_ms": 150543
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 45.08,
+  "mean_cost_usd_excl_failed": null,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 54,
+      "input_tokens": 2780184,
+      "output_tokens": 12507,
+      "total_tokens": 5572875,
+      "latency_seconds": 106.8,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 57.0,
+      "cache_read_tokens": 2725216,
+      "cache_write_tokens": 54968,
+      "prefix_cache_hit_rate": 0.9802,
+      "generation_tokens_per_sec": 117.1,
+      "kv_cache_usage": {
+        "peak": 0.0578,
+        "mean": 0.0385
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 17,
+          "specificity": 20,
+          "risk_awareness": 8,
+          "total": 62,
+          "notes": "The issue provides testable criteria naming `storage.tf`, `ecs-services.tf`, both output layers, and the two actual EFS variables shown in the patch. It correctly scopes removal of the file system, mount targets, security group, task volumes, variables, and outputs. Its largest deficiency is treating destructive infrastructure removal as dependency-free while omitting migration confirmation, backup, rollback, downstream output consumers, and the required `SCOPES_CONFIG_PATH` replacement. No independent task statement or evidence verifies the premise that all EFS data has migrated to S3 and DocumentDB."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 15,
+          "specificity": 18,
+          "risk_awareness": 10,
+          "total": 58,
+          "notes": "The LLD is well grounded in real symbols such as `module.efs`, `efs_all_outbound`, the auth and mcpgw mount names, and the module and root outputs. It precisely identifies most target files and service-level removals. However, deleting the auth-config mount leaves `SCOPES_CONFIG_PATH` invalid unless another location is chosen, and the LLD never makes that load-bearing decision even though the implementation changes it. It also incorrectly predicts a removal-only plan despite ECS task-definition replacement, and provides no concrete state, backup, consumer-compatibility, or rollback treatment."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 11,
+          "specificity": 13,
+          "risk_awareness": 12,
+          "total": 48,
+          "notes": "The review identifies two relevant concerns: dangling `module.efs` references and destruction of potentially remaining EFS data, while also correcting the missing `terraform init` step. Its data-loss concern is dismissed using the unverified migration assertion rather than requiring evidence or a backup gate. Claims of no breaking changes and comprehensive coverage overlook removed Terraform outputs, ECS task replacement, and the undocumented `SCOPES_CONFIG_PATH` change. The role-based approvals are otherwise largely generic, and the stated confirmation that migration is complete cannot be verified from the supplied evidence."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 7,
+          "specificity": 16,
+          "risk_awareness": 10,
+          "total": 46,
+          "notes": "The plan includes validation, planning, static reference checks, and post-deployment checks with concrete commands and expected outcomes. However, its hard-coded `/tmp/swe-clone-remove-efs-from-terraform-aws-ecs/...` paths do not match the submitted repository path, and a fresh plan without the deployed state cannot demonstrate EFS destruction. The assertion that the plan contains no additions is also wrong because changed ECS task definitions require replacement, while several grep checks merely print output or even return success after printing `FAIL`. It omits verification that `/app/auth_server/scopes.yml` exists and works, and incorrectly declares compatibility testing inapplicable despite removal of public outputs and variables."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 12,
+          "total": 71,
+          "notes": "The patch implements the main removal end to end: it deletes the 182-line EFS module, removes auth and mcpgw mounts and volumes, and removes both EFS variables plus module and root outputs. Its changes are tightly scoped and use the repository's existing empty `mountPoints` and `volume` conventions. The largest unresolved correctness risk is the untested substitution of `/app/auth_server/scopes.yml`, whose presence in the built image is not established by the submitted patch. The summary correctly admits validation and planning were not executed, but its claim of no LLD deviation is false and it omits the destructive state transition and downstream output compatibility impact."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 54,
+      "input_tokens": 2611810,
+      "output_tokens": 22787,
+      "total_tokens": 5246407,
+      "latency_seconds": 172.0,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 50.2,
+      "cache_read_tokens": 2560928,
+      "cache_write_tokens": 50882,
+      "prefix_cache_hit_rate": 0.9805,
+      "generation_tokens_per_sec": 132.5,
+      "kv_cache_usage": {
+        "peak": 0.0598,
+        "mean": 0.0415
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 14,
+          "risk_awareness": 13,
+          "total": 51,
+          "notes": "The issue clearly identifies the security objective, affected ECS and IAM surfaces, exclusions, and several testable outcomes. Its largest defect is the proposed same-name plaintext fallback: ECS secret resolution occurs before container startup, so plaintext cannot rescue a task whose secret retrieval fails, and the LLD itself says the two sources cannot be mixed for one name. Creating `aws_secretsmanager_secret_version` resources from Terraform variables also retains secret values in Terraform state, contradicting the stated state-exposure benefit. No independent task statement was supplied, so the exact secret inventory and cited issue `#1026` could not be verified as requirements."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 7,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 53,
+          "notes": "The design is concrete about the target files, twelve variables, Secrets Manager resources, ECS `valueFrom` entries, and IAM integration, with those paths and symbols also represented in the submitted diff. Its central migration decision is internally contradictory: it states that the same variable cannot appear in both `environment` and `secrets`, then prescribes exactly that as the fallback strategy without defining precedence or a deployable phased configuration. The proposed `secret_string = var.*` resources leave values in Terraform state, while the observability section incorrectly implies the migration removes that exposure and guarantees logs contain no secrets. Rollout, rollback, optional-value handling, and service-specific secret placement remain unresolved, and claims about existing issue numbers and MongoDB dual-write behavior could not be independently verified."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 17,
+          "risk_awareness": 17,
+          "total": 59,
+          "notes": "The review surfaces useful concrete risks, including optional empty secrets, startup failure from IAM errors, multiline private-key handling, lingering tfvars values, and the need for migration sequencing. It misses the design's fatal fallback contradiction and incorrectly treats `sensitive = true` as sufficient mitigation even though Terraform still stores sensitive values in state. Its resolution section claims the LLD gained migration commands, tfvars cleanup, and complete variable definitions, but those changes are absent from the submitted LLD. The patch does implement the recommended `jsonencode` private-key representation, while the broad KMS-policy claim and need for resource imports were not substantiated by the available artifacts."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 5,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 48,
+          "notes": "The plan covers Terraform validation, deployed task definitions, IAM, application behavior, security inspection, compatibility, and rollback with concrete intended oracles. Several commands are unusable: a saved plan cannot be applied with a new `-var-file`, `terraform apply -var \"rollback=true\" ...` is invented and syntactically incomplete, and grepping the binary plan file does not count resources reliably. `aws logs filter-log-events` normally succeeds with an empty event list, so the proposed secret-leak commands report failure even when no leak exists, and the fallback test never simulates failed secret retrieval. Task-family names, role and policy names, API endpoints, backend settings, and the `rollback` variable are asserted without repository evidence."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 3,
+          "specificity": 17,
+          "risk_awareness": 7,
+          "total": 40,
+          "notes": "The patch concretely covers secret resources, ECS references, IAM ARNs, conditional Auth0 handling, and JSON extraction for the GitHub private key across the three stated Terraform files. However, the auth-service `secrets = concat(...)` edit inserts `var.auth0_enabled ? [` before the original base list is closed and replaces that closing `],` with the conditional's `] : [],`, leaving the outer list unclosed; Terraform validation should therefore fail. Even after fixing syntax, same-name plaintext entries do not provide fallback when ECS cannot retrieve a secret, Terraform still records each `secret_string`, and `ignore_changes` prevents later variable updates from rotating those values. The summary's claim of no LLD deviation and successful migration is consequently false, and a repository-side apply check could not be completed because the provided command sandbox failed before executing Git."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 46,
+      "input_tokens": 1693448,
+      "output_tokens": 17640,
+      "total_tokens": 3404536,
+      "latency_seconds": 127.2,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 48.6,
+      "cache_read_tokens": 1658112,
+      "cache_write_tokens": 35336,
+      "prefix_cache_hit_rate": 0.9791,
+      "generation_tokens_per_sec": 138.7,
+      "kv_cache_usage": {
+        "peak": 0.0441,
+        "mean": 0.0293
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 61,
+          "notes": "The issue clearly identifies two outbound request flows, proposes bounded changes, and supplies explicit non-goals and acceptance criteria. Its symbol names are inaccurate: the patch context shows `_check_endpoint_reachability` and `HealthMonitoringService`, not `_check_agent_endpoint_reachable` and `HealthService`. The largest gap is omission of redirect validation and DNS rebinding behavior, while backward compatibility is stated without a concrete oracle for existing internal URLs. No independent task statement was supplied, so the proposed allowlist and configuration requirements are only supported by the candidate's internally consistent artifacts."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 50,
+          "notes": "The LLD gives concrete files, configuration, call flows, error behavior, and proposed code. Its core guard resolves a hostname during validation but allows the later HTTP client to resolve it again, and it does not validate redirect targets, leaving DNS rebinding and redirects unresolved. It also contradicts its extraction goal by omitting the `skill_service.py` refactor from the implementation steps, while importing `lru_cache` without decorating `_get_allowlist()` despite claiming that lookup is cached. Incorrect class and function names plus conflicting registration-failure guidance leave important integration decisions for the implementer."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 16,
+          "risk_awareness": 12,
+          "total": 51,
+          "notes": "The review identifies concrete concerns around duplication, synchronous DNS, redirects, IPv6, observability, and migration. It incorrectly praises cached allowlist lookup even though the submitted module has no cache decorator, and it claims the design checks final redirect URLs although the patch only validates the initial URL. Its dismissal of TOCTOU as requiring DNS compromise is technically unsound because an attacker controlling DNS can return different answers between validation and connection. Declaring zero blocking issues is therefore inconsistent with both the unhandled security bypasses and the missing extraction required by the issue."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 5,
+          "specificity": 12,
+          "risk_awareness": 10,
+          "total": 38,
+          "notes": "The plan spans unit, integration, compatibility, deployment, and end-to-end checks, with useful direct cases for private addresses and invalid schemes. However, it imports a nonexistent `_check_agent_endpoint_reachable` symbol and awaits it even though the source context shows synchronous `_check_endpoint_reachability`; it similarly names `HealthService` instead of `HealthMonitoringService`. The allowlist, health, IPv6, rebinding, and redirect examples contain no effective assertions, while `result[0] is True or mock_get.called` can pass without proving correct behavior. Public-DNS tests are nondeterministic, and commands such as `/api/internal/healthcheck` are not established by the submitted source context."
+        },
+        "implementation": {
+          "completeness": 12,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 8,
+          "total": 43,
+          "notes": "The patch targets coherent config, agent-validation, and health-monitoring contexts and adds a focused shared guard before the two outbound calls. It does not add the required unit tests or actually extract the existing skill-service logic, leaving duplicate security implementations despite the stated design. More seriously, pre-resolving with `socket.getaddrinfo()` does not bind the subsequent HTTP connection to the checked address, and redirect targets are never revalidated; synchronous DNS also blocks the async health path. The summary acknowledges the skipped refactor but incorrectly claims redirect handling and unchanged backward behavior, while an independent `git apply --check` could not be completed because repository command execution was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 191,
+      "input_tokens": 12109832,
+      "output_tokens": 30363,
+      "total_tokens": 24250027,
+      "latency_seconds": 258.4,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 35.0,
+      "cache_read_tokens": 12045040,
+      "cache_write_tokens": 64792,
+      "prefix_cache_hit_rate": 0.9946,
+      "generation_tokens_per_sec": 117.5,
+      "kv_cache_usage": {
+        "peak": 0.0781,
+        "mean": 0.0456
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 6,
+          "total": 43,
+          "notes": "The issue concretely names the dependency, service, configuration, tests, Docker metadata, and documentation as removal surfaces. Its largest deficiency is treating DocumentDB as an equivalent drop-in for file-backed search without specifying provisioning, migration, availability, or failure behavior. The submitted factory context shows DocumentDB was selected only for MONGODB_BACKENDS while file storage used FaissSearchRepository, contradicting the implied existing mixed-backend support. With no independent task statement, the claims that FAISS is obsolete and DocumentDB replacement is required or behaviorally equivalent remain unverified."
+        },
+        "lld": {
+          "completeness": 10,
+          "correctness": 6,
+          "specificity": 13,
+          "risk_awareness": 5,
+          "total": 34,
+          "notes": "The LLD names concrete files, interfaces, factory behavior, and deletion steps. Its target architecture depends on an unspecified embedded or external DocumentDB for file storage, but it never selects, configures, provisions, or operates either option. The pre-change factory shown in the diff deliberately confines DocumentDBSearchRepository to MONGODB_BACKENDS, while the LLD supplies no data migration, reindex, Docker Compose, or connection-lifecycle design for changing that boundary. Its compatibility, existing mixed-backend support, and route-call claims could not be independently established, and the rollout plan lacks validation and rollback decisions."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 6,
+          "specificity": 11,
+          "risk_awareness": 11,
+          "total": 40,
+          "notes": "The review identifies the central availability question for file-backed deployments and also raises response parity, latency, TLS, and data-exposure concerns. It then resolves the blocking infrastructure issue by merely asserting that embedded MongoDB or an existing Compose service will be used and declares no blocking findings. The submitted patch contains no embedded database, Compose update, search health check, or fallback, while the original factory branch indicates this is a new backend dependency. It also misses the removed batch indexing calls, deleted-service test references, migration or rebuild requirements, and rollback behavior."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 7,
+          "specificity": 10,
+          "risk_awareness": 6,
+          "total": 34,
+          "notes": "The plan spans registration, search, response shape, dependency removal, Docker build, empty results, and both proposed storage modes. Many steps remain manual or subjective, including \"Restart service,\" relevance judgments, and verification that results are returned correctly, while the submitted evidence does not establish the stated API paths, payloads, or Python 3.14 prerequisite. The response assertion accepts any one result key, and the grep-based E2E checks print FAIL through an OR branch without necessarily producing a failing command status. It omits concrete tests for update and deletion consistency, DocumentDB unavailability, migration or reindexing, and the known remaining imports of the deleted FAISS fixture."
+        },
+        "implementation": {
+          "completeness": 6,
+          "correctness": 3,
+          "specificity": 13,
+          "risk_awareness": 2,
+          "total": 24,
+          "notes": "The patch concretely removes faiss-cpu, FAISS configuration properties, the service implementation, and its dedicated tests, and the summary candidly lists some unfinished work. However, agent_batch_item_processor.py deletes the actual registration and deletion indexing calls and leaves comments claiming those actions, causing stale search state. The factory now always constructs DocumentDBSearchRepository and bypasses the newly added FileSearchRepository, despite the original code selecting DocumentDB only for MONGODB_BACKENDS. The patch adds no replacement tests, retains a FaissSearchRepository alias, omits LLD-identified route changes, and admits API tests still reference the deleted fixture, so its claims of complete removal and preserved behavior are unsupported."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 51,
+      "input_tokens": 1881348,
+      "output_tokens": 19973,
+      "total_tokens": 3782669,
+      "latency_seconds": 143.7,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 34.6,
+      "cache_read_tokens": 1847696,
+      "cache_write_tokens": 33652,
+      "prefix_cache_hit_rate": 0.9821,
+      "generation_tokens_per_sec": 139.0,
+      "kv_cache_usage": {
+        "peak": 0.0455,
+        "mean": 0.0292
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 49,
+          "notes": "The issue provides concrete scope, non-goals, a named feature flag, and acceptance criteria covering both authentication modes. Its central authorization requirement is incorrect: generating a token is local request signing, while database access requires `rds-db:connect` against a DB-user resource ARN, not `rds:GenerateDBAuthToken` against a cluster. It also calls the change self-contained despite requiring database-principal provisioning and potentially a different JDBC driver, and it makes the migration-prone IAM mode the default. The submitted diff context supports the stated existing `master_password` and `KC_DB_PASSWORD` configuration, but no independent task statement was supplied and repository reads could not be completed because the read-only shell consistently failed during sandbox setup."
+        },
+        "lld": {
+          "completeness": 9,
+          "correctness": 2,
+          "specificity": 13,
+          "risk_awareness": 7,
+          "total": 31,
+          "notes": "The LLD names concrete Terraform files, resources, variables, and conditional configuration, which makes its intended change boundary clear. Its load-bearing design is technically invalid: `master_password = \"\"` is not a viable Aurora master credential, the IAM action and resource are wrong, a stock MySQL Connector/J does not gain token generation from `iam=1`, and a `SECRETS` proxy auth block cannot be converted by supplying an empty secret ARN. Database-user creation is left as an open deployment consideration, uses the questionable `AWSAUTH` syntax rather than Aurora MySQL's `AWSAuthenticationPlugin`, and the rollout does not mitigate making this incomplete path the default. Exact repository integration and provider-version compatibility could not be independently verified because repository shell access failed, although the submitted patch context contains the named files and symbols."
+        },
+        "review": {
+          "completeness": 8,
+          "correctness": 3,
+          "specificity": 12,
+          "risk_awareness": 7,
+          "total": 30,
+          "notes": "The review usefully identifies database-user provisioning, fallback behavior, rollback testing, and removal of the obsolete Checkov suppression. It nevertheless explicitly endorses the two most serious false claims: that `iam=1` is native Keycloak/MySQL behavior and that `rds:GenerateDBAuthToken` scoped to the cluster ARN is correct. It misses the invalid empty Aurora master password and proxy secret, the absent token-refresh implementation, and the dangerous default-on migration, then labels all remaining findings non-blocking. Repository-specific assertions such as the role separation and Checkov location were visible in submitted diff context but could not be independently checked because read-only repository commands failed."
+        },
+        "testing": {
+          "completeness": 12,
+          "correctness": 5,
+          "specificity": 14,
+          "risk_awareness": 10,
+          "total": 41,
+          "notes": "The plan covers both flag settings, deployment, health, proxy connectivity, and rollback with reasonably concrete expected states. Several tests cannot work against the submitted patch: a missing password cannot be rejected because the variable defaults to an empty string without validation, `keycloak_db_auth_mode` is not implemented, and the AWS CLI command is `describe-db-proxies`, not `describe-db-proxy`. It also omits the critical token-expiry and pooled-connection renewal case, does not prove static credentials are absent, uses unverified hard-coded resource names, and its realm test never captures or asserts the HTTP 201 status. The exact required Terraform inputs and deployed naming conventions could not be verified because repository shell access was unavailable."
+        },
+        "implementation": {
+          "completeness": 5,
+          "correctness": 1,
+          "specificity": 12,
+          "risk_awareness": 4,
+          "total": 22,
+          "notes": "The patch is narrowly scoped to the four declared Terraform files and implements the proposed flag and conditional task configuration. It cannot deliver IAM authentication: it sets an invalid empty Aurora master password and proxy secret ARN, grants the nonexistent `rds:GenerateDBAuthToken` action on the wrong resource type instead of `rds-db:connect` on a DB-user ARN, and assumes unsupported token generation from `iam=1`. The required IAM-enabled database user and JDBC capability are absent while IAM is enabled by default, so a fresh or upgraded deployment is likely to fail before Keycloak starts; retaining the username secret also does not substantiate the summary's claim that static database credential infrastructure was eliminated. The summary acknowledges the unimplemented database migration and unexecuted verification but still claims exact completion; patch applicability and surrounding source could not be independently checked because every read-only shell invocation failed during sandbox setup."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-05"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "minimax-m2.5",
+  "scores": {
+    "github_issue": {
+      "completeness": 16,
+      "correctness": 14,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 61,
+      "notes": "The issue clearly identifies two outbound request flows, proposes bounded changes, and supplies explicit non-goals and acceptance criteria. Its symbol names are inaccurate: the patch context shows `_check_endpoint_reachability` and `HealthMonitoringService`, not `_check_agent_endpoint_reachable` and `HealthService`. The largest gap is omission of redirect validation and DNS rebinding behavior, while backward compatibility is stated without a concrete oracle for existing internal URLs. No independent task statement was supplied, so the proposed allowlist and configuration requirements are only supported by the candidate's internally consistent artifacts."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 9,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 50,
+      "notes": "The LLD gives concrete files, configuration, call flows, error behavior, and proposed code. Its core guard resolves a hostname during validation but allows the later HTTP client to resolve it again, and it does not validate redirect targets, leaving DNS rebinding and redirects unresolved. It also contradicts its extraction goal by omitting the `skill_service.py` refactor from the implementation steps, while importing `lru_cache` without decorating `_get_allowlist()` despite claiming that lookup is cached. Incorrect class and function names plus conflicting registration-failure guidance leave important integration decisions for the implementer."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 16,
+      "risk_awareness": 12,
+      "total": 51,
+      "notes": "The review identifies concrete concerns around duplication, synchronous DNS, redirects, IPv6, observability, and migration. It incorrectly praises cached allowlist lookup even though the submitted module has no cache decorator, and it claims the design checks final redirect URLs although the patch only validates the initial URL. Its dismissal of TOCTOU as requiring DNS compromise is technically unsound because an attacker controlling DNS can return different answers between validation and connection. Declaring zero blocking issues is therefore inconsistent with both the unhandled security bypasses and the missing extraction required by the issue."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 5,
+      "specificity": 12,
+      "risk_awareness": 10,
+      "total": 38,
+      "notes": "The plan spans unit, integration, compatibility, deployment, and end-to-end checks, with useful direct cases for private addresses and invalid schemes. However, it imports a nonexistent `_check_agent_endpoint_reachable` symbol and awaits it even though the source context shows synchronous `_check_endpoint_reachability`; it similarly names `HealthService` instead of `HealthMonitoringService`. The allowlist, health, IPv6, rebinding, and redirect examples contain no effective assertions, while `result[0] is True or mock_get.called` can pass without proving correct behavior. Public-DNS tests are nondeterministic, and commands such as `/api/internal/healthcheck` are not established by the submitted source context."
+    },
+    "implementation": {
+      "completeness": 12,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 8,
+      "total": 43,
+      "notes": "The patch targets coherent config, agent-validation, and health-monitoring contexts and adds a focused shared guard before the two outbound calls. It does not add the required unit tests or actually extract the existing skill-service logic, leaving duplicate security implementations despite the stated design. More seriously, pre-resolving with `socket.getaddrinfo()` does not bind the subsequent HTTP connection to the checked address, and redirect targets are never revalidated; synchronous DNS also blocks the async health path. The summary acknowledges the skipped refactor but incorrectly claims redirect handling and unchanged backward behavior, while an independent `git apply --check` could not be completed because repository command execution was unavailable."
+    }
+  },
+  "task_score": 48.6,
+  "verdict": "The submission is concrete but materially incomplete: its central SSRF defense remains bypassable through DNS rebinding or redirects, and the proposed tests are largely non-executable or assertion-free.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T18:23:02.148054Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 181508,
+      "cached_input_tokens": 153992,
+      "cache_write_input_tokens": 27502,
+      "output_tokens": 5514,
+      "reasoning_output_tokens": 3817
+    },
+    "duration_ms": 121891
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/minimax-m2.5/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "minimax-m2.5",
+  "model_slug": "minimax-m2.5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 196608
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 138.7,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1693448,
+    "output_tokens": 17640,
+    "cache_read_tokens": 1658112,
+    "cache_write_tokens": 35336,
+    "total_tokens": 3404536,
+    "total_cost_usd": null,
+    "latency_seconds": 127.2,
+    "num_turns": 46,
+    "generation_tokens_per_sec": 138.7,
+    "prefix_cache_hit_rate": 0.9791,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 1693448,
+  "output_tokens": 17640,
+  "latency_seconds": 127.2,
+  "num_turns": 46,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T18:04:57.730967Z",
+  "run_ended_at": "2026-08-05T18:07:06.292462Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1693448,
+    "output_tokens": 17640,
+    "cache_read_tokens": 1658112,
+    "cache_write_tokens": 35336,
+    "total_tokens": 3404536,
+    "total_cost_usd": null,
+    "latency_seconds": 127.2,
+    "num_turns": 46,
+    "generation_tokens_per_sec": 138.7,
+    "prefix_cache_hit_rate": 0.9791,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9791,
+      "prompt_tokens_cached_rate": 0.9791
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 17640,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 1658112,
+      "vllm:prefix_cache_queries_total": 1693448,
+      "vllm:prompt_tokens_by_source_total": 1693448,
+      "vllm:prompt_tokens_cached_total": 1658112,
+      "vllm:prompt_tokens_total": 1693448,
+      "vllm:request_success_total": 46,
+      "vllm:tool_call_parser_invocations_total": 16180
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 46,
+        "sum": 125.2032,
+        "mean": 2.721808
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 17594,
+        "sum": 118.5808,
+        "mean": 0.00674
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 17640,
+        "sum": 52976,
+        "mean": 3.003175
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 46,
+        "sum": 118.5808,
+        "mean": 2.577843
+      },
+      "vllm:request_generation_tokens": {
+        "count": 46,
+        "sum": 17640,
+        "mean": 383.478261
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 46,
+        "sum": 121.428,
+        "mean": 2.639738
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 46,
+        "sum": 17640,
+        "mean": 383.478261
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 46,
+        "sum": 736000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 46,
+        "sum": 46,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 46,
+        "sum": 35336,
+        "mean": 768.173913
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 46,
+        "sum": 2.8472,
+        "mean": 0.061896
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 46,
+        "sum": 1693448,
+        "mean": 36814.086957
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 46,
+        "sum": 0.0005,
+        "mean": 1.1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 46,
+        "sum": 0.31,
+        "mean": 0.00674
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 46,
+        "sum": 6.6324,
+        "mean": 0.144182
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0441,
+          "mean": 0.0293,
+          "samples": 127
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.937,
+          "samples": 127
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 127
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "minimax-m2.5",
+    "scores": {
+      "github_issue": {
+        "completeness": 16,
+        "correctness": 14,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 61,
+        "notes": "The issue clearly identifies two outbound request flows, proposes bounded changes, and supplies explicit non-goals and acceptance criteria. Its symbol names are inaccurate: the patch context shows `_check_endpoint_reachability` and `HealthMonitoringService`, not `_check_agent_endpoint_reachable` and `HealthService`. The largest gap is omission of redirect validation and DNS rebinding behavior, while backward compatibility is stated without a concrete oracle for existing internal URLs. No independent task statement was supplied, so the proposed allowlist and configuration requirements are only supported by the candidate's internally consistent artifacts."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 9,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 50,
+        "notes": "The LLD gives concrete files, configuration, call flows, error behavior, and proposed code. Its core guard resolves a hostname during validation but allows the later HTTP client to resolve it again, and it does not validate redirect targets, leaving DNS rebinding and redirects unresolved. It also contradicts its extraction goal by omitting the `skill_service.py` refactor from the implementation steps, while importing `lru_cache` without decorating `_get_allowlist()` despite claiming that lookup is cached. Incorrect class and function names plus conflicting registration-failure guidance leave important integration decisions for the implementer."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 16,
+        "risk_awareness": 12,
+        "total": 51,
+        "notes": "The review identifies concrete concerns around duplication, synchronous DNS, redirects, IPv6, observability, and migration. It incorrectly praises cached allowlist lookup even though the submitted module has no cache decorator, and it claims the design checks final redirect URLs although the patch only validates the initial URL. Its dismissal of TOCTOU as requiring DNS compromise is technically unsound because an attacker controlling DNS can return different answers between validation and connection. Declaring zero blocking issues is therefore inconsistent with both the unhandled security bypasses and the missing extraction required by the issue."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 5,
+        "specificity": 12,
+        "risk_awareness": 10,
+        "total": 38,
+        "notes": "The plan spans unit, integration, compatibility, deployment, and end-to-end checks, with useful direct cases for private addresses and invalid schemes. However, it imports a nonexistent `_check_agent_endpoint_reachable` symbol and awaits it even though the source context shows synchronous `_check_endpoint_reachability`; it similarly names `HealthService` instead of `HealthMonitoringService`. The allowlist, health, IPv6, rebinding, and redirect examples contain no effective assertions, while `result[0] is True or mock_get.called` can pass without proving correct behavior. Public-DNS tests are nondeterministic, and commands such as `/api/internal/healthcheck` are not established by the submitted source context."
+      },
+      "implementation": {
+        "completeness": 12,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 8,
+        "total": 43,
+        "notes": "The patch targets coherent config, agent-validation, and health-monitoring contexts and adds a focused shared guard before the two outbound calls. It does not add the required unit tests or actually extract the existing skill-service logic, leaving duplicate security implementations despite the stated design. More seriously, pre-resolving with `socket.getaddrinfo()` does not bind the subsequent HTTP connection to the checked address, and redirect targets are never revalidated; synchronous DNS also blocks the async health path. The summary acknowledges the skipped refactor but incorrectly claims redirect handling and unchanged backward behavior, while an independent `git apply --check` could not be completed because repository command execution was unavailable."
+      }
+    },
+    "task_score": 48.6,
+    "verdict": "The submission is concrete but materially incomplete: its central SSRF defense remains bypassable through DNS rebinding or redirects, and the proposed tests are largely non-executable or assertion-free.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T18:23:02.148054Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 181508,
+        "cached_input_tokens": 153992,
+        "cache_write_input_tokens": 27502,
+        "output_tokens": 5514,
+        "reasoning_output_tokens": 3817
+      },
+      "duration_ms": 121891
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "nemotron-ultra-550b",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 50,
+      "notes": "The issue identifies concrete Terraform files, ECS secret injection, IAM permissions, scope, and testable task-definition outcomes. Its central security claim is incorrect: creating aws_secretsmanager_secret_version resources from Terraform variables still records secret_string values in Terraform state, directly conflicting with the no-plaintext-state acceptance criterion. It also simultaneously requires application-level fallback and excludes application changes, while ECS injection cannot fall back automatically and secret rotation still requires replacing running tasks. No independent task statement establishes the cross-account requirement, and the issue provides no corresponding resource-policy acceptance criterion."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 7,
+      "specificity": 18,
+      "risk_awareness": 12,
+      "total": 52,
+      "notes": "The LLD is concrete about secrets.tf, ecs-services.tf, iam.tf, resource conditions, environment names, and startup failure behavior. Its design cannot meet its own state objective because every proposed secret version assigns secret_string from a Terraform variable, and its claimed fallback consists only of removing the managed environment entry and suggesting an out-of-band ECS edit. There are internal inconsistencies: ANS secrets are described as already existing but are later planned as new resources, and the supplied LLD lacks the monitoring, application validation, KMS, and IAM-document changes that the review says were incorporated. Cross-account policies, historical state cleanup, staged migration, and a workable rollback path remain unresolved."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 10,
+      "specificity": 16,
+      "risk_awareness": 14,
+      "total": 53,
+      "notes": "The review identifies concrete concerns around the wildcard KMS principal, missing-secret behavior, rotation, observability, and plaintext emergency overrides. Its largest failure is endorsing the false claims that values leave Terraform state and that plaintext fallback remains, without noticing that Terraform-managed secret versions and ECS environment injection contradict both claims. The resolution section says monitoring.tf, startup validation, a specific execution-role ARN, and aws_iam_policy_document were added to the LLD, but none appears in the submitted LLD. It also does not challenge empty optional secret values or establish that one task execution role covers both ECS service modules."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 7,
+      "specificity": 16,
+      "risk_awareness": 10,
+      "total": 48,
+      "notes": "The plan covers plans, applies, conditional configurations, IAM, task definitions, runtime injection, CloudTrail, updates, and service health with concrete expected states. The initial plan runs from the child module with an unverified ../../../test.tfvars and expects all 24 resources even though the listed variables do not enable the feature flags controlling their counts. The fallback test contains placeholders and no executable oracle, no test inspects Terraform state for secret values, and the proposed destroy test conflicts with prevent_destroy added by the patch. Several API endpoints and AWS resource names are unverified, while printing secrets through get-secret-value and env unnecessarily exposes test credentials."
+    },
+    "implementation": {
+      "completeness": 14,
+      "correctness": 6,
+      "specificity": 17,
+      "risk_awareness": 7,
+      "total": 44,
+      "notes": "The patch concretely adds twelve secret resources, moves matching ECS entries into secrets arrays, extends least-privilege IAM resources, and tightens the submitted KMS policy context. It does not implement the promised state removal or fallback: secret_string remains in Terraform state, plaintext entries are deleted, and ECS cannot inject a missing secret or select a manual fallback automatically. Conditions such as auth0_enabled and registration_gate_enabled can create secret versions from empty optional values, causing apply-time failures, while ignore_changes prevents later Terraform updates from rotating those values. The AWS/SecretsManager alarms use unsupported API-operation metrics, prevent_destroy contradicts the documented destroy workflow, and the availability and suitability of module.ecs_cluster.task_exec_iam_role_arn could not be independently verified because repository command execution was unavailable."
+    }
+  },
+  "task_score": 49.4,
+  "verdict": "The submission is detailed and repository-shaped, but its implementation preserves secrets in Terraform state and provides neither the claimed fallback nor reliable handling of optional values.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T00:40:54.170801Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 286553,
+      "cached_input_tokens": 246495,
+      "cache_write_input_tokens": 40042,
+      "output_tokens": 8192,
+      "reasoning_output_tokens": 6814
+    },
+    "duration_ms": 166968
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "nemotron-ultra-550b",
+  "model_slug": "nemotron-ultra-550b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "nvfp4",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 111.7,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 6257141,
+    "output_tokens": 43771,
+    "cache_read_tokens": 6014976,
+    "cache_write_tokens": 242165,
+    "total_tokens": 12558053,
+    "total_cost_usd": null,
+    "latency_seconds": 391.7,
+    "num_turns": 67,
+    "generation_tokens_per_sec": 111.7,
+    "prefix_cache_hit_rate": 0.9613,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 6257141,
+  "output_tokens": 43771,
+  "latency_seconds": 391.7,
+  "num_turns": 67,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T00:25:42.722809Z",
+  "run_ended_at": "2026-08-06T00:32:18.067870Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 6257141,
+    "output_tokens": 43771,
+    "cache_read_tokens": 6014976,
+    "cache_write_tokens": 242165,
+    "total_tokens": 12558053,
+    "total_cost_usd": null,
+    "latency_seconds": 391.7,
+    "num_turns": 67,
+    "generation_tokens_per_sec": 111.7,
+    "prefix_cache_hit_rate": 0.9613,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9613,
+      "prompt_tokens_cached_rate": 0.9613
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 43771,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 6014976,
+      "vllm:prefix_cache_queries_total": 6257141,
+      "vllm:prompt_tokens_by_source_total": 6257141,
+      "vllm:prompt_tokens_cached_total": 6014976,
+      "vllm:prompt_tokens_total": 6257141,
+      "vllm:request_success_total": 67,
+      "vllm:tool_call_parser_invocations_total": 39433
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 67,
+        "sum": 385.0528,
+        "mean": 5.747057
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 43704,
+        "sum": 354.7925,
+        "mean": 0.008118
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 43771,
+        "sum": 285936,
+        "mean": 6.532544
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 67,
+        "sum": 354.7925,
+        "mean": 5.29541
+      },
+      "vllm:request_generation_tokens": {
+        "count": 67,
+        "sum": 43771,
+        "mean": 653.298507
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 67,
+        "sum": 374.0179,
+        "mean": 5.582356
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 67,
+        "sum": 43771,
+        "mean": 653.298507
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 67,
+        "sum": 1072000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 67,
+        "sum": 67,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 67,
+        "sum": 242165,
+        "mean": 3614.402985
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 67,
+        "sum": 19.2254,
+        "mean": 0.286946
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 67,
+        "sum": 6257141,
+        "mean": 93390.164179
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 67,
+        "sum": 0.0007,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 67,
+        "sum": 0.5455,
+        "mean": 0.008143
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 67,
+        "sum": 30.2767,
+        "mean": 0.451891
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0054,
+          "mean": 0.0035,
+          "samples": 391
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8977,
+          "samples": 391
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 391
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "nemotron-ultra-550b",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 50,
+        "notes": "The issue identifies concrete Terraform files, ECS secret injection, IAM permissions, scope, and testable task-definition outcomes. Its central security claim is incorrect: creating aws_secretsmanager_secret_version resources from Terraform variables still records secret_string values in Terraform state, directly conflicting with the no-plaintext-state acceptance criterion. It also simultaneously requires application-level fallback and excludes application changes, while ECS injection cannot fall back automatically and secret rotation still requires replacing running tasks. No independent task statement establishes the cross-account requirement, and the issue provides no corresponding resource-policy acceptance criterion."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 7,
+        "specificity": 18,
+        "risk_awareness": 12,
+        "total": 52,
+        "notes": "The LLD is concrete about secrets.tf, ecs-services.tf, iam.tf, resource conditions, environment names, and startup failure behavior. Its design cannot meet its own state objective because every proposed secret version assigns secret_string from a Terraform variable, and its claimed fallback consists only of removing the managed environment entry and suggesting an out-of-band ECS edit. There are internal inconsistencies: ANS secrets are described as already existing but are later planned as new resources, and the supplied LLD lacks the monitoring, application validation, KMS, and IAM-document changes that the review says were incorporated. Cross-account policies, historical state cleanup, staged migration, and a workable rollback path remain unresolved."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 10,
+        "specificity": 16,
+        "risk_awareness": 14,
+        "total": 53,
+        "notes": "The review identifies concrete concerns around the wildcard KMS principal, missing-secret behavior, rotation, observability, and plaintext emergency overrides. Its largest failure is endorsing the false claims that values leave Terraform state and that plaintext fallback remains, without noticing that Terraform-managed secret versions and ECS environment injection contradict both claims. The resolution section says monitoring.tf, startup validation, a specific execution-role ARN, and aws_iam_policy_document were added to the LLD, but none appears in the submitted LLD. It also does not challenge empty optional secret values or establish that one task execution role covers both ECS service modules."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 7,
+        "specificity": 16,
+        "risk_awareness": 10,
+        "total": 48,
+        "notes": "The plan covers plans, applies, conditional configurations, IAM, task definitions, runtime injection, CloudTrail, updates, and service health with concrete expected states. The initial plan runs from the child module with an unverified ../../../test.tfvars and expects all 24 resources even though the listed variables do not enable the feature flags controlling their counts. The fallback test contains placeholders and no executable oracle, no test inspects Terraform state for secret values, and the proposed destroy test conflicts with prevent_destroy added by the patch. Several API endpoints and AWS resource names are unverified, while printing secrets through get-secret-value and env unnecessarily exposes test credentials."
+      },
+      "implementation": {
+        "completeness": 14,
+        "correctness": 6,
+        "specificity": 17,
+        "risk_awareness": 7,
+        "total": 44,
+        "notes": "The patch concretely adds twelve secret resources, moves matching ECS entries into secrets arrays, extends least-privilege IAM resources, and tightens the submitted KMS policy context. It does not implement the promised state removal or fallback: secret_string remains in Terraform state, plaintext entries are deleted, and ECS cannot inject a missing secret or select a manual fallback automatically. Conditions such as auth0_enabled and registration_gate_enabled can create secret versions from empty optional values, causing apply-time failures, while ignore_changes prevents later Terraform updates from rotating those values. The AWS/SecretsManager alarms use unsupported API-operation metrics, prevent_destroy contradicts the documented destroy workflow, and the availability and suitability of module.ecs_cluster.task_exec_iam_role_arn could not be independently verified because repository command execution was unavailable."
+      }
+    },
+    "task_score": 49.4,
+    "verdict": "The submission is detailed and repository-shaped, but its implementation preserves secrets in Terraform state and provides neither the claimed fallback nor reliable handling of optional values.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T00:40:54.170801Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 286553,
+        "cached_input_tokens": 246495,
+        "cache_write_input_tokens": 40042,
+        "output_tokens": 8192,
+        "reasoning_output_tokens": 6814
+      },
+      "duration_ms": 166968
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "nemotron-ultra-550b",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 11,
+      "total": 71,
+      "notes": "The issue gives concrete file-level scope and testable criteria for resources, mounts, variables, outputs, validation, and planning. Its named symbols and paths agree internally with the submitted diff, including module.efs, efs_throughput_mode, and the three root outputs. The largest deficiency is declaring no dependencies while omitting EFS data destruction, downstream output consumers, and confirmation that auth-server and mcpgw tolerate losing their mounts. The S3/DocumentDB migration claim could not be independently verified because repository shell inspection was unavailable."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 12,
+      "total": 65,
+      "notes": "The LLD precisely identifies the relevant Terraform files, module references, mount names, output contracts, and SCOPES_CONFIG_PATH change, all internally corroborated by the submitted patch. It nevertheless leaves the load-bearing runtime questions about /app/data, /app/logs, and the replacement scopes file unresolved while claiming there are no open questions or migration needs. Its rollout has no concrete pre-destruction validation or usable fallback, and its assertion that Fargate does not support EBS is outdated. The proposed non-EFS path and absence of external output consumers were not independently verifiable from the working tree."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 22,
+      "total": 77,
+      "notes": "The review's strongest contribution is identifying specific runtime and operational risks: the stale scopes path, mcpgw durability, missing log directories, irreversible data loss, and downstream output consumers. Its resolution tracking is materially inaccurate because it says the LLD added mcpgw verification, directory handling, and rollback documentation, while the submitted LLD steps and rollout do not contain those resolutions. The claimed EFS mount-target cost and statement that terraform state list can verify external remote-state consumers are also unsupported or incorrect. Despite those defects, the prioritized blocking findings are actionable and substantially stress the design."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 9,
+      "specificity": 21,
+      "risk_awareness": 13,
+      "total": 61,
+      "notes": "The plan provides concrete static checks, Terraform validation, plan inspection, deployment health checks, and explicit expected values. Several tests cannot satisfy their own oracles: grep returns status 1 for the expected no-match cases, while tests 1.2.2 and 1.2.3 require status 0, and planned_values.root_module.outputs is not the Terraform plan JSON output location. Test 4.2.1 incorrectly searches planned_values for destroyed resources, which are absent there, and the no-created-resources expectation conflicts with replacement ECS task-definition revisions. Runtime confirmation that scopes.yml exists and /app/data is safely ephemeral remains largely manual, while the supplied variables and commands could not be checked against the working tree."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 9,
+      "total": 65,
+      "notes": "The patch consistently removes the submitted EFS module, its variables and outputs, and the auth-server and mcpgw EFS volume references while replacing the stale scopes path. Its contexts and symbols are internally consistent with the supplied baseline diff, but independent git apply and source inspection were unavailable; the summary also incorrectly says storage.tf contains seven access points when the diff contains six. The implementation does not resolve the review's blocking checks for /app/data, /app/logs, or availability of /app/auth_server/scopes.yml, despite claiming no deviations and no follow-ups. It also omits the promised destruction warning and rollback discussion, so the summary understates the principal operational and data-loss risk."
+    }
+  },
+  "task_score": 67.8,
+  "verdict": "The submission is concrete and largely implements the Terraform removal, but unresolved runtime storage assumptions, inaccurate review resolutions, and multiple invalid test oracles prevent it from being implementation-ready.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T00:42:47.997690Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 167826,
+      "cached_input_tokens": 134315,
+      "cache_write_input_tokens": 33499,
+      "output_tokens": 5512,
+      "reasoning_output_tokens": 3885
+    },
+    "duration_ms": 113815
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "nemotron-ultra-550b",
+  "model_slug": "nemotron-ultra-550b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "nvfp4",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 104.4,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5440713,
+    "output_tokens": 20997,
+    "cache_read_tokens": 5229312,
+    "cache_write_tokens": 211401,
+    "total_tokens": 10902423,
+    "total_cost_usd": null,
+    "latency_seconds": 201.1,
+    "num_turns": 64,
+    "generation_tokens_per_sec": 104.4,
+    "prefix_cache_hit_rate": 0.9611,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5440713,
+  "output_tokens": 20997,
+  "latency_seconds": 201.1,
+  "num_turns": 64,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T00:12:56.796337Z",
+  "run_ended_at": "2026-08-06T00:16:19.810691Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5440713,
+    "output_tokens": 20997,
+    "cache_read_tokens": 5229312,
+    "cache_write_tokens": 211401,
+    "total_tokens": 10902423,
+    "total_cost_usd": null,
+    "latency_seconds": 201.1,
+    "num_turns": 64,
+    "generation_tokens_per_sec": 104.4,
+    "prefix_cache_hit_rate": 0.9611,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9611,
+      "prompt_tokens_cached_rate": 0.9611
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 20997,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 5229312,
+      "vllm:prefix_cache_queries_total": 5440713,
+      "vllm:prompt_tokens_by_source_total": 5440713,
+      "vllm:prompt_tokens_cached_total": 5229312,
+      "vllm:prompt_tokens_total": 5440713,
+      "vllm:request_success_total": 64,
+      "vllm:tool_call_parser_invocations_total": 18883
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 64,
+        "sum": 196.3014,
+        "mean": 3.067209
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 20933,
+        "sum": 170.1255,
+        "mean": 0.008127
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 20997,
+        "sum": 232398,
+        "mean": 11.068153
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 64,
+        "sum": 170.1255,
+        "mean": 2.658211
+      },
+      "vllm:request_generation_tokens": {
+        "count": 64,
+        "sum": 20997,
+        "mean": 328.078125
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 64,
+        "sum": 187.3239,
+        "mean": 2.926935
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 64,
+        "sum": 20997,
+        "mean": 328.078125
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 64,
+        "sum": 1024000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 64,
+        "sum": 64,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 64,
+        "sum": 211401,
+        "mean": 3303.140625
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 64,
+        "sum": 17.1983,
+        "mean": 0.268724
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 64,
+        "sum": 5440713,
+        "mean": 85011.140625
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 64,
+        "sum": 0.0008,
+        "mean": 1.2e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 64,
+        "sum": 0.5192,
+        "mean": 0.008113
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 64,
+        "sum": 26.1914,
+        "mean": 0.409241
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.006,
+          "mean": 0.0032,
+          "samples": 201
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8109,
+          "samples": 201
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 201
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "nemotron-ultra-550b",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 11,
+        "total": 71,
+        "notes": "The issue gives concrete file-level scope and testable criteria for resources, mounts, variables, outputs, validation, and planning. Its named symbols and paths agree internally with the submitted diff, including module.efs, efs_throughput_mode, and the three root outputs. The largest deficiency is declaring no dependencies while omitting EFS data destruction, downstream output consumers, and confirmation that auth-server and mcpgw tolerate losing their mounts. The S3/DocumentDB migration claim could not be independently verified because repository shell inspection was unavailable."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 12,
+        "total": 65,
+        "notes": "The LLD precisely identifies the relevant Terraform files, module references, mount names, output contracts, and SCOPES_CONFIG_PATH change, all internally corroborated by the submitted patch. It nevertheless leaves the load-bearing runtime questions about /app/data, /app/logs, and the replacement scopes file unresolved while claiming there are no open questions or migration needs. Its rollout has no concrete pre-destruction validation or usable fallback, and its assertion that Fargate does not support EBS is outdated. The proposed non-EFS path and absence of external output consumers were not independently verifiable from the working tree."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 22,
+        "total": 77,
+        "notes": "The review's strongest contribution is identifying specific runtime and operational risks: the stale scopes path, mcpgw durability, missing log directories, irreversible data loss, and downstream output consumers. Its resolution tracking is materially inaccurate because it says the LLD added mcpgw verification, directory handling, and rollback documentation, while the submitted LLD steps and rollout do not contain those resolutions. The claimed EFS mount-target cost and statement that terraform state list can verify external remote-state consumers are also unsupported or incorrect. Despite those defects, the prioritized blocking findings are actionable and substantially stress the design."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 9,
+        "specificity": 21,
+        "risk_awareness": 13,
+        "total": 61,
+        "notes": "The plan provides concrete static checks, Terraform validation, plan inspection, deployment health checks, and explicit expected values. Several tests cannot satisfy their own oracles: grep returns status 1 for the expected no-match cases, while tests 1.2.2 and 1.2.3 require status 0, and planned_values.root_module.outputs is not the Terraform plan JSON output location. Test 4.2.1 incorrectly searches planned_values for destroyed resources, which are absent there, and the no-created-resources expectation conflicts with replacement ECS task-definition revisions. Runtime confirmation that scopes.yml exists and /app/data is safely ephemeral remains largely manual, while the supplied variables and commands could not be checked against the working tree."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 9,
+        "total": 65,
+        "notes": "The patch consistently removes the submitted EFS module, its variables and outputs, and the auth-server and mcpgw EFS volume references while replacing the stale scopes path. Its contexts and symbols are internally consistent with the supplied baseline diff, but independent git apply and source inspection were unavailable; the summary also incorrectly says storage.tf contains seven access points when the diff contains six. The implementation does not resolve the review's blocking checks for /app/data, /app/logs, or availability of /app/auth_server/scopes.yml, despite claiming no deviations and no follow-ups. It also omits the promised destruction warning and rollback discussion, so the summary understates the principal operational and data-loss risk."
+      }
+    },
+    "task_score": 67.8,
+    "verdict": "The submission is concrete and largely implements the Terraform removal, but unresolved runtime storage assumptions, inaccurate review resolutions, and multiple invalid test oracles prevent it from being implementation-ready.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T00:42:47.997690Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 167826,
+        "cached_input_tokens": 134315,
+        "cache_write_input_tokens": 33499,
+        "output_tokens": 5512,
+        "reasoning_output_tokens": 3885
+      },
+      "duration_ms": 113815
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "nemotron-ultra-550b",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 20,
+      "risk_awareness": 11,
+      "total": 65,
+      "notes": "The issue identifies concrete targets including `pyproject.toml`, `Settings`, the repository factory, metrics, telemetry, documentation, and tests, with mostly testable acceptance criteria. Its largest flaw is promising no end-user behavior change while the existing factory routes file storage to `FaissSearchRepository`; removing that implementation necessarily removes file-backend search unless a replacement or migration is specified. The stated equivalence or superiority of DocumentDB search is asserted without relevance, latency, or compatibility evidence. No independent task statement was supplied, and the referenced issue #1285 was not available for verification."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 11,
+      "specificity": 19,
+      "risk_awareness": 10,
+      "total": 56,
+      "notes": "The LLD is well grounded in real integration points such as `get_search_repository()`, `SearchRepositoryBase`, route indexing calls, configuration properties, and telemetry files. Its largest deficiency is contradictory file-backend handling: it alternately proposes deleting the repository, always returning DocumentDB, raising an error, and providing a clear error, while the later review claims a no-op design was added when it was not. It also proposes editing the metrics schema without designing an upgrade migration and restricts telemetry to `documentdb` despite retaining file storage. The rollout is generic, lacks a concrete rollback and compatibility sequence, and does not demonstrate its claim that existing data will be re-indexed on startup."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 18,
+      "risk_awareness": 19,
+      "total": 67,
+      "notes": "The review surfaces several real risks: loss of file-backend search, metrics compatibility, relevance changes, circular imports, deployment coordination, and rollback. Its largest correctness problem is claiming that the LLD was revised with a no-op repository, startup validation, null metrics compatibility, and rollback instructions even though those changes are absent from the submitted LLD. It also misses the existing-database column migration problem and the conflict between emitting `search_backend=\"none\"` and accepting only `documentdb`. Claims about production hardening, TLS enforcement, and verified absence of import cycles are not substantiated in the review."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 11,
+      "specificity": 17,
+      "risk_awareness": 13,
+      "total": 57,
+      "notes": "The plan provides concrete lifecycle, API-contract, dependency, configuration, Docker, and negative checks, including a file-backend test that would expose the implementation's silent no-op behavior. Several oracles are ineffective or incomplete: `len(servers) >= 0` can never fail, the agent test performs no registration, and `tests/golden_queries.py` is invoked without being supplied. The metrics check only inspects a function signature and therefore cannot detect that the old field is no longer emitted or that the replacement value is always null. It omits an existing-database upgrade test and producer-versus-collector telemetry validation, while the stated greater-than-80-percent pass target permits substantial regressions."
+    },
+    "implementation": {
+      "completeness": 12,
+      "correctness": 9,
+      "specificity": 16,
+      "risk_awareness": 8,
+      "total": 45,
+      "notes": "The patch implements much of the core removal by deleting `registry/search/service.py`, replacing the file factory branch, removing the dependency and configuration properties, and moving route calls to `SearchRepositoryBase` methods. Two deterministic defects are material: `_build_heartbeat_payload()` emits `none` for file storage while the collector regex accepts only `documentdb`, and historical metrics table creation is edited without an upgrade migration while inserts immediately target `vector_search_time_ms`. Documentation removal is incomplete because the patched context still contains `class FaissService` and the statement that the registry maintains a FAISS index, and the summary admits required unit tests were not updated. The claimed metrics compatibility is inaccurate because the deprecated parameter is accepted but not emitted and `vector_search_time_ms` is always written as null; independent `git apply --check` verification was unavailable in the provided sandbox."
+    }
+  },
+  "task_score": 58.0,
+  "verdict": "The submission is concrete and identifies most relevant surfaces, but unresolved file-backend behavior and serious telemetry and metrics-migration defects make the implementation unsafe to merge.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T00:45:52.079732Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 454339,
+      "cached_input_tokens": 397254,
+      "cache_write_input_tokens": 57067,
+      "output_tokens": 8541,
+      "reasoning_output_tokens": 6810
+    },
+    "duration_ms": 184069
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "nemotron-ultra-550b",
+  "model_slug": "nemotron-ultra-550b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "nvfp4",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 88.3,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 35154791,
+    "output_tokens": 47996,
+    "cache_read_tokens": 34505856,
+    "cache_write_tokens": 722200,
+    "total_tokens": 70430843,
+    "total_cost_usd": null,
+    "latency_seconds": 543.3,
+    "num_turns": 240,
+    "generation_tokens_per_sec": 88.3,
+    "prefix_cache_hit_rate": 0.9795,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 35154791,
+  "output_tokens": 47996,
+  "latency_seconds": 543.3,
+  "num_turns": 240,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T00:03:48.495262Z",
+  "run_ended_at": "2026-08-06T00:12:55.142289Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 35154791,
+    "output_tokens": 47996,
+    "cache_read_tokens": 34505856,
+    "cache_write_tokens": 722200,
+    "total_tokens": 70430843,
+    "total_cost_usd": null,
+    "latency_seconds": 543.3,
+    "num_turns": 240,
+    "generation_tokens_per_sec": 88.3,
+    "prefix_cache_hit_rate": 0.9795,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9795,
+      "prompt_tokens_cached_rate": 0.9795
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 48837,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 34505856,
+      "vllm:prefix_cache_queries_total": 35228056,
+      "vllm:prompt_tokens_by_source_total": 35228056,
+      "vllm:prompt_tokens_cached_total": 34505856,
+      "vllm:prompt_tokens_total": 35228056,
+      "vllm:request_success_total": 241,
+      "vllm:tool_call_parser_invocations_total": 43856
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 241,
+        "sum": 533.5332,
+        "mean": 2.213831
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 48596,
+        "sum": 403.6977,
+        "mean": 0.008307
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 48837,
+        "sum": 771037,
+        "mean": 15.787968
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 241,
+        "sum": 403.6977,
+        "mean": 1.675094
+      },
+      "vllm:request_generation_tokens": {
+        "count": 241,
+        "sum": 48837,
+        "mean": 202.643154
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 241,
+        "sum": 469.1683,
+        "mean": 1.946756
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 241,
+        "sum": 48837,
+        "mean": 202.643154
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 241,
+        "sum": 3678061,
+        "mean": 15261.6639
+      },
+      "vllm:request_params_n": {
+        "count": 241,
+        "sum": 241,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 241,
+        "sum": 722200,
+        "mean": 2996.680498
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 241,
+        "sum": 65.4706,
+        "mean": 0.271662
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 241,
+        "sum": 35228056,
+        "mean": 146174.506224
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 241,
+        "sum": 0.0028,
+        "mean": 1.2e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 241,
+        "sum": 2.0089,
+        "mean": 0.008336
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 241,
+        "sum": 129.9007,
+        "mean": 0.539007
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0076,
+          "mean": 0.0044,
+          "samples": 541
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.7652,
+          "samples": 541
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 541
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "nemotron-ultra-550b",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 20,
+        "risk_awareness": 11,
+        "total": 65,
+        "notes": "The issue identifies concrete targets including `pyproject.toml`, `Settings`, the repository factory, metrics, telemetry, documentation, and tests, with mostly testable acceptance criteria. Its largest flaw is promising no end-user behavior change while the existing factory routes file storage to `FaissSearchRepository`; removing that implementation necessarily removes file-backend search unless a replacement or migration is specified. The stated equivalence or superiority of DocumentDB search is asserted without relevance, latency, or compatibility evidence. No independent task statement was supplied, and the referenced issue #1285 was not available for verification."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 11,
+        "specificity": 19,
+        "risk_awareness": 10,
+        "total": 56,
+        "notes": "The LLD is well grounded in real integration points such as `get_search_repository()`, `SearchRepositoryBase`, route indexing calls, configuration properties, and telemetry files. Its largest deficiency is contradictory file-backend handling: it alternately proposes deleting the repository, always returning DocumentDB, raising an error, and providing a clear error, while the later review claims a no-op design was added when it was not. It also proposes editing the metrics schema without designing an upgrade migration and restricts telemetry to `documentdb` despite retaining file storage. The rollout is generic, lacks a concrete rollback and compatibility sequence, and does not demonstrate its claim that existing data will be re-indexed on startup."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 18,
+        "risk_awareness": 19,
+        "total": 67,
+        "notes": "The review surfaces several real risks: loss of file-backend search, metrics compatibility, relevance changes, circular imports, deployment coordination, and rollback. Its largest correctness problem is claiming that the LLD was revised with a no-op repository, startup validation, null metrics compatibility, and rollback instructions even though those changes are absent from the submitted LLD. It also misses the existing-database column migration problem and the conflict between emitting `search_backend=\"none\"` and accepting only `documentdb`. Claims about production hardening, TLS enforcement, and verified absence of import cycles are not substantiated in the review."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 11,
+        "specificity": 17,
+        "risk_awareness": 13,
+        "total": 57,
+        "notes": "The plan provides concrete lifecycle, API-contract, dependency, configuration, Docker, and negative checks, including a file-backend test that would expose the implementation's silent no-op behavior. Several oracles are ineffective or incomplete: `len(servers) >= 0` can never fail, the agent test performs no registration, and `tests/golden_queries.py` is invoked without being supplied. The metrics check only inspects a function signature and therefore cannot detect that the old field is no longer emitted or that the replacement value is always null. It omits an existing-database upgrade test and producer-versus-collector telemetry validation, while the stated greater-than-80-percent pass target permits substantial regressions."
+      },
+      "implementation": {
+        "completeness": 12,
+        "correctness": 9,
+        "specificity": 16,
+        "risk_awareness": 8,
+        "total": 45,
+        "notes": "The patch implements much of the core removal by deleting `registry/search/service.py`, replacing the file factory branch, removing the dependency and configuration properties, and moving route calls to `SearchRepositoryBase` methods. Two deterministic defects are material: `_build_heartbeat_payload()` emits `none` for file storage while the collector regex accepts only `documentdb`, and historical metrics table creation is edited without an upgrade migration while inserts immediately target `vector_search_time_ms`. Documentation removal is incomplete because the patched context still contains `class FaissService` and the statement that the registry maintains a FAISS index, and the summary admits required unit tests were not updated. The claimed metrics compatibility is inaccurate because the deprecated parameter is accepted but not emitted and `vector_search_time_ms` is always written as null; independent `git apply --check` verification was unavailable in the provided sandbox."
+      }
+    },
+    "task_score": 58.0,
+    "verdict": "The submission is concrete and identifies most relevant surfaces, but unresolved file-backend behavior and serious telemetry and metrics-migration defects make the implementation unsafe to merge.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T00:45:52.079732Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 454339,
+        "cached_input_tokens": 397254,
+        "cache_write_input_tokens": 57067,
+        "output_tokens": 8541,
+        "reasoning_output_tokens": 6810
+      },
+      "duration_ms": 184069
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "nemotron-ultra-550b",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 9,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 56,
+      "notes": "The issue provides concrete acceptance criteria, migration scope, fallback behavior, and explicit non-goals tied to Keycloak, Aurora, RDS Proxy, ECS, and Terraform. Its central requirements conflict: IAM mode is supposed to eliminate the static password while password fallback remains immediately available. It also treats rds:GenerateDBAuthToken as an IAM permission even though token generation is local request signing and authorization is governed by rds-db:connect. Token renewal after connection loss, TLS requirements, and database-user authentication setup are omitted, and no independent task statement was supplied to resolve these ambiguities."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 4,
+      "specificity": 17,
+      "risk_awareness": 9,
+      "total": 44,
+      "notes": "The LLD names real integration points such as terraform/aws-ecs/keycloak-database.tf, keycloak-ecs.tf, secret-rotation.tf, and docker/keycloak/Dockerfile, with concrete proposed Terraform and entrypoint changes. Its implementation depends on Python and boto3 being present in quay.io/keycloak/keycloak:25.0, but the repository Dockerfile adds neither, and it proposes unsupported or ineffective IAM actions and condition keys. A startup-only token cannot authenticate reconnections after 15 minutes, and an ENABLED proxy does not automatically substitute the retained password for Keycloak's expired token. The document also contradicts itself over destroying versus retaining the secret, leaves token refresh as an open question, and omits required TLS and credible rollback-state handling."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 8,
+      "specificity": 18,
+      "risk_awareness": 17,
+      "total": 60,
+      "notes": "The review identifies consequential defects, particularly token expiry, JDBC compatibility, conditional Terraform references, secret lifecycle, rollback sequencing, and missing operational alarms. Its principal resolution is technically unsound: RDS Proxy accepting both authentication methods does not make a Keycloak process holding only an expired IAM token retry with the fallback password. It says resolutions were applied even though the submitted LLD still conditionally destroys the secret and retains the unresolved token-refresh question. It also misses the image's absent Python/boto3 tooling and TLS requirements, while claiming IAM conditions and driver behavior were verified without supporting evidence."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 6,
+      "specificity": 17,
+      "risk_awareness": 15,
+      "total": 56,
+      "notes": "The plan spans Terraform rendering, both feature-flag modes, rollback, realm reads and writes, token expiry, and Aurora failover, with several concrete expected values. Many commands cannot provide their claimed oracle: counted Terraform resources require indexed addresses, docker invocations use || true, and the proposed image supplies neither boto3 nor the assumed tooling. The ECS database test assumes mysql, DB_HOST, and DB_PORT exist in the running Keycloak container, while the deployment checks fall back to a fabricated URL and hard-coded cluster and service names. Most seriously, the expiry and failover tests expect automatic password or fresh-token recovery that the implementation has no mechanism to perform; proposed unit tests are only pass stubs."
+    },
+    "implementation": {
+      "completeness": 7,
+      "correctness": 2,
+      "specificity": 12,
+      "risk_awareness": 3,
+      "total": 24,
+      "notes": "The patch targets the relevant baseline symbols, threading the flag into aws_rds_cluster.keycloak, aws_db_proxy.keycloak, the ECS environment, rotation resources, and the Keycloak image. It is not deployable as written: aws_iam_role_policy does not accept tags, conditional policy branches emit invalid empty Statement objects, and adding count to rotation resources requires every dependent reference and rotation schedule to be updated. The container adds no Python or boto3 dependency, attempts chmod in the inherited non-root Keycloak image, and configures an unverified MariaDB AWS plugin even though KC_DB=mysql uses Keycloak's MySQL driver path. Retaining and ceasing rotation of the static secret contradicts the claimed replacement, while a single startup token cannot reconnect or fall back automatically; the summary acknowledges unverified compatibility and unimplemented documentation but still overstates completeness."
+    }
+  },
+  "task_score": 48.0,
+  "verdict": "The submission is detailed and surfaces several real risks, but the design's authentication model is flawed and the implementation would fail Terraform or container deployment before providing functional RDS IAM authentication.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T00:48:38.326459Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 252724,
+      "cached_input_tokens": 211131,
+      "cache_write_input_tokens": 41579,
+      "output_tokens": 9689,
+      "reasoning_output_tokens": 8172
+    },
+    "duration_ms": 166235
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "nemotron-ultra-550b",
+  "model_slug": "nemotron-ultra-550b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "nvfp4",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 108.4,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 7348108,
+    "output_tokens": 37068,
+    "cache_read_tokens": 7079424,
+    "cache_write_tokens": 268684,
+    "total_tokens": 14733284,
+    "total_cost_usd": null,
+    "latency_seconds": 342.0,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 108.4,
+    "prefix_cache_hit_rate": 0.9634,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 7348108,
+  "output_tokens": 37068,
+  "latency_seconds": 342.0,
+  "num_turns": 80,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T00:32:19.639105Z",
+  "run_ended_at": "2026-08-06T00:38:06.547527Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 7348108,
+    "output_tokens": 37068,
+    "cache_read_tokens": 7079424,
+    "cache_write_tokens": 268684,
+    "total_tokens": 14733284,
+    "total_cost_usd": null,
+    "latency_seconds": 342.0,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 108.4,
+    "prefix_cache_hit_rate": 0.9634,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9634,
+      "prompt_tokens_cached_rate": 0.9634
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 37068,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 7079424,
+      "vllm:prefix_cache_queries_total": 7348108,
+      "vllm:prompt_tokens_by_source_total": 7348108,
+      "vllm:prompt_tokens_cached_total": 7079424,
+      "vllm:prompt_tokens_total": 7348108,
+      "vllm:request_success_total": 80,
+      "vllm:tool_call_parser_invocations_total": 34045
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 80,
+        "sum": 335.4117,
+        "mean": 4.192647
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 36988,
+        "sum": 300.7374,
+        "mean": 0.008131
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 37068,
+        "sum": 305752,
+        "mean": 8.248408
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 80,
+        "sum": 300.7374,
+        "mean": 3.759217
+      },
+      "vllm:request_generation_tokens": {
+        "count": 80,
+        "sum": 37068,
+        "mean": 463.35
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 80,
+        "sum": 322.4896,
+        "mean": 4.03112
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 80,
+        "sum": 37068,
+        "mean": 463.35
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 80,
+        "sum": 1280000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 80,
+        "sum": 80,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 80,
+        "sum": 268684,
+        "mean": 3358.55
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 80,
+        "sum": 21.7522,
+        "mean": 0.271902
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 80,
+        "sum": 7348108,
+        "mean": 91851.35
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 80,
+        "sum": 0.0007,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 80,
+        "sum": 0.6509,
+        "mean": 0.008136
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 80,
+        "sum": 34.6974,
+        "mean": 0.433717
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0055,
+          "mean": 0.0034,
+          "samples": 342
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8538,
+          "samples": 342
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 342
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "nemotron-ultra-550b",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 9,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 56,
+        "notes": "The issue provides concrete acceptance criteria, migration scope, fallback behavior, and explicit non-goals tied to Keycloak, Aurora, RDS Proxy, ECS, and Terraform. Its central requirements conflict: IAM mode is supposed to eliminate the static password while password fallback remains immediately available. It also treats rds:GenerateDBAuthToken as an IAM permission even though token generation is local request signing and authorization is governed by rds-db:connect. Token renewal after connection loss, TLS requirements, and database-user authentication setup are omitted, and no independent task statement was supplied to resolve these ambiguities."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 4,
+        "specificity": 17,
+        "risk_awareness": 9,
+        "total": 44,
+        "notes": "The LLD names real integration points such as terraform/aws-ecs/keycloak-database.tf, keycloak-ecs.tf, secret-rotation.tf, and docker/keycloak/Dockerfile, with concrete proposed Terraform and entrypoint changes. Its implementation depends on Python and boto3 being present in quay.io/keycloak/keycloak:25.0, but the repository Dockerfile adds neither, and it proposes unsupported or ineffective IAM actions and condition keys. A startup-only token cannot authenticate reconnections after 15 minutes, and an ENABLED proxy does not automatically substitute the retained password for Keycloak's expired token. The document also contradicts itself over destroying versus retaining the secret, leaves token refresh as an open question, and omits required TLS and credible rollback-state handling."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 8,
+        "specificity": 18,
+        "risk_awareness": 17,
+        "total": 60,
+        "notes": "The review identifies consequential defects, particularly token expiry, JDBC compatibility, conditional Terraform references, secret lifecycle, rollback sequencing, and missing operational alarms. Its principal resolution is technically unsound: RDS Proxy accepting both authentication methods does not make a Keycloak process holding only an expired IAM token retry with the fallback password. It says resolutions were applied even though the submitted LLD still conditionally destroys the secret and retains the unresolved token-refresh question. It also misses the image's absent Python/boto3 tooling and TLS requirements, while claiming IAM conditions and driver behavior were verified without supporting evidence."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 6,
+        "specificity": 17,
+        "risk_awareness": 15,
+        "total": 56,
+        "notes": "The plan spans Terraform rendering, both feature-flag modes, rollback, realm reads and writes, token expiry, and Aurora failover, with several concrete expected values. Many commands cannot provide their claimed oracle: counted Terraform resources require indexed addresses, docker invocations use || true, and the proposed image supplies neither boto3 nor the assumed tooling. The ECS database test assumes mysql, DB_HOST, and DB_PORT exist in the running Keycloak container, while the deployment checks fall back to a fabricated URL and hard-coded cluster and service names. Most seriously, the expiry and failover tests expect automatic password or fresh-token recovery that the implementation has no mechanism to perform; proposed unit tests are only pass stubs."
+      },
+      "implementation": {
+        "completeness": 7,
+        "correctness": 2,
+        "specificity": 12,
+        "risk_awareness": 3,
+        "total": 24,
+        "notes": "The patch targets the relevant baseline symbols, threading the flag into aws_rds_cluster.keycloak, aws_db_proxy.keycloak, the ECS environment, rotation resources, and the Keycloak image. It is not deployable as written: aws_iam_role_policy does not accept tags, conditional policy branches emit invalid empty Statement objects, and adding count to rotation resources requires every dependent reference and rotation schedule to be updated. The container adds no Python or boto3 dependency, attempts chmod in the inherited non-root Keycloak image, and configures an unverified MariaDB AWS plugin even though KC_DB=mysql uses Keycloak's MySQL driver path. Retaining and ceasing rotation of the static secret contradicts the claimed replacement, while a single startup token cannot reconnect or fall back automatically; the summary acknowledges unverified compatibility and unimplemented documentation but still overstates completeness."
+      }
+    },
+    "task_score": 48.0,
+    "verdict": "The submission is detailed and surfaces several real risks, but the design's authentication model is flawed and the implementation would fail Terraform or container deployment before providing functional RDS IAM authentication.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T00:48:38.326459Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 252724,
+        "cached_input_tokens": 211131,
+        "cache_write_input_tokens": 41579,
+        "output_tokens": 9689,
+        "reasoning_output_tokens": 8172
+      },
+      "duration_ms": 166235
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "nemotron-ultra-550b",
+  "model_slug": "nemotron-ultra-550b",
+  "agent": "pi",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "nvfp4",
+    "context_window": 200000
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T00:40:54.170801Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 286553,
+      "cached_input_tokens": 246495,
+      "cache_write_input_tokens": 40042,
+      "output_tokens": 8192,
+      "reasoning_output_tokens": 6814
+    },
+    "duration_ms": 166968
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 55.2,
+  "mean_cost_usd_excl_failed": null,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 64,
+      "input_tokens": 5440713,
+      "output_tokens": 20997,
+      "total_tokens": 10902423,
+      "latency_seconds": 201.1,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 67.8,
+      "cache_read_tokens": 5229312,
+      "cache_write_tokens": 211401,
+      "prefix_cache_hit_rate": 0.9611,
+      "generation_tokens_per_sec": 104.4,
+      "kv_cache_usage": {
+        "peak": 0.006,
+        "mean": 0.0032
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 11,
+          "total": 71,
+          "notes": "The issue gives concrete file-level scope and testable criteria for resources, mounts, variables, outputs, validation, and planning. Its named symbols and paths agree internally with the submitted diff, including module.efs, efs_throughput_mode, and the three root outputs. The largest deficiency is declaring no dependencies while omitting EFS data destruction, downstream output consumers, and confirmation that auth-server and mcpgw tolerate losing their mounts. The S3/DocumentDB migration claim could not be independently verified because repository shell inspection was unavailable."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 12,
+          "total": 65,
+          "notes": "The LLD precisely identifies the relevant Terraform files, module references, mount names, output contracts, and SCOPES_CONFIG_PATH change, all internally corroborated by the submitted patch. It nevertheless leaves the load-bearing runtime questions about /app/data, /app/logs, and the replacement scopes file unresolved while claiming there are no open questions or migration needs. Its rollout has no concrete pre-destruction validation or usable fallback, and its assertion that Fargate does not support EBS is outdated. The proposed non-EFS path and absence of external output consumers were not independently verifiable from the working tree."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 22,
+          "total": 77,
+          "notes": "The review's strongest contribution is identifying specific runtime and operational risks: the stale scopes path, mcpgw durability, missing log directories, irreversible data loss, and downstream output consumers. Its resolution tracking is materially inaccurate because it says the LLD added mcpgw verification, directory handling, and rollback documentation, while the submitted LLD steps and rollout do not contain those resolutions. The claimed EFS mount-target cost and statement that terraform state list can verify external remote-state consumers are also unsupported or incorrect. Despite those defects, the prioritized blocking findings are actionable and substantially stress the design."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 9,
+          "specificity": 21,
+          "risk_awareness": 13,
+          "total": 61,
+          "notes": "The plan provides concrete static checks, Terraform validation, plan inspection, deployment health checks, and explicit expected values. Several tests cannot satisfy their own oracles: grep returns status 1 for the expected no-match cases, while tests 1.2.2 and 1.2.3 require status 0, and planned_values.root_module.outputs is not the Terraform plan JSON output location. Test 4.2.1 incorrectly searches planned_values for destroyed resources, which are absent there, and the no-created-resources expectation conflicts with replacement ECS task-definition revisions. Runtime confirmation that scopes.yml exists and /app/data is safely ephemeral remains largely manual, while the supplied variables and commands could not be checked against the working tree."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 9,
+          "total": 65,
+          "notes": "The patch consistently removes the submitted EFS module, its variables and outputs, and the auth-server and mcpgw EFS volume references while replacing the stale scopes path. Its contexts and symbols are internally consistent with the supplied baseline diff, but independent git apply and source inspection were unavailable; the summary also incorrectly says storage.tf contains seven access points when the diff contains six. The implementation does not resolve the review's blocking checks for /app/data, /app/logs, or availability of /app/auth_server/scopes.yml, despite claiming no deviations and no follow-ups. It also omits the promised destruction warning and rollback discussion, so the summary understates the principal operational and data-loss risk."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 240,
+      "input_tokens": 35154791,
+      "output_tokens": 47996,
+      "total_tokens": 70430843,
+      "latency_seconds": 543.3,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 58.0,
+      "cache_read_tokens": 34505856,
+      "cache_write_tokens": 722200,
+      "prefix_cache_hit_rate": 0.9795,
+      "generation_tokens_per_sec": 88.3,
+      "kv_cache_usage": {
+        "peak": 0.0076,
+        "mean": 0.0044
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 20,
+          "risk_awareness": 11,
+          "total": 65,
+          "notes": "The issue identifies concrete targets including `pyproject.toml`, `Settings`, the repository factory, metrics, telemetry, documentation, and tests, with mostly testable acceptance criteria. Its largest flaw is promising no end-user behavior change while the existing factory routes file storage to `FaissSearchRepository`; removing that implementation necessarily removes file-backend search unless a replacement or migration is specified. The stated equivalence or superiority of DocumentDB search is asserted without relevance, latency, or compatibility evidence. No independent task statement was supplied, and the referenced issue #1285 was not available for verification."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 10,
+          "total": 56,
+          "notes": "The LLD is well grounded in real integration points such as `get_search_repository()`, `SearchRepositoryBase`, route indexing calls, configuration properties, and telemetry files. Its largest deficiency is contradictory file-backend handling: it alternately proposes deleting the repository, always returning DocumentDB, raising an error, and providing a clear error, while the later review claims a no-op design was added when it was not. It also proposes editing the metrics schema without designing an upgrade migration and restricts telemetry to `documentdb` despite retaining file storage. The rollout is generic, lacks a concrete rollback and compatibility sequence, and does not demonstrate its claim that existing data will be re-indexed on startup."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 18,
+          "risk_awareness": 19,
+          "total": 67,
+          "notes": "The review surfaces several real risks: loss of file-backend search, metrics compatibility, relevance changes, circular imports, deployment coordination, and rollback. Its largest correctness problem is claiming that the LLD was revised with a no-op repository, startup validation, null metrics compatibility, and rollback instructions even though those changes are absent from the submitted LLD. It also misses the existing-database column migration problem and the conflict between emitting `search_backend=\"none\"` and accepting only `documentdb`. Claims about production hardening, TLS enforcement, and verified absence of import cycles are not substantiated in the review."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 17,
+          "risk_awareness": 13,
+          "total": 57,
+          "notes": "The plan provides concrete lifecycle, API-contract, dependency, configuration, Docker, and negative checks, including a file-backend test that would expose the implementation's silent no-op behavior. Several oracles are ineffective or incomplete: `len(servers) >= 0` can never fail, the agent test performs no registration, and `tests/golden_queries.py` is invoked without being supplied. The metrics check only inspects a function signature and therefore cannot detect that the old field is no longer emitted or that the replacement value is always null. It omits an existing-database upgrade test and producer-versus-collector telemetry validation, while the stated greater-than-80-percent pass target permits substantial regressions."
+        },
+        "implementation": {
+          "completeness": 12,
+          "correctness": 9,
+          "specificity": 16,
+          "risk_awareness": 8,
+          "total": 45,
+          "notes": "The patch implements much of the core removal by deleting `registry/search/service.py`, replacing the file factory branch, removing the dependency and configuration properties, and moving route calls to `SearchRepositoryBase` methods. Two deterministic defects are material: `_build_heartbeat_payload()` emits `none` for file storage while the collector regex accepts only `documentdb`, and historical metrics table creation is edited without an upgrade migration while inserts immediately target `vector_search_time_ms`. Documentation removal is incomplete because the patched context still contains `class FaissService` and the statement that the registry maintains a FAISS index, and the summary admits required unit tests were not updated. The claimed metrics compatibility is inaccurate because the deprecated parameter is accepted but not emitted and `vector_search_time_ms` is always written as null; independent `git apply --check` verification was unavailable in the provided sandbox."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 109,
+      "input_tokens": 14297587,
+      "output_tokens": 57159,
+      "total_tokens": 28723313,
+      "latency_seconds": 548.3,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 52.8,
+      "cache_read_tokens": 13939200,
+      "cache_write_tokens": 429367,
+      "prefix_cache_hit_rate": 0.9701,
+      "generation_tokens_per_sec": 104.2,
+      "kv_cache_usage": {
+        "peak": 0.0072,
+        "mean": 0.0045
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 76,
+          "notes": "The issue clearly identifies three outbound paths and gives testable criteria for private-address rejection, allowlists, and secure defaults; the named symbols also appear in the submitted source context. Its largest deficiency is calling the change backward-compatible even though previously working internal agent and server URLs become blocked unless operators add configuration. It also declares the skill path out of scope while requiring extraction and changed allowlist behavior there. Redirect handling and DNS-rebinding risk are absent, and no independent task statement was supplied to verify the asserted issue #1282 requirements."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 9,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 62,
+          "notes": "The LLD is repository-specific, naming real integration points such as `_check_endpoint_reachability`, `check_agent_health`, and `_check_server_endpoint_transport_aware`, with concrete configuration and failure behavior. Its critical flaw is treating validation of `response.url` after a `follow_redirects=True` request as SSRF prevention, although the private redirect target has already been contacted; separate DNS validation also leaves a rebinding TOCTOU gap. It inconsistently says no skill-path modification is intended while changing that path's trust policy, and its stated Helm path differs from the submitted implementation's `charts/mcpgw/values.yaml`. Rollout and logging are addressed, but the claimed sufficiency of the existing validator and deployment surfaces could not be established from an independent task statement."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 9,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 60,
+          "notes": "The review surfaces concrete concerns including redirects, DNS rebinding, IP literals, cache behavior, and operational observability rather than merely approving the design. However, its prescribed redirect fix validates the destination only after the request, and it accepts the DNS TOCTOU risk using an incorrect claim that periodic health checks make the attack window small. The proposed unbounded process-global DNS cache can retain attacker-controlled hostnames and widen stale-resolution exposure, while the IPv6 zone-ID false positive is prioritized above the actual bypass. The resolution log claims all findings were incorporated, but the supplied LLD remains unrevised and the implementation contains no Prometheus counter."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 6,
+          "specificity": 15,
+          "risk_awareness": 13,
+          "total": 51,
+          "notes": "The plan spans utility, three call paths, compatibility, deployment, and rollback, and it supplies many explicit expected outcomes. Several tests are not executable as written: changing environment variables after importing the singleton `settings` does not update its fields, the DNS-cache example uses `socket` without importing it, and multiple important cases are left as `pass`. Public-host and registration examples depend on live DNS and services rather than controlled transports, while the agent health success oracle accepts either healthy or unhealthy. Most importantly, redirect tests only inspect final status and do not assert that no request reached the private target, and no tests are included in the implementation patch."
+        },
+        "implementation": {
+          "completeness": 5,
+          "correctness": 0,
+          "specificity": 8,
+          "risk_awareness": 2,
+          "total": 15,
+          "notes": "The patch attempts concrete integration across the three named request paths, shared configuration, Docker, and Terraform. It is fatally corrupted: the `skill_service.py` hunk deletes roughly 298 unrelated lines and inserts the literal `[Showing lines 1-1450 of 1746 (50.0KB limit). Use offset=1451 to continue.]`, leaving an incomplete `if` block and invalid Python. Even apart from that, health requests use `follow_redirects=True` before checking `response.url`, so the SSRF request has already occurred, and the DNS cache is unbounded and preserves TOCTOU exposure. The summary falsely claims a Prometheus metric and complete review resolution, while the diff defines no counter, only adds a Helm value without template wiring, and includes no tests."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 67,
+      "input_tokens": 6257141,
+      "output_tokens": 43771,
+      "total_tokens": 12558053,
+      "latency_seconds": 391.7,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 49.4,
+      "cache_read_tokens": 6014976,
+      "cache_write_tokens": 242165,
+      "prefix_cache_hit_rate": 0.9613,
+      "generation_tokens_per_sec": 111.7,
+      "kv_cache_usage": {
+        "peak": 0.0054,
+        "mean": 0.0035
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 50,
+          "notes": "The issue identifies concrete Terraform files, ECS secret injection, IAM permissions, scope, and testable task-definition outcomes. Its central security claim is incorrect: creating aws_secretsmanager_secret_version resources from Terraform variables still records secret_string values in Terraform state, directly conflicting with the no-plaintext-state acceptance criterion. It also simultaneously requires application-level fallback and excludes application changes, while ECS injection cannot fall back automatically and secret rotation still requires replacing running tasks. No independent task statement establishes the cross-account requirement, and the issue provides no corresponding resource-policy acceptance criterion."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 52,
+          "notes": "The LLD is concrete about secrets.tf, ecs-services.tf, iam.tf, resource conditions, environment names, and startup failure behavior. Its design cannot meet its own state objective because every proposed secret version assigns secret_string from a Terraform variable, and its claimed fallback consists only of removing the managed environment entry and suggesting an out-of-band ECS edit. There are internal inconsistencies: ANS secrets are described as already existing but are later planned as new resources, and the supplied LLD lacks the monitoring, application validation, KMS, and IAM-document changes that the review says were incorporated. Cross-account policies, historical state cleanup, staged migration, and a workable rollback path remain unresolved."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 10,
+          "specificity": 16,
+          "risk_awareness": 14,
+          "total": 53,
+          "notes": "The review identifies concrete concerns around the wildcard KMS principal, missing-secret behavior, rotation, observability, and plaintext emergency overrides. Its largest failure is endorsing the false claims that values leave Terraform state and that plaintext fallback remains, without noticing that Terraform-managed secret versions and ECS environment injection contradict both claims. The resolution section says monitoring.tf, startup validation, a specific execution-role ARN, and aws_iam_policy_document were added to the LLD, but none appears in the submitted LLD. It also does not challenge empty optional secret values or establish that one task execution role covers both ECS service modules."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 16,
+          "risk_awareness": 10,
+          "total": 48,
+          "notes": "The plan covers plans, applies, conditional configurations, IAM, task definitions, runtime injection, CloudTrail, updates, and service health with concrete expected states. The initial plan runs from the child module with an unverified ../../../test.tfvars and expects all 24 resources even though the listed variables do not enable the feature flags controlling their counts. The fallback test contains placeholders and no executable oracle, no test inspects Terraform state for secret values, and the proposed destroy test conflicts with prevent_destroy added by the patch. Several API endpoints and AWS resource names are unverified, while printing secrets through get-secret-value and env unnecessarily exposes test credentials."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 6,
+          "specificity": 17,
+          "risk_awareness": 7,
+          "total": 44,
+          "notes": "The patch concretely adds twelve secret resources, moves matching ECS entries into secrets arrays, extends least-privilege IAM resources, and tightens the submitted KMS policy context. It does not implement the promised state removal or fallback: secret_string remains in Terraform state, plaintext entries are deleted, and ECS cannot inject a missing secret or select a manual fallback automatically. Conditions such as auth0_enabled and registration_gate_enabled can create secret versions from empty optional values, causing apply-time failures, while ignore_changes prevents later Terraform updates from rotating those values. The AWS/SecretsManager alarms use unsupported API-operation metrics, prevent_destroy contradicts the documented destroy workflow, and the availability and suitability of module.ecs_cluster.task_exec_iam_role_arn could not be independently verified because repository command execution was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 80,
+      "input_tokens": 7348108,
+      "output_tokens": 37068,
+      "total_tokens": 14733284,
+      "latency_seconds": 342.0,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 48.0,
+      "cache_read_tokens": 7079424,
+      "cache_write_tokens": 268684,
+      "prefix_cache_hit_rate": 0.9634,
+      "generation_tokens_per_sec": 108.4,
+      "kv_cache_usage": {
+        "peak": 0.0055,
+        "mean": 0.0034
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 9,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 56,
+          "notes": "The issue provides concrete acceptance criteria, migration scope, fallback behavior, and explicit non-goals tied to Keycloak, Aurora, RDS Proxy, ECS, and Terraform. Its central requirements conflict: IAM mode is supposed to eliminate the static password while password fallback remains immediately available. It also treats rds:GenerateDBAuthToken as an IAM permission even though token generation is local request signing and authorization is governed by rds-db:connect. Token renewal after connection loss, TLS requirements, and database-user authentication setup are omitted, and no independent task statement was supplied to resolve these ambiguities."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 4,
+          "specificity": 17,
+          "risk_awareness": 9,
+          "total": 44,
+          "notes": "The LLD names real integration points such as terraform/aws-ecs/keycloak-database.tf, keycloak-ecs.tf, secret-rotation.tf, and docker/keycloak/Dockerfile, with concrete proposed Terraform and entrypoint changes. Its implementation depends on Python and boto3 being present in quay.io/keycloak/keycloak:25.0, but the repository Dockerfile adds neither, and it proposes unsupported or ineffective IAM actions and condition keys. A startup-only token cannot authenticate reconnections after 15 minutes, and an ENABLED proxy does not automatically substitute the retained password for Keycloak's expired token. The document also contradicts itself over destroying versus retaining the secret, leaves token refresh as an open question, and omits required TLS and credible rollback-state handling."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 17,
+          "total": 60,
+          "notes": "The review identifies consequential defects, particularly token expiry, JDBC compatibility, conditional Terraform references, secret lifecycle, rollback sequencing, and missing operational alarms. Its principal resolution is technically unsound: RDS Proxy accepting both authentication methods does not make a Keycloak process holding only an expired IAM token retry with the fallback password. It says resolutions were applied even though the submitted LLD still conditionally destroys the secret and retains the unresolved token-refresh question. It also misses the image's absent Python/boto3 tooling and TLS requirements, while claiming IAM conditions and driver behavior were verified without supporting evidence."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 6,
+          "specificity": 17,
+          "risk_awareness": 15,
+          "total": 56,
+          "notes": "The plan spans Terraform rendering, both feature-flag modes, rollback, realm reads and writes, token expiry, and Aurora failover, with several concrete expected values. Many commands cannot provide their claimed oracle: counted Terraform resources require indexed addresses, docker invocations use || true, and the proposed image supplies neither boto3 nor the assumed tooling. The ECS database test assumes mysql, DB_HOST, and DB_PORT exist in the running Keycloak container, while the deployment checks fall back to a fabricated URL and hard-coded cluster and service names. Most seriously, the expiry and failover tests expect automatic password or fresh-token recovery that the implementation has no mechanism to perform; proposed unit tests are only pass stubs."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 2,
+          "specificity": 12,
+          "risk_awareness": 3,
+          "total": 24,
+          "notes": "The patch targets the relevant baseline symbols, threading the flag into aws_rds_cluster.keycloak, aws_db_proxy.keycloak, the ECS environment, rotation resources, and the Keycloak image. It is not deployable as written: aws_iam_role_policy does not accept tags, conditional policy branches emit invalid empty Statement objects, and adding count to rotation resources requires every dependent reference and rotation schedule to be updated. The container adds no Python or boto3 dependency, attempts chmod in the inherited non-root Keycloak image, and configures an unverified MariaDB AWS plugin even though KC_DB=mysql uses Keycloak's MySQL driver path. Retaining and ceasing rotation of the static secret contradicts the claimed replacement, while a single startup token cannot reconnect or fall back automatically; the summary acknowledges unverified compatibility and unimplemented documentation but still overstates completeness."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-06"
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "nemotron-ultra-550b",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 76,
+      "notes": "The issue clearly identifies three outbound paths and gives testable criteria for private-address rejection, allowlists, and secure defaults; the named symbols also appear in the submitted source context. Its largest deficiency is calling the change backward-compatible even though previously working internal agent and server URLs become blocked unless operators add configuration. It also declares the skill path out of scope while requiring extraction and changed allowlist behavior there. Redirect handling and DNS-rebinding risk are absent, and no independent task statement was supplied to verify the asserted issue #1282 requirements."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 9,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 62,
+      "notes": "The LLD is repository-specific, naming real integration points such as `_check_endpoint_reachability`, `check_agent_health`, and `_check_server_endpoint_transport_aware`, with concrete configuration and failure behavior. Its critical flaw is treating validation of `response.url` after a `follow_redirects=True` request as SSRF prevention, although the private redirect target has already been contacted; separate DNS validation also leaves a rebinding TOCTOU gap. It inconsistently says no skill-path modification is intended while changing that path's trust policy, and its stated Helm path differs from the submitted implementation's `charts/mcpgw/values.yaml`. Rollout and logging are addressed, but the claimed sufficiency of the existing validator and deployment surfaces could not be established from an independent task statement."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 9,
+      "specificity": 19,
+      "risk_awareness": 14,
+      "total": 60,
+      "notes": "The review surfaces concrete concerns including redirects, DNS rebinding, IP literals, cache behavior, and operational observability rather than merely approving the design. However, its prescribed redirect fix validates the destination only after the request, and it accepts the DNS TOCTOU risk using an incorrect claim that periodic health checks make the attack window small. The proposed unbounded process-global DNS cache can retain attacker-controlled hostnames and widen stale-resolution exposure, while the IPv6 zone-ID false positive is prioritized above the actual bypass. The resolution log claims all findings were incorporated, but the supplied LLD remains unrevised and the implementation contains no Prometheus counter."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 6,
+      "specificity": 15,
+      "risk_awareness": 13,
+      "total": 51,
+      "notes": "The plan spans utility, three call paths, compatibility, deployment, and rollback, and it supplies many explicit expected outcomes. Several tests are not executable as written: changing environment variables after importing the singleton `settings` does not update its fields, the DNS-cache example uses `socket` without importing it, and multiple important cases are left as `pass`. Public-host and registration examples depend on live DNS and services rather than controlled transports, while the agent health success oracle accepts either healthy or unhealthy. Most importantly, redirect tests only inspect final status and do not assert that no request reached the private target, and no tests are included in the implementation patch."
+    },
+    "implementation": {
+      "completeness": 5,
+      "correctness": 0,
+      "specificity": 8,
+      "risk_awareness": 2,
+      "total": 15,
+      "notes": "The patch attempts concrete integration across the three named request paths, shared configuration, Docker, and Terraform. It is fatally corrupted: the `skill_service.py` hunk deletes roughly 298 unrelated lines and inserts the literal `[Showing lines 1-1450 of 1746 (50.0KB limit). Use offset=1451 to continue.]`, leaving an incomplete `if` block and invalid Python. Even apart from that, health requests use `follow_redirects=True` before checking `response.url`, so the SSRF request has already occurred, and the DNS cache is unbounded and preserves TOCTOU exposure. The summary falsely claims a Prometheus metric and complete review resolution, while the diff defines no counter, only adds a Helm value without template wiring, and includes no tests."
+    }
+  },
+  "task_score": 52.8,
+  "verdict": "The design artifacts identify the right surfaces and provide useful detail, but the security model mishandles redirects and DNS rebinding, and the submitted patch is corrupted and unusable.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T00:50:42.522903Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 253260,
+      "cached_input_tokens": 208224,
+      "cache_write_input_tokens": 45024,
+      "output_tokens": 6732,
+      "reasoning_output_tokens": 5229
+    },
+    "duration_ms": 124184
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/nemotron-ultra-550b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "nemotron-ultra-550b",
+  "model_slug": "nemotron-ultra-550b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "nvfp4",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 104.2,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 14297587,
+    "output_tokens": 57159,
+    "cache_read_tokens": 13939200,
+    "cache_write_tokens": 429367,
+    "total_tokens": 28723313,
+    "total_cost_usd": null,
+    "latency_seconds": 548.3,
+    "num_turns": 109,
+    "generation_tokens_per_sec": 104.2,
+    "prefix_cache_hit_rate": 0.9701,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 14297587,
+  "output_tokens": 57159,
+  "latency_seconds": 548.3,
+  "num_turns": 109,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T00:16:21.457283Z",
+  "run_ended_at": "2026-08-06T00:25:41.067165Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 14297587,
+    "output_tokens": 57159,
+    "cache_read_tokens": 13939200,
+    "cache_write_tokens": 429367,
+    "total_tokens": 28723313,
+    "total_cost_usd": null,
+    "latency_seconds": 548.3,
+    "num_turns": 109,
+    "generation_tokens_per_sec": 104.2,
+    "prefix_cache_hit_rate": 0.9701,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9701,
+      "prompt_tokens_cached_rate": 0.9701
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 58082,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 13939200,
+      "vllm:prefix_cache_queries_total": 14368567,
+      "vllm:prompt_tokens_by_source_total": 14368567,
+      "vllm:prompt_tokens_cached_total": 13939200,
+      "vllm:prompt_tokens_total": 14368567,
+      "vllm:request_success_total": 110,
+      "vllm:tool_call_parser_invocations_total": 53526
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 110,
+        "sum": 539.1485,
+        "mean": 4.90135
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 57972,
+        "sum": 477.7749,
+        "mean": 0.008241
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 58082,
+        "sum": 487449,
+        "mean": 8.392428
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 110,
+        "sum": 477.7749,
+        "mean": 4.343408
+      },
+      "vllm:request_generation_tokens": {
+        "count": 110,
+        "sum": 58082,
+        "mean": 528.018182
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 110,
+        "sum": 513.0231,
+        "mean": 4.663846
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 110,
+        "sum": 58082,
+        "mean": 528.018182
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 110,
+        "sum": 1756096,
+        "mean": 15964.509091
+      },
+      "vllm:request_params_n": {
+        "count": 110,
+        "sum": 110,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 110,
+        "sum": 429367,
+        "mean": 3903.336364
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 110,
+        "sum": 35.2482,
+        "mean": 0.320438
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 110,
+        "sum": 14368567,
+        "mean": 130623.336364
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 110,
+        "sum": 0.0012,
+        "mean": 1.1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 110,
+        "sum": 0.9105,
+        "mean": 0.008278
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 110,
+        "sum": 61.4015,
+        "mean": 0.558196
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.0072,
+          "mean": 0.0045,
+          "samples": 547
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8775,
+          "samples": 547
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 547
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "nemotron-ultra-550b",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 76,
+        "notes": "The issue clearly identifies three outbound paths and gives testable criteria for private-address rejection, allowlists, and secure defaults; the named symbols also appear in the submitted source context. Its largest deficiency is calling the change backward-compatible even though previously working internal agent and server URLs become blocked unless operators add configuration. It also declares the skill path out of scope while requiring extraction and changed allowlist behavior there. Redirect handling and DNS-rebinding risk are absent, and no independent task statement was supplied to verify the asserted issue #1282 requirements."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 9,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 62,
+        "notes": "The LLD is repository-specific, naming real integration points such as `_check_endpoint_reachability`, `check_agent_health`, and `_check_server_endpoint_transport_aware`, with concrete configuration and failure behavior. Its critical flaw is treating validation of `response.url` after a `follow_redirects=True` request as SSRF prevention, although the private redirect target has already been contacted; separate DNS validation also leaves a rebinding TOCTOU gap. It inconsistently says no skill-path modification is intended while changing that path's trust policy, and its stated Helm path differs from the submitted implementation's `charts/mcpgw/values.yaml`. Rollout and logging are addressed, but the claimed sufficiency of the existing validator and deployment surfaces could not be established from an independent task statement."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 9,
+        "specificity": 19,
+        "risk_awareness": 14,
+        "total": 60,
+        "notes": "The review surfaces concrete concerns including redirects, DNS rebinding, IP literals, cache behavior, and operational observability rather than merely approving the design. However, its prescribed redirect fix validates the destination only after the request, and it accepts the DNS TOCTOU risk using an incorrect claim that periodic health checks make the attack window small. The proposed unbounded process-global DNS cache can retain attacker-controlled hostnames and widen stale-resolution exposure, while the IPv6 zone-ID false positive is prioritized above the actual bypass. The resolution log claims all findings were incorporated, but the supplied LLD remains unrevised and the implementation contains no Prometheus counter."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 6,
+        "specificity": 15,
+        "risk_awareness": 13,
+        "total": 51,
+        "notes": "The plan spans utility, three call paths, compatibility, deployment, and rollback, and it supplies many explicit expected outcomes. Several tests are not executable as written: changing environment variables after importing the singleton `settings` does not update its fields, the DNS-cache example uses `socket` without importing it, and multiple important cases are left as `pass`. Public-host and registration examples depend on live DNS and services rather than controlled transports, while the agent health success oracle accepts either healthy or unhealthy. Most importantly, redirect tests only inspect final status and do not assert that no request reached the private target, and no tests are included in the implementation patch."
+      },
+      "implementation": {
+        "completeness": 5,
+        "correctness": 0,
+        "specificity": 8,
+        "risk_awareness": 2,
+        "total": 15,
+        "notes": "The patch attempts concrete integration across the three named request paths, shared configuration, Docker, and Terraform. It is fatally corrupted: the `skill_service.py` hunk deletes roughly 298 unrelated lines and inserts the literal `[Showing lines 1-1450 of 1746 (50.0KB limit). Use offset=1451 to continue.]`, leaving an incomplete `if` block and invalid Python. Even apart from that, health requests use `follow_redirects=True` before checking `response.url`, so the SSRF request has already occurred, and the DNS cache is unbounded and preserves TOCTOU exposure. The summary falsely claims a Prometheus metric and complete review resolution, while the diff defines no counter, only adds a Helm value without template wiring, and includes no tests."
+      }
+    },
+    "task_score": 52.8,
+    "verdict": "The design artifacts identify the right surfaces and provide useful detail, but the security model mishandles redirects and DNS rebinding, and the submitted patch is corrupted and unusable.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T00:50:42.522903Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 253260,
+        "cached_input_tokens": 208224,
+        "cache_write_input_tokens": 45024,
+        "output_tokens": 6732,
+        "reasoning_output_tokens": 5229
+      },
+      "duration_ms": 124184
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 15,
+      "specificity": 14,
+      "risk_awareness": 10,
+      "total": 57,
+      "notes": "The issue clearly states the security objective, ECS-only scope, preserved variable names, IAM work, and exclusions. Its largest gap is that \u201call sensitive variables\u201d has no definitive inventory, while the plaintext fallback and no-breaking-change criteria do not define migration behavior. The submitted patch confirms the relevant surfaces include ECS task definitions, Secrets Manager, and execution-role IAM. No independent task statement was supplied, and related issue #1134 could not be verified."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 11,
+      "specificity": 16,
+      "risk_awareness": 12,
+      "total": 56,
+      "notes": "The LLD names concrete Terraform files, resources, environment variables, IAM permissions, and the existing KMS-backed secret pattern reflected in the patch. Its central compatibility decision is incorrect: retaining Terraform variables while removing them from container definitions is not a plaintext runtime fallback, and writing `secret_string = var...` still leaves values in Terraform state. It also leaves optional or empty credentials, dynamic values, rollback mechanics, and the exact per-service inventory unresolved despite calling the plan implementation-ready. Repository shell access failed before these paths and claimed existing patterns could be independently verified against the working tree."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 12,
+      "specificity": 13,
+      "risk_awareness": 16,
+      "total": 56,
+      "notes": "The review surfaces real concerns around state exposure, rollback, incremental deployment, monitoring, local development, and secret lifecycle. It misses the design\u2019s most consequential defects: the claimed fallback does not exist, optional empty values can make secret creation fail, and removing unrelated GitHub settings can break callers. Its claim that all critical findings were addressed is contradicted by the LLD, which still leaves rotation open, provides no executable rollback, and does not resolve state exposure. Recommendations such as \u201cTerraform encryption for state files\u201d and automatic rotation are insufficiently concrete and partly conflict with the stated non-goals."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 7,
+      "specificity": 12,
+      "risk_awareness": 11,
+      "total": 44,
+      "notes": "The plan spans Terraform planning, deployed task definitions, IAM, service startup, API health, and rollback, using concrete AWS and Terraform commands. Several oracles are nonfunctional: `example-secret` and `EXAMPLE_SECRET` do not exist in the implementation, root-module-only plan JSON misses child-module resources, and IAM policy version `v1` is assumed. The backward-compatibility test expects plaintext environment entries that the patch explicitly removes, while ACTIVE status, running count, and generic logs do not prove secret injection or application correctness. Repository access failure prevented verification of the proposed root variables, task-family names, cluster names, log group, `registry_url` output, and `/health` endpoint."
+    },
+    "implementation": {
+      "completeness": 15,
+      "correctness": 7,
+      "specificity": 18,
+      "risk_awareness": 7,
+      "total": 47,
+      "notes": "The patch is concrete and broadly wires thirteen KMS-backed secrets into ECS definitions and the execution-role IAM policy, including conditional Auth0 and Grafana resources. It removes `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_EXTRA_HOSTS`, and `GITHUB_API_BASE_URL` from the registry container without restoring them, and unconditional secret versions for optional credentials risk AWS rejection of empty secret strings. The claimed plaintext fallback is absent, and `aws_secretsmanager_secret_version.secret_string` continues storing secret material in Terraform state despite the stated security motivation. No executable tests accompany the patch, and repository shell failure prevented `git apply --check` or independent validation of its indexes and surrounding source."
+    }
+  },
+  "task_score": 52.0,
+  "verdict": "The submission has a repository-shaped design and substantial patch, but unresolved migration semantics, weak tests, and critical implementation regressions make it unsafe to merge.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T20:48:05.128374Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 169650,
+      "cached_input_tokens": 138171,
+      "cache_write_input_tokens": 31467,
+      "output_tokens": 5911,
+      "reasoning_output_tokens": 4400
+    },
+    "duration_ms": 117662
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,290 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 57.4,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 12591583,
+    "output_tokens": 51990,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 12643573,
+    "total_cost_usd": 64.25766499999999,
+    "latency_seconds": 905.5,
+    "num_turns": 118,
+    "generation_tokens_per_sec": 57.4,
+    "prefix_cache_hit_rate": 0.8111,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 12591583,
+  "output_tokens": 51990,
+  "latency_seconds": 905.5,
+  "num_turns": 118,
+  "total_cost_usd": 64.25766499999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T20:24:08.520672Z",
+  "run_ended_at": "2026-08-05T20:39:14.593637Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 12591583,
+    "output_tokens": 51990,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 12643573,
+    "total_cost_usd": 64.25766499999999,
+    "latency_seconds": 905.5,
+    "num_turns": 118,
+    "generation_tokens_per_sec": 57.4,
+    "prefix_cache_hit_rate": 0.8111,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8111,
+      "prompt_tokens_cached_rate": 0.8111
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 51990,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 10213472,
+      "vllm:prefix_cache_queries_total": 12591583,
+      "vllm:prompt_tokens_by_source_total": 12591583,
+      "vllm:prompt_tokens_cached_total": 10213472,
+      "vllm:prompt_tokens_total": 12591583,
+      "vllm:request_success_total": 118,
+      "vllm:tool_call_parser_invocations_total": 51743
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 118,
+        "sum": 900.8269,
+        "mean": 7.634126
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 51872,
+        "sum": 553.2457,
+        "mean": 0.010666
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 51990,
+        "sum": 2430101,
+        "mean": 46.7417
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 118,
+        "sum": 553.2457,
+        "mean": 4.688523
+      },
+      "vllm:request_generation_tokens": {
+        "count": 118,
+        "sum": 51990,
+        "mean": 440.59322
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 118,
+        "sum": 876.7042,
+        "mean": 7.429697
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 118,
+        "sum": 51990,
+        "mean": 440.59322
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 118,
+        "sum": 1888000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 118,
+        "sum": 118,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 118,
+        "sum": 2378111,
+        "mean": 20153.483051
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 118,
+        "sum": 323.4585,
+        "mean": 2.741174
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 118,
+        "sum": 12591583,
+        "mean": 106708.330508
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 118,
+        "sum": 0.0011,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 118,
+        "sum": 1.2379,
+        "mean": 0.010491
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 118,
+        "sum": 347.6361,
+        "mean": 2.946069
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.6115,
+          "mean": 0.3862,
+          "samples": 901
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9212,
+          "samples": 901
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 901
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 15,
+        "specificity": 14,
+        "risk_awareness": 10,
+        "total": 57,
+        "notes": "The issue clearly states the security objective, ECS-only scope, preserved variable names, IAM work, and exclusions. Its largest gap is that “all sensitive variables” has no definitive inventory, while the plaintext fallback and no-breaking-change criteria do not define migration behavior. The submitted patch confirms the relevant surfaces include ECS task definitions, Secrets Manager, and execution-role IAM. No independent task statement was supplied, and related issue #1134 could not be verified."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 11,
+        "specificity": 16,
+        "risk_awareness": 12,
+        "total": 56,
+        "notes": "The LLD names concrete Terraform files, resources, environment variables, IAM permissions, and the existing KMS-backed secret pattern reflected in the patch. Its central compatibility decision is incorrect: retaining Terraform variables while removing them from container definitions is not a plaintext runtime fallback, and writing `secret_string = var...` still leaves values in Terraform state. It also leaves optional or empty credentials, dynamic values, rollback mechanics, and the exact per-service inventory unresolved despite calling the plan implementation-ready. Repository shell access failed before these paths and claimed existing patterns could be independently verified against the working tree."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 12,
+        "specificity": 13,
+        "risk_awareness": 16,
+        "total": 56,
+        "notes": "The review surfaces real concerns around state exposure, rollback, incremental deployment, monitoring, local development, and secret lifecycle. It misses the design’s most consequential defects: the claimed fallback does not exist, optional empty values can make secret creation fail, and removing unrelated GitHub settings can break callers. Its claim that all critical findings were addressed is contradicted by the LLD, which still leaves rotation open, provides no executable rollback, and does not resolve state exposure. Recommendations such as “Terraform encryption for state files” and automatic rotation are insufficiently concrete and partly conflict with the stated non-goals."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 7,
+        "specificity": 12,
+        "risk_awareness": 11,
+        "total": 44,
+        "notes": "The plan spans Terraform planning, deployed task definitions, IAM, service startup, API health, and rollback, using concrete AWS and Terraform commands. Several oracles are nonfunctional: `example-secret` and `EXAMPLE_SECRET` do not exist in the implementation, root-module-only plan JSON misses child-module resources, and IAM policy version `v1` is assumed. The backward-compatibility test expects plaintext environment entries that the patch explicitly removes, while ACTIVE status, running count, and generic logs do not prove secret injection or application correctness. Repository access failure prevented verification of the proposed root variables, task-family names, cluster names, log group, `registry_url` output, and `/health` endpoint."
+      },
+      "implementation": {
+        "completeness": 15,
+        "correctness": 7,
+        "specificity": 18,
+        "risk_awareness": 7,
+        "total": 47,
+        "notes": "The patch is concrete and broadly wires thirteen KMS-backed secrets into ECS definitions and the execution-role IAM policy, including conditional Auth0 and Grafana resources. It removes `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_EXTRA_HOSTS`, and `GITHUB_API_BASE_URL` from the registry container without restoring them, and unconditional secret versions for optional credentials risk AWS rejection of empty secret strings. The claimed plaintext fallback is absent, and `aws_secretsmanager_secret_version.secret_string` continues storing secret material in Terraform state despite the stated security motivation. No executable tests accompany the patch, and repository shell failure prevented `git apply --check` or independent validation of its indexes and surrounding source."
+      }
+    },
+    "task_score": 52.0,
+    "verdict": "The submission has a repository-shaped design and substantial patch, but unresolved migration semantics, weak tests, and critical implementation regressions make it unsafe to merge.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T20:48:05.128374Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 169650,
+        "cached_input_tokens": 138171,
+        "cache_write_input_tokens": 31467,
+        "output_tokens": 5911,
+        "reasoning_output_tokens": 4400
+      },
+      "duration_ms": 117662
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 16,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 66,
+      "notes": "The issue clearly scopes removal of EFS resources, mounts, variables, outputs, and example configuration, with mostly testable acceptance criteria and explicit non-goals. Its largest deficiency is treating the destructive storage migration precondition as established without specifying deployment sequencing, output compatibility, or recovery requirements. The criteria correctly identify `variables.tf`, `outputs.tf`, task definitions, `terraform validate`, and `terraform plan` as relevant surfaces. The claim that all services already use S3/DocumentDB could not be verified and conflicts with the LLD statement that some services still depend on EFS."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 18,
+      "risk_awareness": 12,
+      "total": 61,
+      "notes": "The strongest material is the concrete mapping from `storage.tf`, `ecs-services.tf`, `variables.tf`, and `outputs.tf` to the exact EFS module, access points, mounts, variables, and outputs shown in the submitted diff. The largest deficiency is the unsafe rollback model: restoring Terraform state cannot recover a deleted EFS filesystem or its data, and the design does not require a staged mount-removal deployment before destruction. It also says both that migration is complete and that some services still depend on EFS, leaving the central go/no-go decision unresolved. Independent working-tree inspection was unavailable because read-only shell calls failed with `bwrap: loopback: Failed RTM_NEWADDR`, so application migration and broader reference claims remain unverified."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 9,
+      "specificity": 12,
+      "risk_awareness": 15,
+      "total": 49,
+      "notes": "The review identifies genuine risks involving residual data, runtime path dependencies, monitoring, Terraform state, rollback, and replacement-storage permissions. Its largest deficiency is approving the design while those risks remain unresolved and claiming resolutions that the LLD does not contain. For example, the LLD provides no concrete data-disposal procedure, S3/DocumentDB security validation, or stakeholder communication plan, while its rollback incorrectly relies on a state backup. The review also misses removal of module outputs as a compatibility concern, and its assumptions about completed application migration could not be independently verified."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 5,
+      "specificity": 12,
+      "risk_awareness": 7,
+      "total": 35,
+      "notes": "The plan at least covers validation, planning, static reference checks, deployment, and post-apply service inspection with concrete commands. Its central plan oracle is incorrect because deleted resources are not represented under `planned_values`; destruction must be checked through `resource_changes`, including nested module addresses. Most grep checks always exit successfully due to `&& echo ... || echo ...`, and the account-wide EFS `jq` check similarly does not reliably assert absence. The hard-coded checkout path, cluster and service names could not be verified, while `terraform apply -auto-approve` is not isolated and no test exercises auth configuration, logging, MCPGW persistence, service stability, or actual rollback."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 20,
+      "risk_awareness": 10,
+      "total": 69,
+      "notes": "The patch directly implements the stated Terraform removal by deleting `module.efs`, its egress rule, two variables, three outputs, and the auth and MCPGW EFS mounts and volume definitions. The supplied contexts and symbols are internally consistent, and empty `mountPoints` and `volume` values preserve the existing module argument shape. The largest risk is performing task-definition replacement and irreversible EFS destruction as one change without establishing the migration precondition, staging the rollout, or addressing consumers of the removed module outputs. A repository-level apply check could not be run because shell execution failed in the sandbox, and the summary's claimed line counts do not match the diff, including 182 deleted lines from `storage.tf` rather than 164."
+    }
+  },
+  "task_score": 56.0,
+  "verdict": "The implementation is focused and plausibly complete, but the submission never establishes the no-EFS-dependency precondition and its rollout, rollback, and test oracles are materially unsafe or ineffective.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T20:50:09.676083Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 142838,
+      "cached_input_tokens": 117475,
+      "cache_write_input_tokens": 25351,
+      "output_tokens": 7171,
+      "reasoning_output_tokens": 5517
+    },
+    "duration_ms": 124536
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,289 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 56.1,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4244741,
+    "output_tokens": 16069,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4260810,
+    "total_cost_usd": 21.62543,
+    "latency_seconds": 286.5,
+    "num_turns": 42,
+    "generation_tokens_per_sec": 56.1,
+    "prefix_cache_hit_rate": 0.8039,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4244741,
+  "output_tokens": 16069,
+  "latency_seconds": 286.5,
+  "num_turns": 42,
+  "total_cost_usd": 21.62543,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T20:07:58.237858Z",
+  "run_ended_at": "2026-08-05T20:12:45.291235Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4244741,
+    "output_tokens": 16069,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4260810,
+    "total_cost_usd": 21.62543,
+    "latency_seconds": 286.5,
+    "num_turns": 42,
+    "generation_tokens_per_sec": 56.1,
+    "prefix_cache_hit_rate": 0.8039,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8039,
+      "prompt_tokens_cached_rate": 0.8039
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 16069,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 3412160,
+      "vllm:prefix_cache_queries_total": 4244741,
+      "vllm:prompt_tokens_by_source_total": 4244741,
+      "vllm:prompt_tokens_cached_total": 3412160,
+      "vllm:prompt_tokens_total": 4244741,
+      "vllm:request_success_total": 42,
+      "vllm:tool_call_parser_invocations_total": 16000
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 42,
+        "sum": 284.5792,
+        "mean": 6.775695
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 16027,
+        "sum": 170.218,
+        "mean": 0.010621
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 16069,
+        "sum": 848650,
+        "mean": 52.81287
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 42,
+        "sum": 170.218,
+        "mean": 4.052809
+      },
+      "vllm:request_generation_tokens": {
+        "count": 42,
+        "sum": 16069,
+        "mean": 382.595238
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 42,
+        "sum": 276.5528,
+        "mean": 6.58459
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 42,
+        "sum": 16069,
+        "mean": 382.595238
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 42,
+        "sum": 672000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 42,
+        "sum": 42,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 42,
+        "sum": 832581,
+        "mean": 19823.357143
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 42,
+        "sum": 106.3348,
+        "mean": 2.531782
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 42,
+        "sum": 4244741,
+        "mean": 101065.261905
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 42,
+        "sum": 0.0004,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 42,
+        "sum": 0.4357,
+        "mean": 0.010374
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 42,
+        "sum": 114.379,
+        "mean": 2.723309
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.5089,
+          "mean": 0.3674,
+          "samples": 286
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9161,
+          "samples": 286
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 286
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 16,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 66,
+        "notes": "The issue clearly scopes removal of EFS resources, mounts, variables, outputs, and example configuration, with mostly testable acceptance criteria and explicit non-goals. Its largest deficiency is treating the destructive storage migration precondition as established without specifying deployment sequencing, output compatibility, or recovery requirements. The criteria correctly identify `variables.tf`, `outputs.tf`, task definitions, `terraform validate`, and `terraform plan` as relevant surfaces. The claim that all services already use S3/DocumentDB could not be verified and conflicts with the LLD statement that some services still depend on EFS."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 18,
+        "risk_awareness": 12,
+        "total": 61,
+        "notes": "The strongest material is the concrete mapping from `storage.tf`, `ecs-services.tf`, `variables.tf`, and `outputs.tf` to the exact EFS module, access points, mounts, variables, and outputs shown in the submitted diff. The largest deficiency is the unsafe rollback model: restoring Terraform state cannot recover a deleted EFS filesystem or its data, and the design does not require a staged mount-removal deployment before destruction. It also says both that migration is complete and that some services still depend on EFS, leaving the central go/no-go decision unresolved. Independent working-tree inspection was unavailable because read-only shell calls failed with `bwrap: loopback: Failed RTM_NEWADDR`, so application migration and broader reference claims remain unverified."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 9,
+        "specificity": 12,
+        "risk_awareness": 15,
+        "total": 49,
+        "notes": "The review identifies genuine risks involving residual data, runtime path dependencies, monitoring, Terraform state, rollback, and replacement-storage permissions. Its largest deficiency is approving the design while those risks remain unresolved and claiming resolutions that the LLD does not contain. For example, the LLD provides no concrete data-disposal procedure, S3/DocumentDB security validation, or stakeholder communication plan, while its rollback incorrectly relies on a state backup. The review also misses removal of module outputs as a compatibility concern, and its assumptions about completed application migration could not be independently verified."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 5,
+        "specificity": 12,
+        "risk_awareness": 7,
+        "total": 35,
+        "notes": "The plan at least covers validation, planning, static reference checks, deployment, and post-apply service inspection with concrete commands. Its central plan oracle is incorrect because deleted resources are not represented under `planned_values`; destruction must be checked through `resource_changes`, including nested module addresses. Most grep checks always exit successfully due to `&& echo ... || echo ...`, and the account-wide EFS `jq` check similarly does not reliably assert absence. The hard-coded checkout path, cluster and service names could not be verified, while `terraform apply -auto-approve` is not isolated and no test exercises auth configuration, logging, MCPGW persistence, service stability, or actual rollback."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 20,
+        "risk_awareness": 10,
+        "total": 69,
+        "notes": "The patch directly implements the stated Terraform removal by deleting `module.efs`, its egress rule, two variables, three outputs, and the auth and MCPGW EFS mounts and volume definitions. The supplied contexts and symbols are internally consistent, and empty `mountPoints` and `volume` values preserve the existing module argument shape. The largest risk is performing task-definition replacement and irreversible EFS destruction as one change without establishing the migration precondition, staging the rollout, or addressing consumers of the removed module outputs. A repository-level apply check could not be run because shell execution failed in the sandbox, and the summary's claimed line counts do not match the diff, including 182 deleted lines from `storage.tf` rather than 164."
+      }
+    },
+    "task_score": 56.0,
+    "verdict": "The implementation is focused and plausibly complete, but the submission never establishes the no-EFS-dependency precondition and its rollout, rollback, and test oracles are materially unsafe or ineffective.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T20:50:09.676083Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 142838,
+        "cached_input_tokens": 117475,
+        "cache_write_input_tokens": 25351,
+        "output_tokens": 7171,
+        "reasoning_output_tokens": 5517
+      },
+      "duration_ms": 124536
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 58,
+      "notes": "The issue defines removal, dependency, documentation, Docker, configuration, and API non-goals with mostly testable boundaries. Its largest gap is assuming DocumentDB is available and functionally equivalent despite the repository's existing file default and backend-specific factory branch. Criteria such as preserving search quality and passing all tests lack measurable oracles, baselines, or migration behavior. No independent task statement was supplied, so the claimed feature-parity requirement cannot be verified beyond the artifacts."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 14,
+      "risk_awareness": 15,
+      "total": 54,
+      "notes": "The LLD correctly names core integration points including registry/search/service.py, registry/repositories/file/search_repository.py, registry/core/config.py, and get_search_repository(). Its backward-compatibility design is internally inconsistent: it proposes a warning and deprecation period while also removing the file backend, and it never explains how DocumentDBSearchRepository can serve file-backed deployments without a database. It omits the numerous API, lifespan, and batch-processor callers that must change before deleting the FAISS service, forcing an implementer to rediscover critical data flows. Migration tooling, parity measurement, benchmark thresholds, and the referenced migration guide are proposed but not concretely specified or evidenced."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 15,
+      "specificity": 14,
+      "risk_awareness": 18,
+      "total": 63,
+      "notes": "The review's strongest contribution is identifying migration, backward compatibility, feature parity, database load, monitoring, and rollback as release conditions. It does not directly challenge the LLD's contradictory immediate removal and 30-day deprecation plans or explain the database prerequisite created for file-backed users. Several persona sections offer generic encryption, compliance, and communication advice without tying recommendations to repository symbols or concrete controls. The approval verdict is premature because its must-fix items have no acceptance thresholds, migration format, or executable rollback procedure."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 10,
+      "specificity": 12,
+      "risk_awareness": 16,
+      "total": 55,
+      "notes": "The plan covers functional, compatibility, failure, performance, deployment, and end-to-end scenarios across the relevant entity types. Its configuration tests contradict the implementation: they expect file settings to log a warning and continue, while registry/core/config.py removes file from ALLOWED_STORAGE_BACKENDS and raises validation errors. Most cases lack repository paths, commands, fixture values, and exact response or ranking oracles; terms such as acceptable latency, reasonable resource usage, and identical quality are not measurable. Pytest is evidenced by the repository tests, but locust, pytest-benchmark, memory_profiler, and test-container support are asserted without demonstrated repository configuration."
+    },
+    "implementation": {
+      "completeness": 13,
+      "correctness": 8,
+      "specificity": 16,
+      "risk_awareness": 7,
+      "total": 44,
+      "notes": "The patch concretely removes faiss-cpu, the FAISS service and adapter, their tests and mock, and reroutes many API and batch callers through get_search_repository(). The largest defect is the unannounced breaking configuration change: file is rejected and the default becomes documentdb, while the summary claims backward compatibility and the updated storage architecture still describes file as a supported legacy backend. In registry/api/server_routes.py newly added index_server calls remain immediately before existing DocumentDB update blocks, while cli/service_mgmt.sh replaces a real metadata check with an unconditional success and tests/conftest.py still logs that FAISS was auto-mocked. The patch deletes extensive search tests without replacement coverage for the factory, routes, configuration, migration, or search parity, so its verification and no-regression claims are unsupported."
+    }
+  },
+  "task_score": 54.8,
+  "verdict": "The submission is broad and concrete about removal, but its hard, untested elimination of file-backend compatibility, contradictory migration story, and no-op validation make it unsafe to merge.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T22:04:16.277432Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 407894,
+      "cached_input_tokens": 344614,
+      "cache_write_input_tokens": 63266,
+      "output_tokens": 7993,
+      "reasoning_output_tokens": 6399
+    },
+    "duration_ms": 165525
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,294 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 0,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 37.0,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 24180167,
+    "output_tokens": 36582,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 24216749,
+    "total_cost_usd": 121.81538499999992,
+    "latency_seconds": 989.0,
+    "num_turns": 251,
+    "generation_tokens_per_sec": 37.0,
+    "prefix_cache_hit_rate": 0.8381,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 24180167,
+  "output_tokens": 36582,
+  "latency_seconds": 989.0,
+  "num_turns": 251,
+  "total_cost_usd": 121.81538499999992,
+  "is_error": true,
+  "result_subtype": "error_max_turns",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "error": "",
+  "api_error_status": null,
+  "run_started_at": "2026-08-05T19:51:24.580489Z",
+  "run_ended_at": "2026-08-05T20:07:54.238470Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 24180167,
+    "output_tokens": 36582,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 24216749,
+    "total_cost_usd": 121.81538499999992,
+    "latency_seconds": 989.0,
+    "num_turns": 251,
+    "generation_tokens_per_sec": 37.0,
+    "prefix_cache_hit_rate": 0.8381,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8381,
+      "prompt_tokens_cached_rate": 0.8381
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 36582,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 20265792,
+      "vllm:prefix_cache_queries_total": 24180167,
+      "vllm:prompt_tokens_by_source_total": 24180167,
+      "vllm:prompt_tokens_cached_total": 20265792,
+      "vllm:prompt_tokens_total": 24180167,
+      "vllm:request_success_total": 253,
+      "vllm:tool_call_parser_invocations_total": 36096
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 253,
+        "sum": 961.3963,
+        "mean": 3.799985
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 36329,
+        "sum": 384.4805,
+        "mean": 0.010583
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 36582,
+        "sum": 3950957,
+        "mean": 108.002761
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 253,
+        "sum": 384.4805,
+        "mean": 1.519686
+      },
+      "vllm:request_generation_tokens": {
+        "count": 253,
+        "sum": 36582,
+        "mean": 144.592885
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 253,
+        "sum": 915.468,
+        "mean": 3.618451
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 253,
+        "sum": 36582,
+        "mean": 144.592885
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 253,
+        "sum": 4048000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 253,
+        "sum": 253,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 253,
+        "sum": 3914375,
+        "mean": 15471.837945
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 253,
+        "sum": 530.9875,
+        "mean": 2.098765
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 253,
+        "sum": 24180167,
+        "mean": 95573.782609
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 253,
+        "sum": 0.0025,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 253,
+        "sum": 2.5958,
+        "mean": 0.01026
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 253,
+        "sum": 577.0208,
+        "mean": 2.280715
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.6107,
+          "mean": 0.332,
+          "samples": 984
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8618,
+          "samples": 984
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 984
+        }
+      }
+    }
+  },
+  "agent_invocations": 2,
+  "topped_up_artifacts": [],
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 58,
+        "notes": "The issue defines removal, dependency, documentation, Docker, configuration, and API non-goals with mostly testable boundaries. Its largest gap is assuming DocumentDB is available and functionally equivalent despite the repository's existing file default and backend-specific factory branch. Criteria such as preserving search quality and passing all tests lack measurable oracles, baselines, or migration behavior. No independent task statement was supplied, so the claimed feature-parity requirement cannot be verified beyond the artifacts."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 14,
+        "risk_awareness": 15,
+        "total": 54,
+        "notes": "The LLD correctly names core integration points including registry/search/service.py, registry/repositories/file/search_repository.py, registry/core/config.py, and get_search_repository(). Its backward-compatibility design is internally inconsistent: it proposes a warning and deprecation period while also removing the file backend, and it never explains how DocumentDBSearchRepository can serve file-backed deployments without a database. It omits the numerous API, lifespan, and batch-processor callers that must change before deleting the FAISS service, forcing an implementer to rediscover critical data flows. Migration tooling, parity measurement, benchmark thresholds, and the referenced migration guide are proposed but not concretely specified or evidenced."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 15,
+        "specificity": 14,
+        "risk_awareness": 18,
+        "total": 63,
+        "notes": "The review's strongest contribution is identifying migration, backward compatibility, feature parity, database load, monitoring, and rollback as release conditions. It does not directly challenge the LLD's contradictory immediate removal and 30-day deprecation plans or explain the database prerequisite created for file-backed users. Several persona sections offer generic encryption, compliance, and communication advice without tying recommendations to repository symbols or concrete controls. The approval verdict is premature because its must-fix items have no acceptance thresholds, migration format, or executable rollback procedure."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 10,
+        "specificity": 12,
+        "risk_awareness": 16,
+        "total": 55,
+        "notes": "The plan covers functional, compatibility, failure, performance, deployment, and end-to-end scenarios across the relevant entity types. Its configuration tests contradict the implementation: they expect file settings to log a warning and continue, while registry/core/config.py removes file from ALLOWED_STORAGE_BACKENDS and raises validation errors. Most cases lack repository paths, commands, fixture values, and exact response or ranking oracles; terms such as acceptable latency, reasonable resource usage, and identical quality are not measurable. Pytest is evidenced by the repository tests, but locust, pytest-benchmark, memory_profiler, and test-container support are asserted without demonstrated repository configuration."
+      },
+      "implementation": {
+        "completeness": 13,
+        "correctness": 8,
+        "specificity": 16,
+        "risk_awareness": 7,
+        "total": 44,
+        "notes": "The patch concretely removes faiss-cpu, the FAISS service and adapter, their tests and mock, and reroutes many API and batch callers through get_search_repository(). The largest defect is the unannounced breaking configuration change: file is rejected and the default becomes documentdb, while the summary claims backward compatibility and the updated storage architecture still describes file as a supported legacy backend. In registry/api/server_routes.py newly added index_server calls remain immediately before existing DocumentDB update blocks, while cli/service_mgmt.sh replaces a real metadata check with an unconditional success and tests/conftest.py still logs that FAISS was auto-mocked. The patch deletes extensive search tests without replacement coverage for the factory, routes, configuration, migration, or search parity, so its verification and no-regression claims are unsupported."
+      }
+    },
+    "task_score": 54.8,
+    "verdict": "The submission is broad and concrete about removal, but its hard, untested elimination of file-backend compatibility, contradictory migration story, and no-op validation make it unsafe to merge.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T22:04:16.277432Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 407894,
+        "cached_input_tokens": 344614,
+        "cache_write_input_tokens": 63266,
+        "output_tokens": 7993,
+        "reasoning_output_tokens": 6399
+      },
+      "duration_ms": 165525
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 11,
+      "specificity": 14,
+      "risk_awareness": 10,
+      "total": 50,
+      "notes": "The issue clearly states the security motivation, affected AWS components, explicit non-goals, and several observable acceptance outcomes. Its largest defect is the contradiction between removing the static password and retaining password fallback and rotation, without defining when credentials may actually be deleted. The repository context shown in the patch includes an RDS proxy and a cluster master password, but the issue omits proxy authentication, database-user provisioning, and Keycloak credential-refresh behavior. No independent task statement was supplied, so requirements beyond the identifier and internally stated goals could not be verified."
+    },
+    "lld": {
+      "completeness": 9,
+      "correctness": 3,
+      "specificity": 8,
+      "risk_awareness": 10,
+      "total": 30,
+      "notes": "The LLD names concrete Terraform resources, the rotation Lambda, configuration variables, and a staged rollback sequence. Its central design is not viable because writing refreshed tokens to `/run/secrets/db-token` does not update Keycloak's JDBC password or connection pool, while the RDS proxy is explicitly left unchanged. The IAM policy uses nonexistent or incorrect actions such as `rds:Connect` and `rds:GenerateAuthenticationToken`; database login requires `rds-db:connect` against an `rds-db` database-user ARN, and the proposed database-user setup remains a stub. Availability of AWS CLI in the stock Keycloak image, the invented container paths, TLS handling, and the required Aurora IAM user configuration are not established by repository evidence."
+    },
+    "review": {
+      "completeness": 9,
+      "correctness": 8,
+      "specificity": 10,
+      "risk_awareness": 12,
+      "total": 39,
+      "notes": "The review correctly identifies connection-pool refresh, fallback behavior, token-file permissions, least privilege, monitoring, and rollback as material concerns. It misses more fundamental blockers: the invalid IAM actions and ARN, unchanged RDS proxy authentication, absent token-to-JDBC integration, missing image packaging, and simulated database-user provisioning. Its resolution section claims the findings were incorporated even though the LLD still uses a wildcard permission, writes an unencrypted plaintext file, and implements notification as logging only. The STS recommendation and several reviewer approvals are unsupported by the repository or a concrete corrected design."
+    },
+    "testing": {
+      "completeness": 9,
+      "correctness": 4,
+      "specificity": 8,
+      "risk_awareness": 7,
+      "total": 28,
+      "notes": "The plan at least spans token generation, database access, fallback, Terraform deployment, ECS inspection, refresh, and rollback. Most tests are comments rather than executable actions with reliable oracles, and variables such as `DB_HOST` and `GENERATED_TOKEN` are never populated. The MySQL IAM command omits required TLS and cleartext-plugin handling, while `list-attached-role-policies` cannot find the inline `aws_iam_role_policy` created by the patch and the Terraform feature variable is unused. It lacks tests for the proxy authentication mode, IAM database user, new connections after token expiry, actual Keycloak consumption of the token, denied permissions, and startup command semantics; the proposed test paths and secret names are also unverified."
+    },
+    "implementation": {
+      "completeness": 3,
+      "correctness": 2,
+      "specificity": 8,
+      "risk_awareness": 3,
+      "total": 16,
+      "notes": "The patch does add the valid cluster setting `enable_iam_database_authentication = true` and supplies concrete changes rather than only prose. It does not implement working Keycloak IAM authentication: the new file is never built into the stock image, the token file is never consumed as the JDBC password, the feature variable is unused, static credentials remain, and the rotation helper explicitly simulates IAM user setup. The diff's own context says the image entrypoint is `kc.sh`, so replacing only `command` with `/bin/sh -c ...` passes shell arguments to `kc.sh` and is likely to prevent startup; its IAM actions and resource ARN are also invalid for database login. The summary materially oversells the patch and contains a meaningless same-path deviation, while independent `git apply --check` verification was unavailable because repository command execution failed."
+    }
+  },
+  "task_score": 32.6,
+  "verdict": "The submission is detailed but technically nonfunctional, with the core Keycloak credential-refresh and RDS IAM authorization path left unresolved and an implementation that likely breaks container startup.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T20:52:29.896751Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 162488,
+      "cached_input_tokens": 133676,
+      "cache_write_input_tokens": 28800,
+      "output_tokens": 7540,
+      "reasoning_output_tokens": 5929
+    },
+    "duration_ms": 140200
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,290 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 57.2,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5849722,
+    "output_tokens": 23463,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5873185,
+    "total_cost_usd": 29.835185,
+    "latency_seconds": 410.2,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 57.2,
+    "prefix_cache_hit_rate": 0.8032,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5849722,
+  "output_tokens": 23463,
+  "latency_seconds": 410.2,
+  "num_turns": 56,
+  "total_cost_usd": 29.835185,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T20:39:16.189556Z",
+  "run_ended_at": "2026-08-05T20:46:06.984906Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5849722,
+    "output_tokens": 23463,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5873185,
+    "total_cost_usd": 29.835185,
+    "latency_seconds": 410.2,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 57.2,
+    "prefix_cache_hit_rate": 0.8032,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8032,
+      "prompt_tokens_cached_rate": 0.8032
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 23463,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 4698672,
+      "vllm:prefix_cache_queries_total": 5849722,
+      "vllm:prompt_tokens_by_source_total": 5849722,
+      "vllm:prompt_tokens_cached_total": 4698672,
+      "vllm:prompt_tokens_total": 5849722,
+      "vllm:request_success_total": 56,
+      "vllm:tool_call_parser_invocations_total": 23353
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 56,
+        "sum": 407.8013,
+        "mean": 7.282165
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 23407,
+        "sum": 248.0386,
+        "mean": 0.010597
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 23463,
+        "sum": 1174513,
+        "mean": 50.058091
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 56,
+        "sum": 248.0386,
+        "mean": 4.429261
+      },
+      "vllm:request_generation_tokens": {
+        "count": 56,
+        "sum": 23463,
+        "mean": 418.982143
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 56,
+        "sum": 396.5204,
+        "mean": 7.080721
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 56,
+        "sum": 23463,
+        "mean": 418.982143
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 56,
+        "sum": 896000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 56,
+        "sum": 56,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 56,
+        "sum": 1151050,
+        "mean": 20554.464286
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 56,
+        "sum": 148.4818,
+        "mean": 2.651461
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 56,
+        "sum": 5849722,
+        "mean": 104459.321429
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 56,
+        "sum": 0.0006,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 56,
+        "sum": 0.5851,
+        "mean": 0.010448
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 56,
+        "sum": 159.7912,
+        "mean": 2.853414
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.5409,
+          "mean": 0.3663,
+          "samples": 409
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9169,
+          "samples": 409
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 409
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 11,
+        "specificity": 14,
+        "risk_awareness": 10,
+        "total": 50,
+        "notes": "The issue clearly states the security motivation, affected AWS components, explicit non-goals, and several observable acceptance outcomes. Its largest defect is the contradiction between removing the static password and retaining password fallback and rotation, without defining when credentials may actually be deleted. The repository context shown in the patch includes an RDS proxy and a cluster master password, but the issue omits proxy authentication, database-user provisioning, and Keycloak credential-refresh behavior. No independent task statement was supplied, so requirements beyond the identifier and internally stated goals could not be verified."
+      },
+      "lld": {
+        "completeness": 9,
+        "correctness": 3,
+        "specificity": 8,
+        "risk_awareness": 10,
+        "total": 30,
+        "notes": "The LLD names concrete Terraform resources, the rotation Lambda, configuration variables, and a staged rollback sequence. Its central design is not viable because writing refreshed tokens to `/run/secrets/db-token` does not update Keycloak's JDBC password or connection pool, while the RDS proxy is explicitly left unchanged. The IAM policy uses nonexistent or incorrect actions such as `rds:Connect` and `rds:GenerateAuthenticationToken`; database login requires `rds-db:connect` against an `rds-db` database-user ARN, and the proposed database-user setup remains a stub. Availability of AWS CLI in the stock Keycloak image, the invented container paths, TLS handling, and the required Aurora IAM user configuration are not established by repository evidence."
+      },
+      "review": {
+        "completeness": 9,
+        "correctness": 8,
+        "specificity": 10,
+        "risk_awareness": 12,
+        "total": 39,
+        "notes": "The review correctly identifies connection-pool refresh, fallback behavior, token-file permissions, least privilege, monitoring, and rollback as material concerns. It misses more fundamental blockers: the invalid IAM actions and ARN, unchanged RDS proxy authentication, absent token-to-JDBC integration, missing image packaging, and simulated database-user provisioning. Its resolution section claims the findings were incorporated even though the LLD still uses a wildcard permission, writes an unencrypted plaintext file, and implements notification as logging only. The STS recommendation and several reviewer approvals are unsupported by the repository or a concrete corrected design."
+      },
+      "testing": {
+        "completeness": 9,
+        "correctness": 4,
+        "specificity": 8,
+        "risk_awareness": 7,
+        "total": 28,
+        "notes": "The plan at least spans token generation, database access, fallback, Terraform deployment, ECS inspection, refresh, and rollback. Most tests are comments rather than executable actions with reliable oracles, and variables such as `DB_HOST` and `GENERATED_TOKEN` are never populated. The MySQL IAM command omits required TLS and cleartext-plugin handling, while `list-attached-role-policies` cannot find the inline `aws_iam_role_policy` created by the patch and the Terraform feature variable is unused. It lacks tests for the proxy authentication mode, IAM database user, new connections after token expiry, actual Keycloak consumption of the token, denied permissions, and startup command semantics; the proposed test paths and secret names are also unverified."
+      },
+      "implementation": {
+        "completeness": 3,
+        "correctness": 2,
+        "specificity": 8,
+        "risk_awareness": 3,
+        "total": 16,
+        "notes": "The patch does add the valid cluster setting `enable_iam_database_authentication = true` and supplies concrete changes rather than only prose. It does not implement working Keycloak IAM authentication: the new file is never built into the stock image, the token file is never consumed as the JDBC password, the feature variable is unused, static credentials remain, and the rotation helper explicitly simulates IAM user setup. The diff's own context says the image entrypoint is `kc.sh`, so replacing only `command` with `/bin/sh -c ...` passes shell arguments to `kc.sh` and is likely to prevent startup; its IAM actions and resource ARN are also invalid for database login. The summary materially oversells the patch and contains a meaningless same-path deviation, while independent `git apply --check` verification was unavailable because repository command execution failed."
+      }
+    },
+    "task_score": 32.6,
+    "verdict": "The submission is detailed but technically nonfunctional, with the core Keycloak credential-refresh and RDS IAM authorization path left unresolved and an implementation that likely breaks container startup.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T20:52:29.896751Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 162488,
+        "cached_input_tokens": 133676,
+        "cache_write_input_tokens": 28800,
+        "output_tokens": 7540,
+        "reasoning_output_tokens": 5929
+      },
+      "duration_ms": 140200
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "claude",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T20:48:05.128374Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 169650,
+      "cached_input_tokens": 138171,
+      "cache_write_input_tokens": 31467,
+      "output_tokens": 5911,
+      "reasoning_output_tokens": 4400
+    },
+    "duration_ms": 117662
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 46.32,
+  "mean_cost_usd_excl_failed": 58.19,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 42,
+      "input_tokens": 4244741,
+      "output_tokens": 16069,
+      "total_tokens": 4260810,
+      "latency_seconds": 286.5,
+      "total_cost_usd": 21.62543,
+      "result_subtype": "success",
+      "task_score": 56.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8039,
+      "generation_tokens_per_sec": 56.1,
+      "kv_cache_usage": {
+        "peak": 0.5089,
+        "mean": 0.3674
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 16,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 66,
+          "notes": "The issue clearly scopes removal of EFS resources, mounts, variables, outputs, and example configuration, with mostly testable acceptance criteria and explicit non-goals. Its largest deficiency is treating the destructive storage migration precondition as established without specifying deployment sequencing, output compatibility, or recovery requirements. The criteria correctly identify `variables.tf`, `outputs.tf`, task definitions, `terraform validate`, and `terraform plan` as relevant surfaces. The claim that all services already use S3/DocumentDB could not be verified and conflicts with the LLD statement that some services still depend on EFS."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 61,
+          "notes": "The strongest material is the concrete mapping from `storage.tf`, `ecs-services.tf`, `variables.tf`, and `outputs.tf` to the exact EFS module, access points, mounts, variables, and outputs shown in the submitted diff. The largest deficiency is the unsafe rollback model: restoring Terraform state cannot recover a deleted EFS filesystem or its data, and the design does not require a staged mount-removal deployment before destruction. It also says both that migration is complete and that some services still depend on EFS, leaving the central go/no-go decision unresolved. Independent working-tree inspection was unavailable because read-only shell calls failed with `bwrap: loopback: Failed RTM_NEWADDR`, so application migration and broader reference claims remain unverified."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 9,
+          "specificity": 12,
+          "risk_awareness": 15,
+          "total": 49,
+          "notes": "The review identifies genuine risks involving residual data, runtime path dependencies, monitoring, Terraform state, rollback, and replacement-storage permissions. Its largest deficiency is approving the design while those risks remain unresolved and claiming resolutions that the LLD does not contain. For example, the LLD provides no concrete data-disposal procedure, S3/DocumentDB security validation, or stakeholder communication plan, while its rollback incorrectly relies on a state backup. The review also misses removal of module outputs as a compatibility concern, and its assumptions about completed application migration could not be independently verified."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 5,
+          "specificity": 12,
+          "risk_awareness": 7,
+          "total": 35,
+          "notes": "The plan at least covers validation, planning, static reference checks, deployment, and post-apply service inspection with concrete commands. Its central plan oracle is incorrect because deleted resources are not represented under `planned_values`; destruction must be checked through `resource_changes`, including nested module addresses. Most grep checks always exit successfully due to `&& echo ... || echo ...`, and the account-wide EFS `jq` check similarly does not reliably assert absence. The hard-coded checkout path, cluster and service names could not be verified, while `terraform apply -auto-approve` is not isolated and no test exercises auth configuration, logging, MCPGW persistence, service stability, or actual rollback."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 10,
+          "total": 69,
+          "notes": "The patch directly implements the stated Terraform removal by deleting `module.efs`, its egress rule, two variables, three outputs, and the auth and MCPGW EFS mounts and volume definitions. The supplied contexts and symbols are internally consistent, and empty `mountPoints` and `volume` values preserve the existing module argument shape. The largest risk is performing task-definition replacement and irreversible EFS destruction as one change without establishing the migration precondition, staging the rollout, or addressing consumers of the removed module outputs. A repository-level apply check could not be run because shell execution failed in the sandbox, and the summary's claimed line counts do not match the diff, including 182 deleted lines from `storage.tf` rather than 164."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 251,
+      "input_tokens": 24180167,
+      "output_tokens": 36582,
+      "total_tokens": 24216749,
+      "latency_seconds": 989.0,
+      "total_cost_usd": 121.81538499999992,
+      "result_subtype": "error_max_turns",
+      "task_score": 54.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8381,
+      "generation_tokens_per_sec": 37.0,
+      "kv_cache_usage": {
+        "peak": 0.6107,
+        "mean": 0.332
+      },
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 58,
+          "notes": "The issue defines removal, dependency, documentation, Docker, configuration, and API non-goals with mostly testable boundaries. Its largest gap is assuming DocumentDB is available and functionally equivalent despite the repository's existing file default and backend-specific factory branch. Criteria such as preserving search quality and passing all tests lack measurable oracles, baselines, or migration behavior. No independent task statement was supplied, so the claimed feature-parity requirement cannot be verified beyond the artifacts."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 14,
+          "risk_awareness": 15,
+          "total": 54,
+          "notes": "The LLD correctly names core integration points including registry/search/service.py, registry/repositories/file/search_repository.py, registry/core/config.py, and get_search_repository(). Its backward-compatibility design is internally inconsistent: it proposes a warning and deprecation period while also removing the file backend, and it never explains how DocumentDBSearchRepository can serve file-backed deployments without a database. It omits the numerous API, lifespan, and batch-processor callers that must change before deleting the FAISS service, forcing an implementer to rediscover critical data flows. Migration tooling, parity measurement, benchmark thresholds, and the referenced migration guide are proposed but not concretely specified or evidenced."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 15,
+          "specificity": 14,
+          "risk_awareness": 18,
+          "total": 63,
+          "notes": "The review's strongest contribution is identifying migration, backward compatibility, feature parity, database load, monitoring, and rollback as release conditions. It does not directly challenge the LLD's contradictory immediate removal and 30-day deprecation plans or explain the database prerequisite created for file-backed users. Several persona sections offer generic encryption, compliance, and communication advice without tying recommendations to repository symbols or concrete controls. The approval verdict is premature because its must-fix items have no acceptance thresholds, migration format, or executable rollback procedure."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 10,
+          "specificity": 12,
+          "risk_awareness": 16,
+          "total": 55,
+          "notes": "The plan covers functional, compatibility, failure, performance, deployment, and end-to-end scenarios across the relevant entity types. Its configuration tests contradict the implementation: they expect file settings to log a warning and continue, while registry/core/config.py removes file from ALLOWED_STORAGE_BACKENDS and raises validation errors. Most cases lack repository paths, commands, fixture values, and exact response or ranking oracles; terms such as acceptable latency, reasonable resource usage, and identical quality are not measurable. Pytest is evidenced by the repository tests, but locust, pytest-benchmark, memory_profiler, and test-container support are asserted without demonstrated repository configuration."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 16,
+          "risk_awareness": 7,
+          "total": 44,
+          "notes": "The patch concretely removes faiss-cpu, the FAISS service and adapter, their tests and mock, and reroutes many API and batch callers through get_search_repository(). The largest defect is the unannounced breaking configuration change: file is rejected and the default becomes documentdb, while the summary claims backward compatibility and the updated storage architecture still describes file as a supported legacy backend. In registry/api/server_routes.py newly added index_server calls remain immediately before existing DocumentDB update blocks, while cli/service_mgmt.sh replaces a real metadata check with an unconditional success and tests/conftest.py still logs that FAISS was auto-mocked. The patch deletes extensive search tests without replacement coverage for the factory, routes, configuration, migration, or search parity, so its verification and no-regression claims are unsupported."
+        }
+      },
+      "is_error": true,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 118,
+      "input_tokens": 12591583,
+      "output_tokens": 51990,
+      "total_tokens": 12643573,
+      "latency_seconds": 905.5,
+      "total_cost_usd": 64.25766499999999,
+      "result_subtype": "success",
+      "task_score": 52.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8111,
+      "generation_tokens_per_sec": 57.4,
+      "kv_cache_usage": {
+        "peak": 0.6115,
+        "mean": 0.3862
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 14,
+          "risk_awareness": 10,
+          "total": 57,
+          "notes": "The issue clearly states the security objective, ECS-only scope, preserved variable names, IAM work, and exclusions. Its largest gap is that \u201call sensitive variables\u201d has no definitive inventory, while the plaintext fallback and no-breaking-change criteria do not define migration behavior. The submitted patch confirms the relevant surfaces include ECS task definitions, Secrets Manager, and execution-role IAM. No independent task statement was supplied, and related issue #1134 could not be verified."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 16,
+          "risk_awareness": 12,
+          "total": 56,
+          "notes": "The LLD names concrete Terraform files, resources, environment variables, IAM permissions, and the existing KMS-backed secret pattern reflected in the patch. Its central compatibility decision is incorrect: retaining Terraform variables while removing them from container definitions is not a plaintext runtime fallback, and writing `secret_string = var...` still leaves values in Terraform state. It also leaves optional or empty credentials, dynamic values, rollback mechanics, and the exact per-service inventory unresolved despite calling the plan implementation-ready. Repository shell access failed before these paths and claimed existing patterns could be independently verified against the working tree."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 12,
+          "specificity": 13,
+          "risk_awareness": 16,
+          "total": 56,
+          "notes": "The review surfaces real concerns around state exposure, rollback, incremental deployment, monitoring, local development, and secret lifecycle. It misses the design\u2019s most consequential defects: the claimed fallback does not exist, optional empty values can make secret creation fail, and removing unrelated GitHub settings can break callers. Its claim that all critical findings were addressed is contradicted by the LLD, which still leaves rotation open, provides no executable rollback, and does not resolve state exposure. Recommendations such as \u201cTerraform encryption for state files\u201d and automatic rotation are insufficiently concrete and partly conflict with the stated non-goals."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 7,
+          "specificity": 12,
+          "risk_awareness": 11,
+          "total": 44,
+          "notes": "The plan spans Terraform planning, deployed task definitions, IAM, service startup, API health, and rollback, using concrete AWS and Terraform commands. Several oracles are nonfunctional: `example-secret` and `EXAMPLE_SECRET` do not exist in the implementation, root-module-only plan JSON misses child-module resources, and IAM policy version `v1` is assumed. The backward-compatibility test expects plaintext environment entries that the patch explicitly removes, while ACTIVE status, running count, and generic logs do not prove secret injection or application correctness. Repository access failure prevented verification of the proposed root variables, task-family names, cluster names, log group, `registry_url` output, and `/health` endpoint."
+        },
+        "implementation": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 18,
+          "risk_awareness": 7,
+          "total": 47,
+          "notes": "The patch is concrete and broadly wires thirteen KMS-backed secrets into ECS definitions and the execution-role IAM policy, including conditional Auth0 and Grafana resources. It removes `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_EXTRA_HOSTS`, and `GITHUB_API_BASE_URL` from the registry container without restoring them, and unconditional secret versions for optional credentials risk AWS rejection of empty secret strings. The claimed plaintext fallback is absent, and `aws_secretsmanager_secret_version.secret_string` continues storing secret material in Terraform state despite the stated security motivation. No executable tests accompany the patch, and repository shell failure prevented `git apply --check` or independent validation of its indexes and surrounding source."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 108,
+      "input_tokens": 10487956,
+      "output_tokens": 38161,
+      "total_tokens": 10526117,
+      "latency_seconds": 672.4,
+      "total_cost_usd": 53.39380500000001,
+      "result_subtype": "success",
+      "task_score": 36.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8173,
+      "generation_tokens_per_sec": 56.8,
+      "kv_cache_usage": {
+        "peak": 0.6125,
+        "mean": 0.3687
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 14,
+          "specificity": 12,
+          "risk_awareness": 9,
+          "total": 50,
+          "notes": "The issue clearly identifies agent-card and health-check fetches, proposes reuse of the existing guard, and states useful exclusions. Its acceptance criteria leave allowlist matching, redirect behavior, failure responses, and the meaning of \"valid URLs\" undecided, while excluding skill-validation changes despite requiring that function to be promoted. The submitted diff contains corresponding contexts for `check_agent_health`, `_check_endpoint_reachability`, and `HealthMonitoringService`, supporting the broad scope. No independent task statement exists, and local source verification was unavailable because the read-only shell failed before execution with a bwrap RTM_NEWADDR error."
+        },
+        "lld": {
+          "completeness": 13,
+          "correctness": 5,
+          "specificity": 18,
+          "risk_awareness": 8,
+          "total": 44,
+          "notes": "The LLD is concrete about files, call sites, configuration, and expected failure paths. Its central security design remains vulnerable to DNS rebinding and redirects: `is_safe_url_with_redirects` checks only the initial URL and is unused, while allowlisted hosts bypass address validation entirely. The proposed `is_safe_url` also repeats `global ssrf_blocked_count` and `global ssrf_allowed_count` after assignments in the same function, which is invalid Python syntax, and its process-local counters are not operational metrics. Repository-only claims about deployment surfaces and the original helper could not be verified because shell access failed before commands ran."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 5,
+          "specificity": 10,
+          "risk_awareness": 9,
+          "total": 34,
+          "notes": "The review at least identifies DNS rebinding, redirect handling, allowlist security, DNS latency, and rollback as relevant concerns. Its largest defect is approving the design with zero blockers while those core SSRF gaps remain unresolved. It also misses the repeated-global syntax error and incorrectly says redirect and security feedback was addressed when the LLD explicitly declines redirect validation. Source-dependent praise about codebase patterns could not be independently verified because repository shell commands could not start."
+        },
+        "testing": {
+          "completeness": 12,
+          "correctness": 7,
+          "specificity": 13,
+          "risk_awareness": 8,
+          "total": 40,
+          "notes": "The utility cases provide concrete expected booleans for public, private, loopback, metadata, IPv6, and allowlisted URLs. The plan omits redirect, DNS rebinding, mixed DNS results, malformed schemes, and an assertion that the HTTP client is never called, so its API checks could pass merely because an internal target is unreachable. Its checklist claims functional and integration tests are implemented, but the submitted patch contains no tests, and several endpoint methods and payloads remain unsubstantiated. The `uv run pytest tests/` command and API routes could not be checked locally because shell execution failed."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 0,
+          "specificity": 7,
+          "risk_awareness": 2,
+          "total": 13,
+          "notes": "The patch attempts validation at the agent-card, agent-health fallback, and multiple resolved server-health endpoints. It imports `registry.utils.url_validation` but contains no creation hunk for the summary's claimed new file, and it neither updates `skill_service.py` nor adds the promised tests. The `agent_routes.py` hunk leaves `status_label = \"healthy\"` between a newly indented `try` and its continuation, while the default streamable-health insertion in `service.py` has an unexpected extra indentation level, making the change syntax-invalid. The summary's claims of exact LLD compliance and no follow-ups are therefore false; `git apply --check` and source comparison could not run because the repository shell failed before command execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 5849722,
+      "output_tokens": 23463,
+      "total_tokens": 5873185,
+      "latency_seconds": 410.2,
+      "total_cost_usd": 29.835185,
+      "result_subtype": "success",
+      "task_score": 32.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8032,
+      "generation_tokens_per_sec": 57.2,
+      "kv_cache_usage": {
+        "peak": 0.5409,
+        "mean": 0.3663
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 14,
+          "risk_awareness": 10,
+          "total": 50,
+          "notes": "The issue clearly states the security motivation, affected AWS components, explicit non-goals, and several observable acceptance outcomes. Its largest defect is the contradiction between removing the static password and retaining password fallback and rotation, without defining when credentials may actually be deleted. The repository context shown in the patch includes an RDS proxy and a cluster master password, but the issue omits proxy authentication, database-user provisioning, and Keycloak credential-refresh behavior. No independent task statement was supplied, so requirements beyond the identifier and internally stated goals could not be verified."
+        },
+        "lld": {
+          "completeness": 9,
+          "correctness": 3,
+          "specificity": 8,
+          "risk_awareness": 10,
+          "total": 30,
+          "notes": "The LLD names concrete Terraform resources, the rotation Lambda, configuration variables, and a staged rollback sequence. Its central design is not viable because writing refreshed tokens to `/run/secrets/db-token` does not update Keycloak's JDBC password or connection pool, while the RDS proxy is explicitly left unchanged. The IAM policy uses nonexistent or incorrect actions such as `rds:Connect` and `rds:GenerateAuthenticationToken`; database login requires `rds-db:connect` against an `rds-db` database-user ARN, and the proposed database-user setup remains a stub. Availability of AWS CLI in the stock Keycloak image, the invented container paths, TLS handling, and the required Aurora IAM user configuration are not established by repository evidence."
+        },
+        "review": {
+          "completeness": 9,
+          "correctness": 8,
+          "specificity": 10,
+          "risk_awareness": 12,
+          "total": 39,
+          "notes": "The review correctly identifies connection-pool refresh, fallback behavior, token-file permissions, least privilege, monitoring, and rollback as material concerns. It misses more fundamental blockers: the invalid IAM actions and ARN, unchanged RDS proxy authentication, absent token-to-JDBC integration, missing image packaging, and simulated database-user provisioning. Its resolution section claims the findings were incorporated even though the LLD still uses a wildcard permission, writes an unencrypted plaintext file, and implements notification as logging only. The STS recommendation and several reviewer approvals are unsupported by the repository or a concrete corrected design."
+        },
+        "testing": {
+          "completeness": 9,
+          "correctness": 4,
+          "specificity": 8,
+          "risk_awareness": 7,
+          "total": 28,
+          "notes": "The plan at least spans token generation, database access, fallback, Terraform deployment, ECS inspection, refresh, and rollback. Most tests are comments rather than executable actions with reliable oracles, and variables such as `DB_HOST` and `GENERATED_TOKEN` are never populated. The MySQL IAM command omits required TLS and cleartext-plugin handling, while `list-attached-role-policies` cannot find the inline `aws_iam_role_policy` created by the patch and the Terraform feature variable is unused. It lacks tests for the proxy authentication mode, IAM database user, new connections after token expiry, actual Keycloak consumption of the token, denied permissions, and startup command semantics; the proposed test paths and secret names are also unverified."
+        },
+        "implementation": {
+          "completeness": 3,
+          "correctness": 2,
+          "specificity": 8,
+          "risk_awareness": 3,
+          "total": 16,
+          "notes": "The patch does add the valid cluster setting `enable_iam_database_authentication = true` and supplies concrete changes rather than only prose. It does not implement working Keycloak IAM authentication: the new file is never built into the stock image, the token file is never consumed as the JDBC password, the feature variable is unused, static credentials remain, and the rotation helper explicitly simulates IAM user setup. The diff's own context says the image entrypoint is `kc.sh`, so replacing only `command` with `/bin/sh -c ...` passes shell arguments to `kc.sh` and is likely to prevent startup; its IAM actions and resource ARN are also invalid for database login. The summary materially oversells the patch and contains a meaningless same-path deviation, while independent `git apply --check` verification was unavailable because repository command execution failed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-05"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 14,
+      "specificity": 12,
+      "risk_awareness": 9,
+      "total": 50,
+      "notes": "The issue clearly identifies agent-card and health-check fetches, proposes reuse of the existing guard, and states useful exclusions. Its acceptance criteria leave allowlist matching, redirect behavior, failure responses, and the meaning of \"valid URLs\" undecided, while excluding skill-validation changes despite requiring that function to be promoted. The submitted diff contains corresponding contexts for `check_agent_health`, `_check_endpoint_reachability`, and `HealthMonitoringService`, supporting the broad scope. No independent task statement exists, and local source verification was unavailable because the read-only shell failed before execution with a bwrap RTM_NEWADDR error."
+    },
+    "lld": {
+      "completeness": 13,
+      "correctness": 5,
+      "specificity": 18,
+      "risk_awareness": 8,
+      "total": 44,
+      "notes": "The LLD is concrete about files, call sites, configuration, and expected failure paths. Its central security design remains vulnerable to DNS rebinding and redirects: `is_safe_url_with_redirects` checks only the initial URL and is unused, while allowlisted hosts bypass address validation entirely. The proposed `is_safe_url` also repeats `global ssrf_blocked_count` and `global ssrf_allowed_count` after assignments in the same function, which is invalid Python syntax, and its process-local counters are not operational metrics. Repository-only claims about deployment surfaces and the original helper could not be verified because shell access failed before commands ran."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 5,
+      "specificity": 10,
+      "risk_awareness": 9,
+      "total": 34,
+      "notes": "The review at least identifies DNS rebinding, redirect handling, allowlist security, DNS latency, and rollback as relevant concerns. Its largest defect is approving the design with zero blockers while those core SSRF gaps remain unresolved. It also misses the repeated-global syntax error and incorrectly says redirect and security feedback was addressed when the LLD explicitly declines redirect validation. Source-dependent praise about codebase patterns could not be independently verified because repository shell commands could not start."
+    },
+    "testing": {
+      "completeness": 12,
+      "correctness": 7,
+      "specificity": 13,
+      "risk_awareness": 8,
+      "total": 40,
+      "notes": "The utility cases provide concrete expected booleans for public, private, loopback, metadata, IPv6, and allowlisted URLs. The plan omits redirect, DNS rebinding, mixed DNS results, malformed schemes, and an assertion that the HTTP client is never called, so its API checks could pass merely because an internal target is unreachable. Its checklist claims functional and integration tests are implemented, but the submitted patch contains no tests, and several endpoint methods and payloads remain unsubstantiated. The `uv run pytest tests/` command and API routes could not be checked locally because shell execution failed."
+    },
+    "implementation": {
+      "completeness": 4,
+      "correctness": 0,
+      "specificity": 7,
+      "risk_awareness": 2,
+      "total": 13,
+      "notes": "The patch attempts validation at the agent-card, agent-health fallback, and multiple resolved server-health endpoints. It imports `registry.utils.url_validation` but contains no creation hunk for the summary's claimed new file, and it neither updates `skill_service.py` nor adds the promised tests. The `agent_routes.py` hunk leaves `status_label = \"healthy\"` between a newly indented `try` and its continuation, while the default streamable-health insertion in `service.py` has an unexpected extra indentation level, making the change syntax-invalid. The summary's claims of exact LLD compliance and no follow-ups are therefore false; `git apply --check` and source comparison could not run because the repository shell failed before command execution."
+    }
+  },
+  "task_score": 36.2,
+  "verdict": "The artifacts are concrete but leave major SSRF gaps, and the implementation is unusable because it omits the shared utility and contains syntax-breaking indentation.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T20:54:56.761197Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 139492,
+      "cached_input_tokens": 114244,
+      "cache_write_input_tokens": 25236,
+      "output_tokens": 7865,
+      "reasoning_output_tokens": 6430
+    },
+    "duration_ms": 146853
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/claude-code/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,289 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "claude",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 56.8,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 10487956,
+    "output_tokens": 38161,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 10526117,
+    "total_cost_usd": 53.39380500000001,
+    "latency_seconds": 672.4,
+    "num_turns": 108,
+    "generation_tokens_per_sec": 56.8,
+    "prefix_cache_hit_rate": 0.8173,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 10487956,
+  "output_tokens": 38161,
+  "latency_seconds": 672.4,
+  "num_turns": 108,
+  "total_cost_usd": 53.39380500000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-08-05T20:12:50.516130Z",
+  "run_ended_at": "2026-08-05T20:24:03.474414Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 10487956,
+    "output_tokens": 38161,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 10526117,
+    "total_cost_usd": 53.39380500000001,
+    "latency_seconds": 672.4,
+    "num_turns": 108,
+    "generation_tokens_per_sec": 56.8,
+    "prefix_cache_hit_rate": 0.8173,
+    "sources": {
+      "input_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).input",
+      "output_tokens": "claude_api.modelUsage (per-model rollup; INCLUDES subagent tokens).output",
+      "cache_read_tokens": "claude_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "claude_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "claude_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or claude_api.duration_ms)",
+      "num_turns": "claude_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.8173,
+      "prompt_tokens_cached_rate": 0.8173
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 38161,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 8572048,
+      "vllm:prefix_cache_queries_total": 10487956,
+      "vllm:prompt_tokens_by_source_total": 10487956,
+      "vllm:prompt_tokens_cached_total": 8572048,
+      "vllm:prompt_tokens_total": 10487956,
+      "vllm:request_success_total": 108,
+      "vllm:tool_call_parser_invocations_total": 37945
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 108,
+        "sum": 668.0485,
+        "mean": 6.185634
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 38053,
+        "sum": 398.2377,
+        "mean": 0.010465
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 38161,
+        "sum": 1954069,
+        "mean": 51.205917
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 108,
+        "sum": 398.2377,
+        "mean": 3.687386
+      },
+      "vllm:request_generation_tokens": {
+        "count": 108,
+        "sum": 38161,
+        "mean": 353.342593
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 108,
+        "sum": 646.679,
+        "mean": 5.987769
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 108,
+        "sum": 38161,
+        "mean": 353.342593
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 108,
+        "sum": 1728000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 108,
+        "sum": 108,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 108,
+        "sum": 1915908,
+        "mean": 17739.888889
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 108,
+        "sum": 248.4413,
+        "mean": 2.300382
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 108,
+        "sum": 10487956,
+        "mean": 97110.703704
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 108,
+        "sum": 0.0011,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 108,
+        "sum": 1.111,
+        "mean": 0.010287
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 108,
+        "sum": 269.8532,
+        "mean": 2.49864
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.6125,
+          "mean": 0.3687,
+          "samples": 669
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9327,
+          "samples": 669
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 669
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 14,
+        "specificity": 12,
+        "risk_awareness": 9,
+        "total": 50,
+        "notes": "The issue clearly identifies agent-card and health-check fetches, proposes reuse of the existing guard, and states useful exclusions. Its acceptance criteria leave allowlist matching, redirect behavior, failure responses, and the meaning of \"valid URLs\" undecided, while excluding skill-validation changes despite requiring that function to be promoted. The submitted diff contains corresponding contexts for `check_agent_health`, `_check_endpoint_reachability`, and `HealthMonitoringService`, supporting the broad scope. No independent task statement exists, and local source verification was unavailable because the read-only shell failed before execution with a bwrap RTM_NEWADDR error."
+      },
+      "lld": {
+        "completeness": 13,
+        "correctness": 5,
+        "specificity": 18,
+        "risk_awareness": 8,
+        "total": 44,
+        "notes": "The LLD is concrete about files, call sites, configuration, and expected failure paths. Its central security design remains vulnerable to DNS rebinding and redirects: `is_safe_url_with_redirects` checks only the initial URL and is unused, while allowlisted hosts bypass address validation entirely. The proposed `is_safe_url` also repeats `global ssrf_blocked_count` and `global ssrf_allowed_count` after assignments in the same function, which is invalid Python syntax, and its process-local counters are not operational metrics. Repository-only claims about deployment surfaces and the original helper could not be verified because shell access failed before commands ran."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 5,
+        "specificity": 10,
+        "risk_awareness": 9,
+        "total": 34,
+        "notes": "The review at least identifies DNS rebinding, redirect handling, allowlist security, DNS latency, and rollback as relevant concerns. Its largest defect is approving the design with zero blockers while those core SSRF gaps remain unresolved. It also misses the repeated-global syntax error and incorrectly says redirect and security feedback was addressed when the LLD explicitly declines redirect validation. Source-dependent praise about codebase patterns could not be independently verified because repository shell commands could not start."
+      },
+      "testing": {
+        "completeness": 12,
+        "correctness": 7,
+        "specificity": 13,
+        "risk_awareness": 8,
+        "total": 40,
+        "notes": "The utility cases provide concrete expected booleans for public, private, loopback, metadata, IPv6, and allowlisted URLs. The plan omits redirect, DNS rebinding, mixed DNS results, malformed schemes, and an assertion that the HTTP client is never called, so its API checks could pass merely because an internal target is unreachable. Its checklist claims functional and integration tests are implemented, but the submitted patch contains no tests, and several endpoint methods and payloads remain unsubstantiated. The `uv run pytest tests/` command and API routes could not be checked locally because shell execution failed."
+      },
+      "implementation": {
+        "completeness": 4,
+        "correctness": 0,
+        "specificity": 7,
+        "risk_awareness": 2,
+        "total": 13,
+        "notes": "The patch attempts validation at the agent-card, agent-health fallback, and multiple resolved server-health endpoints. It imports `registry.utils.url_validation` but contains no creation hunk for the summary's claimed new file, and it neither updates `skill_service.py` nor adds the promised tests. The `agent_routes.py` hunk leaves `status_label = \"healthy\"` between a newly indented `try` and its continuation, while the default streamable-health insertion in `service.py` has an unexpected extra indentation level, making the change syntax-invalid. The summary's claims of exact LLD compliance and no follow-ups are therefore false; `git apply --check` and source comparison could not run because the repository shell failed before command execution."
+      }
+    },
+    "task_score": 36.2,
+    "verdict": "The artifacts are concrete but leave major SSRF gaps, and the implementation is unusable because it omits the shared utility and contains syntax-breaking indentation.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T20:54:56.761197Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 139492,
+        "cached_input_tokens": 114244,
+        "cache_write_input_tokens": 25236,
+        "output_tokens": 7865,
+        "reasoning_output_tokens": 6430
+      },
+      "duration_ms": 146853
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 12,
+      "specificity": 11,
+      "risk_awareness": 10,
+      "total": 48,
+      "notes": "The issue clearly identifies the security motivation, four infrastructure changes, and several explicit exclusions. Its largest deficiency is that \"all sensitive environment variables\" has no inventory, while the plaintext fallback is undefined and conflicts with the criterion prohibiting plaintext exposure. The acceptance criteria name ECS secrets and execution-role permissions but do not define migration sequencing, secret ownership, or observable fallback behavior. No independent task statement was supplied, so broader requirement coverage cannot be verified beyond the task identifier and artifacts."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 7,
+      "specificity": 13,
+      "risk_awareness": 10,
+      "total": 44,
+      "notes": "The design's strongest aspect is its use of concrete Terraform paths and the correct identification of ECS task definitions, execution roles, and Secrets Manager as integration points. Its example writes `var.registry_api_token` through `aws_secretsmanager_secret_version.secret_string`, which still stores the plaintext value in Terraform state and directly defeats a stated requirement. It also leaves key migration decisions as open questions, proposes a non-native `SecretsManager/UnauthorizedSecretAccess` metric, and treats retrieval failures as application errors even though ECS injection failures normally prevent container startup. Claims about `terraform/aws-ecs/secret-rotation.tf`, local ECS-agent caching, and comprehensive operator documentation were not substantiated by the implementation artifact."
+    },
+    "review": {
+      "completeness": 12,
+      "correctness": 8,
+      "specificity": 11,
+      "risk_awareness": 14,
+      "total": 45,
+      "notes": "The review usefully raises rotation, rollback, monitoring, lifecycle, and least-privilege concerns from several operational perspectives. Its largest defect is declaring every blocker resolved when the LLD contains no concrete threat model, implementation timeline, operator guides, or viable rotation workflow for externally owned credentials. It also misses the central Terraform-state exposure and the contradiction between plaintext fallback and plaintext-removal requirements. The frontend-impact and complete-resolution claims could not be verified from any cited source or concrete repository symbol."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 4,
+      "specificity": 10,
+      "risk_awareness": 8,
+      "total": 33,
+      "notes": "The plan covers deployment, IAM, task definitions, authorization, rollback, and application health, which is an appropriately broad test surface. Several commands cannot provide their claimed oracle: applying a saved plan with `-target` is invalid, `describe-tasks` does not expose injected task-definition environment values, and grepping the intended secrets block for `secret` will report a false leak. Unauthorized access accepts any command failure as success, least privilege is reduced to an arbitrary action count, and fallback plus rollback tests are placeholders. The hard-coded clone path, role and policy names, service names, and health endpoints were not established by the supplied repository evidence."
+    },
+    "implementation": {
+      "completeness": 12,
+      "correctness": 6,
+      "specificity": 16,
+      "risk_awareness": 7,
+      "total": 41,
+      "notes": "The patch concretely moves numerous named values into Secrets Manager references and replaces Keycloak's three SSM references with Secrets Manager ARNs. Its largest correctness defect is creating every optional secret version unconditionally even when variables such as `registry_api_keys`, `github_pat`, or registration credentials are empty, while the ECS entries themselves explicitly treat empty values as valid disabled configuration. Every `secret_string = var.*` value remains in Terraform state, the auth task receives several registry-only credentials it did not previously have, no plaintext fallback exists, and no mcp-gateway execution-role policy change establishes access to the new ARNs. The summary's claim of exact LLD conformance and no follow-ups is false because rotation, monitoring, telemetry, variable documentation, and staged rollback were omitted; exact patch applicability could not be independently confirmed because repository command execution failed in the read-only harness."
+    }
+  },
+  "task_score": 42.2,
+  "verdict": "The submission has concrete Terraform direction and a substantial patch, but unresolved state exposure, unsafe optional-secret handling, weak validation, and overstated design conformance prevent it from being implementation-ready.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T22:31:13.102550Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 152521,
+      "cached_input_tokens": 118484,
+      "cache_write_input_tokens": 34027,
+      "output_tokens": 8943,
+      "reasoning_output_tokens": 7390
+    },
+    "duration_ms": 153352
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 85.0,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 9867225,
+    "output_tokens": 36912,
+    "cache_read_tokens": 9756432,
+    "cache_write_tokens": 110793,
+    "total_tokens": 19771362,
+    "total_cost_usd": null,
+    "latency_seconds": 434.1,
+    "num_turns": 100,
+    "generation_tokens_per_sec": 85.0,
+    "prefix_cache_hit_rate": 0.9888,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 9867225,
+  "output_tokens": 36912,
+  "latency_seconds": 434.1,
+  "num_turns": 100,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T22:17:38.596539Z",
+  "run_ended_at": "2026-08-05T22:24:54.751862Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 9867225,
+    "output_tokens": 36912,
+    "cache_read_tokens": 9756432,
+    "cache_write_tokens": 110793,
+    "total_tokens": 19771362,
+    "total_cost_usd": null,
+    "latency_seconds": 434.1,
+    "num_turns": 100,
+    "generation_tokens_per_sec": 85.0,
+    "prefix_cache_hit_rate": 0.9888,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9888,
+      "prompt_tokens_cached_rate": 0.9888
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 36912,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 9756432,
+      "vllm:prefix_cache_queries_total": 9867225,
+      "vllm:prompt_tokens_by_source_total": 9867225,
+      "vllm:prompt_tokens_cached_total": 9756432,
+      "vllm:prompt_tokens_total": 9867225,
+      "vllm:request_success_total": 100,
+      "vllm:tool_call_parser_invocations_total": 36712
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 100,
+        "sum": 430.4898,
+        "mean": 4.304898
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 36812,
+        "sum": 389.9244,
+        "mean": 0.010592
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 36912,
+        "sum": 147705,
+        "mean": 4.001544
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 100,
+        "sum": 389.9244,
+        "mean": 3.899244
+      },
+      "vllm:request_generation_tokens": {
+        "count": 100,
+        "sum": 36912,
+        "mean": 369.12
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 100,
+        "sum": 409.7225,
+        "mean": 4.097225
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 100,
+        "sum": 36912,
+        "mean": 369.12
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 100,
+        "sum": 1600000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 100,
+        "sum": 100,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 100,
+        "sum": 110793,
+        "mean": 1107.93
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 100,
+        "sum": 19.7982,
+        "mean": 0.197982
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 100,
+        "sum": 9867225,
+        "mean": 98672.25
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 100,
+        "sum": 0.001,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 100,
+        "sum": 1.0312,
+        "mean": 0.010312
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 100,
+        "sum": 40.6101,
+        "mean": 0.406101
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.5966,
+          "mean": 0.4061,
+          "samples": 433
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8915,
+          "samples": 433
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 433
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 12,
+        "specificity": 11,
+        "risk_awareness": 10,
+        "total": 48,
+        "notes": "The issue clearly identifies the security motivation, four infrastructure changes, and several explicit exclusions. Its largest deficiency is that \"all sensitive environment variables\" has no inventory, while the plaintext fallback is undefined and conflicts with the criterion prohibiting plaintext exposure. The acceptance criteria name ECS secrets and execution-role permissions but do not define migration sequencing, secret ownership, or observable fallback behavior. No independent task statement was supplied, so broader requirement coverage cannot be verified beyond the task identifier and artifacts."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 7,
+        "specificity": 13,
+        "risk_awareness": 10,
+        "total": 44,
+        "notes": "The design's strongest aspect is its use of concrete Terraform paths and the correct identification of ECS task definitions, execution roles, and Secrets Manager as integration points. Its example writes `var.registry_api_token` through `aws_secretsmanager_secret_version.secret_string`, which still stores the plaintext value in Terraform state and directly defeats a stated requirement. It also leaves key migration decisions as open questions, proposes a non-native `SecretsManager/UnauthorizedSecretAccess` metric, and treats retrieval failures as application errors even though ECS injection failures normally prevent container startup. Claims about `terraform/aws-ecs/secret-rotation.tf`, local ECS-agent caching, and comprehensive operator documentation were not substantiated by the implementation artifact."
+      },
+      "review": {
+        "completeness": 12,
+        "correctness": 8,
+        "specificity": 11,
+        "risk_awareness": 14,
+        "total": 45,
+        "notes": "The review usefully raises rotation, rollback, monitoring, lifecycle, and least-privilege concerns from several operational perspectives. Its largest defect is declaring every blocker resolved when the LLD contains no concrete threat model, implementation timeline, operator guides, or viable rotation workflow for externally owned credentials. It also misses the central Terraform-state exposure and the contradiction between plaintext fallback and plaintext-removal requirements. The frontend-impact and complete-resolution claims could not be verified from any cited source or concrete repository symbol."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 4,
+        "specificity": 10,
+        "risk_awareness": 8,
+        "total": 33,
+        "notes": "The plan covers deployment, IAM, task definitions, authorization, rollback, and application health, which is an appropriately broad test surface. Several commands cannot provide their claimed oracle: applying a saved plan with `-target` is invalid, `describe-tasks` does not expose injected task-definition environment values, and grepping the intended secrets block for `secret` will report a false leak. Unauthorized access accepts any command failure as success, least privilege is reduced to an arbitrary action count, and fallback plus rollback tests are placeholders. The hard-coded clone path, role and policy names, service names, and health endpoints were not established by the supplied repository evidence."
+      },
+      "implementation": {
+        "completeness": 12,
+        "correctness": 6,
+        "specificity": 16,
+        "risk_awareness": 7,
+        "total": 41,
+        "notes": "The patch concretely moves numerous named values into Secrets Manager references and replaces Keycloak's three SSM references with Secrets Manager ARNs. Its largest correctness defect is creating every optional secret version unconditionally even when variables such as `registry_api_keys`, `github_pat`, or registration credentials are empty, while the ECS entries themselves explicitly treat empty values as valid disabled configuration. Every `secret_string = var.*` value remains in Terraform state, the auth task receives several registry-only credentials it did not previously have, no plaintext fallback exists, and no mcp-gateway execution-role policy change establishes access to the new ARNs. The summary's claim of exact LLD conformance and no follow-ups is false because rotation, monitoring, telemetry, variable documentation, and staged rollback were omitted; exact patch applicability could not be independently confirmed because repository command execution failed in the read-only harness."
+      }
+    },
+    "task_score": 42.2,
+    "verdict": "The submission has concrete Terraform direction and a substantial patch, but unresolved state exposure, unsafe optional-secret handling, weak validation, and overstated design conformance prevent it from being implementation-ready.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T22:31:13.102550Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 152521,
+        "cached_input_tokens": 118484,
+        "cache_write_input_tokens": 34027,
+        "output_tokens": 8943,
+        "reasoning_output_tokens": 7390
+      },
+      "duration_ms": 153352
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 18,
+      "risk_awareness": 8,
+      "total": 58,
+      "notes": "The issue provides concrete acceptance criteria covering EFS resources, ECS mounts, variables, outputs, examples, validation, and planning. Its largest deficiency is asserting that no service depends on EFS while excluding application changes and providing no replacement behavior for auth configuration or gateway data. The submitted baseline diff shows mounts at `/app/logs`, `/efs/auth_config`, and `/app/data`, making that dependency claim material rather than hypothetical. No independent task statement establishes the S3/DocumentDB assertion, and migration, data deletion, and output compatibility risks are omitted."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 19,
+      "risk_awareness": 9,
+      "total": 58,
+      "notes": "The LLD names the relevant Terraform files, modules, variables, outputs, access points, and mount paths reflected in the submitted diff. Its load-bearing storage decision remains vague: auth configuration will use environment variables or unspecified alternatives, while MCPGW becomes ephemeral despite the claim that persistent storage moved to S3/DocumentDB. The rollout section contains only three generic phases, and data migration remains an open question without state, backup, destruction, rollback, or output-consumer handling. The claim that the applications already operate correctly without these mounts is not established by the supplied task context."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 9,
+      "specificity": 14,
+      "risk_awareness": 15,
+      "total": 52,
+      "notes": "The review identifies the important mount paths, persistence assumptions, migration risk, downtime, file permissions, and logging security. Its largest defect is approving the design by declaring those concerns resolved without evidence or committed mechanisms. The actual LLD still lists data migration and application dependencies as open questions, and its rollout does not contain the claimed new-deployment or maintenance-window guidance. Terraform state destruction, removed-output consumers, backup validation, and a concrete rollback procedure receive no actionable review."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 6,
+      "specificity": 15,
+      "risk_awareness": 4,
+      "total": 36,
+      "notes": "The plan supplies concrete `terraform init`, `validate`, `plan`, and static-search commands with expected outcomes. Its principal plan oracle is invalid: `planned_values.root_module.resources` excludes nested module resources, `module.efs` is not a resource type, and planned values represent post-apply state rather than proving an EFS destruction occurred. It does not test removal of ECS mount points or volumes, service startup, auth configuration, data persistence, or the acceptance criterion that no service depends on EFS. Backward compatibility, deployment verification, rollback, and end-to-end behavior are incorrectly dismissed as not applicable despite the destructive existing-deployment path."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 8,
+      "total": 66,
+      "notes": "The patch consistently removes the submitted EFS module, security-group rule, task volumes and mounts, module variables, and module and root outputs across five focused Terraform files. The main unresolved correctness risk is runtime behavior: it removes `/efs/auth_config` and `/app/data` without demonstrating the promised environment-based configuration or S3/DocumentDB replacement, and the LLD explicitly characterizes MCPGW storage as ephemeral. The summary also claims no deviations or follow-ups despite the destructive migration and rollback work identified elsewhere, and its ECS line-count table ignores added empty assignments. Independent `git apply --check` against commit `b0fcb2db453f933da63389c0b18ccc044ee505b5` was unavailable in the read-only harness, although the submitted contexts and symbols are internally consistent."
+    }
+  },
+  "task_score": 54.0,
+  "verdict": "The submission precisely identifies and patches direct Terraform EFS references, but it does not resolve or meaningfully test the destructive migration and runtime replacement for currently mounted auth and gateway data.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T22:33:23.276208Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 112761,
+      "cached_input_tokens": 88680,
+      "cache_write_input_tokens": 24071,
+      "output_tokens": 7325,
+      "reasoning_output_tokens": 5877
+    },
+    "duration_ms": 130163
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 92.0,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 7171792,
+    "output_tokens": 24234,
+    "cache_read_tokens": 7101456,
+    "cache_write_tokens": 70336,
+    "total_tokens": 14367818,
+    "total_cost_usd": null,
+    "latency_seconds": 263.5,
+    "num_turns": 107,
+    "generation_tokens_per_sec": 92.0,
+    "prefix_cache_hit_rate": 0.9902,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 7171792,
+  "output_tokens": 24234,
+  "latency_seconds": 263.5,
+  "num_turns": 107,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T22:07:01.346192Z",
+  "run_ended_at": "2026-08-05T22:11:26.420809Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 7171792,
+    "output_tokens": 24234,
+    "cache_read_tokens": 7101456,
+    "cache_write_tokens": 70336,
+    "total_tokens": 14367818,
+    "total_cost_usd": null,
+    "latency_seconds": 263.5,
+    "num_turns": 107,
+    "generation_tokens_per_sec": 92.0,
+    "prefix_cache_hit_rate": 0.9902,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9902,
+      "prompt_tokens_cached_rate": 0.9902
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 24234,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 7101456,
+      "vllm:prefix_cache_queries_total": 7171792,
+      "vllm:prompt_tokens_by_source_total": 7171792,
+      "vllm:prompt_tokens_cached_total": 7101456,
+      "vllm:prompt_tokens_total": 7171792,
+      "vllm:request_success_total": 107,
+      "vllm:tool_call_parser_invocations_total": 24123
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 107,
+        "sum": 260.3958,
+        "mean": 2.433606
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 24127,
+        "sum": 234.3875,
+        "mean": 0.009715
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 24234,
+        "sum": 94570,
+        "mean": 3.902369
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 107,
+        "sum": 234.3875,
+        "mean": 2.190538
+      },
+      "vllm:request_generation_tokens": {
+        "count": 107,
+        "sum": 24234,
+        "mean": 226.485981
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 107,
+        "sum": 245.9419,
+        "mean": 2.298523
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 107,
+        "sum": 24234,
+        "mean": 226.485981
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 107,
+        "sum": 1712000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 107,
+        "sum": 107,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 107,
+        "sum": 70336,
+        "mean": 657.345794
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 107,
+        "sum": 11.5544,
+        "mean": 0.107985
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 107,
+        "sum": 7171792,
+        "mean": 67026.093458
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 107,
+        "sum": 0.0009,
+        "mean": 8e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 107,
+        "sum": 1.0346,
+        "mean": 0.009669
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 107,
+        "sum": 26.0406,
+        "mean": 0.24337
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.384,
+          "mean": 0.2618,
+          "samples": 263
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9316,
+          "samples": 263
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 263
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 18,
+        "risk_awareness": 8,
+        "total": 58,
+        "notes": "The issue provides concrete acceptance criteria covering EFS resources, ECS mounts, variables, outputs, examples, validation, and planning. Its largest deficiency is asserting that no service depends on EFS while excluding application changes and providing no replacement behavior for auth configuration or gateway data. The submitted baseline diff shows mounts at `/app/logs`, `/efs/auth_config`, and `/app/data`, making that dependency claim material rather than hypothetical. No independent task statement establishes the S3/DocumentDB assertion, and migration, data deletion, and output compatibility risks are omitted."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 19,
+        "risk_awareness": 9,
+        "total": 58,
+        "notes": "The LLD names the relevant Terraform files, modules, variables, outputs, access points, and mount paths reflected in the submitted diff. Its load-bearing storage decision remains vague: auth configuration will use environment variables or unspecified alternatives, while MCPGW becomes ephemeral despite the claim that persistent storage moved to S3/DocumentDB. The rollout section contains only three generic phases, and data migration remains an open question without state, backup, destruction, rollback, or output-consumer handling. The claim that the applications already operate correctly without these mounts is not established by the supplied task context."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 9,
+        "specificity": 14,
+        "risk_awareness": 15,
+        "total": 52,
+        "notes": "The review identifies the important mount paths, persistence assumptions, migration risk, downtime, file permissions, and logging security. Its largest defect is approving the design by declaring those concerns resolved without evidence or committed mechanisms. The actual LLD still lists data migration and application dependencies as open questions, and its rollout does not contain the claimed new-deployment or maintenance-window guidance. Terraform state destruction, removed-output consumers, backup validation, and a concrete rollback procedure receive no actionable review."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 6,
+        "specificity": 15,
+        "risk_awareness": 4,
+        "total": 36,
+        "notes": "The plan supplies concrete `terraform init`, `validate`, `plan`, and static-search commands with expected outcomes. Its principal plan oracle is invalid: `planned_values.root_module.resources` excludes nested module resources, `module.efs` is not a resource type, and planned values represent post-apply state rather than proving an EFS destruction occurred. It does not test removal of ECS mount points or volumes, service startup, auth configuration, data persistence, or the acceptance criterion that no service depends on EFS. Backward compatibility, deployment verification, rollback, and end-to-end behavior are incorrectly dismissed as not applicable despite the destructive existing-deployment path."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 8,
+        "total": 66,
+        "notes": "The patch consistently removes the submitted EFS module, security-group rule, task volumes and mounts, module variables, and module and root outputs across five focused Terraform files. The main unresolved correctness risk is runtime behavior: it removes `/efs/auth_config` and `/app/data` without demonstrating the promised environment-based configuration or S3/DocumentDB replacement, and the LLD explicitly characterizes MCPGW storage as ephemeral. The summary also claims no deviations or follow-ups despite the destructive migration and rollback work identified elsewhere, and its ECS line-count table ignores added empty assignments. Independent `git apply --check` against commit `b0fcb2db453f933da63389c0b18ccc044ee505b5` was unavailable in the read-only harness, although the submitted contexts and symbols are internally consistent."
+      }
+    },
+    "task_score": 54.0,
+    "verdict": "The submission precisely identifies and patches direct Terraform EFS references, but it does not resolve or meaningfully test the destructive migration and runtime replacement for currently mounted auth and gateway data.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T22:33:23.276208Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 112761,
+        "cached_input_tokens": 88680,
+        "cache_write_input_tokens": 24071,
+        "output_tokens": 7325,
+        "reasoning_output_tokens": 5877
+      },
+      "duration_ms": 130163
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 60,
+      "notes": "The strongest aspect is the concrete checklist covering Python imports, pyproject.toml, Docker, tests, documentation, search behavior, and API compatibility. Its largest deficiency is the unresolved contradiction between preserving behavior and replacing the default file backend's FAISS search with DocumentDB while declaring algorithm changes and DocumentDB implementation changes out of scope. The submitted factory diff confirms that file and MongoDB backends previously selected distinct search repositories, making this an architectural migration rather than simple dependency removal. No independent task statement was supplied, and the claims that DocumentDB is fully functional for file-backed deployments and that issue 1285 establishes this direction could not be verified."
+    },
+    "lld": {
+      "completeness": 10,
+      "correctness": 5,
+      "specificity": 10,
+      "risk_awareness": 6,
+      "total": 31,
+      "notes": "The LLD names several real integration points corroborated by the patch, including registry/repositories/factory.py, registry/main.py, registry/search/service.py, and SearchRepositoryBase. Its central design remains undecided: the open questions still ask whether to remove or repurpose the service and whether to replace or remove the file repository, despite those being the load-bearing decisions. The existing factory branch shown in the diff deliberately chooses DocumentDB only for MONGODB_BACKENDS, yet the design provides no database provisioning, connection lifecycle, migration, or fallback for STORAGE_BACKEND=file. The claimed /api/search/semantic contract, CLI behavior, referenced design documents, and automatic compatibility of file storage with DocumentDB could not be independently verified."
+    },
+    "review": {
+      "completeness": 8,
+      "correctness": 5,
+      "specificity": 8,
+      "risk_awareness": 7,
+      "total": 28,
+      "notes": "The review's strongest finding is that file-backend compatibility and comprehensive reference removal require explicit attention. Its largest deficiency is approving the design without resolving how a file-only deployment can use DocumentDB or examining the operational dependency this introduces. The resolution claims the LLD now defines an automatic migration and comprehensive search, but that LLD still contains those questions and supplies neither migration mechanics nor a repository-wide search command. Assertions about unchanged security properties, UI impact, and deployment simplification are unsupported by concrete repository evidence."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 6,
+      "specificity": 13,
+      "risk_awareness": 7,
+      "total": 37,
+      "notes": "The plan's strongest aspect is its concrete HTTP payloads and response-field checks for servers, tools, agents, search mode, and relevance scores. Its largest deficiency is that several checks can pass without testing the feature: the UI assertion accepts every nonnegative result count, the error check accepts an empty response, and the Docker and rollback sections merely print PASS. The file-backend test changes STORAGE_BACKEND after startup while leaving restart commented out, and the end-to-end registration setup is also commented out, so neither establishes its prerequisite state. The exact endpoint, CLI command, and DocumentDB environment variables could not be independently verified, and no replacement unit tests exercise the new repository selection or failure behavior."
+    },
+    "implementation": {
+      "completeness": 6,
+      "correctness": 1,
+      "specificity": 6,
+      "risk_awareness": 1,
+      "total": 14,
+      "notes": "The patch does remove faiss-cpu from pyproject.toml and deletes FAISS mocks and tests while updating several documentation references. It does not implement the claimed replacement: registry/search/service.py only removes the import, field, and load call while retaining FaissService and the unchanged FAISS-dependent methods evidenced by the deleted tests, and registry/core/config.py merely comments out properties those methods used. The factory always constructs DocumentDBSearchRepository, making the rewritten FileSearchRepository dead code, while that class silently ignores entity types other than servers and agents and adds no compatibility tests. The summary materially overstates the service rewrite and claims no deviations or follow-ups; patch applicability and any lockfile residue could not be independently checked because repository command execution was unavailable."
+    }
+  },
+  "task_score": 34.0,
+  "verdict": "The issue identifies the main removal surfaces, but the design never resolves file-backend compatibility and the patch leaves FAISS-dependent code while routing all deployments to DocumentDB, making the implementation unmergeable.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T22:36:00.562866Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 296009,
+      "cached_input_tokens": 252105,
+      "cache_write_input_tokens": 43890,
+      "output_tokens": 7034,
+      "reasoning_output_tokens": 5510
+    },
+    "duration_ms": 157273
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 69.8,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 17243235,
+    "output_tokens": 26685,
+    "cache_read_tokens": 17085808,
+    "cache_write_tokens": 193391,
+    "total_tokens": 34549119,
+    "total_cost_usd": null,
+    "latency_seconds": 382.3,
+    "num_turns": 127,
+    "generation_tokens_per_sec": 69.8,
+    "prefix_cache_hit_rate": 0.9888,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 17243235,
+  "output_tokens": 26685,
+  "latency_seconds": 382.3,
+  "num_turns": 127,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T22:00:35.552136Z",
+  "run_ended_at": "2026-08-05T22:06:59.580574Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 17243235,
+    "output_tokens": 26685,
+    "cache_read_tokens": 17085808,
+    "cache_write_tokens": 193391,
+    "total_tokens": 34549119,
+    "total_cost_usd": null,
+    "latency_seconds": 382.3,
+    "num_turns": 127,
+    "generation_tokens_per_sec": 69.8,
+    "prefix_cache_hit_rate": 0.9888,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9888,
+      "prompt_tokens_cached_rate": 0.9888
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 26876,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 17085808,
+      "vllm:prefix_cache_queries_total": 17279199,
+      "vllm:prompt_tokens_by_source_total": 17279199,
+      "vllm:prompt_tokens_cached_total": 17085808,
+      "vllm:prompt_tokens_total": 17279199,
+      "vllm:request_success_total": 128,
+      "vllm:tool_call_parser_invocations_total": 26476
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 128,
+        "sum": 373.9343,
+        "mean": 2.921361
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 26748,
+        "sum": 304.5245,
+        "mean": 0.011385
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 26876,
+        "sum": 220267,
+        "mean": 8.195676
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 128,
+        "sum": 304.5245,
+        "mean": 2.379098
+      },
+      "vllm:request_generation_tokens": {
+        "count": 128,
+        "sum": 26876,
+        "mean": 209.96875
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 128,
+        "sum": 338.2272,
+        "mean": 2.6424
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 128,
+        "sum": 26876,
+        "mean": 209.96875
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 128,
+        "sum": 2031706,
+        "mean": 15872.703125
+      },
+      "vllm:request_params_n": {
+        "count": 128,
+        "sum": 128,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 128,
+        "sum": 193391,
+        "mean": 1510.867188
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 128,
+        "sum": 33.7027,
+        "mean": 0.263303
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 128,
+        "sum": 17279199,
+        "mean": 134993.742188
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 128,
+        "sum": 0.0014,
+        "mean": 1.1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 128,
+        "sum": 1.4157,
+        "mean": 0.01106
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 128,
+        "sum": 69.4818,
+        "mean": 0.542827
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.7317,
+          "mean": 0.5037,
+          "samples": 380
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8237,
+          "samples": 380
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 380
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 60,
+        "notes": "The strongest aspect is the concrete checklist covering Python imports, pyproject.toml, Docker, tests, documentation, search behavior, and API compatibility. Its largest deficiency is the unresolved contradiction between preserving behavior and replacing the default file backend's FAISS search with DocumentDB while declaring algorithm changes and DocumentDB implementation changes out of scope. The submitted factory diff confirms that file and MongoDB backends previously selected distinct search repositories, making this an architectural migration rather than simple dependency removal. No independent task statement was supplied, and the claims that DocumentDB is fully functional for file-backed deployments and that issue 1285 establishes this direction could not be verified."
+      },
+      "lld": {
+        "completeness": 10,
+        "correctness": 5,
+        "specificity": 10,
+        "risk_awareness": 6,
+        "total": 31,
+        "notes": "The LLD names several real integration points corroborated by the patch, including registry/repositories/factory.py, registry/main.py, registry/search/service.py, and SearchRepositoryBase. Its central design remains undecided: the open questions still ask whether to remove or repurpose the service and whether to replace or remove the file repository, despite those being the load-bearing decisions. The existing factory branch shown in the diff deliberately chooses DocumentDB only for MONGODB_BACKENDS, yet the design provides no database provisioning, connection lifecycle, migration, or fallback for STORAGE_BACKEND=file. The claimed /api/search/semantic contract, CLI behavior, referenced design documents, and automatic compatibility of file storage with DocumentDB could not be independently verified."
+      },
+      "review": {
+        "completeness": 8,
+        "correctness": 5,
+        "specificity": 8,
+        "risk_awareness": 7,
+        "total": 28,
+        "notes": "The review's strongest finding is that file-backend compatibility and comprehensive reference removal require explicit attention. Its largest deficiency is approving the design without resolving how a file-only deployment can use DocumentDB or examining the operational dependency this introduces. The resolution claims the LLD now defines an automatic migration and comprehensive search, but that LLD still contains those questions and supplies neither migration mechanics nor a repository-wide search command. Assertions about unchanged security properties, UI impact, and deployment simplification are unsupported by concrete repository evidence."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 6,
+        "specificity": 13,
+        "risk_awareness": 7,
+        "total": 37,
+        "notes": "The plan's strongest aspect is its concrete HTTP payloads and response-field checks for servers, tools, agents, search mode, and relevance scores. Its largest deficiency is that several checks can pass without testing the feature: the UI assertion accepts every nonnegative result count, the error check accepts an empty response, and the Docker and rollback sections merely print PASS. The file-backend test changes STORAGE_BACKEND after startup while leaving restart commented out, and the end-to-end registration setup is also commented out, so neither establishes its prerequisite state. The exact endpoint, CLI command, and DocumentDB environment variables could not be independently verified, and no replacement unit tests exercise the new repository selection or failure behavior."
+      },
+      "implementation": {
+        "completeness": 6,
+        "correctness": 1,
+        "specificity": 6,
+        "risk_awareness": 1,
+        "total": 14,
+        "notes": "The patch does remove faiss-cpu from pyproject.toml and deletes FAISS mocks and tests while updating several documentation references. It does not implement the claimed replacement: registry/search/service.py only removes the import, field, and load call while retaining FaissService and the unchanged FAISS-dependent methods evidenced by the deleted tests, and registry/core/config.py merely comments out properties those methods used. The factory always constructs DocumentDBSearchRepository, making the rewritten FileSearchRepository dead code, while that class silently ignores entity types other than servers and agents and adds no compatibility tests. The summary materially overstates the service rewrite and claims no deviations or follow-ups; patch applicability and any lockfile residue could not be independently checked because repository command execution was unavailable."
+      }
+    },
+    "task_score": 34.0,
+    "verdict": "The issue identifies the main removal surfaces, but the design never resolves file-backend compatibility and the patch leaves FAISS-dependent code while routing all deployments to DocumentDB, making the implementation unmergeable.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T22:36:00.562866Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 296009,
+        "cached_input_tokens": 252105,
+        "cache_write_input_tokens": 43890,
+        "output_tokens": 7034,
+        "reasoning_output_tokens": 5510
+      },
+      "duration_ms": 157273
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 14,
+      "risk_awareness": 8,
+      "total": 47,
+      "notes": "The issue clearly identifies the ECS/Aurora objective, fallback requirement, version constraint, and several testable acceptance criteria. Its largest omission is the existing `aws_db_proxy_target.keycloak` integration and the required database-user IAM setup, TLS behavior, and token-consumption mechanism. The repository artifacts show Secrets Manager password rotation already exists, so the claim that passwords are maintained in configuration files is overstated, while removing the password conflicts with retaining password fallback. No independent task statement was supplied, so the intended fallback semantics cannot be verified beyond the task identifier and artifacts."
+    },
+    "lld": {
+      "completeness": 11,
+      "correctness": 2,
+      "specificity": 13,
+      "risk_awareness": 9,
+      "total": 35,
+      "notes": "The LLD names concrete Terraform files, resources, variables, and a staged rollout with the flag disabled initially. Its central design is not viable: ECS secret values are injected at task startup, Keycloak does not interpret `USE_IAM_AUTH`, `DB_TOKEN_REFRESH_INTERVAL`, or an `iam_token` field, and updating Secrets Manager cannot refresh Keycloak's database password. The proposed policy uses nonexistent IAM action `rds:GenerateDBAuthToken`, attaches it to the execution role instead of the task role, omits `rds-db:connect` on a database-user ARN, and never provisions the MySQL IAM-authenticated user or addresses the existing proxy. Claims that AWS CLI and mysql-client already exist, that fallback is automatic, and that retries or circuit breakers will occur are unsupported or contradicted by the shown configuration."
+    },
+    "review": {
+      "completeness": 12,
+      "correctness": 7,
+      "specificity": 11,
+      "risk_awareness": 14,
+      "total": 44,
+      "notes": "The review usefully identifies token expiration, refresh races, sidecar failure, horizontal scaling, monitoring, and rollback as concerns. It misses the fatal integration defects: Keycloak has no token consumer, ECS secrets do not refresh, the database IAM user is absent, and the policy action and role are wrong. Calling the policy least-privilege is contradicted by its `\"*\"` resource and invalid `rds:GenerateDBAuthToken` action, while frontend direct-database access and ECS role-credential rotation concerns are largely misplaced. An approved-with-changes verdict is not defensible when the review itself lists blockers and the proposed authentication path cannot operate."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 4,
+      "specificity": 15,
+      "risk_awareness": 9,
+      "total": 41,
+      "notes": "The plan spans Terraform, token generation, SQL connectivity, rollback, task-definition inspection, and Keycloak CRUD with several concrete expected values. Its IAM checks are invalid because `aws_iam_role_policy` is inline, while `list-attached-role-policies`, `detach-role-policy`, and the asserted policy ARN operate on managed policies; several referenced Terraform outputs are also unestablished. The fallback test cannot pass as designed because `KC_DB_PASSWORD` is deliberately omitted when IAM mode is enabled, and the SQL test omits IAM-user provisioning and required TLS/cleartext-auth considerations while bypassing the existing proxy path. The admin-token check accepts jq's nonempty `null`, user creation does not assert HTTP status, destructive targeted applies lack cleanup, and no static Terraform validation is included."
+    },
+    "implementation": {
+      "completeness": 5,
+      "correctness": 1,
+      "specificity": 10,
+      "risk_awareness": 4,
+      "total": 20,
+      "notes": "The diff targets the relevant cluster, ECS locals, IAM roles, and variables, and the default-disabled flag preserves the existing password mode. It does not implement IAM authentication end to end: the new script is never invoked, Keycloak ignores the new environment variables, and enabling the flag removes `KC_DB_PASSWORD`, causing startup failure rather than token authentication or fallback. The policy uses invalid `rds:GenerateDBAuthToken`, is attached to `keycloak_task_exec_role`, and omits `rds-db:connect`, the database-user grant, TLS handling, and the existing RDS Proxy path. The summary falsely claims use of the rotation Lambda, while the standalone script hard-codes `keycloak/database` and logs part of the token; exact patch applicability could not be independently checked because the repository command runner failed before file reads."
+    }
+  },
+  "task_score": 37.4,
+  "verdict": "The artifacts are concrete but fundamentally nonfunctional because no implemented path supplies renewable IAM tokens to Keycloak, and the IAM policy, fallback, and database setup are incorrect.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T22:38:14.803669Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 169529,
+      "cached_input_tokens": 139693,
+      "cache_write_input_tokens": 29824,
+      "output_tokens": 6708,
+      "reasoning_output_tokens": 4805
+    },
+    "duration_ms": 134229
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 103.4,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1914353,
+    "output_tokens": 22722,
+    "cache_read_tokens": 1878160,
+    "cache_write_tokens": 36193,
+    "total_tokens": 3851428,
+    "total_cost_usd": null,
+    "latency_seconds": 219.7,
+    "num_turns": 49,
+    "generation_tokens_per_sec": 103.4,
+    "prefix_cache_hit_rate": 0.9811,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 1914353,
+  "output_tokens": 22722,
+  "latency_seconds": 219.7,
+  "num_turns": 49,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T22:24:56.700497Z",
+  "run_ended_at": "2026-08-05T22:28:39.220342Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1914353,
+    "output_tokens": 22722,
+    "cache_read_tokens": 1878160,
+    "cache_write_tokens": 36193,
+    "total_tokens": 3851428,
+    "total_cost_usd": null,
+    "latency_seconds": 219.7,
+    "num_turns": 49,
+    "generation_tokens_per_sec": 103.4,
+    "prefix_cache_hit_rate": 0.9811,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9811,
+      "prompt_tokens_cached_rate": 0.9811
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 22722,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 1878160,
+      "vllm:prefix_cache_queries_total": 1914353,
+      "vllm:prompt_tokens_by_source_total": 1914353,
+      "vllm:prompt_tokens_cached_total": 1878160,
+      "vllm:prompt_tokens_total": 1914353,
+      "vllm:request_success_total": 49,
+      "vllm:tool_call_parser_invocations_total": 22703
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 49,
+        "sum": 216.9657,
+        "mean": 4.427872
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 22673,
+        "sum": 208.4847,
+        "mean": 0.009195
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 22722,
+        "sum": 58915,
+        "mean": 2.592862
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 49,
+        "sum": 208.4847,
+        "mean": 4.254789
+      },
+      "vllm:request_generation_tokens": {
+        "count": 49,
+        "sum": 22722,
+        "mean": 463.714286
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 49,
+        "sum": 213.0609,
+        "mean": 4.348181
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 49,
+        "sum": 22722,
+        "mean": 463.714286
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 49,
+        "sum": 784000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 49,
+        "sum": 49,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 49,
+        "sum": 36193,
+        "mean": 738.632653
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 49,
+        "sum": 4.5762,
+        "mean": 0.093392
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 49,
+        "sum": 1914353,
+        "mean": 39068.428571
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 49,
+        "sum": 0.0004,
+        "mean": 8e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 49,
+        "sum": 0.4455,
+        "mean": 0.009093
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 49,
+        "sum": 8.4894,
+        "mean": 0.173253
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.243,
+          "mean": 0.1645,
+          "samples": 220
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9409,
+          "samples": 220
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 220
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 14,
+        "risk_awareness": 8,
+        "total": 47,
+        "notes": "The issue clearly identifies the ECS/Aurora objective, fallback requirement, version constraint, and several testable acceptance criteria. Its largest omission is the existing `aws_db_proxy_target.keycloak` integration and the required database-user IAM setup, TLS behavior, and token-consumption mechanism. The repository artifacts show Secrets Manager password rotation already exists, so the claim that passwords are maintained in configuration files is overstated, while removing the password conflicts with retaining password fallback. No independent task statement was supplied, so the intended fallback semantics cannot be verified beyond the task identifier and artifacts."
+      },
+      "lld": {
+        "completeness": 11,
+        "correctness": 2,
+        "specificity": 13,
+        "risk_awareness": 9,
+        "total": 35,
+        "notes": "The LLD names concrete Terraform files, resources, variables, and a staged rollout with the flag disabled initially. Its central design is not viable: ECS secret values are injected at task startup, Keycloak does not interpret `USE_IAM_AUTH`, `DB_TOKEN_REFRESH_INTERVAL`, or an `iam_token` field, and updating Secrets Manager cannot refresh Keycloak's database password. The proposed policy uses nonexistent IAM action `rds:GenerateDBAuthToken`, attaches it to the execution role instead of the task role, omits `rds-db:connect` on a database-user ARN, and never provisions the MySQL IAM-authenticated user or addresses the existing proxy. Claims that AWS CLI and mysql-client already exist, that fallback is automatic, and that retries or circuit breakers will occur are unsupported or contradicted by the shown configuration."
+      },
+      "review": {
+        "completeness": 12,
+        "correctness": 7,
+        "specificity": 11,
+        "risk_awareness": 14,
+        "total": 44,
+        "notes": "The review usefully identifies token expiration, refresh races, sidecar failure, horizontal scaling, monitoring, and rollback as concerns. It misses the fatal integration defects: Keycloak has no token consumer, ECS secrets do not refresh, the database IAM user is absent, and the policy action and role are wrong. Calling the policy least-privilege is contradicted by its `\"*\"` resource and invalid `rds:GenerateDBAuthToken` action, while frontend direct-database access and ECS role-credential rotation concerns are largely misplaced. An approved-with-changes verdict is not defensible when the review itself lists blockers and the proposed authentication path cannot operate."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 4,
+        "specificity": 15,
+        "risk_awareness": 9,
+        "total": 41,
+        "notes": "The plan spans Terraform, token generation, SQL connectivity, rollback, task-definition inspection, and Keycloak CRUD with several concrete expected values. Its IAM checks are invalid because `aws_iam_role_policy` is inline, while `list-attached-role-policies`, `detach-role-policy`, and the asserted policy ARN operate on managed policies; several referenced Terraform outputs are also unestablished. The fallback test cannot pass as designed because `KC_DB_PASSWORD` is deliberately omitted when IAM mode is enabled, and the SQL test omits IAM-user provisioning and required TLS/cleartext-auth considerations while bypassing the existing proxy path. The admin-token check accepts jq's nonempty `null`, user creation does not assert HTTP status, destructive targeted applies lack cleanup, and no static Terraform validation is included."
+      },
+      "implementation": {
+        "completeness": 5,
+        "correctness": 1,
+        "specificity": 10,
+        "risk_awareness": 4,
+        "total": 20,
+        "notes": "The diff targets the relevant cluster, ECS locals, IAM roles, and variables, and the default-disabled flag preserves the existing password mode. It does not implement IAM authentication end to end: the new script is never invoked, Keycloak ignores the new environment variables, and enabling the flag removes `KC_DB_PASSWORD`, causing startup failure rather than token authentication or fallback. The policy uses invalid `rds:GenerateDBAuthToken`, is attached to `keycloak_task_exec_role`, and omits `rds-db:connect`, the database-user grant, TLS handling, and the existing RDS Proxy path. The summary falsely claims use of the rotation Lambda, while the standalone script hard-codes `keycloak/database` and logs part of the token; exact patch applicability could not be independently checked because the repository command runner failed before file reads."
+      }
+    },
+    "task_score": 37.4,
+    "verdict": "The artifacts are concrete but fundamentally nonfunctional because no implemented path supplies renewable IAM tokens to Keycloak, and the IAM policy, fallback, and database setup are incorrect.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T22:38:14.803669Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 169529,
+        "cached_input_tokens": 139693,
+        "cache_write_input_tokens": 29824,
+        "output_tokens": 6708,
+        "reasoning_output_tokens": 4805
+      },
+      "duration_ms": 134229
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "pi",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T22:31:13.102550Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 152521,
+      "cached_input_tokens": 118484,
+      "cache_write_input_tokens": 34027,
+      "output_tokens": 8943,
+      "reasoning_output_tokens": 7390
+    },
+    "duration_ms": 153352
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 43.96,
+  "mean_cost_usd_excl_failed": null,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 107,
+      "input_tokens": 7171792,
+      "output_tokens": 24234,
+      "total_tokens": 14367818,
+      "latency_seconds": 263.5,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 54.0,
+      "cache_read_tokens": 7101456,
+      "cache_write_tokens": 70336,
+      "prefix_cache_hit_rate": 0.9902,
+      "generation_tokens_per_sec": 92.0,
+      "kv_cache_usage": {
+        "peak": 0.384,
+        "mean": 0.2618
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 8,
+          "total": 58,
+          "notes": "The issue provides concrete acceptance criteria covering EFS resources, ECS mounts, variables, outputs, examples, validation, and planning. Its largest deficiency is asserting that no service depends on EFS while excluding application changes and providing no replacement behavior for auth configuration or gateway data. The submitted baseline diff shows mounts at `/app/logs`, `/efs/auth_config`, and `/app/data`, making that dependency claim material rather than hypothetical. No independent task statement establishes the S3/DocumentDB assertion, and migration, data deletion, and output compatibility risks are omitted."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 19,
+          "risk_awareness": 9,
+          "total": 58,
+          "notes": "The LLD names the relevant Terraform files, modules, variables, outputs, access points, and mount paths reflected in the submitted diff. Its load-bearing storage decision remains vague: auth configuration will use environment variables or unspecified alternatives, while MCPGW becomes ephemeral despite the claim that persistent storage moved to S3/DocumentDB. The rollout section contains only three generic phases, and data migration remains an open question without state, backup, destruction, rollback, or output-consumer handling. The claim that the applications already operate correctly without these mounts is not established by the supplied task context."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 14,
+          "risk_awareness": 15,
+          "total": 52,
+          "notes": "The review identifies the important mount paths, persistence assumptions, migration risk, downtime, file permissions, and logging security. Its largest defect is approving the design by declaring those concerns resolved without evidence or committed mechanisms. The actual LLD still lists data migration and application dependencies as open questions, and its rollout does not contain the claimed new-deployment or maintenance-window guidance. Terraform state destruction, removed-output consumers, backup validation, and a concrete rollback procedure receive no actionable review."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 6,
+          "specificity": 15,
+          "risk_awareness": 4,
+          "total": 36,
+          "notes": "The plan supplies concrete `terraform init`, `validate`, `plan`, and static-search commands with expected outcomes. Its principal plan oracle is invalid: `planned_values.root_module.resources` excludes nested module resources, `module.efs` is not a resource type, and planned values represent post-apply state rather than proving an EFS destruction occurred. It does not test removal of ECS mount points or volumes, service startup, auth configuration, data persistence, or the acceptance criterion that no service depends on EFS. Backward compatibility, deployment verification, rollback, and end-to-end behavior are incorrectly dismissed as not applicable despite the destructive existing-deployment path."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 8,
+          "total": 66,
+          "notes": "The patch consistently removes the submitted EFS module, security-group rule, task volumes and mounts, module variables, and module and root outputs across five focused Terraform files. The main unresolved correctness risk is runtime behavior: it removes `/efs/auth_config` and `/app/data` without demonstrating the promised environment-based configuration or S3/DocumentDB replacement, and the LLD explicitly characterizes MCPGW storage as ephemeral. The summary also claims no deviations or follow-ups despite the destructive migration and rollback work identified elsewhere, and its ECS line-count table ignores added empty assignments. Independent `git apply --check` against commit `b0fcb2db453f933da63389c0b18ccc044ee505b5` was unavailable in the read-only harness, although the submitted contexts and symbols are internally consistent."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 104,
+      "input_tokens": 8064418,
+      "output_tokens": 33404,
+      "total_tokens": 16162240,
+      "latency_seconds": 366.4,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 52.2,
+      "cache_read_tokens": 7983520,
+      "cache_write_tokens": 80898,
+      "prefix_cache_hit_rate": 0.99,
+      "generation_tokens_per_sec": 91.2,
+      "kv_cache_usage": {
+        "peak": 0.4574,
+        "mean": 0.2995
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 17,
+          "specificity": 16,
+          "risk_awareness": 13,
+          "total": 62,
+          "notes": "The issue clearly identifies two outbound-request paths, the existing `_is_safe_url()` dependency in `registry/services/skill_service.py`, and concrete private-network and metadata-service threats. Its largest deficiency is the unresolved conflict between backwards compatibility and blocking existing internal endpoints, with no migration or allowlist semantics. The acceptance criteria name agent-card and health-check validation, but the broader requirement that all outbound HTTP requests be validated has no bounded inventory or testable definition. No independent task statement was supplied, so requirement coverage beyond the task identifier and internally consistent artifacts could not be verified."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 17,
+          "risk_awareness": 13,
+          "total": 54,
+          "notes": "The design is strongest where it names concrete modules and methods, including `registry/utils/agent_validator.py`, `registry/health/service.py`, and `_check_endpoint_reachability`. Its proposed DNS check is vulnerable to check-then-connect rebinding because `socket.getaddrinfo()` validates one resolution while `httpx` resolves again, and synchronous DNS is introduced into asynchronous health-check paths. It says the helper will be moved from `skill_service.py`, but that file is absent from the change list, while rollback depends on an undefined feature flag and backwards compatibility for existing private endpoints remains unresolved. The asserted `/api/...` routes and root-level Terraform and Helm paths were not independently established by the available evidence."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 14,
+          "risk_awareness": 17,
+          "total": 56,
+          "notes": "The review usefully surfaces DNS rebinding, IPv6 handling, false positives for internal services, observability, integration testing, and rollback concerns. Its largest defect is the final claim that every concern was resolved even though the LLD retains DNS pinning and internal-service bypass as open questions and defines no validation feature flag. The resolution also claims expanded cloud metadata protection, completed deployment wiring, and integration testing that the LLD only sketches or lists as checkboxes. Suggestions such as wildcard allowlists and an administrator bypass are not accompanied by constraints that would prevent them from weakening the SSRF boundary."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 7,
+          "specificity": 13,
+          "risk_awareness": 11,
+          "total": 45,
+          "notes": "The plan covers public, private, metadata, IPv6, allowlist, compatibility, deployment, and lifecycle scenarios across several test levels. Its curl examples merely describe expected status codes without capturing or asserting them, so the suite could appear successful when every request returned the wrong result. Expectations of HTTP 422 conflict with the implementation's agent-validator behavior, which returns an unreachable warning, and public hosts such as `httpbin.org` do not supply the required agent-card behavior. The `/api/...` routes and token path are unverified, while multiple DNS answers, rebinding, redirects, malformed authority forms, no-network-call assertions, and deterministic unit-test setup are missing."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 7,
+          "specificity": 16,
+          "risk_awareness": 8,
+          "total": 44,
+          "notes": "The patch concretely gates `_check_endpoint_reachability`, `_initialize_mcp_session`, `_try_ping_without_auth`, and `_check_server_endpoint_transport_aware`, and checks every address returned by `getaddrinfo()`. It does not actually promote the original helper because there is no change to `registry/services/skill_service.py`, and it omits the promised metrics, feature flag, deployment wiring, and comprehensive outbound-request coverage. Several submitted tests are inherently broken: one calls an async method without awaiting it, the default-endpoint test executes only `pass` before asserting a mock call, and the exception test patches `urllib.parse.urlparse` rather than the imported module symbol. The validator remains vulnerable to DNS rebinding, performs blocking DNS in async paths, logs potentially sensitive full URLs, and the summary's claim of no deviations or follow-ups materially overstates the patch."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 100,
+      "input_tokens": 9867225,
+      "output_tokens": 36912,
+      "total_tokens": 19771362,
+      "latency_seconds": 434.1,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 42.2,
+      "cache_read_tokens": 9756432,
+      "cache_write_tokens": 110793,
+      "prefix_cache_hit_rate": 0.9888,
+      "generation_tokens_per_sec": 85.0,
+      "kv_cache_usage": {
+        "peak": 0.5966,
+        "mean": 0.4061
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 12,
+          "specificity": 11,
+          "risk_awareness": 10,
+          "total": 48,
+          "notes": "The issue clearly identifies the security motivation, four infrastructure changes, and several explicit exclusions. Its largest deficiency is that \"all sensitive environment variables\" has no inventory, while the plaintext fallback is undefined and conflicts with the criterion prohibiting plaintext exposure. The acceptance criteria name ECS secrets and execution-role permissions but do not define migration sequencing, secret ownership, or observable fallback behavior. No independent task statement was supplied, so broader requirement coverage cannot be verified beyond the task identifier and artifacts."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 7,
+          "specificity": 13,
+          "risk_awareness": 10,
+          "total": 44,
+          "notes": "The design's strongest aspect is its use of concrete Terraform paths and the correct identification of ECS task definitions, execution roles, and Secrets Manager as integration points. Its example writes `var.registry_api_token` through `aws_secretsmanager_secret_version.secret_string`, which still stores the plaintext value in Terraform state and directly defeats a stated requirement. It also leaves key migration decisions as open questions, proposes a non-native `SecretsManager/UnauthorizedSecretAccess` metric, and treats retrieval failures as application errors even though ECS injection failures normally prevent container startup. Claims about `terraform/aws-ecs/secret-rotation.tf`, local ECS-agent caching, and comprehensive operator documentation were not substantiated by the implementation artifact."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 8,
+          "specificity": 11,
+          "risk_awareness": 14,
+          "total": 45,
+          "notes": "The review usefully raises rotation, rollback, monitoring, lifecycle, and least-privilege concerns from several operational perspectives. Its largest defect is declaring every blocker resolved when the LLD contains no concrete threat model, implementation timeline, operator guides, or viable rotation workflow for externally owned credentials. It also misses the central Terraform-state exposure and the contradiction between plaintext fallback and plaintext-removal requirements. The frontend-impact and complete-resolution claims could not be verified from any cited source or concrete repository symbol."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 4,
+          "specificity": 10,
+          "risk_awareness": 8,
+          "total": 33,
+          "notes": "The plan covers deployment, IAM, task definitions, authorization, rollback, and application health, which is an appropriately broad test surface. Several commands cannot provide their claimed oracle: applying a saved plan with `-target` is invalid, `describe-tasks` does not expose injected task-definition environment values, and grepping the intended secrets block for `secret` will report a false leak. Unauthorized access accepts any command failure as success, least privilege is reduced to an arbitrary action count, and fallback plus rollback tests are placeholders. The hard-coded clone path, role and policy names, service names, and health endpoints were not established by the supplied repository evidence."
+        },
+        "implementation": {
+          "completeness": 12,
+          "correctness": 6,
+          "specificity": 16,
+          "risk_awareness": 7,
+          "total": 41,
+          "notes": "The patch concretely moves numerous named values into Secrets Manager references and replaces Keycloak's three SSM references with Secrets Manager ARNs. Its largest correctness defect is creating every optional secret version unconditionally even when variables such as `registry_api_keys`, `github_pat`, or registration credentials are empty, while the ECS entries themselves explicitly treat empty values as valid disabled configuration. Every `secret_string = var.*` value remains in Terraform state, the auth task receives several registry-only credentials it did not previously have, no plaintext fallback exists, and no mcp-gateway execution-role policy change establishes access to the new ARNs. The summary's claim of exact LLD conformance and no follow-ups is false because rotation, monitoring, telemetry, variable documentation, and staged rollback were omitted; exact patch applicability could not be independently confirmed because repository command execution failed in the read-only harness."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 49,
+      "input_tokens": 1914353,
+      "output_tokens": 22722,
+      "total_tokens": 3851428,
+      "latency_seconds": 219.7,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 37.4,
+      "cache_read_tokens": 1878160,
+      "cache_write_tokens": 36193,
+      "prefix_cache_hit_rate": 0.9811,
+      "generation_tokens_per_sec": 103.4,
+      "kv_cache_usage": {
+        "peak": 0.243,
+        "mean": 0.1645
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 14,
+          "risk_awareness": 8,
+          "total": 47,
+          "notes": "The issue clearly identifies the ECS/Aurora objective, fallback requirement, version constraint, and several testable acceptance criteria. Its largest omission is the existing `aws_db_proxy_target.keycloak` integration and the required database-user IAM setup, TLS behavior, and token-consumption mechanism. The repository artifacts show Secrets Manager password rotation already exists, so the claim that passwords are maintained in configuration files is overstated, while removing the password conflicts with retaining password fallback. No independent task statement was supplied, so the intended fallback semantics cannot be verified beyond the task identifier and artifacts."
+        },
+        "lld": {
+          "completeness": 11,
+          "correctness": 2,
+          "specificity": 13,
+          "risk_awareness": 9,
+          "total": 35,
+          "notes": "The LLD names concrete Terraform files, resources, variables, and a staged rollout with the flag disabled initially. Its central design is not viable: ECS secret values are injected at task startup, Keycloak does not interpret `USE_IAM_AUTH`, `DB_TOKEN_REFRESH_INTERVAL`, or an `iam_token` field, and updating Secrets Manager cannot refresh Keycloak's database password. The proposed policy uses nonexistent IAM action `rds:GenerateDBAuthToken`, attaches it to the execution role instead of the task role, omits `rds-db:connect` on a database-user ARN, and never provisions the MySQL IAM-authenticated user or addresses the existing proxy. Claims that AWS CLI and mysql-client already exist, that fallback is automatic, and that retries or circuit breakers will occur are unsupported or contradicted by the shown configuration."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 7,
+          "specificity": 11,
+          "risk_awareness": 14,
+          "total": 44,
+          "notes": "The review usefully identifies token expiration, refresh races, sidecar failure, horizontal scaling, monitoring, and rollback as concerns. It misses the fatal integration defects: Keycloak has no token consumer, ECS secrets do not refresh, the database IAM user is absent, and the policy action and role are wrong. Calling the policy least-privilege is contradicted by its `\"*\"` resource and invalid `rds:GenerateDBAuthToken` action, while frontend direct-database access and ECS role-credential rotation concerns are largely misplaced. An approved-with-changes verdict is not defensible when the review itself lists blockers and the proposed authentication path cannot operate."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 4,
+          "specificity": 15,
+          "risk_awareness": 9,
+          "total": 41,
+          "notes": "The plan spans Terraform, token generation, SQL connectivity, rollback, task-definition inspection, and Keycloak CRUD with several concrete expected values. Its IAM checks are invalid because `aws_iam_role_policy` is inline, while `list-attached-role-policies`, `detach-role-policy`, and the asserted policy ARN operate on managed policies; several referenced Terraform outputs are also unestablished. The fallback test cannot pass as designed because `KC_DB_PASSWORD` is deliberately omitted when IAM mode is enabled, and the SQL test omits IAM-user provisioning and required TLS/cleartext-auth considerations while bypassing the existing proxy path. The admin-token check accepts jq's nonempty `null`, user creation does not assert HTTP status, destructive targeted applies lack cleanup, and no static Terraform validation is included."
+        },
+        "implementation": {
+          "completeness": 5,
+          "correctness": 1,
+          "specificity": 10,
+          "risk_awareness": 4,
+          "total": 20,
+          "notes": "The diff targets the relevant cluster, ECS locals, IAM roles, and variables, and the default-disabled flag preserves the existing password mode. It does not implement IAM authentication end to end: the new script is never invoked, Keycloak ignores the new environment variables, and enabling the flag removes `KC_DB_PASSWORD`, causing startup failure rather than token authentication or fallback. The policy uses invalid `rds:GenerateDBAuthToken`, is attached to `keycloak_task_exec_role`, and omits `rds-db:connect`, the database-user grant, TLS handling, and the existing RDS Proxy path. The summary falsely claims use of the rotation Lambda, while the standalone script hard-codes `keycloak/database` and logs part of the token; exact patch applicability could not be independently checked because the repository command runner failed before file reads."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 127,
+      "input_tokens": 17243235,
+      "output_tokens": 26685,
+      "total_tokens": 34549119,
+      "latency_seconds": 382.3,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 34.0,
+      "cache_read_tokens": 17085808,
+      "cache_write_tokens": 193391,
+      "prefix_cache_hit_rate": 0.9888,
+      "generation_tokens_per_sec": 69.8,
+      "kv_cache_usage": {
+        "peak": 0.7317,
+        "mean": 0.5037
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 60,
+          "notes": "The strongest aspect is the concrete checklist covering Python imports, pyproject.toml, Docker, tests, documentation, search behavior, and API compatibility. Its largest deficiency is the unresolved contradiction between preserving behavior and replacing the default file backend's FAISS search with DocumentDB while declaring algorithm changes and DocumentDB implementation changes out of scope. The submitted factory diff confirms that file and MongoDB backends previously selected distinct search repositories, making this an architectural migration rather than simple dependency removal. No independent task statement was supplied, and the claims that DocumentDB is fully functional for file-backed deployments and that issue 1285 establishes this direction could not be verified."
+        },
+        "lld": {
+          "completeness": 10,
+          "correctness": 5,
+          "specificity": 10,
+          "risk_awareness": 6,
+          "total": 31,
+          "notes": "The LLD names several real integration points corroborated by the patch, including registry/repositories/factory.py, registry/main.py, registry/search/service.py, and SearchRepositoryBase. Its central design remains undecided: the open questions still ask whether to remove or repurpose the service and whether to replace or remove the file repository, despite those being the load-bearing decisions. The existing factory branch shown in the diff deliberately chooses DocumentDB only for MONGODB_BACKENDS, yet the design provides no database provisioning, connection lifecycle, migration, or fallback for STORAGE_BACKEND=file. The claimed /api/search/semantic contract, CLI behavior, referenced design documents, and automatic compatibility of file storage with DocumentDB could not be independently verified."
+        },
+        "review": {
+          "completeness": 8,
+          "correctness": 5,
+          "specificity": 8,
+          "risk_awareness": 7,
+          "total": 28,
+          "notes": "The review's strongest finding is that file-backend compatibility and comprehensive reference removal require explicit attention. Its largest deficiency is approving the design without resolving how a file-only deployment can use DocumentDB or examining the operational dependency this introduces. The resolution claims the LLD now defines an automatic migration and comprehensive search, but that LLD still contains those questions and supplies neither migration mechanics nor a repository-wide search command. Assertions about unchanged security properties, UI impact, and deployment simplification are unsupported by concrete repository evidence."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 6,
+          "specificity": 13,
+          "risk_awareness": 7,
+          "total": 37,
+          "notes": "The plan's strongest aspect is its concrete HTTP payloads and response-field checks for servers, tools, agents, search mode, and relevance scores. Its largest deficiency is that several checks can pass without testing the feature: the UI assertion accepts every nonnegative result count, the error check accepts an empty response, and the Docker and rollback sections merely print PASS. The file-backend test changes STORAGE_BACKEND after startup while leaving restart commented out, and the end-to-end registration setup is also commented out, so neither establishes its prerequisite state. The exact endpoint, CLI command, and DocumentDB environment variables could not be independently verified, and no replacement unit tests exercise the new repository selection or failure behavior."
+        },
+        "implementation": {
+          "completeness": 6,
+          "correctness": 1,
+          "specificity": 6,
+          "risk_awareness": 1,
+          "total": 14,
+          "notes": "The patch does remove faiss-cpu from pyproject.toml and deletes FAISS mocks and tests while updating several documentation references. It does not implement the claimed replacement: registry/search/service.py only removes the import, field, and load call while retaining FaissService and the unchanged FAISS-dependent methods evidenced by the deleted tests, and registry/core/config.py merely comments out properties those methods used. The factory always constructs DocumentDBSearchRepository, making the rewritten FileSearchRepository dead code, while that class silently ignores entity types other than servers and agents and adds no compatibility tests. The summary materially overstates the service rewrite and claims no deviations or follow-ups; patch applicability and any lockfile residue could not be independently checked because repository command execution was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-05"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "qwen3-coder-480b",
+  "scores": {
+    "github_issue": {
+      "completeness": 16,
+      "correctness": 17,
+      "specificity": 16,
+      "risk_awareness": 13,
+      "total": 62,
+      "notes": "The issue clearly identifies two outbound-request paths, the existing `_is_safe_url()` dependency in `registry/services/skill_service.py`, and concrete private-network and metadata-service threats. Its largest deficiency is the unresolved conflict between backwards compatibility and blocking existing internal endpoints, with no migration or allowlist semantics. The acceptance criteria name agent-card and health-check validation, but the broader requirement that all outbound HTTP requests be validated has no bounded inventory or testable definition. No independent task statement was supplied, so requirement coverage beyond the task identifier and internally consistent artifacts could not be verified."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 10,
+      "specificity": 17,
+      "risk_awareness": 13,
+      "total": 54,
+      "notes": "The design is strongest where it names concrete modules and methods, including `registry/utils/agent_validator.py`, `registry/health/service.py`, and `_check_endpoint_reachability`. Its proposed DNS check is vulnerable to check-then-connect rebinding because `socket.getaddrinfo()` validates one resolution while `httpx` resolves again, and synchronous DNS is introduced into asynchronous health-check paths. It says the helper will be moved from `skill_service.py`, but that file is absent from the change list, while rollback depends on an undefined feature flag and backwards compatibility for existing private endpoints remains unresolved. The asserted `/api/...` routes and root-level Terraform and Helm paths were not independently established by the available evidence."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 14,
+      "risk_awareness": 17,
+      "total": 56,
+      "notes": "The review usefully surfaces DNS rebinding, IPv6 handling, false positives for internal services, observability, integration testing, and rollback concerns. Its largest defect is the final claim that every concern was resolved even though the LLD retains DNS pinning and internal-service bypass as open questions and defines no validation feature flag. The resolution also claims expanded cloud metadata protection, completed deployment wiring, and integration testing that the LLD only sketches or lists as checkboxes. Suggestions such as wildcard allowlists and an administrator bypass are not accompanied by constraints that would prevent them from weakening the SSRF boundary."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 7,
+      "specificity": 13,
+      "risk_awareness": 11,
+      "total": 45,
+      "notes": "The plan covers public, private, metadata, IPv6, allowlist, compatibility, deployment, and lifecycle scenarios across several test levels. Its curl examples merely describe expected status codes without capturing or asserting them, so the suite could appear successful when every request returned the wrong result. Expectations of HTTP 422 conflict with the implementation's agent-validator behavior, which returns an unreachable warning, and public hosts such as `httpbin.org` do not supply the required agent-card behavior. The `/api/...` routes and token path are unverified, while multiple DNS answers, rebinding, redirects, malformed authority forms, no-network-call assertions, and deterministic unit-test setup are missing."
+    },
+    "implementation": {
+      "completeness": 13,
+      "correctness": 7,
+      "specificity": 16,
+      "risk_awareness": 8,
+      "total": 44,
+      "notes": "The patch concretely gates `_check_endpoint_reachability`, `_initialize_mcp_session`, `_try_ping_without_auth`, and `_check_server_endpoint_transport_aware`, and checks every address returned by `getaddrinfo()`. It does not actually promote the original helper because there is no change to `registry/services/skill_service.py`, and it omits the promised metrics, feature flag, deployment wiring, and comprehensive outbound-request coverage. Several submitted tests are inherently broken: one calls an async method without awaiting it, the default-endpoint test executes only `pass` before asserting a mock call, and the exception test patches `urllib.parse.urlparse` rather than the imported module symbol. The validator remains vulnerable to DNS rebinding, performs blocking DNS in async paths, logs potentially sensitive full URLs, and the summary's claim of no deviations or follow-ups materially overstates the patch."
+    }
+  },
+  "task_score": 52.2,
+  "verdict": "The submission is a mixed, concrete attempt whose largest limitation is that its implementation and tests do not deliver the centralized, compatibility-conscious, rebinding-resistant SSRF boundary claimed by the design.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-05T22:41:29.010397Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 294314,
+      "cached_input_tokens": 257530,
+      "cache_write_input_tokens": 36766,
+      "output_tokens": 9111,
+      "reasoning_output_tokens": 6999
+    },
+    "duration_ms": 194195
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen3-coder-480b/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "qwen3-coder-480b",
+  "model_slug": "qwen3-coder-480b",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 4,
+    "precision": "fp8",
+    "context_window": 200000
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 91.2,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 8064418,
+    "output_tokens": 33404,
+    "cache_read_tokens": 7983520,
+    "cache_write_tokens": 80898,
+    "total_tokens": 16162240,
+    "total_cost_usd": null,
+    "latency_seconds": 366.4,
+    "num_turns": 104,
+    "generation_tokens_per_sec": 91.2,
+    "prefix_cache_hit_rate": 0.99,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 8064418,
+  "output_tokens": 33404,
+  "latency_seconds": 366.4,
+  "num_turns": 104,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-05T22:11:28.006278Z",
+  "run_ended_at": "2026-08-05T22:17:36.831550Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 8064418,
+    "output_tokens": 33404,
+    "cache_read_tokens": 7983520,
+    "cache_write_tokens": 80898,
+    "total_tokens": 16162240,
+    "total_cost_usd": null,
+    "latency_seconds": 366.4,
+    "num_turns": 104,
+    "generation_tokens_per_sec": 91.2,
+    "prefix_cache_hit_rate": 0.99,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.99,
+      "prompt_tokens_cached_rate": 0.99
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 33404,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 7983520,
+      "vllm:prefix_cache_queries_total": 8064418,
+      "vllm:prompt_tokens_by_source_total": 8064418,
+      "vllm:prompt_tokens_cached_total": 7983520,
+      "vllm:prompt_tokens_total": 8064418,
+      "vllm:request_success_total": 104,
+      "vllm:tool_call_parser_invocations_total": 33240
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 104,
+        "sum": 362.1983,
+        "mean": 3.482676
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 33300,
+        "sum": 331.8882,
+        "mean": 0.009967
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 33404,
+        "sum": 114302,
+        "mean": 3.421806
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 104,
+        "sum": 331.8882,
+        "mean": 3.191233
+      },
+      "vllm:request_generation_tokens": {
+        "count": 104,
+        "sum": 33404,
+        "mean": 321.192308
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 104,
+        "sum": 345.4262,
+        "mean": 3.321406
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 104,
+        "sum": 33404,
+        "mean": 321.192308
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 104,
+        "sum": 1664000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 104,
+        "sum": 104,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 104,
+        "sum": 80898,
+        "mean": 777.865385
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 104,
+        "sum": 13.538,
+        "mean": 0.130173
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 104,
+        "sum": 8064418,
+        "mean": 77542.480769
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 104,
+        "sum": 0.0009,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 104,
+        "sum": 1.0273,
+        "mean": 0.009878
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 104,
+        "sum": 30.3491,
+        "mean": 0.291818
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.4574,
+          "mean": 0.2995,
+          "samples": 366
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9044,
+          "samples": 366
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 366
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "qwen3-coder-480b",
+    "scores": {
+      "github_issue": {
+        "completeness": 16,
+        "correctness": 17,
+        "specificity": 16,
+        "risk_awareness": 13,
+        "total": 62,
+        "notes": "The issue clearly identifies two outbound-request paths, the existing `_is_safe_url()` dependency in `registry/services/skill_service.py`, and concrete private-network and metadata-service threats. Its largest deficiency is the unresolved conflict between backwards compatibility and blocking existing internal endpoints, with no migration or allowlist semantics. The acceptance criteria name agent-card and health-check validation, but the broader requirement that all outbound HTTP requests be validated has no bounded inventory or testable definition. No independent task statement was supplied, so requirement coverage beyond the task identifier and internally consistent artifacts could not be verified."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 10,
+        "specificity": 17,
+        "risk_awareness": 13,
+        "total": 54,
+        "notes": "The design is strongest where it names concrete modules and methods, including `registry/utils/agent_validator.py`, `registry/health/service.py`, and `_check_endpoint_reachability`. Its proposed DNS check is vulnerable to check-then-connect rebinding because `socket.getaddrinfo()` validates one resolution while `httpx` resolves again, and synchronous DNS is introduced into asynchronous health-check paths. It says the helper will be moved from `skill_service.py`, but that file is absent from the change list, while rollback depends on an undefined feature flag and backwards compatibility for existing private endpoints remains unresolved. The asserted `/api/...` routes and root-level Terraform and Helm paths were not independently established by the available evidence."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 14,
+        "risk_awareness": 17,
+        "total": 56,
+        "notes": "The review usefully surfaces DNS rebinding, IPv6 handling, false positives for internal services, observability, integration testing, and rollback concerns. Its largest defect is the final claim that every concern was resolved even though the LLD retains DNS pinning and internal-service bypass as open questions and defines no validation feature flag. The resolution also claims expanded cloud metadata protection, completed deployment wiring, and integration testing that the LLD only sketches or lists as checkboxes. Suggestions such as wildcard allowlists and an administrator bypass are not accompanied by constraints that would prevent them from weakening the SSRF boundary."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 7,
+        "specificity": 13,
+        "risk_awareness": 11,
+        "total": 45,
+        "notes": "The plan covers public, private, metadata, IPv6, allowlist, compatibility, deployment, and lifecycle scenarios across several test levels. Its curl examples merely describe expected status codes without capturing or asserting them, so the suite could appear successful when every request returned the wrong result. Expectations of HTTP 422 conflict with the implementation's agent-validator behavior, which returns an unreachable warning, and public hosts such as `httpbin.org` do not supply the required agent-card behavior. The `/api/...` routes and token path are unverified, while multiple DNS answers, rebinding, redirects, malformed authority forms, no-network-call assertions, and deterministic unit-test setup are missing."
+      },
+      "implementation": {
+        "completeness": 13,
+        "correctness": 7,
+        "specificity": 16,
+        "risk_awareness": 8,
+        "total": 44,
+        "notes": "The patch concretely gates `_check_endpoint_reachability`, `_initialize_mcp_session`, `_try_ping_without_auth`, and `_check_server_endpoint_transport_aware`, and checks every address returned by `getaddrinfo()`. It does not actually promote the original helper because there is no change to `registry/services/skill_service.py`, and it omits the promised metrics, feature flag, deployment wiring, and comprehensive outbound-request coverage. Several submitted tests are inherently broken: one calls an async method without awaiting it, the default-endpoint test executes only `pass` before asserting a mock call, and the exception test patches `urllib.parse.urlparse` rather than the imported module symbol. The validator remains vulnerable to DNS rebinding, performs blocking DNS in async paths, logs potentially sensitive full URLs, and the summary's claim of no deviations or follow-ups materially overstates the patch."
+      }
+    },
+    "task_score": 52.2,
+    "verdict": "The submission is a mixed, concrete attempt whose largest limitation is that its implementation and tests do not deliver the centralized, compatibility-conscious, rebinding-resistant SSRF boundary claimed by the design.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-05T22:41:29.010397Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 294314,
+        "cached_input_tokens": 257530,
+        "cache_write_input_tokens": 36766,
+        "output_tokens": 9111,
+        "reasoning_output_tokens": 6999
+      },
+      "duration_ms": 194195
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Consolidates the **trustworthy** benchmark data from the open PRs onto `main` in one clean commit, taking only the files that are correct and avoiding two hazards (see below).

### Landed

| Model | Harness | Source PR |
|---|---|---|
| kimi-k2.7-code | claude-code | #95 |
| deepseek-v3.2 | claude-code | #97 |
| devstral-2-123b | claude-code + pi | #101 |
| minimax-m2.5 | claude-code + pi | #102 |
| qwen3-coder-480b | claude-code + pi | #103 |
| nemotron-ultra-550b | pi | #104 |

### Deliberately excluded

- **kimi-k2.7-code/pi (#96)** and **deepseek-v3.2/pi (#97 pi half)** carry the ~100x token undercount from the pre-#99 harness (4 and 8 output tokens/turn). They need a re-run on the fixed harness (both are H200-class self-hosted models) and are NOT included here.
- **#95 and #97 also carried stale copies of the Anthropic pi directories** (pre-#100). Those were NOT taken, so the corrected Anthropic pi data on `main` is preserved rather than reverted.

### Verification

- The pi runs included (devstral, minimax, qwen3-coder-480b, nemotron) were generated after the fix and show realistic ~260-375 output tokens/turn.
- `eval.json` skill field backfilled to `swe3` (35 files).
- No `session_id`/`repo_root`, AWS keys, private keys, home paths, or UUIDs in committed files.
- No large artifacts committed (only metrics.json / eval.json / run-summary.json); two stray files from #103 (`ARTIFACT-PATH-PROVENANCE.md`, `eval.original-model-failure.json`) dropped.

Charts and per-agent docs will be regenerated once all outstanding PRs are merged.