### PR TITLE
feat(benchmarks): add Grok 4.6 benchmark (pi agent, Bedrock)

### DIFF
--- a/benchmarks/config/litellm-mantle.yaml
+++ b/benchmarks/config/litellm-mantle.yaml
@@ -244,6 +244,13 @@ model_list:
       api_base: https://bedrock-mantle.us-east-1.api.aws/v1
       api_key: os.environ/MANTLE_API_KEY
 
+  # -- xAI (Grok) ----------------------------------------------------
+  - model_name: xai.grok-4.6
+    litellm_params:
+      model: openai/xai.grok-4.6
+      api_base: https://bedrock-mantle.us-east-1.api.aws/v1
+      api_key: os.environ/MANTLE_API_KEY
+
   # -- Google (Gemma) ------------------------------------------------
   - model_name: google.gemma-3-27b-it
     litellm_params:

--- a/benchmarks/scripts/bedrock-mantle-proxy.sh
+++ b/benchmarks/scripts/bedrock-mantle-proxy.sh
@@ -151,7 +151,7 @@ start_proxy() {
 
     export MANTLE_API_KEY
     export LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true
-    setsid uv run --with 'litellm[proxy]' litellm \
+    setsid uv run --with 'litellm[proxy]>=1.72,<1.84' --with 'fastapi<0.116' litellm \
         --config "$CONFIG_FILE" --host "$HOST" --port "$PORT" \
         > "$LOG_FILE" 2>&1 < /dev/null &
     echo $! > "$PID_FILE"

--- a/benchmarks/scripts/run-e2e-benchmark.sh
+++ b/benchmarks/scripts/run-e2e-benchmark.sh
@@ -232,7 +232,7 @@ case "$PROVIDER" in
         ;;
     litellm)
         info "Path: open-weight models on Amazon Bedrock via the LiteLLM proxy (provider=endpoint at $ENDPOINT)."
-        if ! curl -s -m 5 "$ENDPOINT/health" >/dev/null 2>&1; then
+        if ! curl -s -m 5 "$ENDPOINT/health/liveliness" >/dev/null 2>&1; then
             die "LiteLLM proxy not reachable at $ENDPOINT.
        Start it: (cd $BENCHMARKS_DIR && ./scripts/bedrock-mantle-proxy.sh)
        Status:   (cd $BENCHMARKS_DIR && ./scripts/bedrock-mantle-proxy.sh --status)

