### PR TITLE
benchmark: land kimi-k2.7-code pi/swe3 re-run (fixed tokens) from #107

### DIFF
--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "kimi-k2.7-code",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 8,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 55,
+      "notes": "The issue provides a concrete secret inventory, scoped exclusions, and mostly testable acceptance criteria. Its central solution contradicts its security goal: emitting the same credentials as `*_PLAINTEXT` environment entries leaves them visible in task definitions, while `aws_secretsmanager_secret_version.secret_string` also remains in Terraform state. The criterion claiming no sensitive values are rendered in container definitions is therefore incompatible with the proposed fallback. No independent task statement was supplied, and repository command execution was unavailable, so claims about `secrets.tf` and `aws_iam_policy.ecs_secrets_access` could not be directly verified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 7,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 54,
+      "notes": "The LLD names concrete Terraform and Python integration points and specifies resource, IAM, environment, and rollout behavior. However, each source variable simultaneously controls both the managed secret and plaintext fallback, so normal deployments have both or neither; the fallback cannot rescue an ECS secret-retrieval failure because ECS fails before application startup. Gating secret existence on the secret value also forces operators to retain the value in Terraform, while `ignore_changes` makes later variable updates ineffective and removing the value destroys the secret. The asserted files and symbols, including `registry/core/config.py` and `aws_kms_key.secrets`, could not be verified directly against the repository."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 18,
+      "risk_awareness": 18,
+      "total": 66,
+      "notes": "The review's strongest contribution is identifying residual `*_PLAINTEXT` exposure and the surprising seed-only behavior caused by `ignore_changes`. It nevertheless approves the design without resolving those critical defects and misses that secret values remain in Terraform state and that the proposed fallback is unavailable when ECS retrieval fails. Several resolutions are contradicted by the LLD: the deployment checklist does not add root `terraform/aws-ecs/variables.tf`, and the rollout plan stages by environment rather than by secret class. Repository-specific assertions about existing IAM and KMS wiring could not be independently verified."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 5,
+      "specificity": 16,
+      "risk_awareness": 9,
+      "total": 45,
+      "notes": "The plan spans helper precedence, Settings behavior, Terraform planning, IAM, deployment, rollback, and an authentication path. Its central plan checks are invalid because sections 4.1 and 4.3 use the same name regex, so a correct `secrets` entry makes the environment-removal check fail; the scripts also only print failures and never exit nonzero. `aws ecs describe-tasks` does not expose container environment variables, and setting the shared Terraform variable to empty removes both the secret and its plaintext fallback, invalidating the rollback oracle. The hard-coded `REPO_ROOT` differs from the submitted workspace path, while the skeletal GitHub E2E case supplies no executable setup or strong oracle."
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "The implementation artifact is empty, with no patch, summary, target files, or executable change submitted. It therefore cannot implement the design or be checked against the repository, and every implementation criterion receives zero. No implementation deviation or runtime behavior can be assessed beyond its absence."
+    }
+  },
+  "task_score": 44.0,
+  "verdict": "The submission is detailed but unshippable because no implementation was submitted and the proposed migration still preserves plaintext credential exposure in ECS task definitions and Terraform state.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T02:51:42.834256Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 119679,
+      "cached_input_tokens": 93824,
+      "cache_write_input_tokens": 25845,
+      "output_tokens": 7406,
+      "reasoning_output_tokens": 5852
+    },
+    "duration_ms": 105978
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,295 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "kimi-k2.7-code",
+  "model_slug": "kimi-k2.7-code",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 4,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 69.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 11759663,
+    "output_tokens": 73934,
+    "cache_read_tokens": 11509568,
+    "cache_write_tokens": 330666,
+    "total_tokens": 23673831,
+    "total_cost_usd": 0,
+    "latency_seconds": 1008.0,
+    "num_turns": 137,
+    "generation_tokens_per_sec": 69.8,
+    "prefix_cache_hit_rate": 0.9597,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 11759663,
+  "output_tokens": 73934,
+  "latency_seconds": 1008.0,
+  "num_turns": 137,
+  "total_cost_usd": 0,
+  "is_error": true,
+  "result_subtype": "length",
+  "error": "length",
+  "api_error_status": null,
+  "run_started_at": "2026-08-06T02:24:24.304984Z",
+  "run_ended_at": "2026-08-06T02:30:22.594423Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 11759663,
+    "output_tokens": 73934,
+    "cache_read_tokens": 11509568,
+    "cache_write_tokens": 330666,
+    "total_tokens": 23673831,
+    "total_cost_usd": 0,
+    "latency_seconds": 1008.0,
+    "num_turns": 137,
+    "generation_tokens_per_sec": 69.8,
+    "prefix_cache_hit_rate": 0.9597,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9597,
+      "prompt_tokens_cached_rate": 0.9597
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 25405,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 3473664,
+      "vllm:prefix_cache_queries_total": 3619392,
+      "vllm:prompt_tokens_by_source_total": 3619392,
+      "vllm:prompt_tokens_cached_total": 3473664,
+      "vllm:prompt_tokens_total": 3619392,
+      "vllm:request_success_total": 38,
+      "vllm:tool_call_parser_invocations_total": 14677
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 38,
+        "sum": 353.9513,
+        "mean": 9.314507
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 25367,
+        "sum": 331.237,
+        "mean": 0.013058
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 25405,
+        "sum": 171133,
+        "mean": 6.736194
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 38,
+        "sum": 331.237,
+        "mean": 8.716763
+      },
+      "vllm:request_generation_tokens": {
+        "count": 38,
+        "sum": 25405,
+        "mean": 668.552632
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 38,
+        "sum": 346.7082,
+        "mean": 9.1239
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 38,
+        "sum": 25405,
+        "mean": 668.552632
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 38,
+        "sum": 506351,
+        "mean": 13325.026316
+      },
+      "vllm:request_params_n": {
+        "count": 38,
+        "sum": 38,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 38,
+        "sum": 145728,
+        "mean": 3834.947368
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 38,
+        "sum": 15.4712,
+        "mean": 0.407138
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 38,
+        "sum": 3619392,
+        "mean": 95247.157895
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 38,
+        "sum": 0.0003,
+        "mean": 7e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 38,
+        "sum": 0.4631,
+        "mean": 0.012186
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 38,
+        "sum": 22.7279,
+        "mean": 0.598103
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1707,
+          "mean": 0.133,
+          "samples": 356
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9213,
+          "samples": 356
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 356
+        }
+      }
+    }
+  },
+  "cache_read_tokens": 11509568,
+  "cache_creation_tokens": 330666,
+  "agent_invocations": 3,
+  "topped_up_artifacts": [],
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "kimi-k2.7-code",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 8,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 55,
+        "notes": "The issue provides a concrete secret inventory, scoped exclusions, and mostly testable acceptance criteria. Its central solution contradicts its security goal: emitting the same credentials as `*_PLAINTEXT` environment entries leaves them visible in task definitions, while `aws_secretsmanager_secret_version.secret_string` also remains in Terraform state. The criterion claiming no sensitive values are rendered in container definitions is therefore incompatible with the proposed fallback. No independent task statement was supplied, and repository command execution was unavailable, so claims about `secrets.tf` and `aws_iam_policy.ecs_secrets_access` could not be directly verified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 7,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 54,
+        "notes": "The LLD names concrete Terraform and Python integration points and specifies resource, IAM, environment, and rollout behavior. However, each source variable simultaneously controls both the managed secret and plaintext fallback, so normal deployments have both or neither; the fallback cannot rescue an ECS secret-retrieval failure because ECS fails before application startup. Gating secret existence on the secret value also forces operators to retain the value in Terraform, while `ignore_changes` makes later variable updates ineffective and removing the value destroys the secret. The asserted files and symbols, including `registry/core/config.py` and `aws_kms_key.secrets`, could not be verified directly against the repository."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 18,
+        "risk_awareness": 18,
+        "total": 66,
+        "notes": "The review's strongest contribution is identifying residual `*_PLAINTEXT` exposure and the surprising seed-only behavior caused by `ignore_changes`. It nevertheless approves the design without resolving those critical defects and misses that secret values remain in Terraform state and that the proposed fallback is unavailable when ECS retrieval fails. Several resolutions are contradicted by the LLD: the deployment checklist does not add root `terraform/aws-ecs/variables.tf`, and the rollout plan stages by environment rather than by secret class. Repository-specific assertions about existing IAM and KMS wiring could not be independently verified."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 5,
+        "specificity": 16,
+        "risk_awareness": 9,
+        "total": 45,
+        "notes": "The plan spans helper precedence, Settings behavior, Terraform planning, IAM, deployment, rollback, and an authentication path. Its central plan checks are invalid because sections 4.1 and 4.3 use the same name regex, so a correct `secrets` entry makes the environment-removal check fail; the scripts also only print failures and never exit nonzero. `aws ecs describe-tasks` does not expose container environment variables, and setting the shared Terraform variable to empty removes both the secret and its plaintext fallback, invalidating the rollback oracle. The hard-coded `REPO_ROOT` differs from the submitted workspace path, while the skeletal GitHub E2E case supplies no executable setup or strong oracle."
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "The implementation artifact is empty, with no patch, summary, target files, or executable change submitted. It therefore cannot implement the design or be checked against the repository, and every implementation criterion receives zero. No implementation deviation or runtime behavior can be assessed beyond its absence."
+      }
+    },
+    "task_score": 44.0,
+    "verdict": "The submission is detailed but unshippable because no implementation was submitted and the proposed migration still preserves plaintext credential exposure in ECS task definitions and Terraform state.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T02:51:42.834256Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 119679,
+        "cached_input_tokens": 93824,
+        "cache_write_input_tokens": 25845,
+        "output_tokens": 7406,
+        "reasoning_output_tokens": 5852
+      },
+      "duration_ms": 105978
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "kimi-k2.7-code",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 13,
+      "total": 74,
+      "notes": "The issue provides a concrete inventory of variables, outputs, task mounts, scripts, and validation outcomes, making most acceptance criteria directly testable. Its largest deficiency is treating the absence of production EFS data and the sufficiency of S3/DocumentDB as facts without independent task evidence, backup, rollback, or downstream-output consumer handling. The single-AZ motivation is contradicted by the submitted `storage.tf`, where `mount_targets` iterates over every private subnet. With no independent task statement, the runtime persistence and container-image claims remain unverified."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 76,
+      "notes": "The LLD is implementation-ready in its mapping of `module.efs` references, task volumes, outputs, variables, and script branches to specific files and edits. Its load-bearing weakness is asserting that `/app/auth_server/scopes.yml` exists and `/app/data` is transient without showing repository or image evidence for either claim. The submitted diff supports its descriptions of `storage.tf`, `ecs-services.tf`, and `post-deployment-setup.sh`, but the claimed absence of EFS wiring in `main.tf` is not demonstrated by the patch. The rollout acknowledges destruction yet lacks a backup check, irreversible-data warning, rollback strategy, and treatment of external consumers of the removed module outputs."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 19,
+      "risk_awareness": 18,
+      "total": 71,
+      "notes": "The review's strongest contribution is identifying concrete runtime risks around the image-local scopes file, `/app/data`, removed Terraform outputs, and destructive EFS removal. It nevertheless marks these concerns resolved through unsupported statements about published images at tag `1.24.4`, while the implementation summary supplies no corresponding verification. It also misses that the patched `_initialize_scopes` now returns failure whenever `documentdb_cluster_endpoint` is absent, although the old code explicitly supported a non-DocumentDB branch. The question about CI or documentation consumers of `mcp_gateway_efs_*` remains unanswered despite the approved-with-changes verdict."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 12,
+      "specificity": 19,
+      "risk_awareness": 11,
+      "total": 57,
+      "notes": "The plan gives specific static checks and useful oracles for removed symbols, task volumes, scripts, and the scopes path. Its central plan test is not reproducible as written: a fresh clone initialized with `terraform init -backend=false` has no deployed pre-change state from which EFS resources could be planned for destruction. Copying `terraform.tfvars.example` with optional manual adjustments also does not establish a valid plan fixture, and the stated Terraform version requirement is unsupported. No test exercises the modified shell function, the missing-DocumentDB failure, dry-run behavior, container startup, or actual existence of `/app/auth_server/scopes.yml`, while end-to-end coverage is dismissed as inapplicable."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 75,
+      "notes": "The patch directly removes the EFS module, variables, outputs, auth and mcpgw mounts, root outputs, and EFS initialization script, while updating `SCOPES_CONFIG_PATH` and the post-deployment branch consistently. The largest behavioral risk is that `_initialize_scopes` now hard-fails without `documentdb_cluster_endpoint`; the artifacts do not establish that DocumentDB is mandatory for every supported AWS ECS configuration. The diff context is internally consistent around `module.efs`, `efs_volume_configuration`, and `mcp_gateway_efs_id`, but application against the real tree and the asserted `main.tf` wiring could not be independently verified in this environment. The summary acknowledges that Terraform verification was not executed, but it overstates runtime safety and offers no protection or recovery path for potentially populated EFS state."
+    }
+  },
+  "task_score": 70.6,
+  "verdict": "This is a concrete and mostly coherent EFS-removal change, but unsupported runtime-storage assumptions and a plan procedure incapable of validating destruction against existing state materially limit confidence.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T02:54:13.467811Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 181231,
+      "cached_input_tokens": 149391,
+      "cache_write_input_tokens": 31828,
+      "output_tokens": 8643,
+      "reasoning_output_tokens": 7081
+    },
+    "duration_ms": 150622
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "kimi-k2.7-code",
+  "model_slug": "kimi-k2.7-code",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 82.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3411724,
+    "output_tokens": 20371,
+    "cache_read_tokens": 3328016,
+    "cache_write_tokens": 83708,
+    "total_tokens": 6843819,
+    "total_cost_usd": null,
+    "latency_seconds": 247.1,
+    "num_turns": 50,
+    "generation_tokens_per_sec": 82.4,
+    "prefix_cache_hit_rate": 0.9755,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 3411724,
+  "output_tokens": 20371,
+  "latency_seconds": 247.1,
+  "num_turns": 50,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T01:49:58.431616Z",
+  "run_ended_at": "2026-08-06T01:54:06.844442Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3411724,
+    "output_tokens": 20371,
+    "cache_read_tokens": 3328016,
+    "cache_write_tokens": 83708,
+    "total_tokens": 6843819,
+    "total_cost_usd": null,
+    "latency_seconds": 247.1,
+    "num_turns": 50,
+    "generation_tokens_per_sec": 82.4,
+    "prefix_cache_hit_rate": 0.9755,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9755,
+      "prompt_tokens_cached_rate": 0.9755
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 20371,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 3328016,
+      "vllm:prefix_cache_queries_total": 3411724,
+      "vllm:prompt_tokens_by_source_total": 3411724,
+      "vllm:prompt_tokens_cached_total": 3328016,
+      "vllm:prompt_tokens_total": 3411724,
+      "vllm:request_success_total": 50,
+      "vllm:tool_call_parser_invocations_total": 15677
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 50,
+        "sum": 244.7818,
+        "mean": 4.895636
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 20321,
+        "sum": 227.7189,
+        "mean": 0.011206
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 20371,
+        "sum": 104079,
+        "mean": 5.109175
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 50,
+        "sum": 227.7189,
+        "mean": 4.554379
+      },
+      "vllm:request_generation_tokens": {
+        "count": 50,
+        "sum": 20371,
+        "mean": 407.42
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 50,
+        "sum": 237.6977,
+        "mean": 4.753955
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 50,
+        "sum": 20371,
+        "mean": 407.42
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 50,
+        "sum": 800000,
+        "mean": 16000.0
+      },
+      "vllm:request_params_n": {
+        "count": 50,
+        "sum": 50,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 50,
+        "sum": 83708,
+        "mean": 1674.16
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 50,
+        "sum": 9.9788,
+        "mean": 0.199576
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 50,
+        "sum": 3411724,
+        "mean": 68234.48
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 50,
+        "sum": 0.0004,
+        "mean": 7e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 50,
+        "sum": 0.5619,
+        "mean": 0.011238
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 50,
+        "sum": 17.0792,
+        "mean": 0.341583
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1151,
+          "mean": 0.0846,
+          "samples": 247
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9231,
+          "samples": 247
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 247
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "kimi-k2.7-code",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 13,
+        "total": 74,
+        "notes": "The issue provides a concrete inventory of variables, outputs, task mounts, scripts, and validation outcomes, making most acceptance criteria directly testable. Its largest deficiency is treating the absence of production EFS data and the sufficiency of S3/DocumentDB as facts without independent task evidence, backup, rollback, or downstream-output consumer handling. The single-AZ motivation is contradicted by the submitted `storage.tf`, where `mount_targets` iterates over every private subnet. With no independent task statement, the runtime persistence and container-image claims remain unverified."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 76,
+        "notes": "The LLD is implementation-ready in its mapping of `module.efs` references, task volumes, outputs, variables, and script branches to specific files and edits. Its load-bearing weakness is asserting that `/app/auth_server/scopes.yml` exists and `/app/data` is transient without showing repository or image evidence for either claim. The submitted diff supports its descriptions of `storage.tf`, `ecs-services.tf`, and `post-deployment-setup.sh`, but the claimed absence of EFS wiring in `main.tf` is not demonstrated by the patch. The rollout acknowledges destruction yet lacks a backup check, irreversible-data warning, rollback strategy, and treatment of external consumers of the removed module outputs."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 19,
+        "risk_awareness": 18,
+        "total": 71,
+        "notes": "The review's strongest contribution is identifying concrete runtime risks around the image-local scopes file, `/app/data`, removed Terraform outputs, and destructive EFS removal. It nevertheless marks these concerns resolved through unsupported statements about published images at tag `1.24.4`, while the implementation summary supplies no corresponding verification. It also misses that the patched `_initialize_scopes` now returns failure whenever `documentdb_cluster_endpoint` is absent, although the old code explicitly supported a non-DocumentDB branch. The question about CI or documentation consumers of `mcp_gateway_efs_*` remains unanswered despite the approved-with-changes verdict."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 12,
+        "specificity": 19,
+        "risk_awareness": 11,
+        "total": 57,
+        "notes": "The plan gives specific static checks and useful oracles for removed symbols, task volumes, scripts, and the scopes path. Its central plan test is not reproducible as written: a fresh clone initialized with `terraform init -backend=false` has no deployed pre-change state from which EFS resources could be planned for destruction. Copying `terraform.tfvars.example` with optional manual adjustments also does not establish a valid plan fixture, and the stated Terraform version requirement is unsupported. No test exercises the modified shell function, the missing-DocumentDB failure, dry-run behavior, container startup, or actual existence of `/app/auth_server/scopes.yml`, while end-to-end coverage is dismissed as inapplicable."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 75,
+        "notes": "The patch directly removes the EFS module, variables, outputs, auth and mcpgw mounts, root outputs, and EFS initialization script, while updating `SCOPES_CONFIG_PATH` and the post-deployment branch consistently. The largest behavioral risk is that `_initialize_scopes` now hard-fails without `documentdb_cluster_endpoint`; the artifacts do not establish that DocumentDB is mandatory for every supported AWS ECS configuration. The diff context is internally consistent around `module.efs`, `efs_volume_configuration`, and `mcp_gateway_efs_id`, but application against the real tree and the asserted `main.tf` wiring could not be independently verified in this environment. The summary acknowledges that Terraform verification was not executed, but it overstates runtime safety and offers no protection or recovery path for potentially populated EFS state."
+      }
+    },
+    "task_score": 70.6,
+    "verdict": "This is a concrete and mostly coherent EFS-removal change, but unsupported runtime-storage assumptions and a plan procedure incapable of validating destruction against existing state materially limit confidence.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T02:54:13.467811Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 181231,
+        "cached_input_tokens": 149391,
+        "cache_write_input_tokens": 31828,
+        "output_tokens": 8643,
+        "reasoning_output_tokens": 7081
+      },
+      "duration_ms": 150622
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "remove-faiss",
+  "model": "kimi-k2.7-code",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 78,
+      "notes": "The issue clearly defines the dependency-removal goal, explicit non-goals, and testable criteria covering code, configuration, telemetry, metrics, and documentation. Its largest gap is that it mandates an always-DocumentDB factory while claiming file storage remains usable, without defining how file-mode deployments obtain or handle an unavailable DocumentDB connection. Concrete criteria name FaissService, FaissSearchRepository, FaissMetadata, and the faiss_search_time_ms rename. No independent task statement was supplied, and repository reads were unavailable because the read-only shell sandbox failed to initialize, so claims that these symbols and production usage exist could not be independently verified."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 70,
+      "notes": "The LLD provides unusually concrete integration points, deletion lists, startup changes, and caller behavior across registry, metrics-service, infrastructure, tests, and documentation. Its largest deficiency is leaving load-bearing behavior unresolved: always initializing DocumentDB may undermine file-mode startup, while the identified SQLite rename is documented but no executable migration or compatibility strategy is selected. It specifically proposes changing registry/repositories/factory.py, registry/main.py, metrics-service storage, and the telemetry collector's search_backend pattern, but the latter can reject telemetry from older deployments during rollout. Exact paths and signatures could not be independently checked because repository shell access failed, and the design's declaration of no open questions is not justified by these unresolved compatibility issues."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 72,
+      "notes": "The review's strongest contribution is identifying concrete toggle-index drift and SQLite schema-rename consequences rather than merely approving the design. Its largest deficiency is accepting those issues without resolving them: a TODO does not restore the service-layer indexing invariant, and a migration note does not migrate existing databases. It also misses the risk of making DocumentDB initialization unconditional for file-backed deployments and of narrowing the collector schema during mixed-version rollout. The cited files and current dual-indexing behavior could not be independently verified because repository reads were unavailable."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 10,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 57,
+      "notes": "The plan covers dependency removal, grouped responses, toggle behavior, telemetry, documentation, and an end-to-end register-search-disable flow with concrete expected counts. Its largest weakness is that many commands do not enforce their stated oracle: curl lacks status checking, jq length accepts empty or error-shaped responses, and one toggle example contains a literal ellipsis. The hard-coded cd path does not match the submitted repository working directory, and there is no test for existing metrics-database migration, unavailable DocumentDB under file mode, mixed-version telemetry, or disabled-agent indexing. Endpoint paths and request schemas could not be verified against source because repository shell access failed."
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "No implementation was submitted; the implementation artifact is an empty string. There is no patch.diff or implementation summary to apply or compare with the repository. Consequently, none of the proposed deletions, factory changes, migrations, tests, or documentation updates are implemented or verifiable, so all implementation criteria score zero."
+    }
+  },
+  "task_score": 55.4,
+  "verdict": "The design artifacts are concrete and broadly thoughtful, but unresolved file-mode and migration behavior remain material, and the complete absence of an implementation is the largest limitation.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T02:56:17.411879Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 143546,
+      "cached_input_tokens": 119980,
+      "cache_write_input_tokens": 23552,
+      "output_tokens": 5543,
+      "reasoning_output_tokens": 3896
+    },
+    "duration_ms": 123933
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,295 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "kimi-k2.7-code",
+  "model_slug": "kimi-k2.7-code",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 4,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 69.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 16135377,
+    "output_tokens": 57229,
+    "cache_read_tokens": 15884816,
+    "cache_write_tokens": 331061,
+    "total_tokens": 32408483,
+    "total_cost_usd": 0,
+    "latency_seconds": 826.5999999999999,
+    "num_turns": 171,
+    "generation_tokens_per_sec": 69.5,
+    "prefix_cache_hit_rate": 0.9791,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 16135377,
+  "output_tokens": 57229,
+  "latency_seconds": 826.5999999999999,
+  "num_turns": 171,
+  "total_cost_usd": 0,
+  "is_error": true,
+  "result_subtype": "length",
+  "error": "length",
+  "api_error_status": null,
+  "run_started_at": "2026-08-06T01:42:41.763936Z",
+  "run_ended_at": "2026-08-06T01:49:56.847245Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 16135377,
+    "output_tokens": 57229,
+    "cache_read_tokens": 15884816,
+    "cache_write_tokens": 331061,
+    "total_tokens": 32408483,
+    "total_cost_usd": 0,
+    "latency_seconds": 826.5999999999999,
+    "num_turns": 171,
+    "generation_tokens_per_sec": 69.5,
+    "prefix_cache_hit_rate": 0.9791,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9791,
+      "prompt_tokens_cached_rate": 0.9791
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 31047,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 8014928,
+      "vllm:prefix_cache_queries_total": 8186329,
+      "vllm:prompt_tokens_by_source_total": 8186329,
+      "vllm:prompt_tokens_cached_total": 8014928,
+      "vllm:prompt_tokens_total": 8186329,
+      "vllm:request_success_total": 86,
+      "vllm:tool_call_parser_invocations_total": 21106
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 86,
+        "sum": 427.6221,
+        "mean": 4.97235
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 30961,
+        "sum": 389.2552,
+        "mean": 0.012572
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 31047,
+        "sum": 202448,
+        "mean": 6.520694
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 86,
+        "sum": 389.2552,
+        "mean": 4.526223
+      },
+      "vllm:request_generation_tokens": {
+        "count": 86,
+        "sum": 31047,
+        "mean": 361.011628
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 86,
+        "sum": 410.5774,
+        "mean": 4.774156
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 86,
+        "sum": 31047,
+        "mean": 361.011628
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 86,
+        "sum": 1062036,
+        "mean": 12349.255814
+      },
+      "vllm:request_params_n": {
+        "count": 86,
+        "sum": 86,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 86,
+        "sum": 171401,
+        "mean": 1993.034884
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 86,
+        "sum": 21.3222,
+        "mean": 0.247932
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 86,
+        "sum": 8186329,
+        "mean": 95189.872093
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 86,
+        "sum": 0.0006,
+        "mean": 7e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 86,
+        "sum": 1.0643,
+        "mean": 0.012375
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 86,
+        "sum": 38.4046,
+        "mean": 0.446565
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1699,
+          "mean": 0.1183,
+          "samples": 430
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.8977,
+          "samples": 430
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 430
+        }
+      }
+    }
+  },
+  "cache_read_tokens": 15884816,
+  "cache_creation_tokens": 331061,
+  "agent_invocations": 3,
+  "topped_up_artifacts": [],
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "kimi-k2.7-code",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 78,
+        "notes": "The issue clearly defines the dependency-removal goal, explicit non-goals, and testable criteria covering code, configuration, telemetry, metrics, and documentation. Its largest gap is that it mandates an always-DocumentDB factory while claiming file storage remains usable, without defining how file-mode deployments obtain or handle an unavailable DocumentDB connection. Concrete criteria name FaissService, FaissSearchRepository, FaissMetadata, and the faiss_search_time_ms rename. No independent task statement was supplied, and repository reads were unavailable because the read-only shell sandbox failed to initialize, so claims that these symbols and production usage exist could not be independently verified."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 70,
+        "notes": "The LLD provides unusually concrete integration points, deletion lists, startup changes, and caller behavior across registry, metrics-service, infrastructure, tests, and documentation. Its largest deficiency is leaving load-bearing behavior unresolved: always initializing DocumentDB may undermine file-mode startup, while the identified SQLite rename is documented but no executable migration or compatibility strategy is selected. It specifically proposes changing registry/repositories/factory.py, registry/main.py, metrics-service storage, and the telemetry collector's search_backend pattern, but the latter can reject telemetry from older deployments during rollout. Exact paths and signatures could not be independently checked because repository shell access failed, and the design's declaration of no open questions is not justified by these unresolved compatibility issues."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 72,
+        "notes": "The review's strongest contribution is identifying concrete toggle-index drift and SQLite schema-rename consequences rather than merely approving the design. Its largest deficiency is accepting those issues without resolving them: a TODO does not restore the service-layer indexing invariant, and a migration note does not migrate existing databases. It also misses the risk of making DocumentDB initialization unconditional for file-backed deployments and of narrowing the collector schema during mixed-version rollout. The cited files and current dual-indexing behavior could not be independently verified because repository reads were unavailable."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 10,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 57,
+        "notes": "The plan covers dependency removal, grouped responses, toggle behavior, telemetry, documentation, and an end-to-end register-search-disable flow with concrete expected counts. Its largest weakness is that many commands do not enforce their stated oracle: curl lacks status checking, jq length accepts empty or error-shaped responses, and one toggle example contains a literal ellipsis. The hard-coded cd path does not match the submitted repository working directory, and there is no test for existing metrics-database migration, unavailable DocumentDB under file mode, mixed-version telemetry, or disabled-agent indexing. Endpoint paths and request schemas could not be verified against source because repository shell access failed."
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "No implementation was submitted; the implementation artifact is an empty string. There is no patch.diff or implementation summary to apply or compare with the repository. Consequently, none of the proposed deletions, factory changes, migrations, tests, or documentation updates are implemented or verifiable, so all implementation criteria score zero."
+      }
+    },
+    "task_score": 55.4,
+    "verdict": "The design artifacts are concrete and broadly thoughtful, but unresolved file-mode and migration behavior remain material, and the complete absence of an implementation is the largest limitation.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T02:56:17.411879Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 143546,
+        "cached_input_tokens": 119980,
+        "cache_write_input_tokens": 23552,
+        "output_tokens": 5543,
+        "reasoning_output_tokens": 3896
+      },
+      "duration_ms": 123933
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "kimi-k2.7-code",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 14,
+      "total": 68,
+      "notes": "The issue clearly defines the feature flag, affected AWS components, fallback behavior, documentation work, and explicit non-goals. Its largest flaw is promising automatic credential rotation while prescribing a token generated only at task startup; new proxy connections will fail after that token expires. It also inaccurately describes token generation as an AWS API call requiring permission, although `generate-db-auth-token` signs locally and `rds-db:connect` is enforced during connection. No independent task statement was supplied, so requirement coverage beyond the identifier and artifacts is unverifiable."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 5,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 54,
+      "notes": "The LLD names concrete repository files and symbols, separates both flag states, and details task definition, proxy, cluster, secret, IAM, and documentation changes. The proposed ECS commands are nonfunctional because `command` does not replace the existing AWS CLI or Keycloak image entrypoints, so neither `/bin/sh` invocation runs as intended. The policy uses the Aurora cluster resource ID even though the client connects to an RDS Proxy, and `iam_auth = \"ENABLED\"` is not the required Aurora MySQL proxy mode; the design also knowingly leaves a startup token stale after 15 minutes. Its claim that `hashicorp/random` already exists is contradicted by the implementation adding that provider to `main.tf`."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 17,
+      "risk_awareness": 16,
+      "total": 56,
+      "notes": "The review identifies meaningful concerns including token expiry, file permissions, image availability, TLS behavior, and master-user reuse. Its most serious error is praising a policy scoped to the cluster resource ID, which cannot authorize an IAM-authenticated connection to the proxy endpoint. It also misses both container-entrypoint failures and the invalid proxy IAM mode while declaring that no blockers remain. Some recommendations are technically weak, including treating a redundant Terraform `depends_on` as required and naming an unverified `ClientConnectionFailed` proxy metric."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 7,
+      "specificity": 19,
+      "risk_awareness": 10,
+      "total": 53,
+      "notes": "The plan provides concrete plan, JSON inspection, compatibility, rollback, IAM-policy, and deployment checks for both feature states. The CloudTrail oracle is invalid because `aws rds generate-db-auth-token` performs local signing rather than a logged `GenerateDBAuthToken` API request. The readiness loop returns success after 30 failed attempts because its final `sleep` succeeds, and the plan incorrectly expects a cluster-resource IAM ARN for a proxy connection. It never forces a new connection after 15 minutes, so it misses the central stale-token regression, and its Terraform 1.2 prerequisite conflicts with cross-variable validation that requires Terraform 1.9 or newer."
+    },
+    "implementation": {
+      "completeness": 14,
+      "correctness": 3,
+      "specificity": 17,
+      "risk_awareness": 8,
+      "total": 42,
+      "notes": "The submitted diff has coherent baseline context for the existing cluster, proxy, ECS task definition, variables, and documentation, and it structurally preserves the password-auth branch. The IAM path cannot start: both images retain their original entrypoints, so the new `command = [\"/bin/sh\", \"-c\", ...]` arrays are passed to those entrypoints instead of launching a shell. Even after fixing that, the `rds-db:connect` ARN uses `aws_rds_cluster.keycloak.cluster_resource_id` rather than the proxy resource ID, the proxy uses the wrong IAM mode, and the password token is never refreshed. Independent source reads and `git apply --check` could not run because the provided shell failed during sandbox setup, so applicability beyond the submitted matching contexts remains unverified."
+    }
+  },
+  "task_score": 54.6,
+  "verdict": "The artifacts are detailed and repository-shaped, but the proposed IAM path is operationally nonfunctional because of incorrect container entrypoint handling, proxy authorization configuration, and an unrefreshed 15-minute token.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T02:59:31.072106Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 323997,
+      "cached_input_tokens": 281949,
+      "cache_write_input_tokens": 42030,
+      "output_tokens": 10229,
+      "reasoning_output_tokens": 8429
+    },
+    "duration_ms": 193648
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,289 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "kimi-k2.7-code",
+  "model_slug": "kimi-k2.7-code",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 7828648,
+    "output_tokens": 51180,
+    "cache_read_tokens": 7706256,
+    "cache_write_tokens": 181336,
+    "total_tokens": 15767420,
+    "total_cost_usd": null,
+    "latency_seconds": 663.1,
+    "num_turns": 93,
+    "generation_tokens_per_sec": 77.2,
+    "prefix_cache_hit_rate": 0.977,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 7828648,
+  "output_tokens": 51180,
+  "latency_seconds": 663.1,
+  "num_turns": 93,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T02:38:47.797805Z",
+  "run_ended_at": "2026-08-06T02:49:56.312221Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 7828648,
+    "output_tokens": 51180,
+    "cache_read_tokens": 7706256,
+    "cache_write_tokens": 181336,
+    "total_tokens": 15767420,
+    "total_cost_usd": null,
+    "latency_seconds": 663.1,
+    "num_turns": 93,
+    "generation_tokens_per_sec": 77.2,
+    "prefix_cache_hit_rate": 0.977,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.977,
+      "prompt_tokens_cached_rate": 0.977
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 52235,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 7706256,
+      "vllm:prefix_cache_queries_total": 7887592,
+      "vllm:prompt_tokens_by_source_total": 7887592,
+      "vllm:prompt_tokens_cached_total": 7706256,
+      "vllm:prompt_tokens_total": 7887592,
+      "vllm:request_success_total": 94,
+      "vllm:tool_call_parser_invocations_total": 31518
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 94,
+        "sum": 657.713,
+        "mean": 6.996947
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 52141,
+        "sum": 618.4445,
+        "mean": 0.011861
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 52235,
+        "sum": 233571,
+        "mean": 4.471542
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 94,
+        "sum": 618.4445,
+        "mean": 6.579197
+      },
+      "vllm:request_generation_tokens": {
+        "count": 94,
+        "sum": 52235,
+        "mean": 555.691489
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 94,
+        "sum": 641.2967,
+        "mean": 6.822305
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 94,
+        "sum": 52235,
+        "mean": 555.691489
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 94,
+        "sum": 1333512,
+        "mean": 14186.297872
+      },
+      "vllm:request_params_n": {
+        "count": 94,
+        "sum": 94,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 94,
+        "sum": 181336,
+        "mean": 1929.106383
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 94,
+        "sum": 22.8522,
+        "mean": 0.243108
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 94,
+        "sum": 7887592,
+        "mean": 83910.553191
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 94,
+        "sum": 0.0007,
+        "mean": 7e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 94,
+        "sum": 1.1282,
+        "mean": 0.012003
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 94,
+        "sum": 39.3018,
+        "mean": 0.418104
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1675,
+          "mean": 0.1044,
+          "samples": 662
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9275,
+          "samples": 662
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 662
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "kimi-k2.7-code",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 14,
+        "total": 68,
+        "notes": "The issue clearly defines the feature flag, affected AWS components, fallback behavior, documentation work, and explicit non-goals. Its largest flaw is promising automatic credential rotation while prescribing a token generated only at task startup; new proxy connections will fail after that token expires. It also inaccurately describes token generation as an AWS API call requiring permission, although `generate-db-auth-token` signs locally and `rds-db:connect` is enforced during connection. No independent task statement was supplied, so requirement coverage beyond the identifier and artifacts is unverifiable."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 5,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 54,
+        "notes": "The LLD names concrete repository files and symbols, separates both flag states, and details task definition, proxy, cluster, secret, IAM, and documentation changes. The proposed ECS commands are nonfunctional because `command` does not replace the existing AWS CLI or Keycloak image entrypoints, so neither `/bin/sh` invocation runs as intended. The policy uses the Aurora cluster resource ID even though the client connects to an RDS Proxy, and `iam_auth = \"ENABLED\"` is not the required Aurora MySQL proxy mode; the design also knowingly leaves a startup token stale after 15 minutes. Its claim that `hashicorp/random` already exists is contradicted by the implementation adding that provider to `main.tf`."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 17,
+        "risk_awareness": 16,
+        "total": 56,
+        "notes": "The review identifies meaningful concerns including token expiry, file permissions, image availability, TLS behavior, and master-user reuse. Its most serious error is praising a policy scoped to the cluster resource ID, which cannot authorize an IAM-authenticated connection to the proxy endpoint. It also misses both container-entrypoint failures and the invalid proxy IAM mode while declaring that no blockers remain. Some recommendations are technically weak, including treating a redundant Terraform `depends_on` as required and naming an unverified `ClientConnectionFailed` proxy metric."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 7,
+        "specificity": 19,
+        "risk_awareness": 10,
+        "total": 53,
+        "notes": "The plan provides concrete plan, JSON inspection, compatibility, rollback, IAM-policy, and deployment checks for both feature states. The CloudTrail oracle is invalid because `aws rds generate-db-auth-token` performs local signing rather than a logged `GenerateDBAuthToken` API request. The readiness loop returns success after 30 failed attempts because its final `sleep` succeeds, and the plan incorrectly expects a cluster-resource IAM ARN for a proxy connection. It never forces a new connection after 15 minutes, so it misses the central stale-token regression, and its Terraform 1.2 prerequisite conflicts with cross-variable validation that requires Terraform 1.9 or newer."
+      },
+      "implementation": {
+        "completeness": 14,
+        "correctness": 3,
+        "specificity": 17,
+        "risk_awareness": 8,
+        "total": 42,
+        "notes": "The submitted diff has coherent baseline context for the existing cluster, proxy, ECS task definition, variables, and documentation, and it structurally preserves the password-auth branch. The IAM path cannot start: both images retain their original entrypoints, so the new `command = [\"/bin/sh\", \"-c\", ...]` arrays are passed to those entrypoints instead of launching a shell. Even after fixing that, the `rds-db:connect` ARN uses `aws_rds_cluster.keycloak.cluster_resource_id` rather than the proxy resource ID, the proxy uses the wrong IAM mode, and the password token is never refreshed. Independent source reads and `git apply --check` could not run because the provided shell failed during sandbox setup, so applicability beyond the submitted matching contexts remains unverified."
+      }
+    },
+    "task_score": 54.6,
+    "verdict": "The artifacts are detailed and repository-shaped, but the proposed IAM path is operationally nonfunctional because of incorrect container entrypoint handling, proxy authorization configuration, and an unrefreshed 15-minute token.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T02:59:31.072106Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 323997,
+        "cached_input_tokens": 281949,
+        "cache_write_input_tokens": 42030,
+        "output_tokens": 10229,
+        "reasoning_output_tokens": 8429
+      },
+      "duration_ms": 193648
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "kimi-k2.7-code",
+  "model_slug": "kimi-k2.7-code",
+  "agent": "pi",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T02:51:42.834256Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 119679,
+      "cached_input_tokens": 93824,
+      "cache_write_input_tokens": 25845,
+      "output_tokens": 7406,
+      "reasoning_output_tokens": 5852
+    },
+    "duration_ms": 105978
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 60.68,
+  "mean_cost_usd_excl_failed": 0.0,
+  "tasks": [
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 136,
+      "input_tokens": 11629254,
+      "output_tokens": 49265,
+      "total_tokens": 23375159,
+      "latency_seconds": 652.5,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 78.8,
+      "cache_read_tokens": 11506768,
+      "cache_write_tokens": 189872,
+      "prefix_cache_hit_rate": 0.9838,
+      "generation_tokens_per_sec": 75.5,
+      "kv_cache_usage": {
+        "peak": 0.1667,
+        "mean": 0.1016
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 89,
+          "notes": "The issue clearly identifies three outbound request paths, their required failure behavior, configuration, tests, and explicit exclusions. Its largest weakness is broadening GITHUB_EXTRA_HOSTS into a general outbound allowlist while claiming unchanged configuration semantics, which increases trust beyond skill fetching. The submitted diff contexts corroborate the named symbols in agent_validator.py, agent_routes.py, health/service.py, and skill_service.py. No independent task statement was supplied, so requirements beyond the task identifier and artifacts could not be verified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 15,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 81,
+          "notes": "The LLD is concrete about files, call flows, configuration, failure results, deployment wiring, and compatibility. Its load-bearing defect is placing proxy_pass_url validation before transport dispatch: the submitted existing stdio test uses localhost and expects healthy, but this ordering blocks it before stdio handling. It also incorrectly states that httpx follows redirects by default and overlooks sensitive full-URL logging. Claims such as batched health checks and exact baseline behavior could not be independently checked because repository shell access failed."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 80,
+          "notes": "The review finds concrete issues involving synchronous DNS, cache relocation, service-path plumbing, allowlist expansion, redirects, and deployment configuration. Its largest omission is the stdio regression caused by validating localhost before examining supported_transports, despite the affected test appearing in the patch. It also wrongly treats http://127.0.0.1@evil.com as targeting 127.0.0.1; urllib.parse identifies evil.com as the hostname. Frontend behavior and infrastructure requirements were asserted without independently verifiable repository evidence."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 73,
+          "notes": "The plan covers the utility, every guarded call site, compatibility, configuration loading, deployment wiring, and no-request oracles for blocked URLs. The auth-info assertion for http://127.0.0.1@evil.com is technically wrong and will normally fail because the request host is evil.com. Some manual snippets use undefined objects such as AsyncMock and agent_card, disagree on status versus health_status, and omit the existing stdio compatibility case. The uv commands and project prerequisites could not be independently verified against pyproject.toml."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 71,
+          "notes": "The patch implements the shared utility, settings and compose wiring, all three enforcement paths, documentation, and targeted tests. Its largest defect is that _check_server_endpoint_transport_aware validates proxy_pass_url before reading supported_transports, so the retained stdio test using http://localhost:8000 now fails and non-outbound stdio services become unhealthy. test_auth_info_urls_parsed_safely also contains a false expectation for http://127.0.0.1@evil.com, while the summary admits tests were not executed. The documented redirect, DNS-rebinding, and blocking-DNS limitations are honest, but the claimed git apply verification could not be independently confirmed because the repository shell was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 50,
+      "input_tokens": 3411724,
+      "output_tokens": 20371,
+      "total_tokens": 6843819,
+      "latency_seconds": 247.1,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 70.6,
+      "cache_read_tokens": 3328016,
+      "cache_write_tokens": 83708,
+      "prefix_cache_hit_rate": 0.9755,
+      "generation_tokens_per_sec": 82.4,
+      "kv_cache_usage": {
+        "peak": 0.1151,
+        "mean": 0.0846
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 13,
+          "total": 74,
+          "notes": "The issue provides a concrete inventory of variables, outputs, task mounts, scripts, and validation outcomes, making most acceptance criteria directly testable. Its largest deficiency is treating the absence of production EFS data and the sufficiency of S3/DocumentDB as facts without independent task evidence, backup, rollback, or downstream-output consumer handling. The single-AZ motivation is contradicted by the submitted `storage.tf`, where `mount_targets` iterates over every private subnet. With no independent task statement, the runtime persistence and container-image claims remain unverified."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 76,
+          "notes": "The LLD is implementation-ready in its mapping of `module.efs` references, task volumes, outputs, variables, and script branches to specific files and edits. Its load-bearing weakness is asserting that `/app/auth_server/scopes.yml` exists and `/app/data` is transient without showing repository or image evidence for either claim. The submitted diff supports its descriptions of `storage.tf`, `ecs-services.tf`, and `post-deployment-setup.sh`, but the claimed absence of EFS wiring in `main.tf` is not demonstrated by the patch. The rollout acknowledges destruction yet lacks a backup check, irreversible-data warning, rollback strategy, and treatment of external consumers of the removed module outputs."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 19,
+          "risk_awareness": 18,
+          "total": 71,
+          "notes": "The review's strongest contribution is identifying concrete runtime risks around the image-local scopes file, `/app/data`, removed Terraform outputs, and destructive EFS removal. It nevertheless marks these concerns resolved through unsupported statements about published images at tag `1.24.4`, while the implementation summary supplies no corresponding verification. It also misses that the patched `_initialize_scopes` now returns failure whenever `documentdb_cluster_endpoint` is absent, although the old code explicitly supported a non-DocumentDB branch. The question about CI or documentation consumers of `mcp_gateway_efs_*` remains unanswered despite the approved-with-changes verdict."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 12,
+          "specificity": 19,
+          "risk_awareness": 11,
+          "total": 57,
+          "notes": "The plan gives specific static checks and useful oracles for removed symbols, task volumes, scripts, and the scopes path. Its central plan test is not reproducible as written: a fresh clone initialized with `terraform init -backend=false` has no deployed pre-change state from which EFS resources could be planned for destruction. Copying `terraform.tfvars.example` with optional manual adjustments also does not establish a valid plan fixture, and the stated Terraform version requirement is unsupported. No test exercises the modified shell function, the missing-DocumentDB failure, dry-run behavior, container startup, or actual existence of `/app/auth_server/scopes.yml`, while end-to-end coverage is dismissed as inapplicable."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 75,
+          "notes": "The patch directly removes the EFS module, variables, outputs, auth and mcpgw mounts, root outputs, and EFS initialization script, while updating `SCOPES_CONFIG_PATH` and the post-deployment branch consistently. The largest behavioral risk is that `_initialize_scopes` now hard-fails without `documentdb_cluster_endpoint`; the artifacts do not establish that DocumentDB is mandatory for every supported AWS ECS configuration. The diff context is internally consistent around `module.efs`, `efs_volume_configuration`, and `mcp_gateway_efs_id`, but application against the real tree and the asserted `main.tf` wiring could not be independently verified in this environment. The summary acknowledges that Terraform verification was not executed, but it overstates runtime safety and offers no protection or recovery path for potentially populated EFS state."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 4,
+      "artifacts_expected": 6,
+      "num_turns": 171,
+      "input_tokens": 16135377,
+      "output_tokens": 57229,
+      "total_tokens": 32408483,
+      "latency_seconds": 826.5999999999999,
+      "total_cost_usd": 0,
+      "result_subtype": "length",
+      "task_score": 55.4,
+      "cache_read_tokens": 15884816,
+      "cache_write_tokens": 331061,
+      "prefix_cache_hit_rate": 0.9791,
+      "generation_tokens_per_sec": 69.5,
+      "kv_cache_usage": {
+        "peak": 0.1699,
+        "mean": 0.1183
+      },
+      "agent_invocations": 3,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 78,
+          "notes": "The issue clearly defines the dependency-removal goal, explicit non-goals, and testable criteria covering code, configuration, telemetry, metrics, and documentation. Its largest gap is that it mandates an always-DocumentDB factory while claiming file storage remains usable, without defining how file-mode deployments obtain or handle an unavailable DocumentDB connection. Concrete criteria name FaissService, FaissSearchRepository, FaissMetadata, and the faiss_search_time_ms rename. No independent task statement was supplied, and repository reads were unavailable because the read-only shell sandbox failed to initialize, so claims that these symbols and production usage exist could not be independently verified."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 70,
+          "notes": "The LLD provides unusually concrete integration points, deletion lists, startup changes, and caller behavior across registry, metrics-service, infrastructure, tests, and documentation. Its largest deficiency is leaving load-bearing behavior unresolved: always initializing DocumentDB may undermine file-mode startup, while the identified SQLite rename is documented but no executable migration or compatibility strategy is selected. It specifically proposes changing registry/repositories/factory.py, registry/main.py, metrics-service storage, and the telemetry collector's search_backend pattern, but the latter can reject telemetry from older deployments during rollout. Exact paths and signatures could not be independently checked because repository shell access failed, and the design's declaration of no open questions is not justified by these unresolved compatibility issues."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 72,
+          "notes": "The review's strongest contribution is identifying concrete toggle-index drift and SQLite schema-rename consequences rather than merely approving the design. Its largest deficiency is accepting those issues without resolving them: a TODO does not restore the service-layer indexing invariant, and a migration note does not migrate existing databases. It also misses the risk of making DocumentDB initialization unconditional for file-backed deployments and of narrowing the collector schema during mixed-version rollout. The cited files and current dual-indexing behavior could not be independently verified because repository reads were unavailable."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 57,
+          "notes": "The plan covers dependency removal, grouped responses, toggle behavior, telemetry, documentation, and an end-to-end register-search-disable flow with concrete expected counts. Its largest weakness is that many commands do not enforce their stated oracle: curl lacks status checking, jq length accepts empty or error-shaped responses, and one toggle example contains a literal ellipsis. The hard-coded cd path does not match the submitted repository working directory, and there is no test for existing metrics-database migration, unavailable DocumentDB under file mode, mixed-version telemetry, or disabled-agent indexing. Endpoint paths and request schemas could not be verified against source because repository shell access failed."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "No implementation was submitted; the implementation artifact is an empty string. There is no patch.diff or implementation summary to apply or compare with the repository. Consequently, none of the proposed deletions, factory changes, migrations, tests, or documentation updates are implemented or verifiable, so all implementation criteria score zero."
+        }
+      },
+      "is_error": true,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 93,
+      "input_tokens": 7828648,
+      "output_tokens": 51180,
+      "total_tokens": 15767420,
+      "latency_seconds": 663.1,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 54.6,
+      "cache_read_tokens": 7706256,
+      "cache_write_tokens": 181336,
+      "prefix_cache_hit_rate": 0.977,
+      "generation_tokens_per_sec": 77.2,
+      "kv_cache_usage": {
+        "peak": 0.1675,
+        "mean": 0.1044
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 68,
+          "notes": "The issue clearly defines the feature flag, affected AWS components, fallback behavior, documentation work, and explicit non-goals. Its largest flaw is promising automatic credential rotation while prescribing a token generated only at task startup; new proxy connections will fail after that token expires. It also inaccurately describes token generation as an AWS API call requiring permission, although `generate-db-auth-token` signs locally and `rds-db:connect` is enforced during connection. No independent task statement was supplied, so requirement coverage beyond the identifier and artifacts is unverifiable."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 5,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 54,
+          "notes": "The LLD names concrete repository files and symbols, separates both flag states, and details task definition, proxy, cluster, secret, IAM, and documentation changes. The proposed ECS commands are nonfunctional because `command` does not replace the existing AWS CLI or Keycloak image entrypoints, so neither `/bin/sh` invocation runs as intended. The policy uses the Aurora cluster resource ID even though the client connects to an RDS Proxy, and `iam_auth = \"ENABLED\"` is not the required Aurora MySQL proxy mode; the design also knowingly leaves a startup token stale after 15 minutes. Its claim that `hashicorp/random` already exists is contradicted by the implementation adding that provider to `main.tf`."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 16,
+          "total": 56,
+          "notes": "The review identifies meaningful concerns including token expiry, file permissions, image availability, TLS behavior, and master-user reuse. Its most serious error is praising a policy scoped to the cluster resource ID, which cannot authorize an IAM-authenticated connection to the proxy endpoint. It also misses both container-entrypoint failures and the invalid proxy IAM mode while declaring that no blockers remain. Some recommendations are technically weak, including treating a redundant Terraform `depends_on` as required and naming an unverified `ClientConnectionFailed` proxy metric."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 7,
+          "specificity": 19,
+          "risk_awareness": 10,
+          "total": 53,
+          "notes": "The plan provides concrete plan, JSON inspection, compatibility, rollback, IAM-policy, and deployment checks for both feature states. The CloudTrail oracle is invalid because `aws rds generate-db-auth-token` performs local signing rather than a logged `GenerateDBAuthToken` API request. The readiness loop returns success after 30 failed attempts because its final `sleep` succeeds, and the plan incorrectly expects a cluster-resource IAM ARN for a proxy connection. It never forces a new connection after 15 minutes, so it misses the central stale-token regression, and its Terraform 1.2 prerequisite conflicts with cross-variable validation that requires Terraform 1.9 or newer."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 3,
+          "specificity": 17,
+          "risk_awareness": 8,
+          "total": 42,
+          "notes": "The submitted diff has coherent baseline context for the existing cluster, proxy, ECS task definition, variables, and documentation, and it structurally preserves the password-auth branch. The IAM path cannot start: both images retain their original entrypoints, so the new `command = [\"/bin/sh\", \"-c\", ...]` arrays are passed to those entrypoints instead of launching a shell. Even after fixing that, the `rds-db:connect` ARN uses `aws_rds_cluster.keycloak.cluster_resource_id` rather than the proxy resource ID, the proxy uses the wrong IAM mode, and the password token is never refreshed. Independent source reads and `git apply --check` could not run because the provided shell failed during sandbox setup, so applicability beyond the submitted matching contexts remains unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 4,
+      "artifacts_expected": 6,
+      "num_turns": 137,
+      "input_tokens": 11759663,
+      "output_tokens": 73934,
+      "total_tokens": 23673831,
+      "latency_seconds": 1008.0,
+      "total_cost_usd": 0,
+      "result_subtype": "length",
+      "task_score": 44.0,
+      "cache_read_tokens": 11509568,
+      "cache_write_tokens": 330666,
+      "prefix_cache_hit_rate": 0.9597,
+      "generation_tokens_per_sec": 69.8,
+      "kv_cache_usage": {
+        "peak": 0.1707,
+        "mean": 0.133
+      },
+      "agent_invocations": 3,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 55,
+          "notes": "The issue provides a concrete secret inventory, scoped exclusions, and mostly testable acceptance criteria. Its central solution contradicts its security goal: emitting the same credentials as `*_PLAINTEXT` environment entries leaves them visible in task definitions, while `aws_secretsmanager_secret_version.secret_string` also remains in Terraform state. The criterion claiming no sensitive values are rendered in container definitions is therefore incompatible with the proposed fallback. No independent task statement was supplied, and repository command execution was unavailable, so claims about `secrets.tf` and `aws_iam_policy.ecs_secrets_access` could not be directly verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 7,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 54,
+          "notes": "The LLD names concrete Terraform and Python integration points and specifies resource, IAM, environment, and rollout behavior. However, each source variable simultaneously controls both the managed secret and plaintext fallback, so normal deployments have both or neither; the fallback cannot rescue an ECS secret-retrieval failure because ECS fails before application startup. Gating secret existence on the secret value also forces operators to retain the value in Terraform, while `ignore_changes` makes later variable updates ineffective and removing the value destroys the secret. The asserted files and symbols, including `registry/core/config.py` and `aws_kms_key.secrets`, could not be verified directly against the repository."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 18,
+          "risk_awareness": 18,
+          "total": 66,
+          "notes": "The review's strongest contribution is identifying residual `*_PLAINTEXT` exposure and the surprising seed-only behavior caused by `ignore_changes`. It nevertheless approves the design without resolving those critical defects and misses that secret values remain in Terraform state and that the proposed fallback is unavailable when ECS retrieval fails. Several resolutions are contradicted by the LLD: the deployment checklist does not add root `terraform/aws-ecs/variables.tf`, and the rollout plan stages by environment rather than by secret class. Repository-specific assertions about existing IAM and KMS wiring could not be independently verified."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 5,
+          "specificity": 16,
+          "risk_awareness": 9,
+          "total": 45,
+          "notes": "The plan spans helper precedence, Settings behavior, Terraform planning, IAM, deployment, rollback, and an authentication path. Its central plan checks are invalid because sections 4.1 and 4.3 use the same name regex, so a correct `secrets` entry makes the environment-removal check fail; the scripts also only print failures and never exit nonzero. `aws ecs describe-tasks` does not expose container environment variables, and setting the shared Terraform variable to empty removes both the secret and its plaintext fallback, invalidating the rollback oracle. The hard-coded `REPO_ROOT` differs from the submitted workspace path, while the skeletal GitHub E2E case supplies no executable setup or strong oracle."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "The implementation artifact is empty, with no patch, summary, target files, or executable change submitted. It therefore cannot implement the design or be checked against the repository, and every implementation criterion receives zero. No implementation deviation or runtime behavior can be assessed beyond its absence."
+        }
+      },
+      "is_error": true,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-06"
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,65 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "kimi-k2.7-code",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 89,
+      "notes": "The issue clearly identifies three outbound request paths, their required failure behavior, configuration, tests, and explicit exclusions. Its largest weakness is broadening GITHUB_EXTRA_HOSTS into a general outbound allowlist while claiming unchanged configuration semantics, which increases trust beyond skill fetching. The submitted diff contexts corroborate the named symbols in agent_validator.py, agent_routes.py, health/service.py, and skill_service.py. No independent task statement was supplied, so requirements beyond the task identifier and artifacts could not be verified."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 15,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 81,
+      "notes": "The LLD is concrete about files, call flows, configuration, failure results, deployment wiring, and compatibility. Its load-bearing defect is placing proxy_pass_url validation before transport dispatch: the submitted existing stdio test uses localhost and expects healthy, but this ordering blocks it before stdio handling. It also incorrectly states that httpx follows redirects by default and overlooks sensitive full-URL logging. Claims such as batched health checks and exact baseline behavior could not be independently checked because repository shell access failed."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 80,
+      "notes": "The review finds concrete issues involving synchronous DNS, cache relocation, service-path plumbing, allowlist expansion, redirects, and deployment configuration. Its largest omission is the stdio regression caused by validating localhost before examining supported_transports, despite the affected test appearing in the patch. It also wrongly treats http://127.0.0.1@evil.com as targeting 127.0.0.1; urllib.parse identifies evil.com as the hostname. Frontend behavior and infrastructure requirements were asserted without independently verifiable repository evidence."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 12,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 73,
+      "notes": "The plan covers the utility, every guarded call site, compatibility, configuration loading, deployment wiring, and no-request oracles for blocked URLs. The auth-info assertion for http://127.0.0.1@evil.com is technically wrong and will normally fail because the request host is evil.com. Some manual snippets use undefined objects such as AsyncMock and agent_card, disagree on status versus health_status, and omit the existing stdio compatibility case. The uv commands and project prerequisites could not be independently verified against pyproject.toml."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 12,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 71,
+      "notes": "The patch implements the shared utility, settings and compose wiring, all three enforcement paths, documentation, and targeted tests. Its largest defect is that _check_server_endpoint_transport_aware validates proxy_pass_url before reading supported_transports, so the retained stdio test using http://localhost:8000 now fails and non-outbound stdio services become unhealthy. test_auth_info_urls_parsed_safely also contains a false expectation for http://127.0.0.1@evil.com, while the summary admits tests were not executed. The documented redirect, DNS-rebinding, and blocking-DNS limitations are honest, but the claimed git apply verification could not be independently confirmed because the repository shell was unavailable."
+    }
+  },
+  "task_score": 78.8,
+  "verdict": "Strong and specific design work is undermined by a concrete stdio regression and incorrect tests in the implementation.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-06T03:01:29.008193Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 214564,
+      "cached_input_tokens": 167330,
+      "cache_write_input_tokens": 47224,
+      "output_tokens": 8010,
+      "reasoning_output_tokens": 6583
+    },
+    "duration_ms": 117924
+  },
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/kimi-k2.7-code/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,288 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "kimi-k2.7-code",
+  "model_slug": "kimi-k2.7-code",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:8000",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": 8,
+    "precision": "fp8",
+    "context_window": 131072
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 75.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 11629254,
+    "output_tokens": 49265,
+    "cache_read_tokens": 11506768,
+    "cache_write_tokens": 189872,
+    "total_tokens": 23375159,
+    "total_cost_usd": null,
+    "latency_seconds": 652.5,
+    "num_turns": 136,
+    "generation_tokens_per_sec": 75.5,
+    "prefix_cache_hit_rate": 0.9838,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 11629254,
+  "output_tokens": 49265,
+  "latency_seconds": 652.5,
+  "num_turns": 136,
+  "total_cost_usd": null,
+  "is_error": false,
+  "result_subtype": "success",
+  "run_started_at": "2026-08-06T01:54:08.407302Z",
+  "run_ended_at": "2026-08-06T02:05:05.741684Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 11629254,
+    "output_tokens": 49265,
+    "cache_read_tokens": 11506768,
+    "cache_write_tokens": 189872,
+    "total_tokens": 23375159,
+    "total_cost_usd": null,
+    "latency_seconds": 652.5,
+    "num_turns": 136,
+    "generation_tokens_per_sec": 75.5,
+    "prefix_cache_hit_rate": 0.9838,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "vllm_prometheus.counters.vllm:prompt_tokens_cached_total",
+      "cache_write_tokens": "vllm_prometheus derived: vllm:prompt_tokens_total - vllm:prompt_tokens_cached_total (uncached prefill tokens)",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "null (self-hosted: no per-token bill; cost is hardware-derived)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": true,
+    "source": "vllm_prometheus_window",
+    "note": "Window delta of server-wide vLLM metrics; accurate only if this run was the sole traffic on the endpoint during its execution. Gauges are an instantaneous post-run reading and typically read idle between tasks.",
+    "derived": {
+      "prefix_cache_hit_rate": 0.9838,
+      "prompt_tokens_cached_rate": 0.9838
+    },
+    "counters": {
+      "vllm:estimated_flops_per_gpu_total": 0,
+      "vllm:estimated_read_bytes_per_gpu_total": 0,
+      "vllm:estimated_write_bytes_per_gpu_total": 0,
+      "vllm:external_prefix_cache_hits_total": 0,
+      "vllm:external_prefix_cache_queries_total": 0,
+      "vllm:generation_tokens_total": 50020,
+      "vllm:mm_cache_hits_total": 0,
+      "vllm:mm_cache_queries_total": 0,
+      "vllm:num_preemptions_total": 0,
+      "vllm:prefix_cache_hits_total": 11506768,
+      "vllm:prefix_cache_queries_total": 11696640,
+      "vllm:prompt_tokens_by_source_total": 11696640,
+      "vllm:prompt_tokens_cached_total": 11506768,
+      "vllm:prompt_tokens_total": 11696640,
+      "vllm:request_success_total": 137,
+      "vllm:tool_call_parser_invocations_total": 40885
+    },
+    "histograms": {
+      "vllm:e2e_request_latency_seconds": {
+        "count": 137,
+        "sum": 646.5348,
+        "mean": 4.719232
+      },
+      "vllm:inter_token_latency_seconds": {
+        "count": 49883,
+        "sum": 592.5647,
+        "mean": 0.011879
+      },
+      "vllm:iteration_tokens_total": {
+        "count": 50020,
+        "sum": 239892,
+        "mean": 4.795922
+      },
+      "vllm:request_decode_time_seconds": {
+        "count": 137,
+        "sum": 592.5647,
+        "mean": 4.32529
+      },
+      "vllm:request_generation_tokens": {
+        "count": 137,
+        "sum": 50020,
+        "mean": 365.109489
+      },
+      "vllm:request_inference_time_seconds": {
+        "count": 137,
+        "sum": 619.8494,
+        "mean": 4.524449
+      },
+      "vllm:request_max_num_generation_tokens": {
+        "count": 137,
+        "sum": 50020,
+        "mean": 365.109489
+      },
+      "vllm:request_params_max_tokens": {
+        "count": 137,
+        "sum": 1986850,
+        "mean": 14502.554745
+      },
+      "vllm:request_params_n": {
+        "count": 137,
+        "sum": 137,
+        "mean": 1.0
+      },
+      "vllm:request_prefill_kv_computed_tokens": {
+        "count": 137,
+        "sum": 189872,
+        "mean": 1385.927007
+      },
+      "vllm:request_prefill_time_seconds": {
+        "count": 137,
+        "sum": 27.2847,
+        "mean": 0.199158
+      },
+      "vllm:request_prompt_tokens": {
+        "count": 137,
+        "sum": 11696640,
+        "mean": 85376.934307
+      },
+      "vllm:request_queue_time_seconds": {
+        "count": 137,
+        "sum": 0.0009,
+        "mean": 7e-06
+      },
+      "vllm:request_time_per_output_token_seconds": {
+        "count": 137,
+        "sum": 1.6533,
+        "mean": 0.012068
+      },
+      "vllm:time_to_first_token_seconds": {
+        "count": 137,
+        "sum": 54.0238,
+        "mean": 0.394334
+      }
+    },
+    "gauges": {
+      "vllm:cache_config_info": 1,
+      "vllm:engine_sleep_state": 1,
+      "vllm:kv_cache_usage_perc": 0,
+      "vllm:num_requests_running": 0,
+      "vllm:num_requests_waiting": 0,
+      "vllm:num_requests_waiting_by_reason": 0
+    },
+    "gauges_sampled": {
+      "available": true,
+      "source": "vllm_prometheus_poll",
+      "note": "Peak/mean of gauges sampled every 1.0s while the run was in flight. Peak still reflects total server load under the single-tenant assumption, not this run in isolation.",
+      "interval_seconds": 1.0,
+      "gauges": {
+        "vllm:kv_cache_usage_perc": {
+          "peak": 0.1667,
+          "mean": 0.1016,
+          "samples": 649
+        },
+        "vllm:num_requests_running": {
+          "peak": 1.0,
+          "mean": 0.9029,
+          "samples": 649
+        },
+        "vllm:num_requests_waiting": {
+          "peak": 0.0,
+          "mean": 0.0,
+          "samples": 649
+        }
+      }
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "kimi-k2.7-code",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 89,
+        "notes": "The issue clearly identifies three outbound request paths, their required failure behavior, configuration, tests, and explicit exclusions. Its largest weakness is broadening GITHUB_EXTRA_HOSTS into a general outbound allowlist while claiming unchanged configuration semantics, which increases trust beyond skill fetching. The submitted diff contexts corroborate the named symbols in agent_validator.py, agent_routes.py, health/service.py, and skill_service.py. No independent task statement was supplied, so requirements beyond the task identifier and artifacts could not be verified."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 15,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 81,
+        "notes": "The LLD is concrete about files, call flows, configuration, failure results, deployment wiring, and compatibility. Its load-bearing defect is placing proxy_pass_url validation before transport dispatch: the submitted existing stdio test uses localhost and expects healthy, but this ordering blocks it before stdio handling. It also incorrectly states that httpx follows redirects by default and overlooks sensitive full-URL logging. Claims such as batched health checks and exact baseline behavior could not be independently checked because repository shell access failed."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 80,
+        "notes": "The review finds concrete issues involving synchronous DNS, cache relocation, service-path plumbing, allowlist expansion, redirects, and deployment configuration. Its largest omission is the stdio regression caused by validating localhost before examining supported_transports, despite the affected test appearing in the patch. It also wrongly treats http://127.0.0.1@evil.com as targeting 127.0.0.1; urllib.parse identifies evil.com as the hostname. Frontend behavior and infrastructure requirements were asserted without independently verifiable repository evidence."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 12,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 73,
+        "notes": "The plan covers the utility, every guarded call site, compatibility, configuration loading, deployment wiring, and no-request oracles for blocked URLs. The auth-info assertion for http://127.0.0.1@evil.com is technically wrong and will normally fail because the request host is evil.com. Some manual snippets use undefined objects such as AsyncMock and agent_card, disagree on status versus health_status, and omit the existing stdio compatibility case. The uv commands and project prerequisites could not be independently verified against pyproject.toml."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 12,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 71,
+        "notes": "The patch implements the shared utility, settings and compose wiring, all three enforcement paths, documentation, and targeted tests. Its largest defect is that _check_server_endpoint_transport_aware validates proxy_pass_url before reading supported_transports, so the retained stdio test using http://localhost:8000 now fails and non-outbound stdio services become unhealthy. test_auth_info_urls_parsed_safely also contains a false expectation for http://127.0.0.1@evil.com, while the summary admits tests were not executed. The documented redirect, DNS-rebinding, and blocking-DNS limitations are honest, but the claimed git apply verification could not be independently confirmed because the repository shell was unavailable."
+      }
+    },
+    "task_score": 78.8,
+    "verdict": "Strong and specific design work is undermined by a concrete stdio regression and incorrect tests in the implementation.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-06T03:01:29.008193Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 214564,
+        "cached_input_tokens": 167330,
+        "cache_write_input_tokens": 47224,
+        "output_tokens": 8010,
+        "reasoning_output_tokens": 6583
+      },
+      "duration_ms": 117924
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Lands the **data only** from #107 -- shekharprateek's re-run of kimi-k2.7-code pi/swe3 on the fixed token harness (post-#99). This is the conflict-free way to merge #107.

- kimi-k2.7-code / pi / swe3: **5/5 scored, mean 60.68**, ~429 output tokens/turn (vs the ~4/turn undercount in the original #96 run -- ~93x correction).

## Why not merge #107 directly

#107 conflicts on `docs/harness-pi-swe3.md` and 8 chart PNGs. Those are **regenerated from data** once all pending PRs are merged, so the conflicting doc/chart edits are throwaway. This PR takes only the 11 kimi data files (metrics.json / eval.json / run-summary.json) onto a clean branch off `main`, dropping the doc/PNG changes entirely -- no conflict.

## Verification

- Pure add (kimi/pi/swe3 was not on main); no other model dirs touched, so nothing on main is reverted.
- `eval.json` skill backfilled to `swe3`; no `session_id`/`repo_root` or secrets; no large artifacts committed.

Once merged, #107 can be closed as superseded (data landed here).