### PR TITLE
feat(benchmarks): one script to run a batch of models, replacing the throwaway loops

### DIFF
--- a/benchmarks/docs/harness-reference.md
+++ b/benchmarks/docs/harness-reference.md
@@ -328,6 +328,29 @@ cd benchmarks
 ./scripts/run-swe-benchmark.sh --dataset dataset/hello-world.yaml --dry-run
 ```
 
+### Running several models in one batch
+
+`run-e2e-benchmark.sh` runs one model. Benchmarking a dataset usually means running the same thing for three or five models with hours of waiting between each, so [run-benchmark-batch.sh](../scripts/run-benchmark-batch.sh) wraps it in the loop:
+
+```bash
+./scripts/run-benchmark-batch.sh --provider bedrock \
+    --dataset dataset/mcp-gateway-registry-v2.yaml \
+    --models 'us.anthropic.claude-sonnet-5[1m],us.anthropic.claude-opus-5[1m]'
+```
+
+Models run **sequentially, never in parallel** -- on a self-hosted endpoint they would otherwise contend for the same GPU and each other's KV cache, making both the latency and the `vllm_prometheus` block meaningless; on Bedrock they would race for one account's throughput quota. A model that fails does not stop the rest, and every exit code is echoed so a partial batch is diagnosable afterwards.
+
+`--tasks a,b,c` scopes the batch to a subset, which is what you want after adding tasks to a dataset that has already been run: the existing task folders are neither re-run nor (thanks to the judge's `--no-overwrite`) re-judged, and `summarize_run.py` still rebuilds each summary over the full set.
+
+A batch runs for hours or days, so detach it:
+
+```bash
+LOG="logs/batch-$(date -u +%Y%m%dT%H%M%SZ).log"
+setsid nohup ./scripts/run-benchmark-batch.sh ... > "$LOG" 2>&1 < /dev/null &
+```
+
+`setsid` plus a redirect to a file is what makes the run outlive the SSH session: the process ends up with no controlling terminal, so no `SIGHUP` can reach it, and its output goes to disk rather than a pipe that dies with the connection.
+
 ### Running tasks concurrently
 
 The harness runs tasks serially by default (`concurrency: 1`). Set `concurrency` in the config (or `--concurrency N` on the CLI) to run several tasks at once through a thread pool of that width. Each task clones into its own temporary directory, writes to a distinct artifact directory, and runs `claude -p` as an independent subprocess, so the work parallelizes cleanly and wall-clock time drops roughly linearly with the pool width (bounded by the endpoint's own throughput). `--stream` is disabled under concurrency because interleaved event traces from several tasks are unreadable.

--- a/benchmarks/scripts/run-benchmark-batch.sh
+++ b/benchmarks/scripts/run-benchmark-batch.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Run several models through the same benchmark, one after another
+# =============================================================================
+#
+# run-e2e-benchmark.sh runs ONE model. Benchmarking a dataset means running the
+# same thing for three or five models and waiting hours between each, which in
+# practice gets done with a throwaway for-loop that is rewritten (and re-debugged)
+# every time. This is that loop, kept.
+#
+# Models run SEQUENTIALLY, never in parallel. On a self-hosted endpoint they would
+# otherwise contend for the same GPU and each other's KV cache, making both the
+# latency and the vllm_prometheus block meaningless; on Bedrock they would race for
+# the same account throughput quota. Sequential also keeps each judge pass clean.
+#
+# Every run is independent: one model failing does not stop the rest, and the exit
+# code of each is reported in the log so a partial batch is diagnosable afterwards.
+#
+# Usage:
+#   ./scripts/run-benchmark-batch.sh --provider bedrock \
+#       --dataset dataset/mcp-gateway-registry-v2.yaml \
+#       --models 'us.anthropic.claude-sonnet-5[1m],us.anthropic.claude-opus-5[1m]'
+#
+#   # only some tasks (e.g. ones newly added to an already-run dataset)
+#   ./scripts/run-benchmark-batch.sh --provider bedrock \
+#       --dataset dataset/mcp-gateway-registry-v2.yaml \
+#       --models 'us.anthropic.claude-haiku-4-5-20251001-v1:0' \
+#       --tasks 'task-a,task-b'
+#
+#   # a self-hosted model on the local vLLM server
+#   ./scripts/run-benchmark-batch.sh --provider vllm \
+#       --dataset dataset/mcp-gateway-registry-v2.yaml --models qwen3.8-27b
+#
+# Detach it, because a batch runs for hours or days and must outlive the SSH
+# session that started it:
+#
+#   LOG="logs/batch-$(date -u +%Y%m%dT%H%M%SZ).log"
+#   setsid nohup ./scripts/run-benchmark-batch.sh ... > "$LOG" 2>&1 < /dev/null &
+#
+# Options:
+#   --provider   bedrock | litellm | vllm            (required)
+#   --dataset    dataset YAML, relative to benchmarks/ (required)
+#   --models     comma-separated model ids, run in order (required)
+#   --tasks      comma-separated task ids; default is every task in the dataset
+#   --agent      coding agent: pi (default), claude, omp, kiro
+#   --skill      swe3 (default) or swe2
+#   --aws-region region for the codex judge (default us-east-1). Needed even on
+#                the vllm path: the model is local but the judge is on Bedrock.
+# =============================================================================
+set -u
+
+cd "$(dirname "$0")/.."
+
+PROVIDER=""; DATASET=""; MODELS=""; TASKS=""
+AGENT="pi"; SKILL="swe3"; REGION="us-east-1"
+
+die() { printf '\033[0;31m[error]\033[0m %s\n' "$1" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --provider)   PROVIDER="${2:?--provider needs a value}"; shift 2 ;;
+        --dataset)    DATASET="${2:?--dataset needs a value}"; shift 2 ;;
+        --models)     MODELS="${2:?--models needs a value}"; shift 2 ;;
+        --tasks)      TASKS="${2:?--tasks needs a value}"; shift 2 ;;
+        --agent)      AGENT="${2:?--agent needs a value}"; shift 2 ;;
+        --skill)      SKILL="${2:?--skill needs a value}"; shift 2 ;;
+        --aws-region) REGION="${2:?--aws-region needs a value}"; shift 2 ;;
+        -h|--help)    sed -n '2,55p' "$0"; exit 0 ;;
+        *)            die "unknown option: $1 (see --help)" ;;
+    esac
+done
+
+[[ -n "$PROVIDER" ]] || die "--provider is required (bedrock | litellm | vllm)"
+[[ -n "$DATASET"  ]] || die "--dataset is required"
+[[ -n "$MODELS"   ]] || die "--models is required"
+
+# The judge runs `codex exec` against Bedrock regardless of where the model is
+# served, so the region is exported for every provider, not just bedrock.
+export AWS_REGION="$REGION"
+
+TASK_ARG=()
+[[ -n "$TASKS" ]] && TASK_ARG=(--tasks "$TASKS")
+
+IFS=',' read -r -a MODEL_LIST <<< "$MODELS"
+echo "=== BATCH START $(date -u +%FT%TZ): ${#MODEL_LIST[@]} model(s), provider=$PROVIDER, dataset=$DATASET"
+[[ -n "$TASKS" ]] && echo "=== scoped to tasks: $TASKS"
+
+FAILED=()
+for MODEL in "${MODEL_LIST[@]}"; do
+    echo
+    echo "=============================================================="
+    echo "=== START $MODEL at $(date -u +%FT%TZ)"
+    echo "=============================================================="
+    ./scripts/run-e2e-benchmark.sh \
+        --provider "$PROVIDER" --agent "$AGENT" --skill "$SKILL" \
+        --model "$MODEL" "${TASK_ARG[@]}" \
+        --dataset "$DATASET" --yes
+    RC=$?
+    echo "=== END $MODEL rc=$RC at $(date -u +%FT%TZ)"
+    # Keep going: a later model's run does not depend on an earlier one, and
+    # losing four runs because the first failed is worse than a partial batch.
+    [[ $RC -eq 0 ]] || FAILED+=("$MODEL (rc=$RC)")
+done
+
+echo
+if [[ ${#FAILED[@]} -eq 0 ]]; then
+    echo "=== BATCH DONE $(date -u +%FT%TZ): all ${#MODEL_LIST[@]} model(s) succeeded"
+else
+    echo "=== BATCH DONE $(date -u +%FT%TZ): ${#FAILED[@]} of ${#MODEL_LIST[@]} model(s) FAILED"
+    for f in "${FAILED[@]}"; do echo "===   $f"; done
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Replaces the throwaway `for MODEL in ...` loop — written, debugged and discarded three times over the last few runs — with one script that stays.

`run-e2e-benchmark.sh` runs **one** model. Benchmarking a dataset means running the same thing for three or five models with hours of waiting between each. `run-benchmark-batch.sh` is that loop:

```bash
./scripts/run-benchmark-batch.sh --provider bedrock \
    --dataset dataset/mcp-gateway-registry-v2.yaml \
    --models 'us.anthropic.claude-sonnet-5[1m],us.anthropic.claude-opus-5[1m]'