--- a/benchmarks/swe-benchmark-data/grok-4.6/pi/swe3/mcp-gateway-registry/run-summary.json
+++ b/benchmarks/swe-benchmark-data/grok-4.6/pi/swe3/mcp-gateway-registry/run-summary.json
@@ -1,0 +1,365 @@
+{
+  "model": "us.xai.grok-4.6",
+  "model_slug": "grok-4.6",
+  "agent": "pi",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry",
+  "provider": "bedrock",
+  "ref": "1.24.4",
+  "serving": {
+    "instance_type": "t3.medium",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-21T19:01:13.383977Z",
+    "repo_ref": "1.24.4",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 419241,
+      "cached_input_tokens": 349022,
+      "cache_write_input_tokens": 70201,
+      "output_tokens": 9834,
+      "reasoning_output_tokens": 6171
+    },
+    "duration_ms": 118280
+  },
+  "num_tasks": 5,
+  "num_scored": 5,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 56.28,
+  "mean_cost_usd_excl_failed": 13.34,
+  "tasks": [
+    {
+      "task": "ssrf-hardening-outbound-url-validation",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 26,
+      "input_tokens": 2398069,
+      "output_tokens": 18513,
+      "total_tokens": 2423366,
+      "latency_seconds": 900.6,
+      "total_cost_usd": 12.456562,
+      "result_subtype": "success",
+      "task_score": 65.0,
+      "cache_read_tokens": 6784,
+      "cache_write_tokens": null,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 20.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 90,
+          "notes": "The issue's strongest aspect is its testable scope: it names the agent registration, agent health, MCP health, compatibility, configuration, and import-surface requirements. Repository checks confirm the cited symbols and routes exist, including `_is_safe_url` in `registry/services/skill_service.py` and `POST /api/agents/{path}/health`. Its largest gap is the redirect criterion: the referenced skill implementation validates `response.url` only after `follow_redirects=True` has already issued the redirected request, so 'same as skill fetches' is not a safe no-request oracle. No independent task statement was supplied, and the linked external issues could not be verified from repository evidence."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 69,
+          "notes": "The LLD is concretely grounded in the correct files, settings pattern, health status flow, and custom endpoint derivation machinery. Its central security defect is proposing redirect validation after httpx follows redirects, while `registry/health/service.py` uses `follow_redirects=True`; validation then occurs too late to prevent SSRF. The proposed direct re-export also would not preserve existing tests that patch `registry.services.skill_service.settings` and `socket.getaddrinfo`, despite the LLD claiming those tests remain compatible. It usefully addresses DNS failure, exact-host allowlisting, private-network compatibility, observability, rollout, and the acknowledged DNS-rebinding residual risk."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 15,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 69,
+          "notes": "The review surfaces concrete concerns about `cache_clear`, exact hostname matching, private-health compatibility, nginx churn, logging exposure, and DNS rebinding. Its largest omission is failure to challenge redirect handling or the fact that `get_endpoint_url_from_server_info` can select `mcp_endpoint` or `sse_endpoint` on a different host from `proxy_pass_url`. The recommendation to alias the cached shared function is incomplete because existing tests also patch module-local `settings` and `socket.getaddrinfo`, not merely `_trusted_domains.cache_clear`. Claims about private VPC/ECS operating requirements are plausible but are not independently established by the supplied task statement."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 15,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 55,
+          "notes": "The plan provides valid repository-style `uv run pytest` commands and concrete helper oracles for loopback, metadata, trusted hosts, and the compatibility flag. It omits decisive tests for redirects, custom MCP/SSE endpoints, agent-validator request suppression, health-service request suppression, and mixed DNS results. The curl happy-path oracle permits either healthy or unhealthy, and its cookie usage lacks an authentication setup, so it would not reliably prove the feature. It also misses that existing `tests/unit/api/test_agent_routes.py` health tests use a localhost agent and would fail under the new guard unless updated or the validator is mocked; no execution evidence was supplied."
+        },
+        "implementation": {
+          "completeness": 10,
+          "correctness": 8,
+          "specificity": 16,
+          "risk_awareness": 8,
+          "total": 42,
+          "notes": "The patch targets real files and exact baseline blobs, and it does add direct URL guards, settings, documentation, and a focused shared-helper test file. The largest defect is that MCP health validates only `proxy_pass_url`: repository code permits explicit `mcp_endpoint` and `sse_endpoint` on different hosts and follows redirects, leaving strict mode bypassable by a private custom endpoint or public-to-private redirect. Skill validation remains a second local `_is_safe_url` implementation, violating the single-implementation requirement, while post-follow redirect checks still occur after the unsafe request. Existing localhost agent-health tests would regress, wiring tests are absent, and the summary's claim that derived endpoints have the same host is contradicted by `registry/core/endpoint_utils.py`."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-faiss",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 21,
+      "input_tokens": 2859627,
+      "output_tokens": 12691,
+      "total_tokens": 2873342,
+      "latency_seconds": 867.3,
+      "total_cost_usd": 14.615922,
+      "result_subtype": "success",
+      "task_score": 58.6,
+      "cache_read_tokens": 1024,
+      "cache_write_tokens": null,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 14.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 20,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 73,
+          "notes": "The issue clearly identifies the dependency, API contract, mutation paths, documentation, and ranking exclusions with testable acceptance criteria. Its named components are real, including `registry/repositories/documentdb/search_repository.py`, `get_search_repository()`, and `POST /api/search/semantic`. The largest gap is failure to define supported behavior for the still-valid `file` backend or require updating `uv.lock`, build scripts, and CLI checks that affect actual dependency removal. No independent task statement was supplied, so broader requirements beyond the remove-FAISS objective could not be verified."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 19,
+          "risk_awareness": 16,
+          "total": 64,
+          "notes": "The LLD is unusually well grounded in real files and correctly identifies factory routing, startup reindexing, telemetry compatibility, and mutation integration points. Its critical file-backend decision is internally inconsistent: it requires best-effort startup without DocumentDB, but `DocumentDBSearchRepository.initialize()` calls `_get_collection()` before its exception handler and `lifespan()` re-raises initialization failures. Declaring `uv.lock` regeneration out of scope is also incorrect because `.github/workflows/uv-lock-check.yml` enforces freshness and `docker/Dockerfile.registry` uses `uv sync --frozen`, leaving FAISS installed from the lock. The design recognizes migration, metrics, and rollback risks, but does not resolve the startup failure or concretely cover the verified CLI and build-script dependencies."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 15,
+          "specificity": 18,
+          "risk_awareness": 17,
+          "total": 66,
+          "notes": "The review surfaces several repository-specific concerns, notably file-backend behavior, duplicate toggle writes, `build_and_run.sh` FAISS checks, and metrics-schema compatibility. Those concerns are supported by the source, including the live metadata checks in `build_and_run.sh` and the legacy `faiss_search_time_ms` field. Its largest weakness is accepting resolutions that do not actually solve the risks: forced DocumentDB routing can crash file-backed startup, and the implementation does not update the cited script. It also misses the stale-lock build failure and the broad test breakage, so the final approval is not defensible."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 14,
+          "specificity": 13,
+          "risk_awareness": 12,
+          "total": 53,
+          "notes": "The plan covers semantic-search success, empty-query rejection, mutation lifecycle behavior, deployment checks, and the legacy metrics key with useful expected outcomes. The semantic endpoint and expected 400 are consistent with `registry/api/search_routes.py`, and `uv run pytest tests/` is a valid repository command. However, the E2E section refers to `/register` rather than the mounted `/api/register`, supplies no request payloads, and lacks concrete assertions proving a single DocumentDB index mutation. It would not catch the stale `uv.lock`, file-backend startup failure, duplicate indexing, or broken facade tests, and no execution evidence is claimed."
+        },
+        "implementation": {
+          "completeness": 10,
+          "correctness": 6,
+          "specificity": 14,
+          "risk_awareness": 7,
+          "total": 37,
+          "notes": "The diff targets real baseline files and removes the FAISS implementation/import while routing the factory and compatibility facade to `DocumentDBSearchRepository`. The largest defect is that `uv.lock` still lists `faiss-cpu`; `docker/Dockerfile.registry` installs from that lock with `uv sync --frozen`, while the lock-check workflow will also fail. Forced DocumentDB initialization makes valid file-backed deployments fail when MongoDB is unavailable, and retaining unguarded `faiss_service` facade calls creates duplicate DocumentDB writes after service-layer or explicit repository writes, potentially failing requests after persistence. Tests remain broken because config, telemetry, factory, and integration expectations were not updated, the revised integration fixture calls the nonexistent `SearchIndexFacade.add_or_update_agent`, and operator scripts, CLI checks, and live documentation still claim FAISS behavior despite the summary acknowledging those omissions."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "remove-efs-from-terraform-aws-ecs",
+      "complexity": "medium",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 18,
+      "input_tokens": 1587315,
+      "output_tokens": 8246,
+      "total_tokens": 1602345,
+      "latency_seconds": 595.2,
+      "total_cost_usd": 8.146117000000002,
+      "result_subtype": "success",
+      "task_score": 56.2,
+      "cache_read_tokens": 6784,
+      "cache_write_tokens": null,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 13.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 12,
+          "total": 67,
+          "notes": "The issue precisely names verified resources, variables, outputs, and ECS mounts in terraform/aws-ecs. Its largest gap is omitting EFS-dependent deployment tooling: post-deployment-setup.sh requires mcp_gateway_efs_id, run-scopes-init-task.sh provisions an EFS volume, and codebuild.tf still builds that utility. The claim that the bundled auth path is /app/auth_server/scopes.yml conflicts with docker/Dockerfile.auth, which copies auth_server/ directly into /app. No independent task statement or issue #1286 content was available, and the issue acknowledges destructive migration without specifying backup or ordered removal."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 10,
+          "total": 54,
+          "notes": "The LLD is concretely grounded in the five patched Terraform files, and its claims about existing module outputs and absent root EFS variables were verified. Its auth path is incorrect for the auth image because docker/Dockerfile.auth places scopes.yml at /app/scopes.yml, while the supported file backend still consumes SCOPES_CONFIG_PATH. It also omits post-deployment-setup.sh, run-scopes-init-task.sh, Dockerfile.scopes-init, and codebuild.tf, leaving operational EFS dependencies behind. The assertion that Terraform will update tasks before destroying EFS is unsound once the dependency references are removed; a staged apply and data-preservation plan are missing."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 11,
+          "specificity": 17,
+          "risk_awareness": 11,
+          "total": 52,
+          "notes": "The review identifies concrete concerns about root outputs, remote-state consumers, NFS exposure, and existing-stack destruction. It nevertheless approves both the incorrect auth image path and the unsupported claim that Terraform's graph guarantees unmounting before EFS destruction. No reviewer discovers that post-deployment-setup.sh still requires the deleted output or that the scopes-init build and task remain EFS-specific. Treating loss of customized EFS scopes as simply intended, without backup or staged rollout guidance, makes the approval verdict insufficiently defensive."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 14,
+          "specificity": 19,
+          "risk_awareness": 10,
+          "total": 57,
+          "notes": "The plan supplies useful repository-aligned rg checks, terraform init/validate/plan commands, and an ECS task-definition volume oracle; Terraform >=1.2 agrees with main.tf. It does not exercise the recommended post-deployment-setup.sh workflow, which will fail after mcp_gateway_efs_id is removed, or detect remaining scopes-init build wiring. No test verifies that /app/auth_server/scopes.yml exists in the auth image, covers storage_backend=file, or concretely checks both auth and mcpgw health. The proposed rollback only recreates an empty EFS and does not address irreversible data loss or unsafe concurrent destruction."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 8,
+          "total": 51,
+          "notes": "The patch's target blob hashes and contexts match the baseline repository, and it correctly removes the central EFS module, task volumes, variables, and outputs. The new auth SCOPES_CONFIG_PATH is wrong for docker/Dockerfile.auth, which copies auth_server/ to /app rather than /app/auth_server, breaking the supported file backend. Removing mcp_gateway_efs_id also breaks post-deployment-setup.sh at its required-output check, while run-scopes-init-task.sh, Dockerfile.scopes-init, and codebuild.tf retain EFS-specific behavior. The summary's claim of no follow-ups is therefore inaccurate, and the patch provides no staged destruction or preservation mechanism for existing EFS data."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "replace-keycloak-db-password-with-rds-iam",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 25,
+      "input_tokens": 1761320,
+      "output_tokens": 21231,
+      "total_tokens": 1785623,
+      "latency_seconds": 600.1,
+      "total_cost_usd": 9.338911,
+      "result_subtype": "success",
+      "task_score": 52.4,
+      "cache_read_tokens": 3072,
+      "cache_write_tokens": null,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 35.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 63,
+          "notes": "The issue clearly defines ECS/Terraform scope, password fallback, TLS, documentation, and testable acceptance criteria. Its largest omission is the required database-user migration: the repository sets `master_username = var.keycloak_database_username`, so the proposed IAM application user already exists as the password-authenticated master user. It also does not address token expiry for later JDBC pool connections or the always-enabled rotation resources. No independent task statement was supplied, so requirements beyond the task identifier and repository cannot be verified."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 6,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 54,
+          "notes": "The LLD is unusually concrete about real files such as `keycloak-database.tf`, `keycloak-ecs.tf`, the DB-user ARN, TLS parameter, and fallback behavior. Its core design fails because `CREATE USER IF NOT EXISTS 'keycloak'` cannot convert the existing master user created by `master_username = var.keycloak_database_username` to `AWSAuthenticationPlugin`. It also overlooks Docker entrypoint semantics despite the repository explicitly documenting that ECS `command` is appended to the Keycloak `kc.sh` entrypoint, and it leaves the existing rotation Lambda attached to an empty placeholder password. Live AWS transition behavior for `manage_master_user_password` could not be verified in this environment."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 12,
+          "specificity": 18,
+          "risk_awareness": 16,
+          "total": 62,
+          "notes": "The review identifies several concrete defects, including the nonexistent `rds:GenerateDBAuthToken` IAM action, TLS requirements, token lifetime, token logging, and master-password distinctions. Its largest failure is declaring no blockers while missing both the existing master-user/plugin conflict and the invalid shell-wrapper use of ECS `command`. Repository evidence also shows `aws_secretsmanager_secret_rotation.keycloak_db_secret` remains unconditional, contrary to the review's acceptance of an unused placeholder secret. The assertion that the stock Keycloak image contains Bash was not independently verified, and even if true it does not resolve the entrypoint problem."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 10,
+          "specificity": 15,
+          "risk_awareness": 7,
+          "total": 43,
+          "notes": "The plan provides concrete IAM and fallback configurations, exact ECS inspection commands, and expected secret behavior. Most infrastructure checks are plain `grep` operations, with no `terraform fmt`, `terraform validate`, rendered task-definition assertions, real IAM login, delayed pool reconnection, or negative validation coverage. The proposed public `https://${KEYCLOAK_HOST}/health/ready` check conflicts with the repository task health check using the management interface on port 9000, while the ALB targets port 8080 and path `/`. Tests were explicitly not run, and no AWS deployment was available for verification."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 3,
+          "specificity": 18,
+          "risk_awareness": 6,
+          "total": 40,
+          "notes": "The diff targets real baseline files and symbols at commit `b0fcb2db453f933da63389c0b18ccc044ee505b5`, and it concretely adds conditional secrets, TLS, IAM policy, documentation, and fallback variables. The IAM path cannot start because it replaces the Keycloak ECS `command` with `/bin/bash -c ...` without overriding the image entrypoint; the repository explicitly states that `command` becomes arguments to `kc.sh`, so this invokes `kc.sh /bin/bash ...`. Even after fixing startup, the documented `CREATE USER IF NOT EXISTS` is a no-op for the existing `keycloak` master user, and the unconditional rotation Lambda and proxy secret receive an empty password under IAM mode. The summary incorrectly reports no material deviation or blocker; tests were not executed and Terraform was unavailable for provider validation."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "migrate-ecs-env-vars-to-secrets-manager",
+      "complexity": "high",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 33,
+      "input_tokens": 4333633,
+      "output_tokens": 18837,
+      "total_tokens": 4377942,
+      "latency_seconds": 1209.8,
+      "total_cost_usd": 22.15182600000001,
+      "result_subtype": "success",
+      "task_score": 49.2,
+      "cache_read_tokens": 25472,
+      "cache_write_tokens": null,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 15.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 15,
+          "specificity": 17,
+          "risk_awareness": 14,
+          "total": 63,
+          "notes": "The issue clearly defines ECS secret injection, fallback behavior, empty-value handling, IAM scope, and exclusions. The named module files and existing Secrets Manager pattern are present at tag 1.24.4. Its claim to cover all remaining sensitive ECS variables overlooks grafana_admin_password, which remains plaintext twice in observability.tf, and storing values in aws_secretsmanager_secret_version.secret_string does not eliminate Terraform-state exposure. No independent task statement was supplied, and the relevance of linked issue #1134 could not be verified locally."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 59,
+          "notes": "The LLD is unusually concrete about the twelve names, verified files, ECS data flow, exclusive injection, IAM ARNs, and rollout phases. Its core count = var.secret != \"\" design is invalid because these variables are sensitive and Terraform cannot use sensitive-derived values as resource counts. It also omits root-module variable and module-call wiring, making the documented phase-two switch unavailable through terraform/aws-ecs, and it misses the plaintext Grafana password. Duplicate-name, empty-value, startup-failure, and rollback risks are considered, but rotation overwrite behavior and a definite fallback sunset are not."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 8,
+          "specificity": 16,
+          "risk_awareness": 11,
+          "total": 47,
+          "notes": "The review identifies two concrete concerns: mutually exclusive environment/secrets entries and avoiding references to absent secrets. However, its required conditional count remedy is itself invalid for the sensitive variables defined in variables.tf. It approves the design without catching the missing root passthrough, the remaining Grafana plaintext secret, Terraform-state persistence, or the indefinite default-on fallback. The role-based presentation adds little beyond those two findings, so the final approval is not defensible."
+        },
+        "testing": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 13,
+          "risk_awareness": 9,
+          "total": 39,
+          "notes": "The plan gives concrete presence and absence checks for REGISTRY_API_TOKEN and includes plan, deployment, and rollback surfaces. The inject_plaintext_secret_env = false example cannot configure the normal root deployment because terraform/aws-ecs has no such root variable or module argument, while planning the patch would also fail on sensitive-derived counts. Coverage does not enumerate all twelve values, both consuming containers, empty inputs, exact IAM resources, secret-value equivalence, or the remaining Grafana exposure. It also omits the repository's terraform fmt, validate, TFLint, and Checkov checks, and aws ecs describe-tasks ... with a RUNNING comment is not an executable command or strong oracle."
+        },
+        "implementation": {
+          "completeness": 9,
+          "correctness": 3,
+          "specificity": 18,
+          "risk_awareness": 8,
+          "total": 38,
+          "notes": "The patch targets real files and exact baseline blobs at commit b0fcb2db453f933da63389c0b18ccc044ee505b5, and it concretely adds twelve secret pairs, IAM ARNs, and exclusive ECS mappings. It is not deployable as written because every new resource count depends on a sensitive variable, which Terraform rejects as an invalid count argument. The root module does not expose or pass inject_plaintext_secret_env, so ordinary deployments remain permanently on plaintext fallback, and observability.tf still exposes grafana_admin_password. The summary admits the root omission but still overstates migration of the remaining secrets; Terraform was unavailable locally, and the submission itself reports no verification execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-21"
+}

