### PR TITLE
Add vLLM serving guides for DeepSeek V3.2 and Devstral 2 123B

### DIFF
--- a/self-hosted/vllm/models/deepseek-v3.2.md
+++ b/self-hosted/vllm/models/deepseek-v3.2.md
@@ -1,0 +1,77 @@
+# DeepSeek-V3.2 -- serving guidelines
+
+> Per-model serving notes for the vLLM path. See the [directory README](../README.md) for the full install and configuration reference; this file only covers what is specific to **this** model.
+
+| | |
+|---|---|
+| **HF repo** | `deepseek-ai/DeepSeek-V3.2` |
+| **Model card** | [huggingface.co/deepseek-ai/DeepSeek-V3.2](https://huggingface.co/deepseek-ai/DeepSeek-V3.2) |
+| **Type** | MoE -- 685B total, 37B active per token |
+| **Weights on disk** | ~652 GB (FP8) |
+| **Minimum hardware** | 8×H200 141GB (p5en.48xlarge) |
+| **Fits 4×L40S (184 GB)?** | No |
+| **Tool-call parser** | `deepseek_v32` |
+| **Reasoning parser** | none (not a thinking model) |
+| **Native context** | **131,072 (128K)** |
+| **Role** | Frontier open-weight coding and reasoning model from DeepSeek |
+
+## Serve it
+
+**Benchmarked config:** instance `p5en.48xlarge` (8×H200 141GB) · **TP=8** (all 8 GPUs) · precision **FP8** · 131072 (128K) window.
+
+```bash
+MODEL="deepseek-ai/DeepSeek-V3.2" \
+SERVED_NAME="deepseek-v3.2" \
+TP=8 \
+PORT=8000 \
+MAX_MODEL_LEN=131072 \
+GPU_MEM_UTIL=0.90 \
+TOOL_PARSER="deepseek_v32" \
+  ./vllm-serve.sh
+```
+
+Or the raw vLLM command:
+
+```bash
+cd self-hosted/vllm
+mkdir -p logs
+export CUDA_HOME=/opt/pytorch/cuda
+export PATH=/opt/pytorch/cuda/bin:$HOME/vllm-env/bin:$PATH
+export LD_LIBRARY_PATH=/opt/pytorch/cuda/lib:/opt/pytorch/cuda/lib64:${LD_LIBRARY_PATH:-}
+export HF_TOKEN=<your-token>
+
+vllm serve deepseek-ai/DeepSeek-V3.2 \
+  --tensor-parallel-size 8 \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --served-model-name deepseek-v3.2 \
+  --max-model-len 131072 \
+  --gpu-memory-utilization 0.90 \
+  --enable-auto-tool-choice --tool-call-parser deepseek_v32 \
+  --enable-prefix-caching \
+  2>&1 | tee logs/vllm-serve.log
+```
+
+## Instance and access
+
+| | |
+|---|---|
+| **Instance type** | p5en.48xlarge (8×H200 141GB, 1.13 TB VRAM) |
+| **Region** | us-east-2 |
+| **Cost** | ~$63.30/hr on-demand; lower via capacity block |
+| **SSH** | `ssh -i ~/.ssh/mcp-gateway-key.pem ubuntu@<IP>` |
+
+## Disk requirements
+
+Weights are ~652 GB on disk. Ensure at least **1.3 TB free** before downloading. The NVMe scratch at `/opt/dlami/nvme` (27 TB on p5en) is the right location.
+
+## Architecture notes
+
+DeepSeek-V3.2 uses Multi-head Latent Attention (MLA) which compresses the KV cache significantly. vLLM uses the `FLASH_ATTN_MLA` backend automatically. The `deepseek_v32` tool parser handles DeepSeek's native function-calling format.
+
+## Tuning notes
+
+- **No `--trust-remote-code` needed** -- the architecture is natively supported in vLLM.
+- **Startup time:** First boot downloads ~652 GB + weight loading. Allow 20-30 minutes. Subsequent boots (weights cached): ~5-8 minutes.
+- **Prefix caching:** Highly effective for benchmark runs where the system prompt and skill are constant across turns.
+- **CUDA fixes on p5en:** Ensure the CUDA symlinks from `p5en-h200-cuda-fixes.md` are applied before serving.

--- a/self-hosted/vllm/models/devstral-2-123b.md
+++ b/self-hosted/vllm/models/devstral-2-123b.md
@@ -1,0 +1,79 @@
+# Devstral-2-123B -- serving guidelines
+
+> Per-model serving notes for the vLLM path. See the [directory README](../README.md) for the full install and configuration reference; this file only covers what is specific to **this** model.
+
+| | |
+|---|---|
+| **HF repo** | `mistralai/Devstral-2-123B-Instruct-2512` |
+| **Model card** | [huggingface.co/mistralai/Devstral-2-123B-Instruct-2512](https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512) |
+| **Type** | Dense transformer -- 123B parameters (all active) |
+| **Weights on disk** | ~128 GB (FP8, native quantization) |
+| **Minimum hardware** | 4×H200 141GB (half of p5en.48xlarge, TP=4) |
+| **Fits 4×L40S (184 GB)?** | No (weights fit but context window shrinks to ~64K) |
+| **Tool-call parser** | `mistral` |
+| **Reasoning parser** | none |
+| **Native context** | **262,144 (256K)** |
+| **Role** | Mistral AI's coding-focused dense model; strong on agentic tasks |
+
+## Serve it
+
+**Benchmarked config:** instance `p5en.48xlarge` (using 4 of 8 H200 GPUs, TP=4) · precision **FP8** (native) · 262144 (256K) window.
+
+```bash
+MODEL="mistralai/Devstral-2-123B-Instruct-2512" \
+SERVED_NAME="devstral-2-123b" \
+TP=4 \
+PORT=8000 \
+MAX_MODEL_LEN=262144 \
+GPU_MEM_UTIL=0.90 \
+TOOL_PARSER="mistral" \
+  ./vllm-serve.sh
+```
+
+Or the raw vLLM command:
+
+```bash
+cd self-hosted/vllm
+mkdir -p logs
+export CUDA_HOME=/opt/pytorch/cuda
+export PATH=/opt/pytorch/cuda/bin:$HOME/vllm-env/bin:$PATH
+export LD_LIBRARY_PATH=/opt/pytorch/cuda/lib:/opt/pytorch/cuda/lib64:${LD_LIBRARY_PATH:-}
+export HF_TOKEN=<your-token>
+
+vllm serve mistralai/Devstral-2-123B-Instruct-2512 \
+  --tensor-parallel-size 4 \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --served-model-name devstral-2-123b \
+  --max-model-len 262144 \
+  --gpu-memory-utilization 0.90 \
+  --enable-auto-tool-choice --tool-call-parser mistral \
+  --enable-prefix-caching \
+  2>&1 | tee logs/vllm-serve.log
+```
+
+## Instance and access
+
+| | |
+|---|---|
+| **Instance type** | p5en.48xlarge (using 4 of 8×H200 141GB) |
+| **Region** | us-east-2 |
+| **Cost** | ~$63.30/hr on-demand (whole node); TP=4 frees 4 GPUs for concurrent workloads |
+| **SSH** | `ssh -i ~/.ssh/mcp-gateway-key.pem ubuntu@<IP>` |
+
+## Disk requirements
+
+Weights are ~128 GB on disk. Ensure at least **256 GB free** before downloading.
+
+## Architecture notes
+
+Devstral-2-123B is a dense model (all 123B parameters active per token), unlike the MoE models in this directory. It ships natively in FP8 format -- no additional quantization needed, and no `--quantization` flag required for vLLM.
+
+Using TP=4 (half the p5en node) leaves the other 4 GPUs available for a second model or a second benchmark run in parallel.
+
+## Tuning notes
+
+- **No `--trust-remote-code` needed** -- Mistral architecture is natively supported.
+- **Startup time:** First boot downloads ~128 GB + weight loading. Allow 5-10 minutes. Subsequent boots: ~2-3 minutes.
+- **TP=4 vs TP=8:** Quality is identical; TP=4 is preferred to free GPUs. TP=8 is fine if you want more KV cache headroom for very long contexts.
+- **Prefix caching:** Effective for repeated system prompts.


### PR DESCRIPTION
## Summary

Adds missing `self-hosted/vllm/models/` guides for two models that have been benchmarked but lack serving documentation.

### DeepSeek V3.2
- HF: `deepseek-ai/DeepSeek-V3.2`
- 685B MoE (37B active), FP8, ~652 GB
- TP=8, MAX_MODEL_LEN=131072, tool-call-parser: `deepseek_v32`
- No `--trust-remote-code` needed

### Devstral 2 123B
- HF: `mistralai/Devstral-2-123B-Instruct-2512`
- Dense 123B, native FP8, ~128 GB
- TP=4 (uses half the p5en node), MAX_MODEL_LEN=262144, tool-call-parser: `mistral`
- No `--trust-remote-code` needed

Note: Nemotron Ultra 550B guide is pending separate research.

Signed-off-by: shekharprateek