### PR TITLE
fix(benchmarks): count every agent invocation in a task's cost

### DIFF
--- a/.claude/skills/swe3/SKILL.md
+++ b/.claude/skills/swe3/SKILL.md
@@ -49,7 +49,7 @@ The `repo:` path may be a checkout the caller already cloned (including a tempor
 
 1. **Gather Requirements** - Detect the active model and confirm it; ask for the GitHub URL; ask for tag-vs-main; confirm the task; locate or clone the target repo with user approval
 2. **Quick Codebase Review** - Explore the codebase to understand structure
-3. **Create Benchmark Folder** - Create `benchmarks/swe-benchmark-data/{model-name}/{harness-name}/{repo-name}/{problem-name}/` directory. `{harness-name}` is the coding agent producing the run -- `claude-code` when you (Claude Code) run this skill, `pi` for a pi run. When the harness passes an `artifacts_dir:`, use it VERBATIM (it already encodes the right harness); otherwise default `{harness-name}` to `claude-code`.
+3. **Create Benchmark Folder** - If the harness passed an `artifacts_dir:`, that path IS the folder: use it VERBATIM and derive nothing. Only when no `artifacts_dir:` was given, build `benchmarks/swe-benchmark-data/{model-name}/{harness-name}/{repo-name}/{problem-name}/` yourself, where `{harness-name}` is the coding agent producing the run (`claude-code` when you run this skill, `pi` for a pi run).
 4. **Write GitHub Issue** - Create `github-issue.md` with the issue specification
 5. **Deep Codebase Analysis** - Thoroughly explore relevant code
 6. **Write Low-Level Design** - Create `lld.md` with technical details
@@ -206,7 +206,9 @@ This quick review takes 5-10 minutes and helps you ask better clarifying questio
 
 ## Step 3: Create Benchmark Folder
 
-All artifacts live under a top-level `benchmarks/` directory. Within it, every run gets its own `{model-name}/{harness-name}/{repo-name}/{problem-name}/` subfolder. Grouping by model first keeps each model's full set of results together; the `{harness-name}` level (e.g. `claude-code`, `pi`) then keeps runs of the same model by different coding agents from overwriting each other, while still letting models be compared on the same `{repo-name}/{problem-name}` across sibling folders.
+All artifacts live under a top-level `benchmarks/` directory. Within it, every run gets its own `{model-name}/{harness-name}/{scope}/{problem-name}/` subfolder. Grouping by model first keeps each model's full set of results together; the `{harness-name}` level (e.g. `claude-code`, `pi`) then keeps runs of the same model by different coding agents from overwriting each other, while still letting models be compared on the same `{scope}/{problem-name}` across sibling folders.
+
+> **`{scope}` is NOT always the repository name, which is why a derived path is unsafe.** It defaults to the repo name, but a dataset that sets `output_scope` overrides it, so that two datasets over the *same* repository do not share a results folder (for example `mcp-gateway-registry-v2` rather than `mcp-gateway-registry`). You cannot infer that value from the repo URL -- only the caller knows it. If the harness passed `artifacts_dir:` and you build a path from `{repo-name}` instead, the six artifacts land in a sibling folder the harness never looks at: it scores the task **0/6 despite every file being written successfully**, throws the work away, and re-runs the whole task. Use `artifacts_dir:` verbatim whenever it is given.
 
 > **CRITICAL - write to the ABSOLUTE artifact path, never the bare relative string.** The `benchmarks/swe-benchmark-data/...` paths shown throughout this skill are written relative to the repository root for readability. Your working directory is often already inside `benchmarks/` (the harness runs there), so if you pass a bare relative path like `benchmarks/swe-benchmark-data/{model}/...` to Write/Edit it resolves against the cwd and doubles to `benchmarks/benchmarks/swe-benchmark-data/...` -- the files land in the wrong place, the run scores 0/4 artifacts despite "File created successfully", and the work is lost.
 >

--- a/benchmarks/scripts/run-swe-headless.py
+++ b/benchmarks/scripts/run-swe-headless.py
@@ -68,6 +68,25 @@ IMPLEMENTATION_ARTIFACT_FILENAMES = ("patch.diff", "implementation.md")
 ARTIFACT_FILENAMES = DESIGN_ARTIFACT_FILENAMES + IMPLEMENTATION_ARTIFACT_FILENAMES
 GIT_CLONE_TIMEOUT_SECONDS = 300
 
+# A task's true cost is the sum of ALL its agent invocations -- every transient
+# retry and every top-up, not just the pass that happened to succeed. Each
+# _run_task call overwrites metrics.json with only that pass's numbers, so these
+# fields are accumulated across passes and the sums restored. Money and cache
+# tokens belong here as much as turns and tokens: for a retried or topped-up run
+# they are just as real and just as additive, and omitting them undercounts both
+# the cost and the tokens-processed total.
+ADDITIVE_COST_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "num_turns",
+    "latency_seconds",
+    "total_cost_usd",
+    "cache_read_tokens",
+    "cache_creation_tokens",
+)
+# The normalized block renames cache-write; everything else keeps its name.
+MM_BLOCK_KEY = {"cache_creation_tokens": "cache_write_tokens"}
+
 # Sanity floor for output tokens per turn, used to catch a token-accounting bug at
 # run time rather than in PR review. An agent that edits files emits hundreds of
 # output tokens per turn (measured: ~370-730 across claude-code and pi). A value in