--- a/benchmarks/swe-benchmark-data/grok-4.6/pi/swe3/mcp-gateway-registry/run-summary.md
+++ b/benchmarks/swe-benchmark-data/grok-4.6/pi/swe3/mcp-gateway-registry/run-summary.md
@@ -21,4 +21,3 @@
 | migrate-ecs-env-vars-to-secrets-manager | 6/6 | 33 | -- | 22.15 | 49.2 |
 
 Mean over the 5 completed tasks: 56.28 (mean cost $13.34). A 0-score task is a model failure (missing artifacts) and is excluded from the means, pending investigation. Cost is a token-based estimate for self-hosted models.
-

--- a/benchmarks/swe-benchmark-data/grok-4.6/pi/swe3/mcp-gateway-registry/run-summary.md
+++ b/benchmarks/swe-benchmark-data/grok-4.6/pi/swe3/mcp-gateway-registry/run-summary.md
@@ -1,0 +1,24 @@
+# Benchmark run summary: us.xai.grok-4.6 on mcp-gateway-registry
+
+- Model: us.xai.grok-4.6
+- Agent (harness): pi
+- Skill: swe3
+- Provider: bedrock
+- Dataset scope: mcp-gateway-registry (5 tasks, ref 1.24.4)
+- Serving: instance_type=t3.medium
+- Run date: 2026-08-21
+
+5 of 5 tasks scored; no failures.
+
+## Results
+
+| Task | Artifacts | Turns | Prefix-cache | Cost (est $) | Judge score |
+|---|---|---|---|---|---|
+| ssrf-hardening-outbound-url-validation | 6/6 | 26 | -- | 12.46 | 65.0 |
+| remove-faiss | 6/6 | 21 | -- | 14.62 | 58.6 |
+| remove-efs-from-terraform-aws-ecs | 6/6 | 18 | -- | 8.15 | 56.2 |
+| replace-keycloak-db-password-with-rds-iam | 6/6 | 25 | -- | 9.34 | 52.4 |
+| migrate-ecs-env-vars-to-secrets-manager | 6/6 | 33 | -- | 22.15 | 49.2 |
+
+Mean over the 5 completed tasks: 56.28 (mean cost $13.34). A 0-score task is a model failure (missing artifacts) and is excluded from the means, pending investigation. Cost is a token-based estimate for self-hosted models.
+


