### PR TITLE
benchmark: re-run deepseek-v3.2 pi /swe3 on the fixed harness (mean 54.44, 48x token correction, 5/5 clean)

### DIFF
--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "deepseek-v3.2",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 13,
+      "specificity": 17,
+      "risk_awareness": 14,
+      "total": 62,
+      "notes": "The issue clearly states the security motivation, affected infrastructure, scope, exclusions, dependencies, and testable outcomes. Its largest flaw is requiring simultaneous same-name plaintext and secret entries as a fallback, although ECS fails task startup when secret retrieval fails rather than falling back. The submitted patch context corroborates that the named variables and Terraform files are relevant, but managing secret values through Terraform would not remove them from state. No independent task statement was supplied, so the intended variable inventory and migration-period requirements remain unverified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 8,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 58,
+      "notes": "The design is unusually concrete about Terraform paths, variables, resource conditions, ECS integration, deployment phases, and operational failure modes. Its central design is unsound because `secret_string = var.*` retains values in Terraform state, while duplicate plaintext entries cannot rescue a task when ECS cannot retrieve a referenced secret. It also promises canary feature flags and rotation lambdas without designing them, and its resolved rotation decision contradicts both the non-goals and listed file changes. The exact existing IAM wildcard policy and complete secret inventory could not be independently verified because repository command execution was unavailable."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 9,
+      "specificity": 14,
+      "risk_awareness": 16,
+      "total": 54,
+      "notes": "The review surfaces several relevant risks, including shared-secret exposure, rotation propagation, JSON values, plaintext migration overlap, IAM growth, cost, and disaster recovery. Its largest miss is approving the claim that the design eliminates plaintext from Terraform state despite the proposed `aws_secretsmanager_secret_version.secret_string` assignments and retained ECS environment values. It also incorrectly praises least privilege and implemented rotation, recommends irrelevant application caching, and asks about a nonexistent Secrets Manager Standard versus Advanced tier. The verdict table conflicts with the individual Sage verdict, and the exact repository IAM behavior cited as resolved could not be independently verified."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 6,
+      "specificity": 14,
+      "risk_awareness": 12,
+      "total": 47,
+      "notes": "The plan covers creation, task definitions, IAM, KMS, deployment, rollback, audit, negative cases, and service behavior with concrete commands. Several primary oracles are invalid: `terraform plan -detailed-exitcode 2` is malformed, the secret-count check accepts zero, and an `ACTIVE` ECS service does not establish health or secret correctness. The rollback captures the current primary task definition rather than the previous revision, while multiple failure scenarios are comments rather than executable tests and secret values are printed into test output. Its hard-coded `/tmp/swe-clone-migrate-ecs-env-vars-to-secrets-manager/...` path demonstrably differs from the submitted workspace, while `dev.tfvars`, output names, service names, and API paths could not be verified."
+    },
+    "implementation": {
+      "completeness": 10,
+      "correctness": 7,
+      "specificity": 16,
+      "risk_awareness": 8,
+      "total": 41,
+      "notes": "The patch concretely defines nine conditional secret/version pairs and adds matching `valueFrom` entries to the two submitted ECS service blocks using coherent Terraform syntax. Its largest defect is that it removes no plaintext environment entries and still writes every value into Terraform state, so it does not achieve the stated security migration and cannot provide fallback when secret retrieval fails. Applying `ignore_changes` to every secret can leave rotated Terraform inputs using stale secret versions, and injecting GitHub credentials into auth-server contradicts the LLD inventory that limits them to registry. The summary claims ten new categories although the patch contains nine, materially overstates fallback and completion, and patch applicability could not be independently checked because repository command execution failed before invoking Git."
+    }
+  },
+  "task_score": 52.4,
+  "verdict": "The submission is concrete and broad, but its core migration model preserves plaintext exposure, misunderstands ECS secret failure behavior, and is supported by several tests that cannot establish the promised outcome.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T03:54:58.941214Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 247690,
+      "cached_input_tokens": 210914,
+      "cache_write_input_tokens": 36760,
+      "output_tokens": 8146,
+      "reasoning_output_tokens": 6577
+    },
+    "duration_ms": 159919
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 83.8,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3693324,
+    "output_tokens": 29765,
+    "cache_read_tokens": 3604608,
+    "cache_write_tokens": 88716,
+    "total_tokens": 7416413,
+    "total_cost_usd": null,
+    "latency_seconds": 355.0,
+    "num_turns": 60,
+    "generation_tokens_per_sec": 83.8,
+    "prefix_cache_hit_rate": 0.976,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 3693324,
+  "output_tokens": 29765,
+  "latency_seconds": 355.0,
+  "num_turns": 60,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T03:39:53.706474Z",
+  "run_ended_at": "2026-08-06T03:45:48.746369Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3693324,
+    "output_tokens": 29765,
+    "cache_read_tokens": 3604608,
+    "cache_write_tokens": 88716,
+    "total_tokens": 7416413,
+    "total_cost_usd": null,
+    "latency_seconds": 355.0,
+    "num_turns": 60,
+    "generation_tokens_per_sec": 83.8,
+    "prefix_cache_hit_rate": 0.976,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.976,
+      "prompt_tokens_cached_rate": 0.976
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 29765,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 3604608,
+      "vllm:prefix_cache_queries_total": 3693324,
+      "vllm:prompt_tokens_by_source_total": 3693324,
+      "vllm:prompt_tokens_cached_total": 3604608,
+      "vllm:prompt_tokens_total": 3693324,
+      "vllm:request_success_total": 60,
+      "vllm:tool_call_parser_invocations_total": 29684
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 60,
+        "sum": 353.128,
+        "mean": 5.885467
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 29705,
+        "sum": 331.7319,
+        "mean": 0.011168
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 29765,
+        "sum": 118481,
+        "mean": 3.980548
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 60,
+        "sum": 331.7319,
+        "mean": 5.528866
+      },
+      "vllm:request_generation_tokens": {
+        "count": 60,
+        "sum": 29765,
+        "mean": 496.083333
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 60,
+        "sum": 346.2476,
+        "mean": 5.770794
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 60,
+        "sum": 29765,
+        "mean": 496.083333
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 60,
+        "sum": 960000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 60,
+        "sum": 60,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 60,
+        "sum": 88716,
+        "mean": 1478.6
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 60,
+        "sum": 14.5157,
+        "mean": 0.241928
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 60,
+        "sum": 3693324,
+        "mean": 61555.4
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 60,
+        "sum": 0.0006,
+        "mean": 1e-05
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 60,
+        "sum": 0.6688,
+        "mean": 0.011147
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 60,
+        "sum": 21.4079,
+        "mean": 0.356798
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1763,
+          "mean": 0.1217,
+          "samples": 353
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9462,
+          "samples": 353
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 353
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "deepseek-v3.2",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 13,
+        "specificity": 17,
+        "risk_awareness": 14,
+        "total": 62,
+        "notes": "The issue clearly states the security motivation, affected infrastructure, scope, exclusions, dependencies, and testable outcomes. Its largest flaw is requiring simultaneous same-name plaintext and secret entries as a fallback, although ECS fails task startup when secret retrieval fails rather than falling back. The submitted patch context corroborates that the named variables and Terraform files are relevant, but managing secret values through Terraform would not remove them from state. No independent task statement was supplied, so the intended variable inventory and migration-period requirements remain unverified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 8,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 58,
+        "notes": "The design is unusually concrete about Terraform paths, variables, resource conditions, ECS integration, deployment phases, and operational failure modes. Its central design is unsound because `secret_string = var.*` retains values in Terraform state, while duplicate plaintext entries cannot rescue a task when ECS cannot retrieve a referenced secret. It also promises canary feature flags and rotation lambdas without designing them, and its resolved rotation decision contradicts both the non-goals and listed file changes. The exact existing IAM wildcard policy and complete secret inventory could not be independently verified because repository command execution was unavailable."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 9,
+        "specificity": 14,
+        "risk_awareness": 16,
+        "total": 54,
+        "notes": "The review surfaces several relevant risks, including shared-secret exposure, rotation propagation, JSON values, plaintext migration overlap, IAM growth, cost, and disaster recovery. Its largest miss is approving the claim that the design eliminates plaintext from Terraform state despite the proposed `aws_secretsmanager_secret_version.secret_string` assignments and retained ECS environment values. It also incorrectly praises least privilege and implemented rotation, recommends irrelevant application caching, and asks about a nonexistent Secrets Manager Standard versus Advanced tier. The verdict table conflicts with the individual Sage verdict, and the exact repository IAM behavior cited as resolved could not be independently verified."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 6,
+        "specificity": 14,
+        "risk_awareness": 12,
+        "total": 47,
+        "notes": "The plan covers creation, task definitions, IAM, KMS, deployment, rollback, audit, negative cases, and service behavior with concrete commands. Several primary oracles are invalid: `terraform plan -detailed-exitcode 2` is malformed, the secret-count check accepts zero, and an `ACTIVE` ECS service does not establish health or secret correctness. The rollback captures the current primary task definition rather than the previous revision, while multiple failure scenarios are comments rather than executable tests and secret values are printed into test output. Its hard-coded `/tmp/swe-clone-migrate-ecs-env-vars-to-secrets-manager/...` path demonstrably differs from the submitted workspace, while `dev.tfvars`, output names, service names, and API paths could not be verified."
+      },
+      "implementation": {
+        "completeness": 10,
+        "correctness": 7,
+        "specificity": 16,
+        "risk_awareness": 8,
+        "total": 41,
+        "notes": "The patch concretely defines nine conditional secret/version pairs and adds matching `valueFrom` entries to the two submitted ECS service blocks using coherent Terraform syntax. Its largest defect is that it removes no plaintext environment entries and still writes every value into Terraform state, so it does not achieve the stated security migration and cannot provide fallback when secret retrieval fails. Applying `ignore_changes` to every secret can leave rotated Terraform inputs using stale secret versions, and injecting GitHub credentials into auth-server contradicts the LLD inventory that limits them to registry. The summary claims ten new categories although the patch contains nine, materially overstates fallback and completion, and patch applicability could not be independently checked because repository command execution failed before invoking Git."
+      }
+    },
+    "task_score": 52.4,
+    "verdict": "The submission is concrete and broad, but its core migration model preserves plaintext exposure, misunderstands ECS secret failure behavior, and is supported by several tests that cannot establish the promised outcome.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T03:54:58.941214Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 247690,
+        "cached_input_tokens": 210914,
+        "cache_write_input_tokens": 36760,
+        "output_tokens": 8146,
+        "reasoning_output_tokens": 6577
+      },
+      "duration_ms": 159919
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "deepseek-v3.2",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 12,
+      "total": 64,
+      "notes": "The issue gives concrete removal targets and mostly testable acceptance criteria covering resources, task definitions, variables, outputs, and scripts. The named files and symbols correspond to those represented in the submitted patch, including module.efs, mcp_gateway_efs_id, and the auth and mcpgw volumes. Its requirement that terraform plan show only EFS removal conflicts with the necessary ECS task-definition and output changes. The premise that migration is complete and EFS is safely disposable is not independently established, and data verification is only an asserted dependency rather than an acceptance criterion."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 69,
+      "notes": "The LLD is strongly tied to concrete files, resources, mount paths, outputs, and script behavior, and its module.efs and ecs-services.tf references agree with the submitted source contexts. It covers rollout, data checks, service validation, monitoring, and rollback in useful detail. The load-bearing question of whether auth-server and mcpgw function without /efs/auth_config and /app/data remains an open question rather than a resolved design decision. Its EFS snapshot guidance is technically imprecise because EFS recovery uses AWS Backup recovery points, and merely reverting Terraform would recreate an empty filesystem rather than restore deleted data."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 17,
+      "risk_awareness": 18,
+      "total": 66,
+      "notes": "The review identifies concrete risks involving container startup, scopes initialization, IAM permissions, monitoring, data loss, and rollback. Several findings directly correspond to submitted code, including deletion of run-scopes-init-task.sh and the efs_all_outbound rule. The resolution overstates closure because the proposed snapshot and Terraform-revert procedure does not describe a viable EFS data restoration workflow. It also misses the contradictory plan oracle and spends attention on speculative frontend impact without repository evidence of a UI dependency."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 14,
+      "total": 56,
+      "notes": "The plan spans Terraform validation, deployment, ECS behavior, scripts, APIs, rollback, monitoring, IAM, security groups, and negative cases. Several tests cannot reliably fail: the file checks end with successful echo commands, curl failures are masked by || echo, and the integration test is only an echo instruction. It hardcodes default resource names and placeholder registry.domain endpoints, while its expected plan excludes the task-definition changes made by the patch. The rollback test uses a destructive git checkout and the backup-policy command does not verify an EFS recovery point; account-wide metric and alarm-name checks are also weak cleanup oracles."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 17,
+      "specificity": 20,
+      "risk_awareness": 13,
+      "total": 69,
+      "notes": "The patch coherently removes the EFS module, variables, propagated outputs, auth and mcpgw mounts, output validation, EFS runner script, and README claim. Its submitted contexts consistently reference the expected symbols, and empty mountPoints and volume maps follow the existing task-definition structure shown in the diff. The largest behavioral risk is that post-deployment setup now treats a missing DocumentDB endpoint as a successful skip, potentially leaving scopes uninitialized while the summary claims no functional impact. The summary also reports deletion counts inconsistent with its own diff, leaves IAM and alarm cleanup as follow-ups, and repository command execution was unavailable for an independent git apply check."
+    }
+  },
+  "task_score": 64.8,
+  "verdict": "The submission is concrete and broadly implements EFS removal, but unsupported storage-migration assumptions, an invalid rollback model, and weak test oracles leave material deployment and data-loss risk.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T03:56:47.112990Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 188590,
+      "cached_input_tokens": 154324,
+      "cache_write_input_tokens": 34254,
+      "output_tokens": 5928,
+      "reasoning_output_tokens": 4437
+    },
+    "duration_ms": 108160
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 82.4,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4141291,
+    "output_tokens": 23657,
+    "cache_read_tokens": 4070208,
+    "cache_write_tokens": 71083,
+    "total_tokens": 8306239,
+    "total_cost_usd": null,
+    "latency_seconds": 287.2,
+    "num_turns": 84,
+    "generation_tokens_per_sec": 82.4,
+    "prefix_cache_hit_rate": 0.9828,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4141291,
+  "output_tokens": 23657,
+  "latency_seconds": 287.2,
+  "num_turns": 84,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T03:25:24.857970Z",
+  "run_ended_at": "2026-08-06T03:30:12.184451Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4141291,
+    "output_tokens": 23657,
+    "cache_read_tokens": 4070208,
+    "cache_write_tokens": 71083,
+    "total_tokens": 8306239,
+    "total_cost_usd": null,
+    "latency_seconds": 287.2,
+    "num_turns": 84,
+    "generation_tokens_per_sec": 82.4,
+    "prefix_cache_hit_rate": 0.9828,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9828,
+      "prompt_tokens_cached_rate": 0.9828
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 23657,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 4070208,
+      "vllm:prefix_cache_queries_total": 4141291,
+      "vllm:prompt_tokens_by_source_total": 4141291,
+      "vllm:prompt_tokens_cached_total": 4070208,
+      "vllm:prompt_tokens_total": 4141291,
+      "vllm:request_success_total": 84,
+      "vllm:tool_call_parser_invocations_total": 23588
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 84,
+        "sum": 281.8457,
+        "mean": 3.355306
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 23573,
+        "sum": 261.7158,
+        "mean": 0.011102
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 23657,
+        "sum": 94740,
+        "mean": 4.004734
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 84,
+        "sum": 261.7158,
+        "mean": 3.115665
+      },
+      "vllm:request_generation_tokens": {
+        "count": 84,
+        "sum": 23657,
+        "mean": 281.630952
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 84,
+        "sum": 274.2068,
+        "mean": 3.264366
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 84,
+        "sum": 23657,
+        "mean": 281.630952
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 84,
+        "sum": 1344000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 84,
+        "sum": 84,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 84,
+        "sum": 71083,
+        "mean": 846.22619
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 84,
+        "sum": 12.4909,
+        "mean": 0.148702
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 84,
+        "sum": 4141291,
+        "mean": 49301.083333
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 84,
+        "sum": 0.0007,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 84,
+        "sum": 0.931,
+        "mean": 0.011084
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 84,
+        "sum": 20.1446,
+        "mean": 0.239816
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1422,
+          "mean": 0.0926,
+          "samples": 286
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8986,
+          "samples": 286
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 286
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "deepseek-v3.2",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 12,
+        "total": 64,
+        "notes": "The issue gives concrete removal targets and mostly testable acceptance criteria covering resources, task definitions, variables, outputs, and scripts. The named files and symbols correspond to those represented in the submitted patch, including module.efs, mcp_gateway_efs_id, and the auth and mcpgw volumes. Its requirement that terraform plan show only EFS removal conflicts with the necessary ECS task-definition and output changes. The premise that migration is complete and EFS is safely disposable is not independently established, and data verification is only an asserted dependency rather than an acceptance criterion."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 69,
+        "notes": "The LLD is strongly tied to concrete files, resources, mount paths, outputs, and script behavior, and its module.efs and ecs-services.tf references agree with the submitted source contexts. It covers rollout, data checks, service validation, monitoring, and rollback in useful detail. The load-bearing question of whether auth-server and mcpgw function without /efs/auth_config and /app/data remains an open question rather than a resolved design decision. Its EFS snapshot guidance is technically imprecise because EFS recovery uses AWS Backup recovery points, and merely reverting Terraform would recreate an empty filesystem rather than restore deleted data."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 17,
+        "risk_awareness": 18,
+        "total": 66,
+        "notes": "The review identifies concrete risks involving container startup, scopes initialization, IAM permissions, monitoring, data loss, and rollback. Several findings directly correspond to submitted code, including deletion of run-scopes-init-task.sh and the efs_all_outbound rule. The resolution overstates closure because the proposed snapshot and Terraform-revert procedure does not describe a viable EFS data restoration workflow. It also misses the contradictory plan oracle and spends attention on speculative frontend impact without repository evidence of a UI dependency."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 14,
+        "total": 56,
+        "notes": "The plan spans Terraform validation, deployment, ECS behavior, scripts, APIs, rollback, monitoring, IAM, security groups, and negative cases. Several tests cannot reliably fail: the file checks end with successful echo commands, curl failures are masked by || echo, and the integration test is only an echo instruction. It hardcodes default resource names and placeholder registry.domain endpoints, while its expected plan excludes the task-definition changes made by the patch. The rollback test uses a destructive git checkout and the backup-policy command does not verify an EFS recovery point; account-wide metric and alarm-name checks are also weak cleanup oracles."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 17,
+        "specificity": 20,
+        "risk_awareness": 13,
+        "total": 69,
+        "notes": "The patch coherently removes the EFS module, variables, propagated outputs, auth and mcpgw mounts, output validation, EFS runner script, and README claim. Its submitted contexts consistently reference the expected symbols, and empty mountPoints and volume maps follow the existing task-definition structure shown in the diff. The largest behavioral risk is that post-deployment setup now treats a missing DocumentDB endpoint as a successful skip, potentially leaving scopes uninitialized while the summary claims no functional impact. The summary also reports deletion counts inconsistent with its own diff, leaves IAM and alarm cleanup as follow-ups, and repository command execution was unavailable for an independent git apply check."
+      }
+    },
+    "task_score": 64.8,
+    "verdict": "The submission is concrete and broadly implements EFS removal, but unsupported storage-migration assumptions, an invalid rollback model, and weak test oracles leave material deployment and data-loss risk.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T03:56:47.112990Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 188590,
+        "cached_input_tokens": 154324,
+        "cache_write_input_tokens": 34254,
+        "output_tokens": 5928,
+        "reasoning_output_tokens": 4437
+      },
+      "duration_ms": 108160
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "deepseek-v3.2",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 12,
+      "specificity": 16,
+      "risk_awareness": 11,
+      "total": 56,
+      "notes": "The issue clearly inventories dependency, code, configuration, documentation, tests, Docker, and both pyproject.toml and uv.lock. Its largest defect is contradictory behavior: it requires unchanged search and excludes scoring changes while replacing semantic FAISS search with DocumentDB or a later keyword fallback. The submitted diff confirms several named paths and symbols, including registry/search/service.py and registry/repositories/factory.py. With no independent task statement, the claimed equivalence of DocumentDB search and related issue #1285 could not be verified."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 9,
+      "specificity": 15,
+      "risk_awareness": 14,
+      "total": 54,
+      "notes": "The LLD names concrete integration points such as get_search_repository, FaissSearchRepository, server and agent indexing, configuration properties, and file-backend migration. It omits uv.lock from its implementation and file-change plans, leaves error behavior as either empty or keyword results, and contradicts its non-goal by introducing a new ranking algorithm and response metadata. The supplied baseline code shows FAISS search returned tools and richer server and agent fields, while the proposed SimpleSearchRepository design covers only servers and agents and does not preserve those contracts. Claims about Helm, Terraform, existing sanitization, rate limiting, audit logging, and suitability below 1000 entities were not substantiated."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 14,
+      "specificity": 15,
+      "risk_awareness": 17,
+      "total": 62,
+      "notes": "The review's strongest contribution is identifying cache synchronization, degraded search quality, memory growth, input handling, migration, and operational monitoring as concrete risks. It nevertheless declares all critical concerns resolved even though the revised LLD still lacks a concurrency-safe invalidation contract, measurable performance limits, and precise compatibility behavior. The patch confirms these concerns remain: _cache_loaded has no locking, tools are never produced, and the proposed search_backend response metadata is not implemented. The review also misses the unchanged uv.lock, tracked FAISS backup file, deleted tests without replacements, and backward-incompatible result fields."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 7,
+      "specificity": 10,
+      "risk_awareness": 11,
+      "total": 42,
+      "notes": "The plan spans functional, compatibility, deployment, end-to-end, performance, negative, and telemetry checks for both backends. Many oracles are non-tests, allowing empty results, either HTTP 400 or success, or unspecified graceful behavior, so they would not reliably catch the proposed regression. The performance example calls an unimplemented _load_test_data method, the multiline python -c FAISS check is syntactically unreliable, and proposed metadata is absent from the patch. It supplies no replacement unit tests for SimpleSearchRepository and does not check uv.lock consistency, retained FAISS references, cache invalidation, tool results, status filters, or response-field compatibility."
+    },
+    "implementation": {
+      "completeness": 7,
+      "correctness": 3,
+      "specificity": 8,
+      "risk_awareness": 6,
+      "total": 24,
+      "notes": "The summary honestly discloses deferred tests, documentation, telemetry, Docker work, cache invalidation, and degraded search, but those omissions leave most acceptance criteria unmet. The patch removes faiss-cpu only from pyproject.toml, leaves uv.lock untouched, adds a tracked search_repository.py.bak containing FAISS code, deletes 1131 lines of tests without replacements, and preserves the faiss_service compatibility name. Compared with the removed service, SimpleSearchRepository always returns no tools, drops established result fields, applies max_results globally, ignores draft and deprecated filters, and excludes tool data while calculating num_tools, so API behavior is not preserved. The read-only executor could not access the working tree to confirm patch application or repository method signatures, so unverified calls such as list_all receive no correctness credit."
+    }
+  },
+  "task_score": 47.6,
+  "verdict": "The submission identifies the main dependency-removal surfaces and several genuine risks, but the implementation is knowingly incomplete and introduces substantial search and API regressions without replacement tests.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T03:58:59.861478Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 328991,
+      "cached_input_tokens": 270834,
+      "cache_write_input_tokens": 58145,
+      "output_tokens": 7762,
+      "reasoning_output_tokens": 6331
+    },
+    "duration_ms": 132735
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 82.9,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4799967,
+    "output_tokens": 29823,
+    "cache_read_tokens": 4719104,
+    "cache_write_tokens": 80863,
+    "total_tokens": 9629757,
+    "total_cost_usd": null,
+    "latency_seconds": 359.8,
+    "num_turns": 90,
+    "generation_tokens_per_sec": 82.9,
+    "prefix_cache_hit_rate": 0.9832,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4799967,
+  "output_tokens": 29823,
+  "latency_seconds": 359.8,
+  "num_turns": 90,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T03:19:23.216078Z",
+  "run_ended_at": "2026-08-06T03:25:23.230204Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4799967,
+    "output_tokens": 29823,
+    "cache_read_tokens": 4719104,
+    "cache_write_tokens": 80863,
+    "total_tokens": 9629757,
+    "total_cost_usd": null,
+    "latency_seconds": 359.8,
+    "num_turns": 90,
+    "generation_tokens_per_sec": 82.9,
+    "prefix_cache_hit_rate": 0.9832,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9832,
+      "prompt_tokens_cached_rate": 0.9832
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 29823,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 4719104,
+      "vllm:prefix_cache_queries_total": 4799967,
+      "vllm:prompt_tokens_by_source_total": 4799967,
+      "vllm:prompt_tokens_cached_total": 4719104,
+      "vllm:prompt_tokens_total": 4799967,
+      "vllm:request_success_total": 90,
+      "vllm:tool_call_parser_invocations_total": 29739
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 90,
+        "sum": 355.6357,
+        "mean": 3.951508
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 29733,
+        "sum": 331.0862,
+        "mean": 0.011135
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 29823,
+        "sum": 110686,
+        "mean": 3.711431
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 90,
+        "sum": 331.0862,
+        "mean": 3.678736
+      },
+      "vllm:request_generation_tokens": {
+        "count": 90,
+        "sum": 29823,
+        "mean": 331.366667
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 90,
+        "sum": 345.8046,
+        "mean": 3.842274
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 90,
+        "sum": 29823,
+        "mean": 331.366667
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 90,
+        "sum": 1440000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 90,
+        "sum": 90,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 90,
+        "sum": 80863,
+        "mean": 898.477778
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 90,
+        "sum": 14.7184,
+        "mean": 0.163538
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 90,
+        "sum": 4799967,
+        "mean": 53332.966667
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 90,
+        "sum": 0.0007,
+        "mean": 8e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 90,
+        "sum": 0.9996,
+        "mean": 0.011106
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 90,
+        "sum": 24.571,
+        "mean": 0.273011
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1623,
+          "mean": 0.1078,
+          "samples": 358
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9302,
+          "samples": 358
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 358
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "deepseek-v3.2",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 12,
+        "specificity": 16,
+        "risk_awareness": 11,
+        "total": 56,
+        "notes": "The issue clearly inventories dependency, code, configuration, documentation, tests, Docker, and both pyproject.toml and uv.lock. Its largest defect is contradictory behavior: it requires unchanged search and excludes scoring changes while replacing semantic FAISS search with DocumentDB or a later keyword fallback. The submitted diff confirms several named paths and symbols, including registry/search/service.py and registry/repositories/factory.py. With no independent task statement, the claimed equivalence of DocumentDB search and related issue #1285 could not be verified."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 9,
+        "specificity": 15,
+        "risk_awareness": 14,
+        "total": 54,
+        "notes": "The LLD names concrete integration points such as get_search_repository, FaissSearchRepository, server and agent indexing, configuration properties, and file-backend migration. It omits uv.lock from its implementation and file-change plans, leaves error behavior as either empty or keyword results, and contradicts its non-goal by introducing a new ranking algorithm and response metadata. The supplied baseline code shows FAISS search returned tools and richer server and agent fields, while the proposed SimpleSearchRepository design covers only servers and agents and does not preserve those contracts. Claims about Helm, Terraform, existing sanitization, rate limiting, audit logging, and suitability below 1000 entities were not substantiated."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 14,
+        "specificity": 15,
+        "risk_awareness": 17,
+        "total": 62,
+        "notes": "The review's strongest contribution is identifying cache synchronization, degraded search quality, memory growth, input handling, migration, and operational monitoring as concrete risks. It nevertheless declares all critical concerns resolved even though the revised LLD still lacks a concurrency-safe invalidation contract, measurable performance limits, and precise compatibility behavior. The patch confirms these concerns remain: _cache_loaded has no locking, tools are never produced, and the proposed search_backend response metadata is not implemented. The review also misses the unchanged uv.lock, tracked FAISS backup file, deleted tests without replacements, and backward-incompatible result fields."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 7,
+        "specificity": 10,
+        "risk_awareness": 11,
+        "total": 42,
+        "notes": "The plan spans functional, compatibility, deployment, end-to-end, performance, negative, and telemetry checks for both backends. Many oracles are non-tests, allowing empty results, either HTTP 400 or success, or unspecified graceful behavior, so they would not reliably catch the proposed regression. The performance example calls an unimplemented _load_test_data method, the multiline python -c FAISS check is syntactically unreliable, and proposed metadata is absent from the patch. It supplies no replacement unit tests for SimpleSearchRepository and does not check uv.lock consistency, retained FAISS references, cache invalidation, tool results, status filters, or response-field compatibility."
+      },
+      "implementation": {
+        "completeness": 7,
+        "correctness": 3,
+        "specificity": 8,
+        "risk_awareness": 6,
+        "total": 24,
+        "notes": "The summary honestly discloses deferred tests, documentation, telemetry, Docker work, cache invalidation, and degraded search, but those omissions leave most acceptance criteria unmet. The patch removes faiss-cpu only from pyproject.toml, leaves uv.lock untouched, adds a tracked search_repository.py.bak containing FAISS code, deletes 1131 lines of tests without replacements, and preserves the faiss_service compatibility name. Compared with the removed service, SimpleSearchRepository always returns no tools, drops established result fields, applies max_results globally, ignores draft and deprecated filters, and excludes tool data while calculating num_tools, so API behavior is not preserved. The read-only executor could not access the working tree to confirm patch application or repository method signatures, so unverified calls such as list_all receive no correctness credit."
+      }
+    },
+    "task_score": 47.6,
+    "verdict": "The submission identifies the main dependency-removal surfaces and several genuine risks, but the implementation is knowingly incomplete and introduces substantial search and API regressions without replacement tests.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T03:58:59.861478Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 328991,
+        "cached_input_tokens": 270834,
+        "cache_write_input_tokens": 58145,
+        "output_tokens": 7762,
+        "reasoning_output_tokens": 6331
+      },
+      "duration_ms": 132735
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "deepseek-v3.2",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 11,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 59,
+      "notes": "The issue clearly identifies the security objective, limits the change to ECS, and provides several testable infrastructure outcomes. Its execution-role requirement is technically suspect because application AWS credentials normally come from an ECS task role, while the submitted source context names `keycloak_task_exec_role`. The largest gap is the unresolved contradiction between removing `keycloak_database_password` and retaining password fallback, with no alternate credential bootstrap or migration contract. No independent task statement was supplied, so requirements beyond the identifier and repository-backed current behavior could not be verified."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 5,
+      "specificity": 16,
+      "risk_awareness": 14,
+      "total": 50,
+      "notes": "The LLD names real integration points including `keycloak-database.tf`, `keycloak-ecs.tf`, the proxy, secret, container, and rotation code, and it discusses rollout and rollback. Its core architecture conflates RDS Proxy client IAM authentication with direct database IAM authentication: the existing proxy uses `auth_scheme = \"SECRETS\"`, while the design both requires client IAM and changes the same database user to `AWSAuthenticationPlugin`, undermining the proxy backend credential and password fallback. It also proposes the nonexistent `rds:GenerateDBAuthToken` permission and an impossible refresh mechanism in which a background shell updates an already-running Keycloak process's environment and connection pool. CloudTrail token-generation auditing, startup timing, and periodic reconnection behavior are asserted without a feasible implementation or repository evidence."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 9,
+      "specificity": 18,
+      "risk_awareness": 18,
+      "total": 62,
+      "notes": "The review surfaces concrete concerns about token refresh, task-role use, secret migration, idempotent SQL, fallback, deployment validation, and connection pooling. Its largest deficiency is approving the revised design after the response merely claims that a background process can update `KC_DB_PASSWORD` and re-establish Keycloak connections, which does not solve credential refresh for an existing JVM datasource. It also misses the `SECRETS`-backed RDS Proxy versus `AWSAuthenticationPlugin` conflict and repeats the false premise that `GenerateDBAuthToken` is an auditable API permission. Several peripheral assertions about Fargate requirements, pricing, and CloudTrail are posed or accepted without repository or implementation evidence."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 6,
+      "specificity": 16,
+      "risk_awareness": 14,
+      "total": 50,
+      "notes": "The plan covers infrastructure state, fallback, rollback, health, token refresh, and an end-to-end Keycloak login with concrete expected outputs. However, `aws rds generate-db-auth-token` runs under the operator's credentials rather than the ECS task role, and the IAM simulation uses `rds:GenerateDBAuthToken` plus a cluster ARN instead of validating `rds-db:connect` against the applicable `dbuser` resource. Password fallback tests change only Secrets Manager and never restore a compatible database password/plugin, while the refresh test merely searches logs and would not prove that new database connections succeed after token expiry. Hard-coded names such as `keycloak/database`, `keycloak-proxy`, and `/keycloak/admin_password` are not established by the submitted repository evidence, and the listed unit and integration tests remain checklist placeholders."
+    },
+    "implementation": {
+      "completeness": 7,
+      "correctness": 2,
+      "specificity": 13,
+      "risk_awareness": 7,
+      "total": 29,
+      "notes": "The patch touches the expected Terraform, container, SQL, example, and documentation surfaces, but it does not deliver a functioning renewable IAM-authenticated connection path. Most critically, `generate-rds-token.sh` writes status logs and the token to stdout while `start-keycloak.sh` captures all stdout into `KC_DB_PASSWORD`, so the initial credential contains log lines and cannot authenticate. The proxy remains `auth_scheme = \"SECRETS\"` with an empty password while the SQL changes the same user to `AWSAuthenticationPlugin`; the patch also grants runtime access to the execution role, uses nonexistent `rds:GenerateDBAuthToken`, and leaves Keycloak with a startup-only token that expires for future pooled connections. The summary admits refresh and monitoring are absent but incorrectly calls periodic ECS restarts sufficient; independent `git apply --check` could not be executed because the provided read-only command sandbox failed before launching commands."
+    }
+  },
+  "task_score": 50.0,
+  "verdict": "The submission is detailed and repository-oriented, but its central RDS Proxy and token-lifecycle design is technically invalid, and the patch would fail before establishing a usable IAM-authenticated Keycloak connection.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T04:01:13.389888Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 196147,
+      "cached_input_tokens": 162031,
+      "cache_write_input_tokens": 34104,
+      "output_tokens": 7669,
+      "reasoning_output_tokens": 6079
+    },
+    "duration_ms": 133516
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 85.3,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3691197,
+    "output_tokens": 33108,
+    "cache_read_tokens": 3627328,
+    "cache_write_tokens": 63869,
+    "total_tokens": 7415502,
+    "total_cost_usd": null,
+    "latency_seconds": 388.2,
+    "num_turns": 85,
+    "generation_tokens_per_sec": 85.3,
+    "prefix_cache_hit_rate": 0.9827,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 3691197,
+  "output_tokens": 33108,
+  "latency_seconds": 388.2,
+  "num_turns": 85,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T03:45:50.312705Z",
+  "run_ended_at": "2026-08-06T03:52:18.559778Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3691197,
+    "output_tokens": 33108,
+    "cache_read_tokens": 3627328,
+    "cache_write_tokens": 63869,
+    "total_tokens": 7415502,
+    "total_cost_usd": null,
+    "latency_seconds": 388.2,
+    "num_turns": 85,
+    "generation_tokens_per_sec": 85.3,
+    "prefix_cache_hit_rate": 0.9827,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9827,
+      "prompt_tokens_cached_rate": 0.9827
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 33108,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 3627328,
+      "vllm:prefix_cache_queries_total": 3691197,
+      "vllm:prompt_tokens_by_source_total": 3691197,
+      "vllm:prompt_tokens_cached_total": 3627328,
+      "vllm:prompt_tokens_total": 3691197,
+      "vllm:request_success_total": 85,
+      "vllm:tool_call_parser_invocations_total": 33057
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 85,
+        "sum": 384.4883,
+        "mean": 4.523392
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 33023,
+        "sum": 365.4078,
+        "mean": 0.011065
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 33108,
+        "sum": 96977,
+        "mean": 2.929111
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 85,
+        "sum": 365.4078,
+        "mean": 4.298915
+      },
+      "vllm:request_generation_tokens": {
+        "count": 85,
+        "sum": 33108,
+        "mean": 389.505882
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 85,
+        "sum": 377.3939,
+        "mean": 4.439929
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 85,
+        "sum": 33108,
+        "mean": 389.505882
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 85,
+        "sum": 1360000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 85,
+        "sum": 85,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 85,
+        "sum": 63869,
+        "mean": 751.4
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 85,
+        "sum": 11.9862,
+        "mean": 0.141014
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 85,
+        "sum": 3691197,
+        "mean": 43425.847059
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 85,
+        "sum": 0.0007,
+        "mean": 8e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 85,
+        "sum": 0.9392,
+        "mean": 0.01105
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 85,
+        "sum": 19.0915,
+        "mean": 0.224606
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1302,
+          "mean": 0.0839,
+          "samples": 386
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9585,
+          "samples": 386
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 386
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "deepseek-v3.2",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 11,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 59,
+        "notes": "The issue clearly identifies the security objective, limits the change to ECS, and provides several testable infrastructure outcomes. Its execution-role requirement is technically suspect because application AWS credentials normally come from an ECS task role, while the submitted source context names `keycloak_task_exec_role`. The largest gap is the unresolved contradiction between removing `keycloak_database_password` and retaining password fallback, with no alternate credential bootstrap or migration contract. No independent task statement was supplied, so requirements beyond the identifier and repository-backed current behavior could not be verified."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 5,
+        "specificity": 16,
+        "risk_awareness": 14,
+        "total": 50,
+        "notes": "The LLD names real integration points including `keycloak-database.tf`, `keycloak-ecs.tf`, the proxy, secret, container, and rotation code, and it discusses rollout and rollback. Its core architecture conflates RDS Proxy client IAM authentication with direct database IAM authentication: the existing proxy uses `auth_scheme = \"SECRETS\"`, while the design both requires client IAM and changes the same database user to `AWSAuthenticationPlugin`, undermining the proxy backend credential and password fallback. It also proposes the nonexistent `rds:GenerateDBAuthToken` permission and an impossible refresh mechanism in which a background shell updates an already-running Keycloak process's environment and connection pool. CloudTrail token-generation auditing, startup timing, and periodic reconnection behavior are asserted without a feasible implementation or repository evidence."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 9,
+        "specificity": 18,
+        "risk_awareness": 18,
+        "total": 62,
+        "notes": "The review surfaces concrete concerns about token refresh, task-role use, secret migration, idempotent SQL, fallback, deployment validation, and connection pooling. Its largest deficiency is approving the revised design after the response merely claims that a background process can update `KC_DB_PASSWORD` and re-establish Keycloak connections, which does not solve credential refresh for an existing JVM datasource. It also misses the `SECRETS`-backed RDS Proxy versus `AWSAuthenticationPlugin` conflict and repeats the false premise that `GenerateDBAuthToken` is an auditable API permission. Several peripheral assertions about Fargate requirements, pricing, and CloudTrail are posed or accepted without repository or implementation evidence."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 6,
+        "specificity": 16,
+        "risk_awareness": 14,
+        "total": 50,
+        "notes": "The plan covers infrastructure state, fallback, rollback, health, token refresh, and an end-to-end Keycloak login with concrete expected outputs. However, `aws rds generate-db-auth-token` runs under the operator's credentials rather than the ECS task role, and the IAM simulation uses `rds:GenerateDBAuthToken` plus a cluster ARN instead of validating `rds-db:connect` against the applicable `dbuser` resource. Password fallback tests change only Secrets Manager and never restore a compatible database password/plugin, while the refresh test merely searches logs and would not prove that new database connections succeed after token expiry. Hard-coded names such as `keycloak/database`, `keycloak-proxy`, and `/keycloak/admin_password` are not established by the submitted repository evidence, and the listed unit and integration tests remain checklist placeholders."
+      },
+      "implementation": {
+        "completeness": 7,
+        "correctness": 2,
+        "specificity": 13,
+        "risk_awareness": 7,
+        "total": 29,
+        "notes": "The patch touches the expected Terraform, container, SQL, example, and documentation surfaces, but it does not deliver a functioning renewable IAM-authenticated connection path. Most critically, `generate-rds-token.sh` writes status logs and the token to stdout while `start-keycloak.sh` captures all stdout into `KC_DB_PASSWORD`, so the initial credential contains log lines and cannot authenticate. The proxy remains `auth_scheme = \"SECRETS\"` with an empty password while the SQL changes the same user to `AWSAuthenticationPlugin`; the patch also grants runtime access to the execution role, uses nonexistent `rds:GenerateDBAuthToken`, and leaves Keycloak with a startup-only token that expires for future pooled connections. The summary admits refresh and monitoring are absent but incorrectly calls periodic ECS restarts sufficient; independent `git apply --check` could not be executed because the provided read-only command sandbox failed before launching commands."
+      }
+    },
+    "task_score": 50.0,
+    "verdict": "The submission is detailed and repository-oriented, but its central RDS Proxy and token-lifecycle design is technically invalid, and the patch would fail before establishing a usable IAM-authenticated Keycloak connection.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T04:01:13.389888Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 196147,
+        "cached_input_tokens": 162031,
+        "cache_write_input_tokens": 34104,
+        "output_tokens": 7669,
+        "reasoning_output_tokens": 6079
+      },
+      "duration_ms": 133516
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "pi",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T03:54:58.941214Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 247690,
+      "cached_input_tokens": 210914,
+      "cache_write_input_tokens": 36760,
+      "output_tokens": 8146,
+      "reasoning_output_tokens": 6577
+    },
+    "duration_ms": 159919
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 54.44,
+  "mean_cost_usd_excl_failed": null,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 84,
+      "input_tokens": 4141291,
+      "output_tokens": 23657,
+      "total_tokens": 8306239,
+      "latency_seconds": 287.2,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 64.8,
+      "cache_read_tokens": 4070208,
+      "cache_write_tokens": 71083,
+      "prefix_cache_hit_rate": 0.9828,
+      "generation_tokens_per_sec": 82.4,
+      "kv_cache_usage": {
+        "peak": 0.1422,
+        "mean": 0.0926
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 64,
+          "notes": "The issue gives concrete removal targets and mostly testable acceptance criteria covering resources, task definitions, variables, outputs, and scripts. The named files and symbols correspond to those represented in the submitted patch, including module.efs, mcp_gateway_efs_id, and the auth and mcpgw volumes. Its requirement that terraform plan show only EFS removal conflicts with the necessary ECS task-definition and output changes. The premise that migration is complete and EFS is safely disposable is not independently established, and data verification is only an asserted dependency rather than an acceptance criterion."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 69,
+          "notes": "The LLD is strongly tied to concrete files, resources, mount paths, outputs, and script behavior, and its module.efs and ecs-services.tf references agree with the submitted source contexts. It covers rollout, data checks, service validation, monitoring, and rollback in useful detail. The load-bearing question of whether auth-server and mcpgw function without /efs/auth_config and /app/data remains an open question rather than a resolved design decision. Its EFS snapshot guidance is technically imprecise because EFS recovery uses AWS Backup recovery points, and merely reverting Terraform would recreate an empty filesystem rather than restore deleted data."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 17,
+          "risk_awareness": 18,
+          "total": 66,
+          "notes": "The review identifies concrete risks involving container startup, scopes initialization, IAM permissions, monitoring, data loss, and rollback. Several findings directly correspond to submitted code, including deletion of run-scopes-init-task.sh and the efs_all_outbound rule. The resolution overstates closure because the proposed snapshot and Terraform-revert procedure does not describe a viable EFS data restoration workflow. It also misses the contradictory plan oracle and spends attention on speculative frontend impact without repository evidence of a UI dependency."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 14,
+          "total": 56,
+          "notes": "The plan spans Terraform validation, deployment, ECS behavior, scripts, APIs, rollback, monitoring, IAM, security groups, and negative cases. Several tests cannot reliably fail: the file checks end with successful echo commands, curl failures are masked by || echo, and the integration test is only an echo instruction. It hardcodes default resource names and placeholder registry.domain endpoints, while its expected plan excludes the task-definition changes made by the patch. The rollback test uses a destructive git checkout and the backup-policy command does not verify an EFS recovery point; account-wide metric and alarm-name checks are also weak cleanup oracles."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 17,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 69,
+          "notes": "The patch coherently removes the EFS module, variables, propagated outputs, auth and mcpgw mounts, output validation, EFS runner script, and README claim. Its submitted contexts consistently reference the expected symbols, and empty mountPoints and volume maps follow the existing task-definition structure shown in the diff. The largest behavioral risk is that post-deployment setup now treats a missing DocumentDB endpoint as a successful skip, potentially leaving scopes uninitialized while the summary claims no functional impact. The summary also reports deletion counts inconsistent with its own diff, leaves IAM and alarm cleanup as follow-ups, and repository command execution was unavailable for an independent git apply check."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 99,
+      "input_tokens": 5854803,
+      "output_tokens": 49007,
+      "total_tokens": 11758613,
+      "latency_seconds": 578.2,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 57.4,
+      "cache_read_tokens": 5762944,
+      "cache_write_tokens": 91859,
+      "prefix_cache_hit_rate": 0.9843,
+      "generation_tokens_per_sec": 84.8,
+      "kv_cache_usage": {
+        "peak": 0.182,
+        "mean": 0.1119
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 21,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 75,
+          "notes": "The issue clearly identifies the agent-card and health-check request paths, with concrete acceptance criteria and useful non-goals. Its repository claims align with the diff preimages for `skill_service.py::_is_safe_url`, `agent_validator.py::_check_endpoint_reachability`, and health use of `proxy_pass_url`. The largest deficiency is the unqualified backward-compatibility promise, since existing private-address health targets would become blocked, and it omits redirect and DNS time-of-check/time-of-use risks. No independent task statement was supplied, and the cited audit finding and issue #938 could not be independently verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 19,
+          "risk_awareness": 13,
+          "total": 58,
+          "notes": "The LLD gives concrete integration points, configuration behavior, status handling, observability, rollout, and file-level implementation guidance. It incorrectly places `HealthStatus` in `registry/schemas/server_update_models.py` even though the submitted source shows it in `registry/constants.py`, and its proposed meter construction does not match the repository's `_meter` adapter pattern. Most importantly, caching a DNS answer does not pin `httpx` to that answer, so the client can independently resolve a private address after validation and the claimed rebinding protection is unsound. The cache is also unbounded, synchronous DNS is placed on an async health path, broad `Exception` handling remains despite contrary claims, and the compatibility impact on existing private services is unresolved."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 18,
+          "risk_awareness": 18,
+          "total": 65,
+          "notes": "The review surfaces relevant concerns including DNS rebinding, IPv6, blocking DNS in async code, thread safety, configuration coupling, false positives, and observability. Cipher's rebinding concern and Byte's async-resolution concern are the strongest specific findings. Its largest defect is declaring those concerns resolved by a 60-second validation cache, which does not control the HTTP client's later DNS resolution; it likewise claims exception handling was narrowed although the design retains `except Exception`. It does not catch the incorrect health-status location or repository-specific metrics API and therefore overstates its final approval."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 7,
+          "specificity": 12,
+          "risk_awareness": 15,
+          "total": 51,
+          "notes": "The plan spans direct private addresses, IPv6, allowlists, health lifecycle, metrics, performance, rollback, and skill-service compatibility. Many commands are placeholders or use unverified routes and payloads, while outcomes such as \"201 or 422\" are not meaningful oracles; no concrete mock wiring is provided for the reserved example domains. The obfuscation expectations are incorrect for `localhost@evil.com` and `evil.com#@localhost`, whose parsed host is `evil.com`, and the rebinding test merely confirms a cached validation answer rather than where the HTTP request connects. It also omits a decisive redirect/TOCTOU test and no executable tests accompany the implementation despite the acceptance criterion requiring them."
+        },
+        "implementation": {
+          "completeness": 11,
+          "correctness": 7,
+          "specificity": 14,
+          "risk_awareness": 6,
+          "total": 38,
+          "notes": "The patch adds straightforward private-address checks at the named agent and health paths and refactors skill callers to a shared utility using source symbols present in the submitted preimages. Its central security claim is false because `socket.getaddrinfo` only validates one resolution while `httpx` resolves again for the request, so DNS rebinding remains possible and the cache can make that mismatch persist. It adds no tests, leaves the duration histogram unused, leaves immediate-check timestamps stale when blocked, removes private skill-service symbols without updating the cited tests, and introduces an unbounded cache plus an unreported 1,745-line `skill_service.py.backup`. The summary also incorrectly claims no broad exception handling and omits the backup file; an independent `git apply --check` could not be run because repository command execution failed before launch in the read-only harness."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 60,
+      "input_tokens": 3693324,
+      "output_tokens": 29765,
+      "total_tokens": 7416413,
+      "latency_seconds": 355.0,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 52.4,
+      "cache_read_tokens": 3604608,
+      "cache_write_tokens": 88716,
+      "prefix_cache_hit_rate": 0.976,
+      "generation_tokens_per_sec": 83.8,
+      "kv_cache_usage": {
+        "peak": 0.1763,
+        "mean": 0.1217
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 13,
+          "specificity": 17,
+          "risk_awareness": 14,
+          "total": 62,
+          "notes": "The issue clearly states the security motivation, affected infrastructure, scope, exclusions, dependencies, and testable outcomes. Its largest flaw is requiring simultaneous same-name plaintext and secret entries as a fallback, although ECS fails task startup when secret retrieval fails rather than falling back. The submitted patch context corroborates that the named variables and Terraform files are relevant, but managing secret values through Terraform would not remove them from state. No independent task statement was supplied, so the intended variable inventory and migration-period requirements remain unverified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 58,
+          "notes": "The design is unusually concrete about Terraform paths, variables, resource conditions, ECS integration, deployment phases, and operational failure modes. Its central design is unsound because `secret_string = var.*` retains values in Terraform state, while duplicate plaintext entries cannot rescue a task when ECS cannot retrieve a referenced secret. It also promises canary feature flags and rotation lambdas without designing them, and its resolved rotation decision contradicts both the non-goals and listed file changes. The exact existing IAM wildcard policy and complete secret inventory could not be independently verified because repository command execution was unavailable."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 9,
+          "specificity": 14,
+          "risk_awareness": 16,
+          "total": 54,
+          "notes": "The review surfaces several relevant risks, including shared-secret exposure, rotation propagation, JSON values, plaintext migration overlap, IAM growth, cost, and disaster recovery. Its largest miss is approving the claim that the design eliminates plaintext from Terraform state despite the proposed `aws_secretsmanager_secret_version.secret_string` assignments and retained ECS environment values. It also incorrectly praises least privilege and implemented rotation, recommends irrelevant application caching, and asks about a nonexistent Secrets Manager Standard versus Advanced tier. The verdict table conflicts with the individual Sage verdict, and the exact repository IAM behavior cited as resolved could not be independently verified."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 6,
+          "specificity": 14,
+          "risk_awareness": 12,
+          "total": 47,
+          "notes": "The plan covers creation, task definitions, IAM, KMS, deployment, rollback, audit, negative cases, and service behavior with concrete commands. Several primary oracles are invalid: `terraform plan -detailed-exitcode 2` is malformed, the secret-count check accepts zero, and an `ACTIVE` ECS service does not establish health or secret correctness. The rollback captures the current primary task definition rather than the previous revision, while multiple failure scenarios are comments rather than executable tests and secret values are printed into test output. Its hard-coded `/tmp/swe-clone-migrate-ecs-env-vars-to-secrets-manager/...` path demonstrably differs from the submitted workspace, while `dev.tfvars`, output names, service names, and API paths could not be verified."
+        },
+        "implementation": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 16,
+          "risk_awareness": 8,
+          "total": 41,
+          "notes": "The patch concretely defines nine conditional secret/version pairs and adds matching `valueFrom` entries to the two submitted ECS service blocks using coherent Terraform syntax. Its largest defect is that it removes no plaintext environment entries and still writes every value into Terraform state, so it does not achieve the stated security migration and cannot provide fallback when secret retrieval fails. Applying `ignore_changes` to every secret can leave rotated Terraform inputs using stale secret versions, and injecting GitHub credentials into auth-server contradicts the LLD inventory that limits them to registry. The summary claims ten new categories although the patch contains nine, materially overstates fallback and completion, and patch applicability could not be independently checked because repository command execution failed before invoking Git."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 85,
+      "input_tokens": 3691197,
+      "output_tokens": 33108,
+      "total_tokens": 7415502,
+      "latency_seconds": 388.2,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 50.0,
+      "cache_read_tokens": 3627328,
+      "cache_write_tokens": 63869,
+      "prefix_cache_hit_rate": 0.9827,
+      "generation_tokens_per_sec": 85.3,
+      "kv_cache_usage": {
+        "peak": 0.1302,
+        "mean": 0.0839
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 59,
+          "notes": "The issue clearly identifies the security objective, limits the change to ECS, and provides several testable infrastructure outcomes. Its execution-role requirement is technically suspect because application AWS credentials normally come from an ECS task role, while the submitted source context names `keycloak_task_exec_role`. The largest gap is the unresolved contradiction between removing `keycloak_database_password` and retaining password fallback, with no alternate credential bootstrap or migration contract. No independent task statement was supplied, so requirements beyond the identifier and repository-backed current behavior could not be verified."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 5,
+          "specificity": 16,
+          "risk_awareness": 14,
+          "total": 50,
+          "notes": "The LLD names real integration points including `keycloak-database.tf`, `keycloak-ecs.tf`, the proxy, secret, container, and rotation code, and it discusses rollout and rollback. Its core architecture conflates RDS Proxy client IAM authentication with direct database IAM authentication: the existing proxy uses `auth_scheme = \"SECRETS\"`, while the design both requires client IAM and changes the same database user to `AWSAuthenticationPlugin`, undermining the proxy backend credential and password fallback. It also proposes the nonexistent `rds:GenerateDBAuthToken` permission and an impossible refresh mechanism in which a background shell updates an already-running Keycloak process's environment and connection pool. CloudTrail token-generation auditing, startup timing, and periodic reconnection behavior are asserted without a feasible implementation or repository evidence."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 9,
+          "specificity": 18,
+          "risk_awareness": 18,
+          "total": 62,
+          "notes": "The review surfaces concrete concerns about token refresh, task-role use, secret migration, idempotent SQL, fallback, deployment validation, and connection pooling. Its largest deficiency is approving the revised design after the response merely claims that a background process can update `KC_DB_PASSWORD` and re-establish Keycloak connections, which does not solve credential refresh for an existing JVM datasource. It also misses the `SECRETS`-backed RDS Proxy versus `AWSAuthenticationPlugin` conflict and repeats the false premise that `GenerateDBAuthToken` is an auditable API permission. Several peripheral assertions about Fargate requirements, pricing, and CloudTrail are posed or accepted without repository or implementation evidence."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 6,
+          "specificity": 16,
+          "risk_awareness": 14,
+          "total": 50,
+          "notes": "The plan covers infrastructure state, fallback, rollback, health, token refresh, and an end-to-end Keycloak login with concrete expected outputs. However, `aws rds generate-db-auth-token` runs under the operator's credentials rather than the ECS task role, and the IAM simulation uses `rds:GenerateDBAuthToken` plus a cluster ARN instead of validating `rds-db:connect` against the applicable `dbuser` resource. Password fallback tests change only Secrets Manager and never restore a compatible database password/plugin, while the refresh test merely searches logs and would not prove that new database connections succeed after token expiry. Hard-coded names such as `keycloak/database`, `keycloak-proxy`, and `/keycloak/admin_password` are not established by the submitted repository evidence, and the listed unit and integration tests remain checklist placeholders."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 2,
+          "specificity": 13,
+          "risk_awareness": 7,
+          "total": 29,
+          "notes": "The patch touches the expected Terraform, container, SQL, example, and documentation surfaces, but it does not deliver a functioning renewable IAM-authenticated connection path. Most critically, `generate-rds-token.sh` writes status logs and the token to stdout while `start-keycloak.sh` captures all stdout into `KC_DB_PASSWORD`, so the initial credential contains log lines and cannot authenticate. The proxy remains `auth_scheme = \"SECRETS\"` with an empty password while the SQL changes the same user to `AWSAuthenticationPlugin`; the patch also grants runtime access to the execution role, uses nonexistent `rds:GenerateDBAuthToken`, and leaves Keycloak with a startup-only token that expires for future pooled connections. The summary admits refresh and monitoring are absent but incorrectly calls periodic ECS restarts sufficient; independent `git apply --check` could not be executed because the provided read-only command sandbox failed before launching commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 90,
+      "input_tokens": 4799967,
+      "output_tokens": 29823,
+      "total_tokens": 9629757,
+      "latency_seconds": 359.8,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 47.6,
+      "cache_read_tokens": 4719104,
+      "cache_write_tokens": 80863,
+      "prefix_cache_hit_rate": 0.9832,
+      "generation_tokens_per_sec": 82.9,
+      "kv_cache_usage": {
+        "peak": 0.1623,
+        "mean": 0.1078
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 16,
+          "risk_awareness": 11,
+          "total": 56,
+          "notes": "The issue clearly inventories dependency, code, configuration, documentation, tests, Docker, and both pyproject.toml and uv.lock. Its largest defect is contradictory behavior: it requires unchanged search and excludes scoring changes while replacing semantic FAISS search with DocumentDB or a later keyword fallback. The submitted diff confirms several named paths and symbols, including registry/search/service.py and registry/repositories/factory.py. With no independent task statement, the claimed equivalence of DocumentDB search and related issue #1285 could not be verified."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 15,
+          "risk_awareness": 14,
+          "total": 54,
+          "notes": "The LLD names concrete integration points such as get_search_repository, FaissSearchRepository, server and agent indexing, configuration properties, and file-backend migration. It omits uv.lock from its implementation and file-change plans, leaves error behavior as either empty or keyword results, and contradicts its non-goal by introducing a new ranking algorithm and response metadata. The supplied baseline code shows FAISS search returned tools and richer server and agent fields, while the proposed SimpleSearchRepository design covers only servers and agents and does not preserve those contracts. Claims about Helm, Terraform, existing sanitization, rate limiting, audit logging, and suitability below 1000 entities were not substantiated."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 14,
+          "specificity": 15,
+          "risk_awareness": 17,
+          "total": 62,
+          "notes": "The review's strongest contribution is identifying cache synchronization, degraded search quality, memory growth, input handling, migration, and operational monitoring as concrete risks. It nevertheless declares all critical concerns resolved even though the revised LLD still lacks a concurrency-safe invalidation contract, measurable performance limits, and precise compatibility behavior. The patch confirms these concerns remain: _cache_loaded has no locking, tools are never produced, and the proposed search_backend response metadata is not implemented. The review also misses the unchanged uv.lock, tracked FAISS backup file, deleted tests without replacements, and backward-incompatible result fields."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 7,
+          "specificity": 10,
+          "risk_awareness": 11,
+          "total": 42,
+          "notes": "The plan spans functional, compatibility, deployment, end-to-end, performance, negative, and telemetry checks for both backends. Many oracles are non-tests, allowing empty results, either HTTP 400 or success, or unspecified graceful behavior, so they would not reliably catch the proposed regression. The performance example calls an unimplemented _load_test_data method, the multiline python -c FAISS check is syntactically unreliable, and proposed metadata is absent from the patch. It supplies no replacement unit tests for SimpleSearchRepository and does not check uv.lock consistency, retained FAISS references, cache invalidation, tool results, status filters, or response-field compatibility."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 3,
+          "specificity": 8,
+          "risk_awareness": 6,
+          "total": 24,
+          "notes": "The summary honestly discloses deferred tests, documentation, telemetry, Docker work, cache invalidation, and degraded search, but those omissions leave most acceptance criteria unmet. The patch removes faiss-cpu only from pyproject.toml, leaves uv.lock untouched, adds a tracked search_repository.py.bak containing FAISS code, deletes 1131 lines of tests without replacements, and preserves the faiss_service compatibility name. Compared with the removed service, SimpleSearchRepository always returns no tools, drops established result fields, applies max_results globally, ignores draft and deprecated filters, and excludes tool data while calculating num_tools, so API behavior is not preserved. The read-only executor could not access the working tree to confirm patch application or repository method signatures, so unverified calls such as list_all receive no correctness credit."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-06"
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "deepseek-v3.2",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 21,
+      "specificity": 20,
+      "risk_awareness": 14,
+      "total": 75,
+      "notes": "The issue clearly identifies the agent-card and health-check request paths, with concrete acceptance criteria and useful non-goals. Its repository claims align with the diff preimages for `skill_service.py::_is_safe_url`, `agent_validator.py::_check_endpoint_reachability`, and health use of `proxy_pass_url`. The largest deficiency is the unqualified backward-compatibility promise, since existing private-address health targets would become blocked, and it omits redirect and DNS time-of-check/time-of-use risks. No independent task statement was supplied, and the cited audit finding and issue #938 could not be independently verified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 8,
+      "specificity": 19,
+      "risk_awareness": 13,
+      "total": 58,
+      "notes": "The LLD gives concrete integration points, configuration behavior, status handling, observability, rollout, and file-level implementation guidance. It incorrectly places `HealthStatus` in `registry/schemas/server_update_models.py` even though the submitted source shows it in `registry/constants.py`, and its proposed meter construction does not match the repository's `_meter` adapter pattern. Most importantly, caching a DNS answer does not pin `httpx` to that answer, so the client can independently resolve a private address after validation and the claimed rebinding protection is unsound. The cache is also unbounded, synchronous DNS is placed on an async health path, broad `Exception` handling remains despite contrary claims, and the compatibility impact on existing private services is unresolved."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 12,
+      "specificity": 18,
+      "risk_awareness": 18,
+      "total": 65,
+      "notes": "The review surfaces relevant concerns including DNS rebinding, IPv6, blocking DNS in async code, thread safety, configuration coupling, false positives, and observability. Cipher's rebinding concern and Byte's async-resolution concern are the strongest specific findings. Its largest defect is declaring those concerns resolved by a 60-second validation cache, which does not control the HTTP client's later DNS resolution; it likewise claims exception handling was narrowed although the design retains `except Exception`. It does not catch the incorrect health-status location or repository-specific metrics API and therefore overstates its final approval."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 7,
+      "specificity": 12,
+      "risk_awareness": 15,
+      "total": 51,
+      "notes": "The plan spans direct private addresses, IPv6, allowlists, health lifecycle, metrics, performance, rollback, and skill-service compatibility. Many commands are placeholders or use unverified routes and payloads, while outcomes such as \"201 or 422\" are not meaningful oracles; no concrete mock wiring is provided for the reserved example domains. The obfuscation expectations are incorrect for `localhost@evil.com` and `evil.com#@localhost`, whose parsed host is `evil.com`, and the rebinding test merely confirms a cached validation answer rather than where the HTTP request connects. It also omits a decisive redirect/TOCTOU test and no executable tests accompany the implementation despite the acceptance criterion requiring them."
+    },
+    "implementation": {
+      "completeness": 11,
+      "correctness": 7,
+      "specificity": 14,
+      "risk_awareness": 6,
+      "total": 38,
+      "notes": "The patch adds straightforward private-address checks at the named agent and health paths and refactors skill callers to a shared utility using source symbols present in the submitted preimages. Its central security claim is false because `socket.getaddrinfo` only validates one resolution while `httpx` resolves again for the request, so DNS rebinding remains possible and the cache can make that mismatch persist. It adds no tests, leaves the duration histogram unused, leaves immediate-check timestamps stale when blocked, removes private skill-service symbols without updating the cited tests, and introduces an unbounded cache plus an unreported 1,745-line `skill_service.py.backup`. The summary also incorrectly claims no broad exception handling and omits the backup file; an independent `git apply --check` could not be run because repository command execution failed before launch in the read-only harness."
+    }
+  },
+  "task_score": 57.4,
+  "verdict": "The submission identifies the right SSRF surfaces and provides substantial design detail, but its claimed DNS-rebinding defense does not bind validated addresses to outbound connections, and the implementation lacks the promised tests.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T04:03:22.241975Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 311206,
+      "cached_input_tokens": 257570,
+      "cache_write_input_tokens": 53624,
+      "output_tokens": 6544,
+      "reasoning_output_tokens": 4884
+    },
+    "duration_ms": 128839
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,287 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 84.8,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5854803,
+    "output_tokens": 49007,
+    "cache_read_tokens": 5762944,
+    "cache_write_tokens": 91859,
+    "total_tokens": 11758613,
+    "total_cost_usd": null,
+    "latency_seconds": 578.2,
+    "num_turns": 99,
+    "generation_tokens_per_sec": 84.8,
+    "prefix_cache_hit_rate": 0.9843,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5854803,
+  "output_tokens": 49007,
+  "latency_seconds": 578.2,
+  "num_turns": 99,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T03:30:13.795523Z",
+  "run_ended_at": "2026-08-06T03:39:52.136605Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5854803,
+    "output_tokens": 49007,
+    "cache_read_tokens": 5762944,
+    "cache_write_tokens": 91859,
+    "total_tokens": 11758613,
+    "total_cost_usd": null,
+    "latency_seconds": 578.2,
+    "num_turns": 99,
+    "generation_tokens_per_sec": 84.8,
+    "prefix_cache_hit_rate": 0.9843,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9843,
+      "prompt_tokens_cached_rate": 0.9843
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 49007,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 5762944,
+      "vllm:prefix_cache_queries_total": 5854803,
+      "vllm:prompt_tokens_by_source_total": 5854803,
+      "vllm:prompt_tokens_cached_total": 5762944,
+      "vllm:prompt_tokens_total": 5854803,
+      "vllm:request_success_total": 99,
+      "vllm:tool_call_parser_invocations_total": 48881
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 99,
+        "sum": 573.8175,
+        "mean": 5.796136
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 48908,
+        "sum": 544.8328,
+        "mean": 0.01114
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 49007,
+        "sum": 140866,
+        "mean": 2.874406
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 99,
+        "sum": 544.8328,
+        "mean": 5.503362
+      },
+      "vllm:request_generation_tokens": {
+        "count": 99,
+        "sum": 49007,
+        "mean": 495.020202
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 99,
+        "sum": 562.3206,
+        "mean": 5.680006
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 99,
+        "sum": 49007,
+        "mean": 495.020202
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 99,
+        "sum": 1584000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 99,
+        "sum": 99,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 99,
+        "sum": 91859,
+        "mean": 927.868687
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 99,
+        "sum": 17.4878,
+        "mean": 0.176644
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 99,
+        "sum": 5854803,
+        "mean": 59139.424242
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 99,
+        "sum": 0.0009,
+        "mean": 9e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 99,
+        "sum": 1.1023,
+        "mean": 0.011134
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 99,
+        "sum": 29.0089,
+        "mean": 0.293019
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.182,
+          "mean": 0.1119,
+          "samples": 575
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9461,
+          "samples": 575
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 575
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "deepseek-v3.2",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 21,
+        "specificity": 20,
+        "risk_awareness": 14,
+        "total": 75,
+        "notes": "The issue clearly identifies the agent-card and health-check request paths, with concrete acceptance criteria and useful non-goals. Its repository claims align with the diff preimages for `skill_service.py::_is_safe_url`, `agent_validator.py::_check_endpoint_reachability`, and health use of `proxy_pass_url`. The largest deficiency is the unqualified backward-compatibility promise, since existing private-address health targets would become blocked, and it omits redirect and DNS time-of-check/time-of-use risks. No independent task statement was supplied, and the cited audit finding and issue #938 could not be independently verified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 8,
+        "specificity": 19,
+        "risk_awareness": 13,
+        "total": 58,
+        "notes": "The LLD gives concrete integration points, configuration behavior, status handling, observability, rollout, and file-level implementation guidance. It incorrectly places `HealthStatus` in `registry/schemas/server_update_models.py` even though the submitted source shows it in `registry/constants.py`, and its proposed meter construction does not match the repository's `_meter` adapter pattern. Most importantly, caching a DNS answer does not pin `httpx` to that answer, so the client can independently resolve a private address after validation and the claimed rebinding protection is unsound. The cache is also unbounded, synchronous DNS is placed on an async health path, broad `Exception` handling remains despite contrary claims, and the compatibility impact on existing private services is unresolved."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 12,
+        "specificity": 18,
+        "risk_awareness": 18,
+        "total": 65,
+        "notes": "The review surfaces relevant concerns including DNS rebinding, IPv6, blocking DNS in async code, thread safety, configuration coupling, false positives, and observability. Cipher's rebinding concern and Byte's async-resolution concern are the strongest specific findings. Its largest defect is declaring those concerns resolved by a 60-second validation cache, which does not control the HTTP client's later DNS resolution; it likewise claims exception handling was narrowed although the design retains `except Exception`. It does not catch the incorrect health-status location or repository-specific metrics API and therefore overstates its final approval."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 7,
+        "specificity": 12,
+        "risk_awareness": 15,
+        "total": 51,
+        "notes": "The plan spans direct private addresses, IPv6, allowlists, health lifecycle, metrics, performance, rollback, and skill-service compatibility. Many commands are placeholders or use unverified routes and payloads, while outcomes such as \"201 or 422\" are not meaningful oracles; no concrete mock wiring is provided for the reserved example domains. The obfuscation expectations are incorrect for `localhost@evil.com` and `evil.com#@localhost`, whose parsed host is `evil.com`, and the rebinding test merely confirms a cached validation answer rather than where the HTTP request connects. It also omits a decisive redirect/TOCTOU test and no executable tests accompany the implementation despite the acceptance criterion requiring them."
+      },
+      "implementation": {
+        "completeness": 11,
+        "correctness": 7,
+        "specificity": 14,
+        "risk_awareness": 6,
+        "total": 38,
+        "notes": "The patch adds straightforward private-address checks at the named agent and health paths and refactors skill callers to a shared utility using source symbols present in the submitted preimages. Its central security claim is false because `socket.getaddrinfo` only validates one resolution while `httpx` resolves again for the request, so DNS rebinding remains possible and the cache can make that mismatch persist. It adds no tests, leaves the duration histogram unused, leaves immediate-check timestamps stale when blocked, removes private skill-service symbols without updating the cited tests, and introduces an unbounded cache plus an unreported 1,745-line `skill_service.py.backup`. The summary also incorrectly claims no broad exception handling and omits the backup file; an independent `git apply --check` could not be run because repository command execution failed before launch in the read-only harness."
+      }
+    },
+    "task_score": 57.4,
+    "verdict": "The submission identifies the right SSRF surfaces and provides substantial design detail, but its claimed DNS-rebinding defense does not bind validated addresses to outbound connections, and the implementation lacks the promised tests.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T04:03:22.241975Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 311206,
+        "cached_input_tokens": 257570,
+        "cache_write_input_tokens": 53624,
+        "output_tokens": 6544,
+        "reasoning_output_tokens": 4884
+      },
+      "duration_ms": 128839
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Re-runs **deepseek-v3.2 / pi / swe3** on the fixed harness, replacing the row that **#105 deliberately excluded** from `main` as *"undercounted pi token/cost, pre-#99 harness"*. First trustworthy token/cost data for this pairing.