@@ -2690,6 +2709,100 @@ def _missing_artifacts(config: RunnerConfig, dataset: Dataset, task: Task) -> li
     return [f for f in ARTIFACT_FILENAMES if not (out_dir / f).exists()]
 
 
+def _pass_cost_value(record: dict[str, Any], key: str) -> float:
+    """Read one additive cost field from a single pass's metrics record.
+
+    Args:
+        record: A parsed metrics.json (or an in-memory summary) for one pass.
+        key: A member of :data:`ADDITIVE_COST_FIELDS`.
+
+    Returns:
+        The field's value, or 0 when the pass did not report it. The normalized
+        block is preferred over the top-level mirror because it is what
+        ``summarize_run`` reads.
+    """
+    block = record.get("metrics") or record.get("metrics_that_matter") or {}
+    val = block.get(MM_BLOCK_KEY.get(key, key))
+    if val is None:
+        val = record.get(key)
+    return val or 0
+
+
+def _fold_pass_into_totals(
+    totals: dict[str, Any],
+    record: dict[str, Any],
+) -> dict[str, Any]:
+    """Add one pass's additive cost fields into a running total.
+
+    Args:
+        totals: The running totals, keyed by :data:`ADDITIVE_COST_FIELDS`.
+        record: The pass to fold in.
+
+    Returns:
+        The same ``totals`` dict, mutated.
+    """
+    for key in ADDITIVE_COST_FIELDS:
+        totals[key] = (totals.get(key) or 0) + _pass_cost_value(record, key)
+    return totals
+
+
+def _write_cost_totals(
+    path: Path,
+    totals: dict[str, Any],
+    invocations: int,
+    context: str,
+    topped_up: list[str] | None = None,
+) -> None:
+    """Restore summed multi-invocation cost into a task's metrics.json.
+
+    The final pass left metrics.json holding only its own numbers. This writes
+    the summed additive fields to the top-level fields AND to the normalized
+    block ("metrics", plus its "metrics_that_matter" alias), because
+    ``summarize_run`` reads the normalized block -- writing only one place would
+    leave the summary showing a single pass. Best-effort: a write failure is
+    logged, not fatal.
+
+    Args:
+        path: The task's metrics.json.
+        totals: Summed additive fields across every agent invocation.
+        invocations: How many agent invocations the task actually took.
+        context: Label for the token-accounting trace.
+        topped_up: Artifacts produced by a top-up pass, when any.
+    """
+    record = _read_json_file(path)
+    if record is None:
+        return
+    record.update(totals)
+    for block_name in ("metrics", "metrics_that_matter"):
+        block = record.get(block_name)
+        if not isinstance(block, dict):
+            continue
+        for key, value in totals.items():
+            target = MM_BLOCK_KEY.get(key, key)
+            if target in block:
+                block[target] = value
+        # total_tokens is derived, not additive; recompute it from the summed
+        # parts so the partition-vs-additive rule (issue #136) is applied
+        # consistently and does not ~2x double-count self-hosted partition runs.
+        if "total_tokens" in block:
+            block["total_tokens"] = compute_total_tokens_processed(
+                totals.get("input_tokens") or 0,
+                totals.get("output_tokens") or 0,
+                totals.get("cache_read_tokens") or 0,
+                totals.get("cache_creation_tokens") or 0,
+                context=f"{context}/{block_name}",
+            )
+    record["agent_invocations"] = invocations
+    if topped_up is not None:
+        record["topped_up_artifacts"] = topped_up
+    try:
+        path.write_text(
+            json.dumps(record, indent=2, default=str) + "\n", encoding="utf-8"
+        )
+    except OSError:
+        logger.warning("could not write summed cost totals to %s", path)
+
+
 def _maybe_topup(
     config: RunnerConfig,
     dataset: Dataset,
@@ -2727,39 +2840,12 @@ def _maybe_topup(
     """
     invocations = summary.get("attempts", 1)
     topped_up: list[str] = []
-    # A task's true cost is the sum of ALL its agent invocations. Each _run_task
-    # call overwrites metrics.json with only that pass's numbers, so accumulate the
-    # additive cost fields across the main run and every top-up and restore the
-    # summed values at the end. This MUST include the money (total_cost_usd) and
-    # the cache tokens (cache_read/creation) -- for a topped-up Bedrock task those
-    # are as real and as additive as turns/tokens; leaving them out undercounts the
-    # cost and the tokens-processed total. The fields live in metrics_that_matter
-    # (which summarize_run reads) and are mirrored top-level, so we read from the
-    # nested block and write the sums back to both. Seed from the main run.
-    additive = (
-        "input_tokens",
-        "output_tokens",
-        "num_turns",
-        "latency_seconds",
-        "total_cost_usd",
-        "cache_read_tokens",
-        "cache_creation_tokens",
-    )
+    # Seed the running cost from what is already on disk. That record ALREADY
+    # holds the sum across any transient retries (_run_task_with_retries folded
+    # them in before we were called), so top-ups accumulate on top of it rather
+    # than restarting the count. See ADDITIVE_COST_FIELDS for why these fields.
     base = _read_json_file(_artifact_dir(config, dataset, task) / "metrics.json") or {}
-
-    # The normalized block ("metrics", aliased as "metrics_that_matter") renames
-    # cache-write to cache_write_tokens; total_cost_usd lives there too now.
-    _MM_KEY = {"cache_creation_tokens": "cache_write_tokens"}
-
-    def _pass_value(record: dict[str, Any], key: str) -> float:
-        """Read an additive field from a pass, preferring the normalized block."""
-        block = record.get("metrics") or record.get("metrics_that_matter") or {}
-        val = block.get(_MM_KEY.get(key, key))
-        if val is None:
-            val = record.get(key)
-        return val or 0
-
-    totals = {k: _pass_value(base, k) for k in additive}
+    totals = {k: _pass_cost_value(base, k) for k in ADDITIVE_COST_FIELDS}
     for topup in range(1, config.max_topups + 1):
         if summary.get("ok"):
             break
@@ -2804,8 +2890,7 @@ def _maybe_topup(
         pass_metrics = (
             _read_json_file(_artifact_dir(config, dataset, task) / "metrics.json") or {}
         )
-        for k in additive:
-            totals[k] = (totals[k] or 0) + _pass_value(pass_metrics, k)
+        _fold_pass_into_totals(totals, pass_metrics)
         topped_up = [
             f for f in missing if (_artifact_dir(config, dataset, task) / f).exists()
         ]
@@ -2828,54 +2913,27 @@ def _annotate_metrics_topup(
     topped_up: list[str],
     totals: dict[str, Any],
 ) -> None:
-    """Record top-up provenance + summed cost into the task's metrics.json.
+    """Record top-up provenance and summed cost into the task's metrics.json.
 
-    The final top-up left metrics.json holding only its own pass. Restore the
-    additive fields -- tokens, turns, latency, total_cost_usd, and cache tokens --
-    to the sum across all agent invocations (the task's true cost) and record how
-    many invocations it took and which artifacts were topped up. The summed values
-    are written to the top-level fields AND to the normalized block ("metrics",
-    plus its "metrics_that_matter" alias), because summarize_run reads them from
-    the normalized block -- writing only one place would leave the summary showing
-    a single pass. Best-effort: a write failure is logged, not fatal.
+    Thin wrapper over :func:`_write_cost_totals` that also records which
+    artifacts a top-up produced, so a completed-but-assisted run stays
+    distinguishable from a clean one.
+
+    Args:
+        config: The runner config.
+        dataset: The loaded dataset.
+        task: The task whose metrics.json to annotate.
+        invocations: Total agent invocations across retries and top-ups.
+        topped_up: Artifacts produced by a top-up pass.
+        totals: Summed additive cost fields across every invocation.
     """
-    path = _artifact_dir(config, dataset, task) / "metrics.json"
-    record = _read_json_file(path)
-    if record is None:
-        return
-    # Top-level copy.
-    record.update(totals)
-    # Normalized block(s): "metrics" is canonical, "metrics_that_matter" the alias.
-    # The block renames cache-write to cache_write_tokens; recompute total_tokens.
-    mm_key = {"cache_creation_tokens": "cache_write_tokens"}
-    for block_name in ("metrics", "metrics_that_matter"):
-        block = record.get(block_name)
-        if not isinstance(block, dict):
-            continue
-        for k, v in totals.items():
-            target = mm_key.get(k, k)
-            if target in block:
-                block[target] = v
-        # total_tokens is derived, not in `additive`; recompute from the summed
-        # parts via compute_total_tokens_processed so the partition-vs-additive
-        # rule (issue #136) is applied consistently and does not ~2x double-count
-        # self-hosted partition runs.
-        if "total_tokens" in block:
-            block["total_tokens"] = compute_total_tokens_processed(
-                totals.get("input_tokens") or 0,
-                totals.get("output_tokens") or 0,
-                totals.get("cache_read_tokens") or 0,
-                totals.get("cache_creation_tokens") or 0,
-                context=f"run-swe-headless:_annotate_metrics_topup/{block_name}",
-            )
-    record["agent_invocations"] = invocations
-    record["topped_up_artifacts"] = topped_up
-    try:
-        path.write_text(
-            json.dumps(record, indent=2, default=str) + "\n", encoding="utf-8"
-        )
-    except OSError:
-        logger.warning("[task=%s] could not annotate metrics.json top-up", task.id)
+    _write_cost_totals(
+        _artifact_dir(config, dataset, task) / "metrics.json",
+        totals,
+        invocations,
+        context="run-swe-headless:_annotate_metrics_topup",
+        topped_up=topped_up,
+    )
 
 
 def _read_json_file(path: Path) -> dict[str, Any] | None:
@@ -2909,6 +2967,13 @@ def _run_task_safe(
     """
     attempts = config.max_retries + 1
     last: dict[str, Any] = {"task": task.id, "ok": False, "artifacts": 0}
+    # Cost carried over from attempts that were discarded. A failed attempt still
+    # burned real tokens, turns and wall-clock on the GPU, so dropping it would
+    # understate the task's true cost by roughly the number of attempts it took.
+    # _clear_partial_artifacts deletes metrics.json, so each attempt is folded in
+    # BEFORE the wipe; the sum is restored onto the final record after the loop.
+    carried: dict[str, Any] = {}
+    metrics_path = _artifact_dir(config, dataset, task) / "metrics.json"
     for attempt in range(1, attempts + 1):
         if attempt > 1:
             logger.warning(
@@ -2919,6 +2984,9 @@ def _run_task_safe(
                 attempt - 1,
                 config.max_retries,
             )
+            prior = _read_json_file(metrics_path)
+            if prior is not None:
+                _fold_pass_into_totals(carried, prior)
             _clear_partial_artifacts(config, dataset, task)
         try:
             summary = _run_task(
@@ -2954,6 +3022,20 @@ def _run_task_safe(
             total,
             attempts,
         )
+    # Fold the discarded attempts back in so metrics.json reports what the task
+    # actually cost, not just its final pass. Done before any top-up, which seeds
+    # its own running total from this record.
+    if carried:
+        totals = _fold_pass_into_totals(
+            dict(carried), _read_json_file(metrics_path) or {}
+        )
+        _write_cost_totals(
+            metrics_path,
+            totals,
+            last.get("attempts", attempts),
+            context="run-swe-headless:_run_task_safe",
+        )
+
     # Outer completion loop: if the task is design-complete but missing the
     # implementation artifacts, try focused top-ups to finish it (see _maybe_topup).
     if not last.get("ok") and config.max_topups > 0:

--- a/benchmarks/tests/test_run_swe_headless.py
+++ b/benchmarks/tests/test_run_swe_headless.py
@@ -8,6 +8,7 @@ git-clone paths are not exercised here.
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import sys
 import tempfile
@@ -1336,3 +1337,157 @@ class TestCheckTokenAccounting(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestMultiInvocationCostAccounting(unittest.TestCase):
+    """A task's recorded cost must be the sum of every agent invocation.
+
+    A transient retry throws away the failed attempt's artifacts, but that
+    attempt still burned real tokens, turns and wall-clock. Recording only the
+    successful pass understates the task's true cost by roughly the number of
+    attempts it took -- which matters because cost per task is the headline
+    number this repo publishes.
+    """
+
+    def test_pass_value_prefers_normalized_block(self) -> None:
+        record = {
+            "input_tokens": 111,
+            "metrics_that_matter": {"input_tokens": 222},
+        }
+        self.assertEqual(harness._pass_cost_value(record, "input_tokens"), 222)
+
+    def test_pass_value_falls_back_to_top_level(self) -> None:
+        record = {"input_tokens": 111}
+        self.assertEqual(harness._pass_cost_value(record, "input_tokens"), 111)
+
+    def test_pass_value_is_zero_when_absent(self) -> None:
+        self.assertEqual(harness._pass_cost_value({}, "input_tokens"), 0)
+
+    def test_pass_value_reads_renamed_cache_write(self) -> None:
+        record = {"metrics": {"cache_write_tokens": 77}}
+        self.assertEqual(harness._pass_cost_value(record, "cache_creation_tokens"), 77)
+
+    def test_fold_sums_across_passes(self) -> None:
+        totals: dict[str, object] = {}
+        harness._fold_pass_into_totals(totals, {"input_tokens": 100, "num_turns": 3})
+        harness._fold_pass_into_totals(totals, {"input_tokens": 50, "num_turns": 4})
+        self.assertEqual(totals["input_tokens"], 150)
+        self.assertEqual(totals["num_turns"], 7)
+
+    def test_write_cost_totals_updates_both_views(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "metrics.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "input_tokens": 10,
+                        "metrics_that_matter": {
+                            "input_tokens": 10,
+                            "cache_write_tokens": 1,
+                            "total_tokens": 11,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            totals = {"input_tokens": 30, "cache_creation_tokens": 5}
+            harness._write_cost_totals(path, totals, 2, context="test")
+            rec = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(rec["input_tokens"], 30)
+            self.assertEqual(rec["metrics_that_matter"]["input_tokens"], 30)
+            # The cache-write rename is honored inside the normalized block.
+            self.assertEqual(rec["metrics_that_matter"]["cache_write_tokens"], 5)
+            # total_tokens is derived, so it is recomputed from the summed parts.
+            self.assertNotEqual(rec["metrics_that_matter"]["total_tokens"], 11)
+            self.assertEqual(rec["agent_invocations"], 2)
+
+    def test_write_cost_totals_is_noop_without_a_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "metrics.json"
+            harness._write_cost_totals(missing, {"input_tokens": 1}, 2, context="t")
+            self.assertFalse(missing.exists())
+
+    def test_retry_records_the_sum_of_both_attempts(self) -> None:
+        """Regression: a retried task reported only its final pass's cost.
+
+        The first attempt wrote six artifacts to a sibling folder (a dataset
+        with an output_scope), scored 0/6, and was retried. Its ~2.1M input
+        tokens vanished from metrics.json, halving the reported cost.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(output_dir=tmp, max_retries=1, max_topups=0)
+            art = harness._artifact_dir(cfg, _ds(), _task())
+            art.mkdir(parents=True, exist_ok=True)
+            metrics_path = art / "metrics.json"
+
+            attempts = {"n": 0}
+
+            def _fake_run_task(*args: object, **kwargs: object) -> dict[str, object]:
+                attempts["n"] += 1
+                first = attempts["n"] == 1
+                metrics_path.write_text(
+                    json.dumps(
+                        {
+                            "input_tokens": 2_000_000 if first else 3_000_000,
+                            "output_tokens": 1_000 if first else 2_000,
+                            "num_turns": 37 if first else 56,
+                            "latency_seconds": 100.0 if first else 120.0,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                # The first attempt produced no artifacts the harness can see.
+                return {
+                    "task": _task().id,
+                    "ok": not first,
+                    "artifacts": 0 if first else 6,
+                }
+
+            with mock.patch.object(harness, "_run_task", _fake_run_task):
+                harness._run_task_safe(
+                    cfg,
+                    _ds(),
+                    _task(),
+                    stream=False,
+                    concurrent=False,
+                    position=1,
+                    total=1,
+                )
+
+            rec = json.loads(metrics_path.read_text(encoding="utf-8"))
+            self.assertEqual(attempts["n"], 2, "the task should have retried once")
+            # Both attempts, not just the successful one.
+            self.assertEqual(rec["input_tokens"], 5_000_000)
+            self.assertEqual(rec["output_tokens"], 3_000)
+            self.assertEqual(rec["num_turns"], 93)
+            self.assertAlmostEqual(rec["latency_seconds"], 220.0)
+            self.assertEqual(rec["agent_invocations"], 2)
+
+    def test_single_attempt_cost_is_left_untouched(self) -> None:
+        """A task that succeeds first time must not be rewritten or annotated."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(output_dir=tmp, max_retries=1, max_topups=0)
+            art = harness._artifact_dir(cfg, _ds(), _task())
+            art.mkdir(parents=True, exist_ok=True)
+            metrics_path = art / "metrics.json"
+
+            def _fake_run_task(*args: object, **kwargs: object) -> dict[str, object]:
+                metrics_path.write_text(
+                    json.dumps({"input_tokens": 42, "num_turns": 7}), encoding="utf-8"
+                )
+                return {"task": _task().id, "ok": True, "artifacts": 6}
+
+            with mock.patch.object(harness, "_run_task", _fake_run_task):
+                harness._run_task_safe(
+                    cfg,
+                    _ds(),
+                    _task(),
+                    stream=False,
+                    concurrent=False,
+                    position=1,
+                    total=1,
+                )
+
+            rec = json.loads(metrics_path.read_text(encoding="utf-8"))
+            self.assertEqual(rec["input_tokens"], 42)
+            self.assertNotIn("agent_invocations", rec)


### PR DESCRIPTION
## Problem

A task whose artifacts land outside `artifacts_dir` scores 0/6 and is retried. The retry produces the right files, so the run looks healthy -- but `metrics.json` holds only the successful pass. The discarded attempt's tokens, turns and wall-clock vanish, so a retried task reports roughly **half its true cost**.

Cost per task is the headline number this repo publishes, which makes a silent 2x understatement the worst kind of bug here. It is the same class of error as #136, from the opposite direction.

Observed on `qwen3-coder-30b` (omp, `/swe3`, v2 dataset):

| | Attempt 1 | Attempt 2 | Recorded |
|---|---|---|---|
| Result | INCOMPLETE 0/6 | OK 6/6 | |
| Input tokens | 2,087,845 | 3,615,952 | **3,615,952** |
| Turns | 37 | 56 | **56** |
| Wall-clock | 135.7s | 123.9s | **123.9s** |

Attempt 1 is absent entirely: 2.1M input tokens unaccounted for.

## Cause

Two independent halves.

**The artifacts went to the wrong folder.** The `/swe3` skill offered a derivable path template (`{repo-name}/{problem-name}`) alongside the authoritative `artifacts_dir:` the harness passes. `{repo-name}` equals the scope for every v1 dataset, so the conflict was invisible -- until the v2 dataset set `output_scope` and the two diverged (`mcp-gateway-registry-v2` vs `mcp-gateway-registry`). The model followed the template, wrote six perfect artifacts into a sibling folder the harness never reads, and scored 0/6.

**The retry's cost was dropped.** `_maybe_topup` already summed cost across invocations and documented why. `_run_task_safe` simply never did -- each attempt replaced the previous summary wholesale, and `_clear_partial_artifacts` deleted the prior `metrics.json` before the next pass.

## Fix

Shared rather than duplicated: `ADDITIVE_COST_FIELDS`, `_pass_cost_value`, `_fold_pass_into_totals` and `_write_cost_totals` are now module-level. `_maybe_topup` and `_annotate_metrics_topup` delegate to them, and `_run_task_safe` folds each discarded attempt in *before* `_clear_partial_artifacts` wipes its `metrics.json`.

Because the retry sum is restored before any top-up runs, a task that both retries and tops up now accumulates across all of them. `total_tokens` stays derived, recomputed through `compute_total_tokens_processed` so the partition-vs-additive rule from #136 still holds and self-hosted runs are not double-counted.

The skill now leads with `artifacts_dir` and states what a derived path actually costs.

## Verification

Confirmed against a live run after the fix -- a retried task now reports both passes:

```
lifecycle-workflow-webhooks   agent_invocations: 2   22,451,124 input tokens   219 turns   14.1 min
```

A task that succeeds first time is left untouched, with no `agent_invocations` key -- covered by its own test.

- 296 tests pass (9 new), including a regression test asserting a retried task reports the sum of both attempts
- ruff, mypy and bandit clean

## Notes

Harness-level and agent-agnostic: it applies to `claude`, `pi`, `omp` and `kiro` alike. The SKILL.md half is a no-op on datasets without `output_scope`.

Published `/swe3` v2 results predating this fix likely carry the same understatement on any task that retried; worth a re-check separately.