### PR DESCRIPTION
## Summary

- Benchmark xAI Grok 4.6 (`us.xai.grok-4.6`) on the mcp-gateway-registry dataset (5 tasks) using the pi coding agent via Amazon Bedrock Converse. **Mean score: 56.28** ($13.34/task avg).
- Pin `litellm[proxy]` version range (`>=1.72,<1.84` + `fastapi<0.116`) to fix an import crash with newer litellm/fastapi combinations.
- Use `/health/liveliness` for the LiteLLM proxy pre-flight check -- the full `/health` endpoint times out within 5s when many models are configured.
- Add `xai.grok-4.6` to `litellm-mantle.yaml` (not yet served by bedrock-mantle, but ready for when it is).

### Per-task results

| Task | Turns | Cost | Score |
|------|-------|------|-------|
| ssrf-hardening-outbound-url-validation | 26 | $12.46 | 65.0 |
| remove-faiss | 21 | $14.62 | 58.6 |
| remove-efs-from-terraform-aws-ecs | 18 | $8.15 | 56.2 |
| replace-keycloak-db-password-with-rds-iam | 25 | $9.34 | 52.4 |
| migrate-ecs-env-vars-to-secrets-manager | 33 | $22.15 | 49.2 |

### Notes

- Grok 4.6 is NOT yet on bedrock-mantle (the OpenAI-compatible endpoint), so the `--provider litellm` path fails. It also fails via `--provider bedrock --agent claude` due to a metadata regex validation error in Bedrock for xAI models. The successful path is `--provider bedrock --agent pi` which uses pi's native Bedrock Converse SDK client.

## Test plan

- [x] Full 5-task benchmark completed successfully (5/5 tasks, all 6 artifacts each)
- [x] Codex judge scored all 5 tasks
- [x] LiteLLM proxy starts cleanly with the pinned version
- [x] Pre-flight `/health/liveliness` check passes within 5s timeout