**Mean 54.44, 5/5 clean** -- every task produced 6/6 artifacts on a single attempt, no retries, no failures.

## The token fix, verified

| | PR #97 (old) | this run | factor |
|---|---:|---:|---:|
| output tokens | 3,327 | 165,360 | **50x** |
| output/turn | 8.3 | **395.6** | **48x** |

8.3 output tokens per turn is impossible for an agent making file edits. 396/turn matches the other post-fix pi runs on `main` (~260-430). All five tasks land in the healthy band, and the new run-time guard stayed silent on every one:

| Task | output/turn |
|---|---:|
| migrate-ecs-env-vars-to-secrets-manager | 496.1 |
| ssrf-hardening-outbound-url-validation | 495.0 |
| replace-keycloak-db-password-with-rds-iam | 389.5 |
| remove-faiss | 331.4 |
| remove-efs-from-terraform-aws-ecs | 281.6 |

## Results

| Task | Artifacts | Turns | Prefix-cache | Judge score |
|---|---|---:|---:|---:|
| remove-efs-from-terraform-aws-ecs | 6/6 | 84 | 98.3% | **64.8** |
| ssrf-hardening-outbound-url-validation | 6/6 | 99 | 98.4% | 57.4 |
| migrate-ecs-env-vars-to-secrets-manager | 6/6 | 60 | 97.6% | 52.4 |
| replace-keycloak-db-password-with-rds-iam | 6/6 | 85 | 98.3% | 50.0 |
| remove-faiss | 6/6 | 90 | 98.3% | 47.6 |

