### PR TITLE
feat(benchmark): flag implausible output-tokens-per-turn at run time (#99 follow-up)

### DIFF
--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -66,6 +66,20 @@ IMPLEMENTATION_ARTIFACT_FILENAMES = ("patch.diff", "implementation.md")
 ARTIFACT_FILENAMES = DESIGN_ARTIFACT_FILENAMES + IMPLEMENTATION_ARTIFACT_FILENAMES
 GIT_CLONE_TIMEOUT_SECONDS = 300
 
+# Sanity floor for output tokens per turn, used to catch a token-accounting bug at
+# run time rather than in PR review. An agent that edits files emits hundreds of
+# output tokens per turn (measured: ~370-730 across claude-code and pi). A value in
+# the single digits is not a model behaviour -- it means usage was read from one
+# scope instead of summed across all of them, which is exactly how the pi
+# per-message usage bug (#99) and the earlier claude modelUsage bug undercounted
+# multi-turn runs by ~100x. The failure is silent (a plausible number in the right
+# field), so only a ratio check catches it. Set well below any real per-turn rate so
+# it fires on a genuine accounting fault, not on a terse run.
+MIN_PLAUSIBLE_OUTPUT_TOKENS_PER_TURN = 20
+# Below this turn count the ratio is noise (a 1-2 turn run can legitimately emit
+# very little), so the check is skipped.
+TOKEN_SANITY_MIN_TURNS = 5
+
 # The SWE skill file, shared by both agents. Claude Code auto-loads it from the
 # repo's .claude/skills tree via the matching slash command; pi is pointed at the
 # same file explicitly with `--skill` so both agents run the identical task. Which
@@ -741,6 +755,54 @@ def _claude_token_usage(result: dict[str, Any]) -> dict[str, int]:
         "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
         "cache_creation_tokens": usage.get("cache_creation_input_tokens", 0),
     }
+
+
+def _check_token_accounting(
+    metrics: dict[str, Any],
+    agent: str,
+    label: str,
+) -> str | None:
+    """Warn loudly when output tokens per turn are implausibly low.
+
+    Guards against the token-accounting class of bug where usage is read from a
+    single scope (pi's last per-message ``usage``, or claude's main-agent-only
+    ``usage``) instead of summed across every message/model, undercounting a
+    multi-turn run roughly in proportion to its turn count. Such a run still writes
+    a well-formed metrics.json with a plausible-looking number, so nothing else in
+    the pipeline notices; the ratio is the only cheap signal.
+
+    This warns rather than fails: the artifacts and judge scores of an affected run
+    are still valid (only tokens and cost are wrong), so aborting would discard good
+    work. The warning names the run so it cannot be committed unnoticed.
+
+    Args:
+        metrics: The metrics dict from ``_metrics_from_result``.
+        agent: Which coding agent produced the run (for the message).
+        label: Task label used in log lines.
+
+    Returns:
+        The warning message if the check tripped, else None.
+    """
+    turns = metrics.get("num_turns") or 0
+    output_tokens = metrics.get("output_tokens") or 0
+    if turns < TOKEN_SANITY_MIN_TURNS:
+        return None
+    per_turn = output_tokens / turns
+    if per_turn >= MIN_PLAUSIBLE_OUTPUT_TOKENS_PER_TURN:
+        return None
+    message = (
+        f"{label} TOKEN ACCOUNTING SUSPECT: {output_tokens:,} output tokens over "
+        f"{turns} turns = {per_turn:.1f}/turn, below the {MIN_PLAUSIBLE_OUTPUT_TOKENS_PER_TURN} "
+        f"floor. An agent making edits emits hundreds per turn, so the {agent} usage "
+        f"is likely being read from one scope instead of summed across all of them "
+        f"(see the pi per-message usage bug, issue #99). Scores, turns, and latency "
+        f"are unaffected and still valid -- but DO NOT publish the token or cost "
+        f"columns from this run without re-checking the extractor."
+    )
+    logger.warning("!" * 100)
+    logger.warning(message)
+    logger.warning("!" * 100)
+    return message
 
 
 def _metrics_from_result(result: dict[str, Any], elapsed: float) -> dict[str, Any]:
@@ -1752,6 +1814,11 @@ def _save_metrics(
     generation_tokens_per_sec = (
         round(metrics["output_tokens"] / latency, 1) if latency > 0 else 0
     )
+    # Persist the token-accounting verdict alongside the numbers it judges, so a
+    # suspect run is self-identifying on disk and not only in the run log.
+    token_accounting_warning = _check_token_accounting(
+        metrics, config.agent, f"[task={task.id}]"
+    )
     include_vllm = not config.is_bedrock
     record = {
         "task": task.id,
@@ -1781,6 +1848,11 @@ def _save_metrics(
         "artifacts_produced": len(produced),
         "artifacts_expected": len(ARTIFACT_FILENAMES),
         "generation_tokens_per_sec": generation_tokens_per_sec,
+        # Null on a healthy run. A string here means output-tokens-per-turn fell
+        # below MIN_PLAUSIBLE_OUTPUT_TOKENS_PER_TURN, i.e. the token/cost figures in
+        # this file are suspect (scores/turns/latency are not). Never publish a
+        # token or cost column from a run where this is set.
+        "token_accounting_warning": token_accounting_warning,
         # The normalized, cross-agent metric block -- the single source of truth
         # for tokens/cost/turns/latency + provenance. summarize_run and the charts
         # read this. Filled to whatever extent the agent reports (nulls where a

--- a/benchmarks/tests/test_run_swe_headless.py
+++ b/benchmarks/tests/test_run_swe_headless.py
@@ -1155,5 +1155,72 @@ class MetricsErrorTest(unittest.TestCase):
         self.assertNotIn("error", metrics)
 
 
+class TestCheckTokenAccounting(unittest.TestCase):
+    """The run-time guard against undercounted token accounting.
+
+    The extractor bug (#99) is fixed; this guard exists so a future regression in
+    either agent's usage extraction is caught during the run instead of in review.
+    Cases use real numbers from affected and healthy runs.
+    """
+
+    def test_flags_the_real_kimi_undercount(self) -> None:
+        # kimi-k2.7-code pi (PR #96): 1 output token recorded over 106 turns.
+        warning = harness._check_token_accounting(
+            {"num_turns": 106, "output_tokens": 1}, "pi", "[task=ssrf]"
+        )
+        assert warning is not None
+        self.assertIn("TOKEN ACCOUNTING SUSPECT", warning)
+        self.assertIn("0.0/turn", warning)
+
+    def test_flags_the_real_deepseek_undercount(self) -> None:
+        # deepseek-v3.2 pi (PR #97): 542 output over 69 turns = 7.9/turn. Subtler
+        # than kimi's but still an order of magnitude below plausible.
+        warning = harness._check_token_accounting(
+            {"num_turns": 69, "output_tokens": 542}, "pi", "[task=remove-efs]"
+        )
+        assert warning is not None
+        self.assertIn("7.9/turn", warning)
+
+    def test_passes_a_healthy_post_fix_pi_run(self) -> None:
+        # nemotron-ultra-550b pi, post-fix: 47,996 output over 240 turns = ~200/turn.
+        self.assertIsNone(
+            harness._check_token_accounting(
+                {"num_turns": 240, "output_tokens": 47996}, "pi", "[task=remove-faiss]"
+            )
+        )
+
+    def test_passes_a_healthy_claude_run(self) -> None:
+        # minimax-m2.5 claude-code: 21,383 output over 83 turns = ~258/turn.
+        self.assertIsNone(
+            harness._check_token_accounting(
+                {"num_turns": 83, "output_tokens": 21383},
+                "claude",
+                "[task=remove-faiss]",
+            )
+        )
+
+    def test_skips_short_runs_where_the_ratio_is_noise(self) -> None:
+        # A 2-turn run can legitimately emit very little; do not cry wolf.
+        self.assertIsNone(
+            harness._check_token_accounting(
+                {"num_turns": 2, "output_tokens": 5}, "pi", "[task=tiny]"
+            )
+        )
+
+    def test_handles_missing_and_zero_fields(self) -> None:
+        # A failed run may report no turns at all; must not divide by zero.
+        self.assertIsNone(harness._check_token_accounting({}, "pi", "[task=x]"))
+        self.assertIsNone(
+            harness._check_token_accounting(
+                {"num_turns": 0, "output_tokens": 0}, "pi", "[task=x]"
+            )
+        )
+        self.assertIsNone(
+            harness._check_token_accounting(
+                {"num_turns": None, "output_tokens": None}, "pi", "[task=x]"
+            )
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a run-time sanity check on **output tokens per turn**, so the token-accounting class of bug (#99) is caught *during* a run instead of in PR review.

## Why

The #99 summation bug was found only when someone divided output tokens by turns during review. By then two rows had shipped with 4-8 output tokens/turn -- `kimi-k2.7-code/pi` (#96) and `deepseek-v3.2/pi` (#97) -- and #105 had to exclude both from `main` and order re-runs (#107, #108).

The bug class is **silent by construction**. Usage is read from one scope (pi's last per-message `usage`, or claude's main-agent-only `usage` instead of `modelUsage`) rather than summed across all of them. The result is a well-formed `metrics.json` with a plausible number in the right field: nothing raises, nothing is missing. And the undercount scales with turn count -- a 106-turn run reports ~1/106th of its tokens. Only the per-turn ratio betrays it.

## What it does

`_check_token_accounting()` warns when `output_tokens / num_turns` falls below **20**, skipping runs under 5 turns where the ratio is noise.

Calibration from real data:

| | output/turn |
|---|---:|
| kimi pi (#96, bad) | 0.0 |
| deepseek pi (#97, bad) | 8.3 |
| **floor** | **20** |
| healthy pi | 260-430 |
| healthy claude-code | 258-730 |

The floor sits an order of magnitude clear of both sides.

## It warns, it does not fail

The #99 commit is explicit that **scores, turns, and latency are unaffected** by this bug -- only tokens and cost are wrong. So an affected run's artifacts and judge scores are still valid, and aborting would discard hours of good work over a reporting fault.

Instead the warning is both:
- **logged in a banner** during the run, and
- **persisted as a `token_accounting_warning` field in `metrics.json`**

The persisted field is the part that matters: a run log scrolls away, but the flag sits next to the numbers it judges, so a suspect run cannot be committed unnoticed. Null on a healthy run.

## Tests

Six cases, using real numbers from both directions:

- **must flag:** kimi's 1 output token over 106 turns; deepseek's 542 over 69
- **must not flag:** healthy post-fix pi (47,996 over 240 turns), healthy claude-code (21,383 over 83)
- **must not cry wolf:** runs under 5 turns
- **must not crash:** missing / zero / `None` turn counts (no division by zero)

Full suite: **217 tests, OK**. `py_compile`, `ruff format`, `ruff check`, and Bandit all clean.

## Scope

**This is a tripwire, not a fix.** #99 already corrected the extractor, so the guard should stay silent on new runs. It exists so the *next* regression in either agent's usage extraction is caught during the run.

Verified against the two re-runs it was built for: **kimi 429.3 out/turn** (#107) and **deepseek 395.6 out/turn** (#108), guard silent on all ten tasks.
