### PR TITLE
benchmark: Claude Sonnet 5 (pi, Bedrock) -- 5/5 tasks, mean 60.56

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "model": "us.anthropic.claude-sonnet-5",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 75,
+      "notes": "The issue gives a concrete twelve-variable inventory, service split, file list, precedence rules, and testable acceptance criteria that largely match terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf. Its claim that empty values are currently omitted is false: the baseline task definitions emit fixed environment entries even when their variables default to empty strings. Cross-account support is incomplete because iam.tf grants KMS decryption only on aws_kms_key.secrets, and the claim that the repository lacks a relevant Helm surface is contradicted by charts/registry and charts/auth-server. No independent task statement was supplied, so broader requirement coverage beyond the ECS-focused task identifier cannot be verified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 12,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 66,
+      "notes": "The LLD is unusually concrete about real files, locals, container wiring, IAM resources, precedence, and rollout mechanics, and those integration points exist at the pinned repository revision. Its backward-compatibility model is wrong because the baseline uses unconditional environment entries, while the proposed filtered locals omit empty values and reorder nonempty entries at the end of each list. The advertised cross-account design also lacks caller-side kms:Decrypt permission for an externally owned customer-managed key, which is required alongside the external key policy. Several review resolutions are not actually present in the submitted LLD, including the warning design, rotation restart guidance, and detailed cross-account KMS treatment."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 11,
+      "specificity": 20,
+      "risk_awareness": 15,
+      "total": 62,
+      "notes": "The review raises specific concerns about JSON and PEM secret formats, map-key typos, delayed ARN validation, rotation, and cross-account KMS rather than merely approving the design. It misses the baseline empty-entry contradiction and endorses a warning whose count depends on sensitive variables, a Terraform-invalid construction. Its resolution section claims changes were incorporated into the LLD even though the submitted LLD still defers the warning and lacks the stated rotation and KMS additions. Real AWS behavior and the claimed CloudTrail configuration details were not verified in the submission."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 18,
+      "risk_awareness": 15,
+      "total": 61,
+      "notes": "The plan covers ARN precedence, plaintext fallback, registry-only scoping, IAM resources, rollback, steady state, formatting, validation, and runtime secret resolution. However, the byte-for-byte baseline expectation cannot hold because the patch moves entries into map-derived lists, and the both-unset expectation contradicts the current unconditional environment entries. Section 2.3 places -var before -var-file and provides a Python command that performs no assertion, while the deployment command references a nonexistent registry_task_definition_arn output before falling back to a placeholder. No Terraform or AWS checks were executed, so the critical sensitive-count failure would remain undetected."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 8,
+      "specificity": 22,
+      "risk_awareness": 10,
+      "total": 58,
+      "notes": "The patch targets the correct eight files, all preimage blob hashes match the repository, and it wires all twelve ARN variables through declarations, module forwarding, ECS secrets, IAM resources, and examples. The added null_resource uses count derived from sensitive plaintext variables, which Terraform rejects because sensitive values cannot determine resource count; its local-exec output would also be suppressed as sensitive, so the claimed warning does not work. The patch also changes empty-value behavior and list ordering despite claiming zero behavior change, and it cannot consume cross-account secrets encrypted with an external customer-managed KMS key because the execution-role policy grants decryption only on aws_kms_key.secrets. The summary honestly reports that validation and planning were not executed, but it consequently oversells an implementation that is not plan-ready and deviates materially from its compatibility and cross-account claims."
+    }
+  },
+  "task_score": 64.4,
+  "verdict": "The submission is highly specific and mostly grounded, but the implementation is not deployable because its migration warning derives resource count from sensitive values, with additional compatibility and cross-account KMS gaps.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-07T17:11:52.446636Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 359800,
+      "cached_input_tokens": 283884,
+      "cache_write_input_tokens": 75904,
+      "output_tokens": 8345,
+      "reasoning_output_tokens": 5023
+    },
+    "duration_ms": 145948
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/migrate-ecs-env-vars-to-secrets-manager/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "migrate-ecs-env-vars-to-secrets-manager",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "secrets-manager",
+    "terraform",
+    "ecs",
+    "iam"
+  ],
+  "model": "us.anthropic.claude-sonnet-5",
+  "model_slug": "claude-sonnet-5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 1.4,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 1076,
+    "cache_read_tokens": 160860,
+    "cache_write_tokens": 373,
+    "total_tokens": 162311,
+    "total_cost_usd": 0.04386850000000001,
+    "latency_seconds": 764.8,
+    "num_turns": 55,
+    "generation_tokens_per_sec": 1.4,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2,
+  "output_tokens": 1076,
+  "latency_seconds": 764.8,
+  "num_turns": 55,
+  "total_cost_usd": 0.04386850000000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 160860,
+  "cache_creation_tokens": 373,
+  "run_started_at": "2026-08-07T16:40:11.667815Z",
+  "run_ended_at": "2026-08-07T16:52:56.669329Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 1076,
+    "cache_read_tokens": 160860,
+    "cache_write_tokens": 373,
+    "total_tokens": 162311,
+    "total_cost_usd": 0.04386850000000001,
+    "latency_seconds": 764.8,
+    "num_turns": 55,
+    "generation_tokens_per_sec": 1.4,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "migrate-ecs-env-vars-to-secrets-manager",
+    "model": "us.anthropic.claude-sonnet-5",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 75,
+        "notes": "The issue gives a concrete twelve-variable inventory, service split, file list, precedence rules, and testable acceptance criteria that largely match terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf. Its claim that empty values are currently omitted is false: the baseline task definitions emit fixed environment entries even when their variables default to empty strings. Cross-account support is incomplete because iam.tf grants KMS decryption only on aws_kms_key.secrets, and the claim that the repository lacks a relevant Helm surface is contradicted by charts/registry and charts/auth-server. No independent task statement was supplied, so broader requirement coverage beyond the ECS-focused task identifier cannot be verified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 12,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 66,
+        "notes": "The LLD is unusually concrete about real files, locals, container wiring, IAM resources, precedence, and rollout mechanics, and those integration points exist at the pinned repository revision. Its backward-compatibility model is wrong because the baseline uses unconditional environment entries, while the proposed filtered locals omit empty values and reorder nonempty entries at the end of each list. The advertised cross-account design also lacks caller-side kms:Decrypt permission for an externally owned customer-managed key, which is required alongside the external key policy. Several review resolutions are not actually present in the submitted LLD, including the warning design, rotation restart guidance, and detailed cross-account KMS treatment."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 11,
+        "specificity": 20,
+        "risk_awareness": 15,
+        "total": 62,
+        "notes": "The review raises specific concerns about JSON and PEM secret formats, map-key typos, delayed ARN validation, rotation, and cross-account KMS rather than merely approving the design. It misses the baseline empty-entry contradiction and endorses a warning whose count depends on sensitive variables, a Terraform-invalid construction. Its resolution section claims changes were incorporated into the LLD even though the submitted LLD still defers the warning and lacks the stated rotation and KMS additions. Real AWS behavior and the claimed CloudTrail configuration details were not verified in the submission."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 18,
+        "risk_awareness": 15,
+        "total": 61,
+        "notes": "The plan covers ARN precedence, plaintext fallback, registry-only scoping, IAM resources, rollback, steady state, formatting, validation, and runtime secret resolution. However, the byte-for-byte baseline expectation cannot hold because the patch moves entries into map-derived lists, and the both-unset expectation contradicts the current unconditional environment entries. Section 2.3 places -var before -var-file and provides a Python command that performs no assertion, while the deployment command references a nonexistent registry_task_definition_arn output before falling back to a placeholder. No Terraform or AWS checks were executed, so the critical sensitive-count failure would remain undetected."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 8,
+        "specificity": 22,
+        "risk_awareness": 10,
+        "total": 58,
+        "notes": "The patch targets the correct eight files, all preimage blob hashes match the repository, and it wires all twelve ARN variables through declarations, module forwarding, ECS secrets, IAM resources, and examples. The added null_resource uses count derived from sensitive plaintext variables, which Terraform rejects because sensitive values cannot determine resource count; its local-exec output would also be suppressed as sensitive, so the claimed warning does not work. The patch also changes empty-value behavior and list ordering despite claiming zero behavior change, and it cannot consume cross-account secrets encrypted with an external customer-managed KMS key because the execution-role policy grants decryption only on aws_kms_key.secrets. The summary honestly reports that validation and planning were not executed, but it consequently oversells an implementation that is not plan-ready and deviates materially from its compatibility and cross-account claims."
+      }
+    },
+    "task_score": 64.4,
+    "verdict": "The submission is highly specific and mostly grounded, but the implementation is not deployable because its migration warning derives resource count from sensitive values, with additional compatibility and cross-account KMS gaps.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-07T17:11:52.446636Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 359800,
+        "cached_input_tokens": 283884,
+        "cache_write_input_tokens": 75904,
+        "output_tokens": 8345,
+        "reasoning_output_tokens": 5023
+      },
+      "duration_ms": 145948
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "model": "us.anthropic.claude-sonnet-5",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 74,
+      "notes": "The issue precisely identifies the existing EFS module, outputs, task-definition mounts, and deployment scripts, all of which exist at the cited paths. Repository checks confirm the root storage_backend defaults to documentdb and Dockerfile.auth places scopes.yml at /app/scopes.yml. Its largest gap is the omitted scopes-init build surface in terraform/aws-ecs/codebuild.tf and related documentation, plus no backup or staged-rollout criterion before destructive EFS removal. No independent task statement was supplied, so the broader assertion that EFS has no live operational value cannot be fully verified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 70,
+      "notes": "The LLD is unusually repository-specific and correctly traces module.efs references, SCOPES_CONFIG_PATH, root/module variables, and the existing registry volume pattern. It misses terraform/aws-ecs/codebuild.tf, which still provisions and builds mcp-gateway-scopes-init, and docs/deployment-modes.md still directs operators to the deleted script. Its claim that one apply safely drains old EFS-mounted tasks before deleting mount targets is not supported by an explicit Terraform dependency or staged rollout, while warning-and-skipping scope initialization can hide a missing backend. Claims about live data being unused and interruption-free removal remain unverified without runtime or state evidence."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 17,
+      "total": 69,
+      "notes": "The review surfaces concrete concerns about image paths, missing backend output, dangling IAM references, and live-state destruction rather than merely approving the design. Its resolution claiming no documentation references run-scopes-init-task.sh is contradicted by docs/deployment-modes.md:218, and it overlooks the scopes-init ECR/build entries in terraform/aws-ecs/codebuild.tf. The asserted safe ECS-to-EFS destruction ordering is also unsupported by a staged apply or explicit dependency. Despite those errors, the review provides prioritized findings and materially improves the LLD's failure handling and rollout discussion."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 11,
+      "specificity": 19,
+      "risk_awareness": 14,
+      "total": 60,
+      "notes": "The plan includes useful validate, plan-JSON, formatting, dangling-reference, and unrelated-resource oracles. The proposed negative shell test is not executable as described because post-deployment-setup.sh overwrites OUTPUTS_FILE and unconditionally runs main when sourced, while `|| true` masks failure. The file-backend test never sets storage_backend=file, and the greps omit mcp-gateway-scopes-init references that remain in codebuild.tf and documentation. Terraform was unavailable in the repository environment and the artifact explicitly reports no execution, so its validate and plan expectations remain unverified."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 72,
+      "notes": "The patch targets real files at the pinned 1.24.4 commit, and every preimage blob hash matches the diff index; the core EFS module, outputs, variables, mounts, and script caller are consistently removed. It is not end-to-end cleanup because terraform/aws-ecs/codebuild.tf still creates and builds mcp-gateway-scopes-init, while docs/deployment-modes.md retains a command for the deleted script. Treating a missing DocumentDB endpoint as a successful skip can conceal uninitialized scopes, and the patch provides no staged migration or data-preservation safeguard for existing EFS state. The summary accurately discloses that Terraform validation and deployment tests were not run, and no contrary source-context mismatch was found."
+    }
+  },
+  "task_score": 69.0,
+  "verdict": "The submission is strongly grounded and implements the core removal, but incomplete scopes-init cleanup, invalid test mechanics, and an under-specified destructive rollout materially limit production readiness.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-07T17:16:21.923800Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 1320819,
+      "cached_input_tokens": 1206035,
+      "cache_write_input_tokens": 114752,
+      "output_tokens": 11697,
+      "reasoning_output_tokens": 5323
+    },
+    "duration_ms": 269446
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/remove-efs-from-terraform-aws-ecs/metrics.json
@@ -1,0 +1,150 @@
+{
+  "task": "remove-efs-from-terraform-aws-ecs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "terraform",
+    "aws",
+    "ecs",
+    "storage",
+    "infrastructure"
+  ],
+  "model": "us.anthropic.claude-sonnet-5",
+  "model_slug": "claude-sonnet-5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 1.8,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 910,
+    "cache_read_tokens": 119553,
+    "cache_write_tokens": 360,
+    "total_tokens": 120825,
+    "total_cost_usd": 0.0339146,
+    "latency_seconds": 516.2,
+    "num_turns": 50,
+    "generation_tokens_per_sec": 1.8,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2,
+  "output_tokens": 910,
+  "latency_seconds": 516.2,
+  "num_turns": 50,
+  "total_cost_usd": 0.0339146,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 119553,
+  "cache_creation_tokens": 360,
+  "run_started_at": "2026-08-07T16:16:16.484081Z",
+  "run_ended_at": "2026-08-07T16:24:52.759646Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 910,
+    "cache_read_tokens": 119553,
+    "cache_write_tokens": 360,
+    "total_tokens": 120825,
+    "total_cost_usd": 0.0339146,
+    "latency_seconds": 516.2,
+    "num_turns": 50,
+    "generation_tokens_per_sec": 1.8,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "remove-efs-from-terraform-aws-ecs",
+    "model": "us.anthropic.claude-sonnet-5",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 74,
+        "notes": "The issue precisely identifies the existing EFS module, outputs, task-definition mounts, and deployment scripts, all of which exist at the cited paths. Repository checks confirm the root storage_backend defaults to documentdb and Dockerfile.auth places scopes.yml at /app/scopes.yml. Its largest gap is the omitted scopes-init build surface in terraform/aws-ecs/codebuild.tf and related documentation, plus no backup or staged-rollout criterion before destructive EFS removal. No independent task statement was supplied, so the broader assertion that EFS has no live operational value cannot be fully verified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 70,
+        "notes": "The LLD is unusually repository-specific and correctly traces module.efs references, SCOPES_CONFIG_PATH, root/module variables, and the existing registry volume pattern. It misses terraform/aws-ecs/codebuild.tf, which still provisions and builds mcp-gateway-scopes-init, and docs/deployment-modes.md still directs operators to the deleted script. Its claim that one apply safely drains old EFS-mounted tasks before deleting mount targets is not supported by an explicit Terraform dependency or staged rollout, while warning-and-skipping scope initialization can hide a missing backend. Claims about live data being unused and interruption-free removal remain unverified without runtime or state evidence."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 17,
+        "total": 69,
+        "notes": "The review surfaces concrete concerns about image paths, missing backend output, dangling IAM references, and live-state destruction rather than merely approving the design. Its resolution claiming no documentation references run-scopes-init-task.sh is contradicted by docs/deployment-modes.md:218, and it overlooks the scopes-init ECR/build entries in terraform/aws-ecs/codebuild.tf. The asserted safe ECS-to-EFS destruction ordering is also unsupported by a staged apply or explicit dependency. Despite those errors, the review provides prioritized findings and materially improves the LLD's failure handling and rollout discussion."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 11,
+        "specificity": 19,
+        "risk_awareness": 14,
+        "total": 60,
+        "notes": "The plan includes useful validate, plan-JSON, formatting, dangling-reference, and unrelated-resource oracles. The proposed negative shell test is not executable as described because post-deployment-setup.sh overwrites OUTPUTS_FILE and unconditionally runs main when sourced, while `|| true` masks failure. The file-backend test never sets storage_backend=file, and the greps omit mcp-gateway-scopes-init references that remain in codebuild.tf and documentation. Terraform was unavailable in the repository environment and the artifact explicitly reports no execution, so its validate and plan expectations remain unverified."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 72,
+        "notes": "The patch targets real files at the pinned 1.24.4 commit, and every preimage blob hash matches the diff index; the core EFS module, outputs, variables, mounts, and script caller are consistently removed. It is not end-to-end cleanup because terraform/aws-ecs/codebuild.tf still creates and builds mcp-gateway-scopes-init, while docs/deployment-modes.md retains a command for the deleted script. Treating a missing DocumentDB endpoint as a successful skip can conceal uninitialized scopes, and the patch provides no staged migration or data-preservation safeguard for existing EFS state. The summary accurately discloses that Terraform validation and deployment tests were not run, and no contrary source-context mismatch was found."
+      }
+    },
+    "task_score": 69.0,
+    "verdict": "The submission is strongly grounded and implements the core removal, but incomplete scopes-init cleanup, invalid test mechanics, and an under-specified destructive rollout materially limit production readiness.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-07T17:16:21.923800Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 1320819,
+        "cached_input_tokens": 1206035,
+        "cache_write_input_tokens": 114752,
+        "output_tokens": 11697,
+        "reasoning_output_tokens": 5323
+      },
+      "duration_ms": 269446
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/remove-faiss/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "remove-faiss",
+  "model": "us.anthropic.claude-sonnet-5",
+  "scores": {
+    "github_issue": {
+      "completeness": 16,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 67,
+      "notes": "The issue precisely identifies real components including `FaissService`, `get_search_repository()`, startup indexing, telemetry, and the `AgentService.index_agent()` contract defect. Repository inspection confirms those symbols and the redundant direct FAISS calls exist at the cited integration points. Its largest deficiency is declaring broken tests, most documentation, and `uv.lock` out of scope while promising FAISS removal and unchanged search behavior; it also omits migration of existing file-backed entities into the initially empty DocumentDB index. No independent task statement was supplied, so the intended tolerance for that scope reduction cannot be verified beyond the `remove-faiss` identifier."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 10,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 63,
+      "notes": "The LLD is unusually concrete about real files, repository interfaces, call sites, and the intentional MongoDB requirement for file-backed deployments. Its central startup decision is unsafe for upgrades: the current file backend stores search data only in FAISS, yet the design switches to DocumentDB and removes the startup backfill, leaving existing servers and agents absent from search. It also names the nonexistent `/api/servers/search/semantic` endpoint, mischaracterizes several remaining test patches as collection-time failures, and accepts an out-of-sync lockfile despite the repository's `uv lock --check` workflow. The claimed clean application against a separate clone could not be independently rerun because no standalone `patch.diff` file exists in the repository, although sampled hunk contexts match ref `1.24.4`."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 18,
+      "risk_awareness": 16,
+      "total": 59,
+      "notes": "The review raises concrete concerns about the new MongoDB dependency, hardcoded verification script settings, shell injection, and tests that still patch the deleted module. It nevertheless approves a design that knowingly leaves CI tests broken and misses both the absent file-to-DocumentDB index migration and the stale `uv.lock`. Its claimed 503 resolution is not supported: `DocumentDBSearchRepository.search()` catches ordinary backend failures and returns empty result groups, while startup connection failure prevents serving the endpoint at all. The role-based findings are specific, but the final non-blocking verdict is not defensible given these repository-verified failures."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 4,
+      "specificity": 16,
+      "risk_awareness": 12,
+      "total": 46,
+      "notes": "The plan attempts functional, lifecycle, deployment, rollback, negative, and factory-routing coverage with explicit expected states. Most critical HTTP checks cannot exercise the feature: server search is actually `/api/search/semantic`, agent discovery expects query parameters rather than the submitted JSON body, agent toggle is `/api/agents/{path}/toggle`, and refresh is `/api/refresh/{path}`. The Mongo-unreachable procedure is also invalid because `docker compose up registry` starts its `mongodb-init` dependency, which in turn starts MongoDB, and the proposed regression tests are not included in the patch. It lacks the essential upgrade test proving existing file-backed entities are backfilled, while explicitly allowing numerous known test failures before merge."
+    },
+    "implementation": {
+      "completeness": 10,
+      "correctness": 6,
+      "specificity": 17,
+      "risk_awareness": 11,
+      "total": 44,
+      "notes": "The patch targets real symbols and correctly rewires the factory, fixes `AgentService.index_agent()`, removes production FAISS imports, and replaces non-redundant toggle indexing calls with repository methods. It is not end-to-end complete: existing file-backed data receives no DocumentDB backfill after the startup sweep is removed, so upgraded deployments can return empty search results until every entity is mutated. Leaving `uv.lock` unchanged means the default frozen Docker build still installs `faiss-cpu`, the locked CPU build and lock-check CI can fail, and dozens of tests still resolve the deleted `registry.search.service` module. The summary discloses several deferred items but incorrectly claims no substantive LLD deviation and misses the migration failure; the brittle all-dimensions Mongo query can also report stale records."
+    }
+  },
+  "task_score": 55.8,
+  "verdict": "The submission is highly specific but not mergeable because it omits index migration, leaves dependency locking and tests broken, and supplies largely invalid verification commands.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-07T17:20:35.318757Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 1609039,
+      "cached_input_tokens": 1468080,
+      "cache_write_input_tokens": 140931,
+      "output_tokens": 10577,
+      "reasoning_output_tokens": 5029
+    },
+    "duration_ms": 253372
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/remove-faiss/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "remove-faiss",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "dependency-removal",
+    "python",
+    "fastapi",
+    "search",
+    "docker",
+    "docs"
+  ],
+  "model": "us.anthropic.claude-sonnet-5",
+  "model_slug": "claude-sonnet-5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 0.5,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 907,
+    "cache_read_tokens": 300346,
+    "cache_write_tokens": 379,
+    "total_tokens": 301634,
+    "total_cost_usd": 0.0700907,
+    "latency_seconds": 1741.8,
+    "num_turns": 250,
+    "generation_tokens_per_sec": 0.5,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2,
+  "output_tokens": 907,
+  "latency_seconds": 1741.8,
+  "num_turns": 250,
+  "total_cost_usd": 0.0700907,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 300346,
+  "cache_creation_tokens": 379,
+  "run_started_at": "2026-08-07T15:47:10.193815Z",
+  "run_ended_at": "2026-08-07T16:16:12.456600Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 907,
+    "cache_read_tokens": 300346,
+    "cache_write_tokens": 379,
+    "total_tokens": 301634,
+    "total_cost_usd": 0.0700907,
+    "latency_seconds": 1741.8,
+    "num_turns": 250,
+    "generation_tokens_per_sec": 0.5,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "remove-faiss",
+    "model": "us.anthropic.claude-sonnet-5",
+    "scores": {
+      "github_issue": {
+        "completeness": 16,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 67,
+        "notes": "The issue precisely identifies real components including `FaissService`, `get_search_repository()`, startup indexing, telemetry, and the `AgentService.index_agent()` contract defect. Repository inspection confirms those symbols and the redundant direct FAISS calls exist at the cited integration points. Its largest deficiency is declaring broken tests, most documentation, and `uv.lock` out of scope while promising FAISS removal and unchanged search behavior; it also omits migration of existing file-backed entities into the initially empty DocumentDB index. No independent task statement was supplied, so the intended tolerance for that scope reduction cannot be verified beyond the `remove-faiss` identifier."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 10,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 63,
+        "notes": "The LLD is unusually concrete about real files, repository interfaces, call sites, and the intentional MongoDB requirement for file-backed deployments. Its central startup decision is unsafe for upgrades: the current file backend stores search data only in FAISS, yet the design switches to DocumentDB and removes the startup backfill, leaving existing servers and agents absent from search. It also names the nonexistent `/api/servers/search/semantic` endpoint, mischaracterizes several remaining test patches as collection-time failures, and accepts an out-of-sync lockfile despite the repository's `uv lock --check` workflow. The claimed clean application against a separate clone could not be independently rerun because no standalone `patch.diff` file exists in the repository, although sampled hunk contexts match ref `1.24.4`."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 18,
+        "risk_awareness": 16,
+        "total": 59,
+        "notes": "The review raises concrete concerns about the new MongoDB dependency, hardcoded verification script settings, shell injection, and tests that still patch the deleted module. It nevertheless approves a design that knowingly leaves CI tests broken and misses both the absent file-to-DocumentDB index migration and the stale `uv.lock`. Its claimed 503 resolution is not supported: `DocumentDBSearchRepository.search()` catches ordinary backend failures and returns empty result groups, while startup connection failure prevents serving the endpoint at all. The role-based findings are specific, but the final non-blocking verdict is not defensible given these repository-verified failures."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 4,
+        "specificity": 16,
+        "risk_awareness": 12,
+        "total": 46,
+        "notes": "The plan attempts functional, lifecycle, deployment, rollback, negative, and factory-routing coverage with explicit expected states. Most critical HTTP checks cannot exercise the feature: server search is actually `/api/search/semantic`, agent discovery expects query parameters rather than the submitted JSON body, agent toggle is `/api/agents/{path}/toggle`, and refresh is `/api/refresh/{path}`. The Mongo-unreachable procedure is also invalid because `docker compose up registry` starts its `mongodb-init` dependency, which in turn starts MongoDB, and the proposed regression tests are not included in the patch. It lacks the essential upgrade test proving existing file-backed entities are backfilled, while explicitly allowing numerous known test failures before merge."
+      },
+      "implementation": {
+        "completeness": 10,
+        "correctness": 6,
+        "specificity": 17,
+        "risk_awareness": 11,
+        "total": 44,
+        "notes": "The patch targets real symbols and correctly rewires the factory, fixes `AgentService.index_agent()`, removes production FAISS imports, and replaces non-redundant toggle indexing calls with repository methods. It is not end-to-end complete: existing file-backed data receives no DocumentDB backfill after the startup sweep is removed, so upgraded deployments can return empty search results until every entity is mutated. Leaving `uv.lock` unchanged means the default frozen Docker build still installs `faiss-cpu`, the locked CPU build and lock-check CI can fail, and dozens of tests still resolve the deleted `registry.search.service` module. The summary discloses several deferred items but incorrectly claims no substantive LLD deviation and misses the migration failure; the brittle all-dimensions Mongo query can also report stale records."
+      }
+    },
+    "task_score": 55.8,
+    "verdict": "The submission is highly specific but not mergeable because it omits index migration, leaves dependency locking and tests broken, and supplies largely invalid verification commands.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-07T17:20:35.318757Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 1609039,
+        "cached_input_tokens": 1468080,
+        "cache_write_input_tokens": 140931,
+        "output_tokens": 10577,
+        "reasoning_output_tokens": 5029
+      },
+      "duration_ms": 253372
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "model": "us.anthropic.claude-sonnet-5",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 72,
+      "notes": "The issue clearly defines both authentication modes, explicit exclusions, documentation work, and testable Terraform and ECS acceptance criteria. Repository checks confirm the named RDS cluster, Secrets Manager rotation, ECS valueFrom wiring, and DocumentDB IAM precedent. Its largest correctness defect is overstating exposure and auditability: ecs:DescribeTaskDefinition reveals the secret ARN rather than its value, and RDS IAM connections are not discrete per-connection CloudTrail events. No independent task statement was supplied, while the claimed AWS JDBC plugin and upstream issue references could not be verified from the repository."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 8,
+      "specificity": 18,
+      "risk_awareness": 15,
+      "total": 57,
+      "notes": "The LLD is unusually concrete about existing files, the direct cluster endpoint, dbuser ARN construction, separate task-definition shapes, TLS, rollback, and token lifetime. Those repository integration points largely exist, including aws_rds_cluster.keycloak, the ECS locals, the generic CodeBuild pipeline, and cluster_resource_id support. Its central dependency remains an unverified JDBC plugin, class, and artifact, and the submitted implementation confirms that the promised pinned download was only a placeholder. It also leaves no secure source for the required master password and proposes running mysql locally even though keycloak_db ingress permits only the Keycloak ECS and rotation-Lambda security groups."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 75,
+      "notes": "The review's strongest work is identifying three concrete blockers: the invented KC_DB_URL_PROPERTIES surface, nullable ECS fields, and TLS without identity verification. Each finding states a consequence and an actionable resolution that appears in the revised LLD. However, it endorses the plugin and local bootstrap architecture without verifying the artifact, notices neither the missing usable master credential nor the database security-group barrier, and therefore misses failures more fundamental than its listed blockers. The frontend section adds little, but the backend, SRE, and security findings are specific and materially useful."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 7,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 54,
+      "notes": "The plan covers both flag values, Terraform validation, IAM scoping, task-definition shape, init-container status, rollback, negative startup behavior, and an OIDC flow with concrete expected results. Several commands cannot work as written: the repository exports keycloak_url rather than keycloak_domain, tfvars edits target the repository root despite -chdir, the second bootstrap run loses its required environment, and a local mysql client cannot reach the private cluster through the checked security groups. The public /health/ready check also targets port 8080 while the real task health check uses Keycloak's management port 9000, and test -n accepts jq's literal null as a token. Most importantly, no test forces a new physical connection after token expiry or proves the IAM path never stores KC_DB_PASSWORD, so it misses the feature's defining regression risks."
+    },
+    "implementation": {
+      "completeness": 9,
+      "correctness": 3,
+      "specificity": 16,
+      "risk_awareness": 6,
+      "total": 34,
+      "notes": "The diff contexts and symbols match the exact 1.24.4 baseline, and the patch attempts all major surfaces: cluster configuration, task role, ECS wiring, image build, documentation, and bootstrap SQL. It is not deployable from source because the Dockerfile downloads the essential plugin from example-artifact-repo.invalid, while the default public init image and claimed plugin class are unsupported by repository evidence. Worse, an omitted password produces a publicly derivable md5 master password but stores an empty password in Secrets Manager, so the documented bootstrap command cannot authenticate; its local network path is blocked by keycloak-security-groups.tf as well. Supplying a password still writes it to the always-created secret in IAM mode, violating acceptance criteria, and the summary acknowledges placeholders and credential drift while inaccurately claiming the default IAM path now works."
+    }
+  },
+  "task_score": 58.4,
+  "verdict": "The submission provides detailed, repository-aware design material, but its unverified JDBC dependency and unusable master-password/bootstrap path make the actual implementation nonfunctional and insecure.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-07T17:24:17.317513Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 782405,
+      "cached_input_tokens": 673999,
+      "cache_write_input_tokens": 108386,
+      "output_tokens": 12710,
+      "reasoning_output_tokens": 8267
+    },
+    "duration_ms": 221982
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/replace-keycloak-db-password-with-rds-iam/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "replace-keycloak-db-password-with-rds-iam",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "aws",
+    "rds",
+    "iam",
+    "keycloak",
+    "terraform"
+  ],
+  "model": "us.anthropic.claude-sonnet-5",
+  "model_slug": "claude-sonnet-5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 0.8,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 810,
+    "cache_read_tokens": 174925,
+    "cache_write_tokens": 350,
+    "total_tokens": 176087,
+    "total_cost_usd": 0.043964,
+    "latency_seconds": 986.1,
+    "num_turns": 67,
+    "generation_tokens_per_sec": 0.8,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2,
+  "output_tokens": 810,
+  "latency_seconds": 986.1,
+  "num_turns": 67,
+  "total_cost_usd": 0.043964,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 174925,
+  "cache_creation_tokens": 350,
+  "run_started_at": "2026-08-07T16:52:59.599975Z",
+  "run_ended_at": "2026-08-07T17:09:25.802788Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 810,
+    "cache_read_tokens": 174925,
+    "cache_write_tokens": 350,
+    "total_tokens": 176087,
+    "total_cost_usd": 0.043964,
+    "latency_seconds": 986.1,
+    "num_turns": 67,
+    "generation_tokens_per_sec": 0.8,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "replace-keycloak-db-password-with-rds-iam",
+    "model": "us.anthropic.claude-sonnet-5",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 72,
+        "notes": "The issue clearly defines both authentication modes, explicit exclusions, documentation work, and testable Terraform and ECS acceptance criteria. Repository checks confirm the named RDS cluster, Secrets Manager rotation, ECS valueFrom wiring, and DocumentDB IAM precedent. Its largest correctness defect is overstating exposure and auditability: ecs:DescribeTaskDefinition reveals the secret ARN rather than its value, and RDS IAM connections are not discrete per-connection CloudTrail events. No independent task statement was supplied, while the claimed AWS JDBC plugin and upstream issue references could not be verified from the repository."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 8,
+        "specificity": 18,
+        "risk_awareness": 15,
+        "total": 57,
+        "notes": "The LLD is unusually concrete about existing files, the direct cluster endpoint, dbuser ARN construction, separate task-definition shapes, TLS, rollback, and token lifetime. Those repository integration points largely exist, including aws_rds_cluster.keycloak, the ECS locals, the generic CodeBuild pipeline, and cluster_resource_id support. Its central dependency remains an unverified JDBC plugin, class, and artifact, and the submitted implementation confirms that the promised pinned download was only a placeholder. It also leaves no secure source for the required master password and proposes running mysql locally even though keycloak_db ingress permits only the Keycloak ECS and rotation-Lambda security groups."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 75,
+        "notes": "The review's strongest work is identifying three concrete blockers: the invented KC_DB_URL_PROPERTIES surface, nullable ECS fields, and TLS without identity verification. Each finding states a consequence and an actionable resolution that appears in the revised LLD. However, it endorses the plugin and local bootstrap architecture without verifying the artifact, notices neither the missing usable master credential nor the database security-group barrier, and therefore misses failures more fundamental than its listed blockers. The frontend section adds little, but the backend, SRE, and security findings are specific and materially useful."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 7,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 54,
+        "notes": "The plan covers both flag values, Terraform validation, IAM scoping, task-definition shape, init-container status, rollback, negative startup behavior, and an OIDC flow with concrete expected results. Several commands cannot work as written: the repository exports keycloak_url rather than keycloak_domain, tfvars edits target the repository root despite -chdir, the second bootstrap run loses its required environment, and a local mysql client cannot reach the private cluster through the checked security groups. The public /health/ready check also targets port 8080 while the real task health check uses Keycloak's management port 9000, and test -n accepts jq's literal null as a token. Most importantly, no test forces a new physical connection after token expiry or proves the IAM path never stores KC_DB_PASSWORD, so it misses the feature's defining regression risks."
+      },
+      "implementation": {
+        "completeness": 9,
+        "correctness": 3,
+        "specificity": 16,
+        "risk_awareness": 6,
+        "total": 34,
+        "notes": "The diff contexts and symbols match the exact 1.24.4 baseline, and the patch attempts all major surfaces: cluster configuration, task role, ECS wiring, image build, documentation, and bootstrap SQL. It is not deployable from source because the Dockerfile downloads the essential plugin from example-artifact-repo.invalid, while the default public init image and claimed plugin class are unsupported by repository evidence. Worse, an omitted password produces a publicly derivable md5 master password but stores an empty password in Secrets Manager, so the documented bootstrap command cannot authenticate; its local network path is blocked by keycloak-security-groups.tf as well. Supplying a password still writes it to the always-created secret in IAM mode, violating acceptance criteria, and the summary acknowledges placeholders and credential drift while inaccurately claiming the default IAM path now works."
+      }
+    },
+    "task_score": 58.4,
+    "verdict": "The submission provides detailed, repository-aware design material, but its unverified JDBC dependency and unusable master-password/bootstrap path make the actual implementation nonfunctional and insecure.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-07T17:24:17.317513Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 782405,
+        "cached_input_tokens": 673999,
+        "cache_write_input_tokens": 108386,
+        "output_tokens": 12710,
+        "reasoning_output_tokens": 8267
+      },
+      "duration_ms": 221982
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,365 @@
+{
+  "model": "us.anthropic.claude-sonnet-5",
+  "model_slug": "claude-sonnet-5",
+  "agent": "pi",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "bedrock",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-07T17:11:52.446636Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 359800,
+      "cached_input_tokens": 283884,
+      "cache_write_input_tokens": 75904,
+      "output_tokens": 8345,
+      "reasoning_output_tokens": 5023
+    },
+    "duration_ms": 145948
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 60.56,
+  "mean_cost_usd_excl_failed": 0.05,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 50,
+      "input_tokens": 2,
+      "output_tokens": 910,
+      "total_tokens": 120825,
+      "latency_seconds": 516.2,
+      "total_cost_usd": 0.0339146,
+      "result_subtype": "success",
+      "task_score": 69.0,
+      "cache_read_tokens": 119553,
+      "cache_write_tokens": 360,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 1.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 74,
+          "notes": "The issue precisely identifies the existing EFS module, outputs, task-definition mounts, and deployment scripts, all of which exist at the cited paths. Repository checks confirm the root storage_backend defaults to documentdb and Dockerfile.auth places scopes.yml at /app/scopes.yml. Its largest gap is the omitted scopes-init build surface in terraform/aws-ecs/codebuild.tf and related documentation, plus no backup or staged-rollout criterion before destructive EFS removal. No independent task statement was supplied, so the broader assertion that EFS has no live operational value cannot be fully verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 70,
+          "notes": "The LLD is unusually repository-specific and correctly traces module.efs references, SCOPES_CONFIG_PATH, root/module variables, and the existing registry volume pattern. It misses terraform/aws-ecs/codebuild.tf, which still provisions and builds mcp-gateway-scopes-init, and docs/deployment-modes.md still directs operators to the deleted script. Its claim that one apply safely drains old EFS-mounted tasks before deleting mount targets is not supported by an explicit Terraform dependency or staged rollout, while warning-and-skipping scope initialization can hide a missing backend. Claims about live data being unused and interruption-free removal remain unverified without runtime or state evidence."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 69,
+          "notes": "The review surfaces concrete concerns about image paths, missing backend output, dangling IAM references, and live-state destruction rather than merely approving the design. Its resolution claiming no documentation references run-scopes-init-task.sh is contradicted by docs/deployment-modes.md:218, and it overlooks the scopes-init ECR/build entries in terraform/aws-ecs/codebuild.tf. The asserted safe ECS-to-EFS destruction ordering is also unsupported by a staged apply or explicit dependency. Despite those errors, the review provides prioritized findings and materially improves the LLD's failure handling and rollout discussion."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 60,
+          "notes": "The plan includes useful validate, plan-JSON, formatting, dangling-reference, and unrelated-resource oracles. The proposed negative shell test is not executable as described because post-deployment-setup.sh overwrites OUTPUTS_FILE and unconditionally runs main when sourced, while `|| true` masks failure. The file-backend test never sets storage_backend=file, and the greps omit mcp-gateway-scopes-init references that remain in codebuild.tf and documentation. Terraform was unavailable in the repository environment and the artifact explicitly reports no execution, so its validate and plan expectations remain unverified."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 72,
+          "notes": "The patch targets real files at the pinned 1.24.4 commit, and every preimage blob hash matches the diff index; the core EFS module, outputs, variables, mounts, and script caller are consistently removed. It is not end-to-end cleanup because terraform/aws-ecs/codebuild.tf still creates and builds mcp-gateway-scopes-init, while docs/deployment-modes.md retains a command for the deleted script. Treating a missing DocumentDB endpoint as a successful skip can conceal uninitialized scopes, and the patch provides no staged migration or data-preservation safeguard for existing EFS state. The summary accurately discloses that Terraform validation and deployment tests were not run, and no contrary source-context mismatch was found."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 55,
+      "input_tokens": 2,
+      "output_tokens": 1076,
+      "total_tokens": 162311,
+      "latency_seconds": 764.8,
+      "total_cost_usd": 0.04386850000000001,
+      "result_subtype": "success",
+      "task_score": 64.4,
+      "cache_read_tokens": 160860,
+      "cache_write_tokens": 373,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 1.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 75,
+          "notes": "The issue gives a concrete twelve-variable inventory, service split, file list, precedence rules, and testable acceptance criteria that largely match terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf. Its claim that empty values are currently omitted is false: the baseline task definitions emit fixed environment entries even when their variables default to empty strings. Cross-account support is incomplete because iam.tf grants KMS decryption only on aws_kms_key.secrets, and the claim that the repository lacks a relevant Helm surface is contradicted by charts/registry and charts/auth-server. No independent task statement was supplied, so broader requirement coverage beyond the ECS-focused task identifier cannot be verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 66,
+          "notes": "The LLD is unusually concrete about real files, locals, container wiring, IAM resources, precedence, and rollout mechanics, and those integration points exist at the pinned repository revision. Its backward-compatibility model is wrong because the baseline uses unconditional environment entries, while the proposed filtered locals omit empty values and reorder nonempty entries at the end of each list. The advertised cross-account design also lacks caller-side kms:Decrypt permission for an externally owned customer-managed key, which is required alongside the external key policy. Several review resolutions are not actually present in the submitted LLD, including the warning design, rotation restart guidance, and detailed cross-account KMS treatment."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 62,
+          "notes": "The review raises specific concerns about JSON and PEM secret formats, map-key typos, delayed ARN validation, rotation, and cross-account KMS rather than merely approving the design. It misses the baseline empty-entry contradiction and endorses a warning whose count depends on sensitive variables, a Terraform-invalid construction. Its resolution section claims changes were incorporated into the LLD even though the submitted LLD still defers the warning and lacks the stated rotation and KMS additions. Real AWS behavior and the claimed CloudTrail configuration details were not verified in the submission."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 15,
+          "total": 61,
+          "notes": "The plan covers ARN precedence, plaintext fallback, registry-only scoping, IAM resources, rollback, steady state, formatting, validation, and runtime secret resolution. However, the byte-for-byte baseline expectation cannot hold because the patch moves entries into map-derived lists, and the both-unset expectation contradicts the current unconditional environment entries. Section 2.3 places -var before -var-file and provides a Python command that performs no assertion, while the deployment command references a nonexistent registry_task_definition_arn output before falling back to a placeholder. No Terraform or AWS checks were executed, so the critical sensitive-count failure would remain undetected."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 22,
+          "risk_awareness": 10,
+          "total": 58,
+          "notes": "The patch targets the correct eight files, all preimage blob hashes match the repository, and it wires all twelve ARN variables through declarations, module forwarding, ECS secrets, IAM resources, and examples. The added null_resource uses count derived from sensitive plaintext variables, which Terraform rejects because sensitive values cannot determine resource count; its local-exec output would also be suppressed as sensitive, so the claimed warning does not work. The patch also changes empty-value behavior and list ordering despite claiming zero behavior change, and it cannot consume cross-account secrets encrypted with an external customer-managed KMS key because the execution-role policy grants decryption only on aws_kms_key.secrets. The summary honestly reports that validation and planning were not executed, but it consequently oversells an implementation that is not plan-ready and deviates materially from its compatibility and cross-account claims."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 67,
+      "input_tokens": 2,
+      "output_tokens": 810,
+      "total_tokens": 176087,
+      "latency_seconds": 986.1,
+      "total_cost_usd": 0.043964,
+      "result_subtype": "success",
+      "task_score": 58.4,
+      "cache_read_tokens": 174925,
+      "cache_write_tokens": 350,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 0.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 72,
+          "notes": "The issue clearly defines both authentication modes, explicit exclusions, documentation work, and testable Terraform and ECS acceptance criteria. Repository checks confirm the named RDS cluster, Secrets Manager rotation, ECS valueFrom wiring, and DocumentDB IAM precedent. Its largest correctness defect is overstating exposure and auditability: ecs:DescribeTaskDefinition reveals the secret ARN rather than its value, and RDS IAM connections are not discrete per-connection CloudTrail events. No independent task statement was supplied, while the claimed AWS JDBC plugin and upstream issue references could not be verified from the repository."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 15,
+          "total": 57,
+          "notes": "The LLD is unusually concrete about existing files, the direct cluster endpoint, dbuser ARN construction, separate task-definition shapes, TLS, rollback, and token lifetime. Those repository integration points largely exist, including aws_rds_cluster.keycloak, the ECS locals, the generic CodeBuild pipeline, and cluster_resource_id support. Its central dependency remains an unverified JDBC plugin, class, and artifact, and the submitted implementation confirms that the promised pinned download was only a placeholder. It also leaves no secure source for the required master password and proposes running mysql locally even though keycloak_db ingress permits only the Keycloak ECS and rotation-Lambda security groups."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 75,
+          "notes": "The review's strongest work is identifying three concrete blockers: the invented KC_DB_URL_PROPERTIES surface, nullable ECS fields, and TLS without identity verification. Each finding states a consequence and an actionable resolution that appears in the revised LLD. However, it endorses the plugin and local bootstrap architecture without verifying the artifact, notices neither the missing usable master credential nor the database security-group barrier, and therefore misses failures more fundamental than its listed blockers. The frontend section adds little, but the backend, SRE, and security findings are specific and materially useful."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 54,
+          "notes": "The plan covers both flag values, Terraform validation, IAM scoping, task-definition shape, init-container status, rollback, negative startup behavior, and an OIDC flow with concrete expected results. Several commands cannot work as written: the repository exports keycloak_url rather than keycloak_domain, tfvars edits target the repository root despite -chdir, the second bootstrap run loses its required environment, and a local mysql client cannot reach the private cluster through the checked security groups. The public /health/ready check also targets port 8080 while the real task health check uses Keycloak's management port 9000, and test -n accepts jq's literal null as a token. Most importantly, no test forces a new physical connection after token expiry or proves the IAM path never stores KC_DB_PASSWORD, so it misses the feature's defining regression risks."
+        },
+        "implementation": {
+          "completeness": 9,
+          "correctness": 3,
+          "specificity": 16,
+          "risk_awareness": 6,
+          "total": 34,
+          "notes": "The diff contexts and symbols match the exact 1.24.4 baseline, and the patch attempts all major surfaces: cluster configuration, task role, ECS wiring, image build, documentation, and bootstrap SQL. It is not deployable from source because the Dockerfile downloads the essential plugin from example-artifact-repo.invalid, while the default public init image and claimed plugin class are unsupported by repository evidence. Worse, an omitted password produces a publicly derivable md5 master password but stores an empty password in Secrets Manager, so the documented bootstrap command cannot authenticate; its local network path is blocked by keycloak-security-groups.tf as well. Supplying a password still writes it to the always-created secret in IAM mode, violating acceptance criteria, and the summary acknowledges placeholders and credential drift while inaccurately claiming the default IAM path now works."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 250,
+      "input_tokens": 2,
+      "output_tokens": 907,
+      "total_tokens": 301634,
+      "latency_seconds": 1741.8,
+      "total_cost_usd": 0.0700907,
+      "result_subtype": "success",
+      "task_score": 55.8,
+      "cache_read_tokens": 300346,
+      "cache_write_tokens": 379,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 0.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 67,
+          "notes": "The issue precisely identifies real components including `FaissService`, `get_search_repository()`, startup indexing, telemetry, and the `AgentService.index_agent()` contract defect. Repository inspection confirms those symbols and the redundant direct FAISS calls exist at the cited integration points. Its largest deficiency is declaring broken tests, most documentation, and `uv.lock` out of scope while promising FAISS removal and unchanged search behavior; it also omits migration of existing file-backed entities into the initially empty DocumentDB index. No independent task statement was supplied, so the intended tolerance for that scope reduction cannot be verified beyond the `remove-faiss` identifier."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 10,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 63,
+          "notes": "The LLD is unusually concrete about real files, repository interfaces, call sites, and the intentional MongoDB requirement for file-backed deployments. Its central startup decision is unsafe for upgrades: the current file backend stores search data only in FAISS, yet the design switches to DocumentDB and removes the startup backfill, leaving existing servers and agents absent from search. It also names the nonexistent `/api/servers/search/semantic` endpoint, mischaracterizes several remaining test patches as collection-time failures, and accepts an out-of-sync lockfile despite the repository's `uv lock --check` workflow. The claimed clean application against a separate clone could not be independently rerun because no standalone `patch.diff` file exists in the repository, although sampled hunk contexts match ref `1.24.4`."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 16,
+          "total": 59,
+          "notes": "The review raises concrete concerns about the new MongoDB dependency, hardcoded verification script settings, shell injection, and tests that still patch the deleted module. It nevertheless approves a design that knowingly leaves CI tests broken and misses both the absent file-to-DocumentDB index migration and the stale `uv.lock`. Its claimed 503 resolution is not supported: `DocumentDBSearchRepository.search()` catches ordinary backend failures and returns empty result groups, while startup connection failure prevents serving the endpoint at all. The role-based findings are specific, but the final non-blocking verdict is not defensible given these repository-verified failures."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 4,
+          "specificity": 16,
+          "risk_awareness": 12,
+          "total": 46,
+          "notes": "The plan attempts functional, lifecycle, deployment, rollback, negative, and factory-routing coverage with explicit expected states. Most critical HTTP checks cannot exercise the feature: server search is actually `/api/search/semantic`, agent discovery expects query parameters rather than the submitted JSON body, agent toggle is `/api/agents/{path}/toggle`, and refresh is `/api/refresh/{path}`. The Mongo-unreachable procedure is also invalid because `docker compose up registry` starts its `mongodb-init` dependency, which in turn starts MongoDB, and the proposed regression tests are not included in the patch. It lacks the essential upgrade test proving existing file-backed entities are backfilled, while explicitly allowing numerous known test failures before merge."
+        },
+        "implementation": {
+          "completeness": 10,
+          "correctness": 6,
+          "specificity": 17,
+          "risk_awareness": 11,
+          "total": 44,
+          "notes": "The patch targets real symbols and correctly rewires the factory, fixes `AgentService.index_agent()`, removes production FAISS imports, and replaces non-redundant toggle indexing calls with repository methods. It is not end-to-end complete: existing file-backed data receives no DocumentDB backfill after the startup sweep is removed, so upgraded deployments can return empty search results until every entity is mutated. Leaving `uv.lock` unchanged means the default frozen Docker build still installs `faiss-cpu`, the locked CPU build and lock-check CI can fail, and dozens of tests still resolve the deleted `registry.search.service` module. The summary discloses several deferred items but incorrectly claims no substantive LLD deviation and misses the migration failure; the brittle all-dimensions Mongo query can also report stale records."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 73,
+      "input_tokens": 2,
+      "output_tokens": 917,
+      "total_tokens": 148107,
+      "latency_seconds": 912.7,
+      "total_cost_usd": 0.03941660000000001,
+      "result_subtype": "success",
+      "task_score": 55.2,
+      "cache_read_tokens": 146838,
+      "cache_write_tokens": 350,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 1.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 67,
+          "notes": "The issue clearly identifies the existing skill guard, two vulnerable paths, compatibility constraints, and testable defaults. The cited symbols exist in `skill_service.py`, `agent_validator.py`, and `health/service.py`. Its largest gap is omitting the unguarded `POST /agents/{path}/health` requests and the user-controlled `mcp_endpoint` and `sse_endpoint` URLs that health checks prefer over `proxy_pass_url`. No independent task statement establishes the intended breadth, and the proposed exclusion of followed redirects leaves a known SSRF route."
+        },
+        "lld": {
+          "completeness": 13,
+          "correctness": 10,
+          "specificity": 22,
+          "risk_awareness": 13,
+          "total": 58,
+          "notes": "The LLD is unusually concrete about settings, modes, call flow, compatibility, and file-level changes. However, `get_endpoint_url_from_server_info()` gives explicit `mcp_endpoint` and `sse_endpoint` values priority, so validating only `proxy_pass_url` is not the claimed choke point. Its supposedly unconditional metadata block is also bypassed by `extra_trusted_hosts`, while permissive mode does not reject unspecified addresses such as `0.0.0.0`. The claim that existing skill tests remain unchanged is contradicted by tests patching `registry.services.skill_service.socket.getaddrinfo` while the design removes that module import."
+        },
+        "review": {
+          "completeness": 11,
+          "correctness": 12,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 53,
+          "notes": "The review identifies a concrete precedence risk and converts it into a named wildcard-CIDR regression test. It misses the more consequential custom-endpoint bypass, the separate agent health-check route, the trusted-host metadata bypass, and the broken legacy patch target. Its frontend uncertainty was directly checkable: `registry/templates/index.html` already uses `status.startsWith('unhealthy')`. The positive verdict therefore does not adequately stress the security design, and the claimed follow-up tickets cannot be verified."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 19,
+          "risk_awareness": 13,
+          "total": 53,
+          "notes": "The unit cases have concrete policy oracles and explicitly assert that blocked requests never reach the HTTP client. The permissive health tests incorrectly assert `client.get` is called, although the supplied `streamable-http` configuration follows `_initialize_mcp_session()` through `client.post`, so those tests would fail. The manual plan invents `POST /api/agents/validate` and `POST /api/servers`; the repository exposes `/api/agents/register` and form-based `/api/servers/register`, while `/api/servers/health` returns nested status objects. Coverage also omits explicit endpoint overrides, the existing agent health route, trusted-host metadata bypass, redirects, and `0.0.0.0`, and no tests were executed."
+        },
+        "implementation": {
+          "completeness": 11,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 8,
+          "total": 45,
+          "notes": "The repository is at the claimed `b0fcb2db` baseline, and the embedded diff's target files, symbols, and contexts match the source. The implementation validates `proxy_pass_url` but then may request user-controlled `mcp_endpoint` or `sse_endpoint`, and it leaves `POST /agents/{path}/health` wholly unguarded. `is_safe_url()` also returns early for trusted hosts before checking metadata, and removing `skill_service.socket` breaks three existing test patches. New configuration is absent from documentation and deployment wiring, the new health tests contain the wrong request oracle, and the summary overstates end-to-end protection despite reporting no executed tests."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-07"
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "model": "us.anthropic.claude-sonnet-5",
+  "scores": {
+    "github_issue": {
+      "completeness": 14,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 67,
+      "notes": "The issue clearly identifies the existing skill guard, two vulnerable paths, compatibility constraints, and testable defaults. The cited symbols exist in `skill_service.py`, `agent_validator.py`, and `health/service.py`. Its largest gap is omitting the unguarded `POST /agents/{path}/health` requests and the user-controlled `mcp_endpoint` and `sse_endpoint` URLs that health checks prefer over `proxy_pass_url`. No independent task statement establishes the intended breadth, and the proposed exclusion of followed redirects leaves a known SSRF route."
+    },
+    "lld": {
+      "completeness": 13,
+      "correctness": 10,
+      "specificity": 22,
+      "risk_awareness": 13,
+      "total": 58,
+      "notes": "The LLD is unusually concrete about settings, modes, call flow, compatibility, and file-level changes. However, `get_endpoint_url_from_server_info()` gives explicit `mcp_endpoint` and `sse_endpoint` values priority, so validating only `proxy_pass_url` is not the claimed choke point. Its supposedly unconditional metadata block is also bypassed by `extra_trusted_hosts`, while permissive mode does not reject unspecified addresses such as `0.0.0.0`. The claim that existing skill tests remain unchanged is contradicted by tests patching `registry.services.skill_service.socket.getaddrinfo` while the design removes that module import."
+    },
+    "review": {
+      "completeness": 11,
+      "correctness": 12,
+      "specificity": 18,
+      "risk_awareness": 12,
+      "total": 53,
+      "notes": "The review identifies a concrete precedence risk and converts it into a named wildcard-CIDR regression test. It misses the more consequential custom-endpoint bypass, the separate agent health-check route, the trusted-host metadata bypass, and the broken legacy patch target. Its frontend uncertainty was directly checkable: `registry/templates/index.html` already uses `status.startsWith('unhealthy')`. The positive verdict therefore does not adequately stress the security design, and the claimed follow-up tickets cannot be verified."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 8,
+      "specificity": 19,
+      "risk_awareness": 13,
+      "total": 53,
+      "notes": "The unit cases have concrete policy oracles and explicitly assert that blocked requests never reach the HTTP client. The permissive health tests incorrectly assert `client.get` is called, although the supplied `streamable-http` configuration follows `_initialize_mcp_session()` through `client.post`, so those tests would fail. The manual plan invents `POST /api/agents/validate` and `POST /api/servers`; the repository exposes `/api/agents/register` and form-based `/api/servers/register`, while `/api/servers/health` returns nested status objects. Coverage also omits explicit endpoint overrides, the existing agent health route, trusted-host metadata bypass, redirects, and `0.0.0.0`, and no tests were executed."
+    },
+    "implementation": {
+      "completeness": 11,
+      "correctness": 8,
+      "specificity": 18,
+      "risk_awareness": 8,
+      "total": 45,
+      "notes": "The repository is at the claimed `b0fcb2db` baseline, and the embedded diff's target files, symbols, and contexts match the source. The implementation validates `proxy_pass_url` but then may request user-controlled `mcp_endpoint` or `sse_endpoint`, and it leaves `POST /agents/{path}/health` wholly unguarded. `is_safe_url()` also returns early for trusted hosts before checking metadata, and removing `skill_service.socket` breaks three existing test patches. New configuration is absent from documentation and deployment wiring, the new health tests contain the wrong request oracle, and the summary overstates end-to-end protection despite reporting no executed tests."
+    }
+  },
+  "task_score": 55.2,
+  "verdict": "The submission is detailed and repository-aware, but critical unvalidated outbound URL paths and non-runnable tests leave the SSRF hardening materially incomplete.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-07T17:27:42.650784Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 1118480,
+      "cached_input_tokens": 986663,
+      "cache_write_input_tokens": 131795,
+      "output_tokens": 9999,
+      "reasoning_output_tokens": 4995
+    },
+    "duration_ms": 205297
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/pi/swe3/mcp-gateway-registry/ssrf-hardening-outbound-url-validation/metrics.json
@@ -1,0 +1,150 @@
+{
+  "task": "ssrf-hardening-outbound-url-validation",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.4",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "ssrf",
+    "python",
+    "fastapi",
+    "input-validation"
+  ],
+  "model": "us.anthropic.claude-sonnet-5",
+  "model_slug": "claude-sonnet-5",
+  "agent": "pi",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 1.0,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 917,
+    "cache_read_tokens": 146838,
+    "cache_write_tokens": 350,
+    "total_tokens": 148107,
+    "total_cost_usd": 0.03941660000000001,
+    "latency_seconds": 912.7,
+    "num_turns": 73,
+    "generation_tokens_per_sec": 1.0,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2,
+  "output_tokens": 917,
+  "latency_seconds": 912.7,
+  "num_turns": 73,
+  "total_cost_usd": 0.03941660000000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 146838,
+  "cache_creation_tokens": 350,
+  "run_started_at": "2026-08-07T16:24:55.845544Z",
+  "run_ended_at": "2026-08-07T16:40:08.719676Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2,
+    "output_tokens": 917,
+    "cache_read_tokens": 146838,
+    "cache_write_tokens": 350,
+    "total_tokens": 148107,
+    "total_cost_usd": 0.03941660000000001,
+    "latency_seconds": 912.7,
+    "num_turns": 73,
+    "generation_tokens_per_sec": 1.0,
+    "sources": {
+      "input_tokens": "pi_api.usage.input",
+      "output_tokens": "pi_api.usage.output",
+      "cache_read_tokens": "pi_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "pi_api.usage.cache_creation_input_tokens",
+      "total_tokens": "sum(input + output + cache_read + cache_write)",
+      "total_cost_usd": "pi_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or pi_api.duration_ms)",
+      "num_turns": "pi_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "ssrf-hardening-outbound-url-validation",
+    "model": "us.anthropic.claude-sonnet-5",
+    "scores": {
+      "github_issue": {
+        "completeness": 14,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 67,
+        "notes": "The issue clearly identifies the existing skill guard, two vulnerable paths, compatibility constraints, and testable defaults. The cited symbols exist in `skill_service.py`, `agent_validator.py`, and `health/service.py`. Its largest gap is omitting the unguarded `POST /agents/{path}/health` requests and the user-controlled `mcp_endpoint` and `sse_endpoint` URLs that health checks prefer over `proxy_pass_url`. No independent task statement establishes the intended breadth, and the proposed exclusion of followed redirects leaves a known SSRF route."
+      },
+      "lld": {
+        "completeness": 13,
+        "correctness": 10,
+        "specificity": 22,
+        "risk_awareness": 13,
+        "total": 58,
+        "notes": "The LLD is unusually concrete about settings, modes, call flow, compatibility, and file-level changes. However, `get_endpoint_url_from_server_info()` gives explicit `mcp_endpoint` and `sse_endpoint` values priority, so validating only `proxy_pass_url` is not the claimed choke point. Its supposedly unconditional metadata block is also bypassed by `extra_trusted_hosts`, while permissive mode does not reject unspecified addresses such as `0.0.0.0`. The claim that existing skill tests remain unchanged is contradicted by tests patching `registry.services.skill_service.socket.getaddrinfo` while the design removes that module import."
+      },
+      "review": {
+        "completeness": 11,
+        "correctness": 12,
+        "specificity": 18,
+        "risk_awareness": 12,
+        "total": 53,
+        "notes": "The review identifies a concrete precedence risk and converts it into a named wildcard-CIDR regression test. It misses the more consequential custom-endpoint bypass, the separate agent health-check route, the trusted-host metadata bypass, and the broken legacy patch target. Its frontend uncertainty was directly checkable: `registry/templates/index.html` already uses `status.startsWith('unhealthy')`. The positive verdict therefore does not adequately stress the security design, and the claimed follow-up tickets cannot be verified."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 8,
+        "specificity": 19,
+        "risk_awareness": 13,
+        "total": 53,
+        "notes": "The unit cases have concrete policy oracles and explicitly assert that blocked requests never reach the HTTP client. The permissive health tests incorrectly assert `client.get` is called, although the supplied `streamable-http` configuration follows `_initialize_mcp_session()` through `client.post`, so those tests would fail. The manual plan invents `POST /api/agents/validate` and `POST /api/servers`; the repository exposes `/api/agents/register` and form-based `/api/servers/register`, while `/api/servers/health` returns nested status objects. Coverage also omits explicit endpoint overrides, the existing agent health route, trusted-host metadata bypass, redirects, and `0.0.0.0`, and no tests were executed."
+      },
+      "implementation": {
+        "completeness": 11,
+        "correctness": 8,
+        "specificity": 18,
+        "risk_awareness": 8,
+        "total": 45,
+        "notes": "The repository is at the claimed `b0fcb2db` baseline, and the embedded diff's target files, symbols, and contexts match the source. The implementation validates `proxy_pass_url` but then may request user-controlled `mcp_endpoint` or `sse_endpoint`, and it leaves `POST /agents/{path}/health` wholly unguarded. `is_safe_url()` also returns early for trusted hosts before checking metadata, and removing `skill_service.socket` breaks three existing test patches. New configuration is absent from documentation and deployment wiring, the new health tests contain the wrong request oracle, and the summary overstates end-to-end protection despite reporting no executed tests."
+      }
+    },
+    "task_score": 55.2,
+    "verdict": "The submission is detailed and repository-aware, but critical unvalidated outbound URL paths and non-runnable tests leave the SSRF hardening materially incomplete.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-07T17:27:42.650784Z",
+      "repo_ref": "1.24.4",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 1118480,
+        "cached_input_tokens": 986663,
+        "cache_write_input_tokens": 131795,
+        "output_tokens": 9999,
+        "reasoning_output_tokens": 4995
+      },
+      "duration_ms": 205297
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/claude-code/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/claude-code/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,383 @@
+{
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "claude",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 131072
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-04T23:33:44.835870Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 258535,
+      "cached_input_tokens": 215515,
+      "cache_write_input_tokens": 43006,
+      "output_tokens": 7229,
+      "reasoning_output_tokens": 5884
+    },
+    "duration_ms": 130765
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 53.72,
+  "mean_cost_usd_excl_failed": 70.57,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 106,
+      "input_tokens": 6955183,
+      "output_tokens": 34555,
+      "total_tokens": 6989738,
+      "latency_seconds": 516.2,
+      "total_cost_usd": 35.639790000000005,
+      "result_subtype": "success",
+      "task_score": 67.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8907,
+      "generation_tokens_per_sec": 66.9,
+      "kv_cache_usage": {
+        "peak": 0.174,
+        "mean": 0.1159
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 11,
+          "total": 68,
+          "notes": "The issue inventories the relevant Terraform resources, task-definition mounts, variables, outputs, application configuration, and validation outcomes, and those paths and symbols align with the supplied patch hunks. Its acceptance criteria are mostly testable, particularly removal of the named mounts and successful Terraform validation and planning. The largest deficiency is treating destructive deletion as dependency-free and data migration as unnecessary solely because EFS is assumed unused, despite the current task definitions and SCOPES_CONFIG_PATH actively referencing it. No independent task statement or issue #1286 was supplied, so the claims that S3 and DocumentDB cover all persistence and that EFS has no data could not be verified."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 19,
+          "risk_awareness": 17,
+          "total": 70,
+          "notes": "The LLD provides a concrete file-by-file removal plan matching the supplied module.efs references, ECS volumes, variables, and outputs, and it considers deployment, rollback, and data-loss risk. It incorrectly describes the scopes_loader.py fallback as the absolute EFS path when the shown code resolves repository-relative auth_server/auth_config/scopes.yml; removing that fallback is therefore not justified by EFS removal. The proposed single patch also cannot implement its own first deployment phase of disabling mounts while retaining EFS, and reverting later would recreate an empty file system unless a valid AWS Backup recovery point exists. CloudTrail EFS API events do not establish absence of NFS file activity, an AWS EFS secure-deletion feature is not identified, and repository-specific IAM, alarm, documentation, and persistent-storage claims remain unverified."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 13,
+          "specificity": 16,
+          "risk_awareness": 18,
+          "total": 65,
+          "notes": "The SRE and backend sections identify the most important hazards: destructive data loss, task-update ordering, hidden writers, backup, and rollback. The review nevertheless closes every concern based largely on assumptions, including a claim that no file-based configuration was found even though the supplied Terraform sets SCOPES_CONFIG_PATH to an EFS-mounted scopes file and mounts /app/data and /app/logs. Its proposed CloudTrail audit cannot detect ordinary NFS reads and writes, and the referenced EFS secure-deletion feature is unsupported. Recommendations are actionable at a high level, but the approving verdict is not defensible until actual EFS metrics, contents, consumers, and a realizable two-stage rollout are verified."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 12,
+          "specificity": 15,
+          "risk_awareness": 17,
+          "total": 63,
+          "notes": "The plan spans Terraform validation, staging deployment, service behavior, security, monitoring, performance, and rollback, with useful expected plan changes and service-state oracles. Many cases are not executable as written: terraform plan lacks backend, credentials, and variable-file details; the existing scopes-loader test suite and health endpoints are not named; and MCPGW persistence is qualified with \"if applicable\" rather than a defined state oracle. CloudTrail cannot prove absence of NFS access, AWS EFS secure deletion is not a concrete operation, alarm-name searches do not prove metric cleanup, and recreating EFS does not restore its prior data. The plan also omits a precise source-wide reference scan and a regression test for the repository-relative scopes fallback removed by the patch."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 71,
+          "notes": "The patch coherently removes the supplied EFS module, both ECS volume configurations and mount points, the EFS-backed environment variable, module variables, and root and child outputs. Its clearest defect is deleting the repository-relative auth_server/auth_config/scopes.yml fallback merely because its comment says EFS; that code does not reference the /efs mount and may be an independent compatibility path. Documentation required by the issue is explicitly left unchanged, and a single Terraform apply may destroy mount targets concurrently with replacement task deployment despite the summary prescribing a staged rollout. Repository command execution failed in the read-only harness, so patch applicability, Terraform validation, and source-wide absence of remaining EFS references could not be independently verified; the summary also overstates rollback because recreated EFS is empty without a tested backup recovery path."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 211,
+      "input_tokens": 14006362,
+      "output_tokens": 93156,
+      "total_tokens": 14099518,
+      "latency_seconds": 1317.3,
+      "total_cost_usd": 72.36070999999997,
+      "result_subtype": "success",
+      "task_score": 60.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8839,
+      "generation_tokens_per_sec": 70.7,
+      "kv_cache_usage": {
+        "peak": 0.1763,
+        "mean": 0.1216
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 21,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 76,
+          "notes": "The strongest aspect is its clear scope across agent, server, CLI, configuration, compatibility, and tests, with explicit non-goals. The named files and symbols, including `skill_service.py`, `check_agent_health`, and `_check_server_endpoint_transport_aware`, correspond to the submitted source diff. Its largest deficiency is limited treatment of redirect-based SSRF, DNS rebinding, blocking DNS calls, sensitive URL logging, and migration for currently reachable private services. No independent task statement was supplied, so issue number `#1282`, release history, and requirements beyond the task identifier could not be independently verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 13,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 64,
+          "notes": "The LLD is unusually concrete about files, call sites, exception behavior, configuration merging, and utility implementation. Its integration points align with the diff, including `registry/api/agent_routes.py`, `registry/health/service.py`, and the existing skill-service helpers. The largest flaw is that validation and HTTP connection perform separate DNS resolutions, leaving DNS rebinding possible, while redirect destinations may be checked only after a request has occurred. It also inconsistently uses `SSRF_TRUSTED_HOSTS` and `SSRF_ALLOWED_HOSTS`, leaves exception inheritance open, and claims backward compatibility without a pre-deployment allowlist migration."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 9,
+          "specificity": 17,
+          "risk_awareness": 16,
+          "total": 57,
+          "notes": "The review's strongest finding is the genuine DNS rebinding gap, supplemented by useful concerns about URL logging, configuration validation, and operational status distinctions. Its headline critical IPv6 finding is contradicted by the reviewed LLD, whose `is_private_ip` design already uses IPv6-aware `ipaddress` properties plus `fc00::/7` and `2001:db8::/32` checks. It also claims metrics and docstrings are missing despite explicit LLD sections for both, and discusses a CLI fallback import that the LLD does not propose. The review misses the concrete `requests` redirect bypass and ultimately prioritizes already-addressed findings above the unresolved rebinding defect."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 7,
+          "specificity": 17,
+          "risk_awareness": 15,
+          "total": 57,
+          "notes": "The strongest aspect is the broad matrix of private ranges, IPv6 cases, configuration combinations, negative paths, and explicit expected values. Several proposed tests do not match the source: they instantiate `HealthCheckService` although the patch shows `HealthMonitoringService`, and call `_check_server_endpoint_transport_aware` without the `server_info` consumed by that method. The API test expects a top-level `error`, while the implementation raises `HTTPException(detail=str(e))`, and snippets also omit imports such as `socket` and `AsyncMock`. The plan lacks redirect and DNS-rebinding tests, contains timing assertions that are inherently flaky, and provides no verified repository test command."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 18,
+          "risk_awareness": 7,
+          "total": 46,
+          "notes": "The patch is focused and reaches the principal source symbols, extracting the utility and adding checks to agent, server, CLI, and skill paths. Its largest security defect is that `requests.get` follows redirects by default after validating only the initial CLI URL, while all clients remain vulnerable to DNS rebinding between `getaddrinfo` and connection establishment. The patch adds no tests and omits the existing allowlist-test update identified by the LLD despite deleting `_trusted_domains`, `_is_private_ip`, and `_is_safe_url`. The summary overstates consistency: the API emits a FastAPI `detail` string rather than the designed structured error, and server health returns a different status text than the testing plan expects."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 423,
+      "input_tokens": 29157979,
+      "output_tokens": 147431,
+      "total_tokens": 29305410,
+      "latency_seconds": 2258.4,
+      "total_cost_usd": 149.47566999999998,
+      "result_subtype": "success",
+      "task_score": 51.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8811,
+      "generation_tokens_per_sec": 62.3,
+      "kv_cache_usage": {
+        "peak": 0.1791,
+        "mean": 0.1101
+      },
+      "agent_invocations": 2,
+      "topped_up_artifacts": [
+        "patch.diff",
+        "implementation.md"
+      ],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 19,
+          "risk_awareness": 15,
+          "total": 67,
+          "notes": "The issue gives a concrete removal inventory and testable criteria covering pyproject.toml, registry/search/service.py, the file search repository, configuration, tests, and documentation. Those components and the file-versus-MongoDB factory split are supported by the submitted source diff. Its largest weakness is the unresolved core behavior for file-backed users, while simultaneously claiming end users are unaffected and search remains identical. No independent task statement establishes DocumentDB equivalence or permits removal of the broader file storage backend, so those claims remain unverified."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 16,
+          "risk_awareness": 13,
+          "total": 53,
+          "notes": "The LLD is grounded in real symbols including get_search_repository(), MONGODB_BACKENDS, Settings, and the startup search initialization, and it provides a phased file-level plan. It does not map all direct FaissService callers to the SearchRepositoryBase interface, leaving a load-bearing integration decision unresolved. The default backend remains an open choice, migration scripting is conditional, and the proposed partial rollback cannot work after deleting both the FAISS repository and service. It recognizes migration, local-development, latency, and rollout risks, but its caching, pooling, migration, and fallback guidance is largely speculative and not implementation-ready."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 15,
+          "risk_awareness": 17,
+          "total": 57,
+          "notes": "The review correctly prioritizes migration disruption, local development, database outages, documentation, and performance regression. It provides actionable recommendations such as configuration errors, MongoDB-backed development setup, and connectivity health checks. It misses the LLD's invalid rollback, unresolved backend default, non-search consequences of rejecting storage_backend=\"file\", and the repository interface mismatch later exposed by the patch. Claims that DocumentDB is production-proven, imposes no new operational burden, and preserves API behavior are unsupported, making the final assertion that all critical issues are addressed unjustified."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 13,
+          "risk_awareness": 18,
+          "total": 59,
+          "notes": "The plan spans unit, integration, migration, failure, performance, Docker, and dependency checks, including relevant existing paths such as tests/unit/core/test_config.py and tests/integration/test_search_integration.py. Most cases lack concrete fixtures, commands, and exact result oracles; phrases such as results being identical or correct would not reliably detect ranking or indexing regressions. It also proposes unverified scripts, tools, environments, migration behavior, and a FAISS baseline without establishing their repository support. Its strongest aspect is broad risk coverage, but it fails to require removal of stale imports such as the implementation's remaining registry.api.search_routes.faiss_service patch targets."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 1,
+          "specificity": 11,
+          "risk_awareness": 3,
+          "total": 22,
+          "notes": "The patch removes the dependency, FAISS service, file search repository, configuration properties, and factory branch, so it implements part of the proposed removal. It is syntactically invalid in registry/api/server_routes.py because it deletes the opening add_or_update_service call while leaving its arguments and closing parenthesis. Calls added in agent_routes.py and agent_batch_item_processor.py use add_or_update_entity, while the repository abstraction shown in the deleted wrapper exposes index_entity, and integration tests still patch the deleted registry.api.search_routes.faiss_service symbol. The summary admits remaining FAISS tests, documentation, and deployment scripts, while uv.lock and several acceptance-criteria areas are omitted; an independent git apply check could not be run because the command sandbox failed before execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 90,
+      "input_tokens": 5940812,
+      "output_tokens": 39419,
+      "total_tokens": 5980231,
+      "latency_seconds": 562.8,
+      "total_cost_usd": 30.689535000000006,
+      "result_subtype": "success",
+      "task_score": 47.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8781,
+      "generation_tokens_per_sec": 70.0,
+      "kv_cache_usage": {
+        "peak": 0.1758,
+        "mean": 0.119
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 16,
+          "risk_awareness": 13,
+          "total": 56,
+          "notes": "The issue clearly states the credential-rotation problem, ECS scope, non-goals, and mostly observable acceptance criteria. Its largest defect is contradictory and technically incorrect acceptance criteria: it requires removing the password while retaining password fallback, and names nonexistent `rds:GenerateDBAuthToken` authorization on the execution role rather than `rds-db:connect` on the task role. It also leaves RDS Proxy as either configured or removed and omits IAM database-user provisioning and token lifecycle behavior. No independent task statement was supplied, and the claimed issue references and ECS-only constraint could not be verified."
+        },
+        "lld": {
+          "completeness": 13,
+          "correctness": 5,
+          "specificity": 14,
+          "risk_awareness": 14,
+          "total": 46,
+          "notes": "The LLD names the principal Terraform and container files and recognizes token expiry, fallback, secret migration, observability, and rollout concerns. The central design remains undecided between an unverified `useAwsIam=true` mode and a wrapper whose exported password cannot be refreshed inside the already-running Keycloak process. Its proposed policy uses nonexistent `rds:GenerateDBAuthToken` and cluster ARNs instead of an `rds-db:connect` DB-user ARN, while setting `master_password = null` without managed master credentials and never provisioning a MySQL user with `AWSAuthenticationPlugin`. Claims about Connector/J native IAM support and RDS Proxy handling reauthentication are unsupported, so the detailed steps would require substantial redesign."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 9,
+          "specificity": 14,
+          "risk_awareness": 17,
+          "total": 55,
+          "notes": "The review correctly identifies native-driver support and token refresh as blockers and raises useful migration, least-privilege, token exposure, and rollback risks. Its largest deficiency is declaring those blockers resolved merely because verification and several possible strategies were listed, despite the LLD still having no viable committed authentication mechanism. It misses the invalid IAM action and resource ARN, absent database-user plugin configuration, invalid fresh-cluster password handling, and falsely states that token generation is a CloudTrail-recorded API call. Multi-region failover and load-balancer canary recommendations are not grounded in supplied repository or task evidence."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 5,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 46,
+          "notes": "The plan spans Terraform, direct database connectivity, password fallback, ECS readiness, login, expiry, performance, security, and rollback, with useful concrete oracles such as `SELECT 1`. Several tests are not executable or do not prove their claims: the token is not a JWT, an ECS role normally cannot be assumed by the operator, and `list-attached-role-policies` cannot inspect the inline `aws_iam_role_policy` changed by the patch. The expiry test deploys no stated workload, supplies CloudWatch start time in seconds rather than milliseconds, and treats absence of matching logs as proof of successful refresh. Hard-coded clone paths, role names, secret names, ALB names, and public health endpoints could not be verified against the repository."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 2,
+          "specificity": 17,
+          "risk_awareness": 7,
+          "total": 34,
+          "notes": "The patch concretely touches the expected Terraform variables, cluster, proxy, ECS policy, image, and wrapper surfaces, but it omits IAM-enabled MySQL user provisioning, rotation cleanup, and working long-lived credential delivery. The Docker build is likely to fail because `COPY` creates a root-owned script after `USER keycloak` and the following `chmod` runs unprivileged; even if built, changing ECS `command` passes the wrapper path to the existing `kc.sh` entrypoint instead of executing it. Authentication remains nonfunctional because the policy uses the wrong action and ARN, `master_password = null` cannot bootstrap a fresh cluster, and a background subshell cannot update Keycloak's environment for new pooled connections. The summary materially overclaims least privilege, CloudTrail auditing, compatibility, and token refresh; independent `git apply --check` and source inspection were unavailable because every read-only shell command failed with a sandbox `RTM_NEWADDR` error."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 179,
+      "input_tokens": 12375581,
+      "output_tokens": 113074,
+      "total_tokens": 12488655,
+      "latency_seconds": 1534.5,
+      "total_cost_usd": 64.70475500000003,
+      "result_subtype": "success",
+      "task_score": 42.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": 0.8751,
+      "generation_tokens_per_sec": 73.7,
+      "kv_cache_usage": {
+        "peak": 0.1789,
+        "mean": 0.1272
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 13,
+          "risk_awareness": 8,
+          "total": 43,
+          "notes": "The issue names affected services, defines exclusions, and gives acceptance criteria for Secrets Manager and IAM integration. Its central security claim is incorrect because Terraform-managed aws_secretsmanager_secret_version.secret_string values remain in Terraform state, and retaining plaintext task-definition environment entries preserves the original exposure. The proposed fallback is also unsound: ECS resolves secrets before container startup, so failure to retrieve one prevents the application from falling back to a duplicate plaintext variable. No independent task statement was supplied, and Issue #1134 could not be verified from the available evidence."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 6,
+          "specificity": 13,
+          "risk_awareness": 11,
+          "total": 44,
+          "notes": "The LLD names concrete Terraform files, variables, ECS containers, secret resources, and IAM integration points reflected in the submitted diff. Its load-bearing migration model is wrong: ECS injects Secrets Manager values at task initialization, so application retries, dual reads, and runtime fallback cannot recover from secret retrieval failure. The Grafana design crosses the separate observability module boundary without defining inputs or outputs, while terraform output -json cannot extract arbitrary input-variable values for the proposed migration. Risk coverage is broad but often speculative or invalid, including unimplemented EventBridge behavior and a cost calculation where 100 calls per minute would cost about $21.90 monthly at the stated rate, not $0.22."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 13,
+          "risk_awareness": 15,
+          "total": 49,
+          "notes": "The review correctly identifies that ECS tasks need replacement after secret rotation and that the existing KMS role-name wildcard is broad. It misses the more fundamental defects that Terraform secret versions still store values in state and that ECS startup failure cannot trigger application-level environment fallback. Several recommendations are technically weak: explicit depends_on is unnecessary where resource references already create dependencies, and terraform output cannot generally recover input variables. The final READY FOR IMPLEMENTATION verdict is unsupported because the appended LLD text describes scripts, alarms, replication, and restart automation without actually specifying or implementing them."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 10,
+          "risk_awareness": 14,
+          "total": 46,
+          "notes": "The plan spans Terraform, IAM, deployment, rollback, security, and performance, and includes several measurable thresholds. Most cases remain labels rather than executable tests with exact setup, actions, commands, and expected resource values; even terraform validate lacks a working directory and initialization procedure. BC-02 and the suggested secret-deletion fallback test assert impossible behavior because ECS must retrieve referenced secrets before starting the container, while runtime refresh and caching tests do not match ECS environment injection. Checkov, Terratest, Postman, workspace behavior, compliance requirements, and the 99.9% target are not established by repository or task evidence, and allowing only 90% of cases to pass could accept critical failures."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 4,
+          "specificity": 12,
+          "risk_awareness": 5,
+          "total": 29,
+          "notes": "The patch concretely adds secret resources, IAM ARNs, and ECS secret entries across three Terraform files, but it does not implement the claimed secure migration end to end. Every new secret value is still supplied through Terraform secret_string, plaintext environment entries are retained, and ECS cannot provide the summary's fallback when secret initialization fails. It grants and injects registry-only webhook, gate, and GitHub values into auth-server, injects Auth0 and Grafana values into registry, and never wires the Grafana secret into terraform/aws-ecs/modules/observability/main.tf; the wildcard KMS patterns are also not specific roles as claimed. No tests, documentation, migration script, rotation restart, or real rollback mechanism are included, and independent git apply or source validation was unavailable because repository command execution failed in the provided read-only environment."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-04",
+  "skill": "swe3"
+}

--- a/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/deepseek-v3.2/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,380 @@
+{
+  "model": "deepseek-v3.2",
+  "model_slug": "deepseek-v3.2",
+  "agent": "pi",
+  "scope": "mcp-gateway-registry",
+  "provider": "endpoint",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "p5en.48xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": 131072
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-04T21:23:49.002528Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 162177,
+      "cached_input_tokens": 132258,
+      "cache_write_input_tokens": 29907,
+      "output_tokens": 6371,
+      "reasoning_output_tokens": 4881
+    },
+    "duration_ms": 130615
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 50.84,
+  "mean_cost_usd_excl_failed": null,
+  "tasks": [
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 69,
+      "input_tokens": 62190,
+      "output_tokens": 542,
+      "total_tokens": 2920707,
+      "latency_seconds": 321.3,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 57.6,
+      "cache_read_tokens": 2797824,
+      "cache_write_tokens": 60151,
+      "prefix_cache_hit_rate": 0.979,
+      "generation_tokens_per_sec": 1.7,
+      "kv_cache_usage": {
+        "peak": 0.1176,
+        "mean": 0.0738
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 66,
+          "notes": "The issue clearly identifies the Terraform surfaces and provides mostly testable removal criteria and explicit exclusions. Its largest deficiency is treating migration and absence of runtime EFS dependencies as confirmed facts despite active auth, logging, and mcpgw mounts in the submitted baseline. The patch context confirms the named storage, ECS, variable, and output symbols exist. No independent task statement supports the S3/DocumentDB migration, related issue #1286, or assertion that data migration is complete."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 58,
+          "notes": "The LLD is strongest in mapping concrete files, EFS module outputs, mount points, and removal steps. Its largest defect is choosing `/app/config/scopes.yml` without establishing that the container image contains that file; the implementation itself notes another existing baked path, `/app/auth_server/scopes.yml`. The proposed phased rollout is not realized by a configuration that removes ECS references and EFS resources together, while `terraform state rm` would orphan resources and restoring stale state cannot recover destroyed EFS data. The supplied baseline context confirms `SCOPES_CONFIG_PATH`, contradicting the LLD's repeated `AUTH_CONFIG_PATH` symbol."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 16,
+          "risk_awareness": 17,
+          "total": 60,
+          "notes": "The review usefully identifies the configuration-path dependency, service-first rollout, state handling, monitoring, and application validation as material concerns. Its largest weakness is declaring those concerns resolved without validating the proposed path or noticing that the single patch cannot enforce the claimed two-stage deployment. The recommended `terraform state rm` does not destroy EFS and the suggested state-backup restoration does not restore deleted filesystem contents. Several persona sections add generic compliance and UX observations without repository evidence, and the final approval is stronger than the unresolved risks justify."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 17,
+          "risk_awareness": 13,
+          "total": 52,
+          "notes": "The plan includes concrete Terraform validation, plan review, file-specific checks, state backup, and post-deployment areas. A central assertion is self-contradictory: the global EFS grep expects zero matches although the implementation deliberately adds multiple comments containing `EFS`. The hard-coded `TF_DIR` is environment-specific, and `terraform output` inspects current state rather than proving downstream compatibility or source-output removal. Runtime validation merely echoes manual instructions, so it would not establish that `/app/config/scopes.yml` exists, that services become healthy, or that authorization behavior remains correct."
+        },
+        "implementation": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 19,
+          "risk_awareness": 8,
+          "total": 52,
+          "notes": "The diff concretely removes the EFS module, security-group rule, task volumes, mount points, variables, and outputs, so it implements the structural removal portion of the design. Its largest defect is redirecting `SCOPES_CONFIG_PATH` to `/app/config/scopes.yml` without any image or configuration change establishing that path, despite the summary identifying an existing `/app/auth_server/scopes.yml` path. Removing both task dependencies and EFS resources in one apply also fails the LLD's phased rollout and permits EFS destruction before replacement tasks are proven healthy. The submitted preimage is internally consistent, but independent `git apply --check` and broader repository searches could not be completed because repository commands were unavailable in the read-only execution sandbox."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 99,
+      "input_tokens": 94111,
+      "output_tokens": 862,
+      "total_tokens": 6371067,
+      "latency_seconds": 485.1,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 54.4,
+      "cache_read_tokens": 6184832,
+      "cache_write_tokens": 91262,
+      "prefix_cache_hit_rate": 0.9855,
+      "generation_tokens_per_sec": 1.8,
+      "kv_cache_usage": {
+        "peak": 0.1781,
+        "mean": 0.1174
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 19,
+          "risk_awareness": 16,
+          "total": 73,
+          "notes": "The issue clearly identifies the existing `skill_service.py` guard and the agent-validation, agent-health, and server-health paths later targeted by the patch. Its acceptance criteria and non-goals are mostly concrete and testable. The largest gap is the unconditional backward-compatibility promise: existing private agents would be blocked without an inventory, migration, or applicable allowlist plan. No independent task statement was supplied, and the asserted security finding in issue #1282 could not be verified."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 15,
+          "risk_awareness": 13,
+          "total": 54,
+          "notes": "The LLD names real submitted symbols and files, including `_check_endpoint_reachability`, `check_agent_health`, and the health service, and gives a concrete shared-module direction. It incorrectly says the existing `_is_safe_url()` validates redirects and claims twelve skill-service call sites, while the patch shows eight replacements and redirect checks occur only after response handling. The health-service instruction remains `_check_server_endpoint_transport_aware or similar`, exception behavior is left open, and the promised response shape and 400/422 behavior are inconsistent. It recognizes DNS latency, circular imports, and false positives, but does not resolve redirect/transport DNS races, migration of existing private agents, or a practical rollback."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 15,
+          "risk_awareness": 17,
+          "total": 57,
+          "notes": "The review surfaces several material concerns, especially synchronous DNS in async paths, incomplete HTTP-client auditing, inconsistent errors, false positives, and rollout observability. Its resolution section then marks work complete that is absent from the reviewed LLD, including metrics, a feature flag, and a completed audit. The claimed two-second `socket.getaddrinfo()` timeout is not supported by Python's API, and validator-side TTL caching does not pin the address subsequently resolved by `httpx`. It also misses the vague backward-compatibility promise and the fact that post-request redirect inspection cannot prevent the redirected request itself."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 6,
+          "specificity": 14,
+          "risk_awareness": 15,
+          "total": 51,
+          "notes": "The plan covers public/private addresses, IPv6, metadata services, configuration, registration, both health paths, redirects, compatibility, and performance with concrete expected outcomes. Several examples are unusable: a synchronous `def` contains `await`, and mocks patch `registry.utils.ssrf_validation.is_safe_url` even though consumers import the function directly into their own modules. The trusted-host test expects `raw.internal-github.example.com` to match an exact allowlist entry for `internal-github.example.com`, while the Docker test queries an undeclared container name. API prefixes and request schemas could not be independently established, and the plan also tests unimplemented feature flags, metrics, and error response fields."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 2,
+          "specificity": 15,
+          "risk_awareness": 7,
+          "total": 37,
+          "notes": "The patch touches every named production integration point and consistently replaces the eight skill-service calls with the shared function. However, `_resolve_hostname_with_cache()` passes an unsupported `timeout` keyword to `socket.getaddrinfo`; the resulting exception is converted into a failed validation, so every non-allowlisted public URL is blocked and existing skill behavior regresses. Its DNS cache does not prevent rebinding because `httpx` performs a separate resolution, the cache is unbounded, metrics are never used by callers, and no tests accompany removal of the old private helpers. The summary overstates comprehensive coverage while admitting other clients were not audited, and independent `git apply --check` verification was unavailable in the repository execution environment."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 75,
+      "input_tokens": 90321,
+      "output_tokens": 509,
+      "total_tokens": 4798702,
+      "latency_seconds": 361.4,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 52.0,
+      "cache_read_tokens": 4617536,
+      "cache_write_tokens": 90336,
+      "prefix_cache_hit_rate": 0.9808,
+      "generation_tokens_per_sec": 1.4,
+      "kv_cache_usage": {
+        "peak": 0.1704,
+        "mean": 0.1056
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 66,
+          "notes": "The issue provides concrete acceptance criteria covering the dependency, service, factory, settings, tests, and documentation, and the submitted diff context corroborates `pyproject.toml`, `registry/search/service.py`, and the repository factory as relevant targets. Its largest gap is the unresolved file-backend behavior: transparent, identical search conflicts with replacing FAISS semantic search with limited keyword matching. Criteria such as ensuring all search functionality and identical user behavior lack precise result-quality or compatibility oracles, while `uv.lock` and rollout or rollback requirements are omitted. The asserted equivalence and readiness of DocumentDB could not be independently verified because repository shell inspection failed in the provided read-only environment."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 14,
+          "risk_awareness": 13,
+          "total": 51,
+          "notes": "The LLD names several concrete integration points that are corroborated by the patch, including `get_search_repository`, `SearchRepositoryBase`, the file search repository, and DocumentDB selection. Its load-bearing architecture is inconsistent: Step 1 and the diagrams route all search to DocumentDB, while Step 3 introduces keyword-only file search and the goals still promise maintained search behavior. The proposed file implementation contains placeholders, ignores the compatibility consequences of losing semantic and tool search, and makes unverified claims about `FaissMetadata`, telemetry fields, metrics, and file-backend deprecation. Failure handling and rollout remain generic phases and open questions rather than decisions about migration, fallback, index population, or rollback."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 17,
+          "risk_awareness": 19,
+          "total": 68,
+          "notes": "The strongest part is its concrete identification of the central file-backend compatibility problem, along with latency, migration, retry, credential, and search-quality risks. The resolution section then weakens the review by declaring architectural and security findings resolved without corresponding design evidence, and it treats warning logs as a migration strategy. Claims that DocumentDB becomes mandatory for every deployment conflict with the later local keyword-search resolution, while the implementation status admits API routes, tests, and documentation are still pending. Existing TLS enforcement, audit logging, and credential handling were asserted but could not be verified from the available repository evidence."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 15,
+          "total": 55,
+          "notes": "The plan covers functional, compatibility, deployment, dependency, failure, recovery, and lifecycle scenarios and usually states an expected status or result shape. Its central curl commands are not grounded in the shown API: `semantic_search` accepts a `SemanticSearchRequest`, while the plan sends GET query parameters, and several registration payloads, status codes, environment variables, and test paths are merely assumed. Many oracles remain subjective, such as relevant, comparable, or basic results, and the plan does not pin filtering behavior or prove that the new in-memory file index is populated after restart. The proposed rollback cannot work by only re-adding the dependency after deleting the service, and the repository commands could not be independently validated because the read-only executor failed."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 2,
+          "specificity": 9,
+          "risk_awareness": 5,
+          "total": 20,
+          "notes": "The patch concretely removes the declared dependency, changes factory selection, rewrites the file repository, updates three search-route strings, and deletes the FAISS service. It is not an operable removal because its own summary admits that API routes and `agent_batch_item_processor.py` still import the deleted service, causing import failures before the advertised behavior can run. The replacement also keeps data only in `_entity_store`, makes `rebuild_index` a no-op, ignores draft and deprecated filters, drops tool matching, and includes no tests or `uv.lock` update. The summary inaccurately lists `tests/fixtures/mocks/mock_faiss.py` as deleted although no such diff is present, and independent `git apply --check` or source validation was unavailable due the repository executor failure."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 83,
+      "input_tokens": 75214,
+      "output_tokens": 687,
+      "total_tokens": 3940116,
+      "latency_seconds": 403.8,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 50.6,
+      "cache_read_tokens": 3794816,
+      "cache_write_tokens": 69399,
+      "prefix_cache_hit_rate": 0.982,
+      "generation_tokens_per_sec": 1.7,
+      "kv_cache_usage": {
+        "peak": 0.1423,
+        "mean": 0.0879
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 14,
+          "risk_awareness": 12,
+          "total": 54,
+          "notes": "The issue clearly states the security objective, affected ECS services, scope exclusions, and broad acceptance criteria. Its largest deficiency is that placing Terraform-provided values in Secrets Manager does not remove those values from Terraform state, undermining a central stated motivation. Criteria such as \"where applicable,\" \"no breaking changes,\" and plaintext fallback lack testable migration and removal conditions. No independent task statement exists, and repository command execution was unavailable, so issue #1134 and the exact service inventory remain unverified."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 16,
+          "risk_awareness": 14,
+          "total": 54,
+          "notes": "The LLD provides concrete Terraform paths, a 31-item inventory, IAM grouping, ECS injection examples, and a phased rollout outline. Its core design still writes every secret through aws_secretsmanager_secret_version.secret_string, leaving secret values in Terraform state, while rotation and fallback-removal decisions remain open. It also treats aggregate values such as auth_server_extra_env as directly migratable secrets and uses var.use_secrets_manager without defining its complete module wiring. Claims about module.ecs_service_auth, per-service execution roles, policy sizes, and the inventory could not be independently verified because repository commands were unavailable."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 12,
+          "specificity": 15,
+          "risk_awareness": 18,
+          "total": 61,
+          "notes": "The review's strongest contribution is its concrete attention to IAM limits, least privilege, rotation coordination, plaintext fallback, monitoring, and rollback ownership. It misses the fundamental persistence of secret_string values in Terraform state and recommends runtime refresh behavior that ECS environment injection cannot provide without application changes or task restarts. Its assertion that five policies are each below 6,144 characters is unsupported by a rendered-policy calculation, and the post-resolution document never gives a coherent final verdict. Repository-specific role and policy claims could not be independently verified due unavailable command execution."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 48,
+          "notes": "The plan covers Terraform, KMS, IAM, ECS task definitions, CloudTrail, rollback, and application health with concrete commands and expected outcomes. Several tests are technically unsound: an ECS task-definition migration must change task definitions and normally services, IAM policy version v1 is not stable, and ECS-injected values do not refresh transparently after secret rotation. Test 2.3 explicitly prints secrets through env despite claiming they are not shown, while execute-command omits its required interactive mode and the curl check suppresses failure with || true. Deployment names, test.tfvars, TF_VAR_name, and the proposed endpoint could not be verified against the repository."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 7,
+          "specificity": 16,
+          "risk_awareness": 9,
+          "total": 36,
+          "notes": "The patch concretely adds four aws_secretsmanager_secret resources, corresponding versions, IAM ARNs, and two use_secrets_manager declarations. It never changes ecs-services.tf, never references the new flag, and migrates none of the runtime environment variables, so the requested behavior is not implemented. The secret_string assignments retain values in Terraform state, the monolithic policy broadens access, and recovery_window_in_days = 0 weakens recovery. The summary candidly lists most omissions, but its deployment instructions incorrectly imply the unused default flag enables Secrets Manager; patch applicability could not be independently checked because repository commands were unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 76,
+      "input_tokens": 72598,
+      "output_tokens": 727,
+      "total_tokens": 3478558,
+      "latency_seconds": 446.7,
+      "total_cost_usd": null,
+      "result_subtype": "success",
+      "task_score": 39.6,
+      "cache_read_tokens": 3335104,
+      "cache_write_tokens": 70129,
+      "prefix_cache_hit_rate": 0.9794,
+      "generation_tokens_per_sec": 1.6,
+      "kv_cache_usage": {
+        "peak": 0.1375,
+        "mean": 0.0839
+      },
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 10,
+          "total": 47,
+          "notes": "The issue clearly identifies the existing Secrets Manager password, affected AWS components, compatibility goal, documentation, and explicit exclusions. Baseline diff context confirms the named Aurora cluster, RDS Proxy, ECS configuration, database password variable, and Keycloak container exist. Its critical path is unsound: startup-only tokens do not support later pooled connections, `rds:GenerateDBAuthToken` is not the authorization action, and removing the password conflicts with password fallback through a secrets-backed proxy. No independent task statement establishes the claimed ECS-only scope, and the issue omits database-user provisioning, TLS, upgrade defaults, and credential-renewal acceptance criteria."
+        },
+        "lld": {
+          "completeness": 11,
+          "correctness": 3,
+          "specificity": 13,
+          "risk_awareness": 10,
+          "total": 37,
+          "notes": "The LLD names relevant repository files and recognizes token expiry, image dependencies, rollback, monitoring, and compatibility as design concerns. Its refresh daemon only exports a variable in its own shell and explicitly leaves datasource notification as a placeholder, so Keycloak continues using the expired startup credential. The proxy remains `auth_scheme = \"SECRETS\"` while its secret password becomes empty, the proposed nested password object is incompatible with the proxy secret schema, and the IAM policy uses the wrong action, role, condition, and resource model. Major decisions remain open despite the production-ready claim, including long-running connection renewal and password removal, while ECS-only scope cannot be independently verified from the absent task statement."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 5,
+          "specificity": 13,
+          "risk_awareness": 13,
+          "total": 43,
+          "notes": "The review's strongest contribution is identifying token lifetime, CLI image cost, region binding, permission scope, observability, fallback, and operational recovery as concrete concerns. It then incorrectly marks token refresh resolved even though the daemon cannot change Keycloak's environment or datasource and its circuit breaker merely exits. It also misses the secrets-backed proxy's required backend password, database-user setup, task-role versus execution-role distinction, breaking default change, and invalid wrapper path. Claims of zero downtime, CloudTrail records for locally generated auth tokens, tight IAM scoping, and implemented metrics are unsupported or contradicted by the patch."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 3,
+          "specificity": 14,
+          "risk_awareness": 13,
+          "total": 45,
+          "notes": "The plan spans both authentication modes, retries, rollout, IAM scope, infrastructure state, long-running behavior, failure recovery, monitoring, security, and rollback. Its primary script test executes rather than sources the script and then inspects a parent-shell export, while also treating the signed URL-like IAM token as base64; both oracles are invalid. `terraform validate` does not accept `-var`, BSD `date -v` is used in an otherwise Linux-oriented environment, daemon liveness proves no credential refresh, and startup-log greps can pass after a broken container exits. Hard-coded deployment names and `keycloak_url` are not established by repository evidence, and tests expect custom metrics that implementation.md explicitly says were not implemented."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 1,
+          "specificity": 13,
+          "risk_awareness": 4,
+          "total": 26,
+          "notes": "The diff targets plausible baseline symbols including `aws_db_proxy.keycloak`, `aws_rds_cluster.keycloak`, `local.keycloak_container_env`, the password variable, and the Keycloak 25 Dockerfile. It cannot start as written because it creates `/opt/keycloak/entrypoint-wrapper.sh` but invokes `/opt/keycloak/bin/entrypoint-wrapper.sh`; the Keycloak minimal image also does not reliably provide the proposed `microdnf` installation path. Token command substitution captures progress logs into `KC_DB_PASSWORD`, `set -e` bypasses fallback, the daemon cannot update Keycloak, and runtime permissions are added to an execution-role policy using invalid IAM semantics. The proxy still requires a secret while IAM mode empties it, fallback has no password, the default breaks existing deployments, and the summary's least-privilege, refresh, no-password, CloudTrail, and zero-downtime claims contradict the code or acknowledged omissions."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-04",
+  "skill": "swe3"
+}


### PR DESCRIPTION
## Summary

- Adds benchmark results for **Claude Sonnet 5** driven by the **pi** coding agent on **Amazon Bedrock** (swe3 skill, single-agent harness).
- 5/5 tasks completed on `mcp-gateway-registry` (ref 1.24.4), all scored by the codex judge (openai.gpt-5.6-sol, high effort).
- Mean task score: **60.56** (no failures excluded).

## Results

| Task | Turns | Cost | Score |
|---|---|---|---|
| remove-efs-from-terraform-aws-ecs | 50 | $0.03 | 69.0 |
| migrate-ecs-env-vars-to-secrets-manager | 55 | $0.04 | 64.4 |
| replace-keycloak-db-password-with-rds-iam | 67 | $0.04 | 58.4 |
| remove-faiss | 250 | $0.07 | 55.8 |
| ssrf-hardening-outbound-url-validation | 73 | $0.04 | 55.2 |

## Configuration

- Provider: Amazon Bedrock (us-east-1)
- Model: us.anthropic.claude-sonnet-5
- Agent: pi (v0.84.1)
- Skill: swe3 (single-agent)
- Judge: openai.gpt-5.6-sol via codex exec (reasoning effort: high)

## Test plan

- [x] All 5 tasks produced 6/6 artifacts
- [x] All 5 tasks scored by the judge (no errors)
- [x] run-summary.json written with correct mean and per-task breakdowns
- [x] No failed tasks