**On the score change:** mean moves 50.84 -> 54.44. That is a larger swing than kimi's 0.44 (#107) and should be read as **run-to-run variance on a 5-task dataset, not a correction** -- the judge grades artifacts, no artifact count changed hands, and the token bug never touched scores.

**`remove-faiss` completed cleanly in 90 turns.** That task has been the outlier for every other model on this dataset: kimi pi failed it at 4/6 over three attempts (#107), qwen3-coder-480b claude-code needed a manual path fix (#103), minimax pi took 191 turns. DeepSeek handling it in one attempt is the strongest single-task robustness result on it so far.

## Serving configuration

`p5en.48xlarge`, **TP=8**, **FP8**, **131,072-token** window, repo ref `1.24.4`, judged by `openai.gpt-5.6-sol` via `codex exec` at high reasoning effort. GPU KV cache 519,808 tokens.

131,072 matches the window the existing `claude-code` row on `main` was recorded at, so **the pair is directly comparable**. It is below the 200K recommended floor, but unlike kimi at the same window, **no task showed window pressure here** -- no retries, no truncation, no incomplete artifact sets.

## Known caveats

**The existing claude-code row has incomplete serving metadata** -- `tensor_parallel_size: null`, `precision: null`, while this row records `8` / `fp8`. That row cannot be regenerated (only its `run-summary.json` is committed, with no per-task `metrics.json` for `summarize_run.py` to read), so it was left as-is rather than hand-edited.

**pi does not report cost.** `total_cost_usd` is null per task, so run cost is derived from wall-clock alone and **pi-vs-Claude-Code dollars are not comparable**. Pre-existing across all pi runs.

**Cost column uses the g6e rate.** Priced at the `g6e.12xlarge` default of $10.49/hr while it ran on `p5en.48xlarge`, matching the other p5en rows; `docs/cost-per-task-methodology.md` documents the gap.

## What is committed

`run-summary.json` plus per-task `metrics.json` and `eval.json` per the gitignore allowlist; the six design/implementation artifacts stay local. Regenerates the pi harness doc and all four chart variants per harness.

## Verification

- Cut from the current `origin/main` (post-#105), so no conflict with the landed data.
- Pre-flight clean; judge: 5 scored, 0 failed.
- Security scan of the staged diff: no credential, host name, or user path in any committed file; recorded endpoint is loopback and `aws_region` null throughout.
- Companion PRs: **#107** (kimi-k2.7-code pi re-run, the other row #105 excluded) and a run-time guard that flags this class of undercount during the run rather than in review.

## Note for reviewers

Serving DeepSeek required reaping orphaned GPU workers first. `pkill -f "vllm serve"` kills the launcher but leaves 8 `VLLM::Worker` processes holding ~132 GB each with no serving endpoint, which makes the next model fail at boot with `Free memory on device cuda:N ... is less than desired GPU memory utilization`. `pkill -9 -f "VLLM::"` is needed as well. Worth adding to the vllm-setup notes.