```

It subsumes all three ad-hoc drivers used to produce the v2 results (`_v2-sonnet-opus.sh`, `_v2-newtasks.sh`, `_v2-qwen38.sh`), which differed only in model list, provider and an optional task filter. None of those were ever committed; this is what should have been.

## Design notes worth reviewing

**Sequential is a correctness requirement, not a default.** Run in parallel on a self-hosted endpoint, models contend for the same GPU and each other's KV cache — which makes the latency figures *and* the entire `vllm_prometheus` block meaningless, since those are window deltas of server-wide counters. On Bedrock they race for one account's throughput quota. Sequential also keeps each judge pass clean.

**A failing model does not abort the batch.** Losing four queued runs because the first died is worse than a partial batch. Each exit code is echoed, failures are summarised at the end, and the script exits non-zero if any model failed.

**`--tasks` scopes a batch to a subset.** This is the case that keeps coming up — tasks added to a dataset that has already been run. Existing folders are neither re-run nor re-judged (the judge's `--no-overwrite` handles the second), and `summarize_run.py` still rebuilds each summary over the full set. It's how the 5 trivial tasks were backfilled onto three models that had already done 15.

**`AWS_REGION` is exported for every provider, not just `bedrock`.** The codex judge reaches Bedrock regardless of where the model is served, so a `vllm` batch needs it too. Forgetting this is what makes a self-hosted run fail at the judge step after hours of agent time.

## Docs

`harness-reference.md` gains a "Running several models in one batch" section, including why a batch must be detached with `setsid` plus a file redirect: no controlling terminal means no `SIGHUP` can reach it, and output goes to disk rather than a pipe that dies with the connection. That has bitten at least once.

## Testing

- `bash -n` clean; shellcheck-style arg handling verified by hand:
  - missing `--provider` → `--provider is required (bedrock | litellm | vllm)`
  - missing `--dataset` → `--dataset is required`
  - unknown flag → `unknown option: --bogus (see --help)`
  - `--help` prints the header block
- All internal markdown links resolve.

## Not included

A **qwen3.8-27b run over the full 21-task v2 dataset is in flight** on this branch (3 of 21 done at time of writing, ~26h remaining). Its results are deliberately *not* in this PR: 3 task folders with no `run-summary.json`, referenced by no doc and no chart, is a state a later reader cannot distinguish from a run that died. They land in a follow-up once the run completes and the summary, charts and docs can go with them.

`_v2-qwen38.sh` also stays untracked for now — it is the script currently executing, and bash reads a running script incrementally by byte offset, so removing it mid-run risks corrupting execution. It goes when the run finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
