### PR TITLE
feat(skills): setup-machine -- bootstrap a fresh box for benchmarking

### DIFF
--- a/.claude/skills/setup-machine/SKILL.md
+++ b/.claude/skills/setup-machine/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: setup-machine
+description: "Examine the instance this repo is checked out on, report exactly which dependencies are missing, and install them. Detects the machine (OS, vCPU/RAM, disk, EC2 instance type, GPU), then installs the core stack every path needs -- git, a global git identity, the GitHub CLI (gh), Python 3.10+, Node.js 22+, uv, the claude / codex / pi CLIs, the AWS CLI, pre-commit, and a synced venv for each of the two uv projects. When an NVIDIA GPU is present it ALSO installs vLLM, nvtop and nvitop; with no GPU it skips those three and says so. Use when the user asks what needs installing, wants the machine bootstrapped or set up, hits a missing-command error (uv/claude/codex/pi/gh not found), or is preparing a fresh EC2 box to run benchmarks. Wraps .claude/skills/setup-machine/setup-machine.sh."
+license: Apache-2.0
+metadata:
+  author: Amit Arora
+  version: "1.0"
+---
+
+# Setup Machine Skill
+
+Use this skill to take a machine from a bare checkout to one that can actually run this repository, without the user guessing which of the four agent CLIs, two uv projects, and (optionally) the GPU serving stack they are missing.
+
+The skill is a thin driver over [`setup-machine.sh`](setup-machine.sh), which holds all the detection and install logic. Run the script; do not re-derive its checks by hand, and do not install anything it does not plan.
+
+**The GPU stack is conditional.** If `nvidia-smi` reports at least one GPU, the plan includes **vLLM, nvtop and nvitop**. If it does not, those three are skipped and reported as skipped -- never silently dropped, and never installed on a CPU-only box where they are useless.
+
+## Workflow
+
+1. **Examine** -- run the script in its default `--check` mode: machine facts, what is present, the full install plan. Nothing is changed.
+2. **Announce** -- relay the plan to the user loudly and in full, including what is being skipped and why.
+3. **Install** -- re-run with `--install`, echoing each component as it completes.
+4. **Summarize** -- report the final table and the next steps the script prints.
+
+---
+
+## Step 1 -- Examine the instance
+
+```bash
+cd <repo root>
+./.claude/skills/setup-machine/setup-machine.sh
+```
+
+Default mode is `--check`: it detects and prints, and installs nothing. It reports:
+
+- **The machine** -- OS, kernel, vCPU, RAM, free disk, EC2 instance type (via IMDSv2, best effort), and the GPU line: count, model, and driver version, or `none detected`.
+- **Already present** -- every component found, with its version.
+- **The install plan** -- a numbered list of what is missing, each with the reason this repo needs it.
+- **Skipped** -- the GPU stack when there is no GPU (or `--skip-gpu` was passed).
+- **Advisories** -- where the vLLM venv will live (see below), and an 8-GPU NVSwitch warning pointing at [`p5en-h200-cuda-fixes.md`](../vllm-setup/p5en-h200-cuda-fixes.md) on a p5-class node.
+
+### Where the vLLM venv lands
+
+A GPU AMI's root disk is routinely ~29 GB, which is not enough for torch and the CUDA wheels, let alone model weights -- while the same box has a multi-TB ephemeral NVMe mounted. The script resolves this itself rather than failing partway through a download:
+
+1. An explicitly set `VLLM_ENV` always wins, and is reported as such.
+2. Otherwise, if `$HOME`'s volume has less than 40 GB free, it picks a large volume -- preferring the Deep Learning AMI's `/opt/dlami/nvme` by name, else the largest writable real filesystem -- and puts the venv, `UV_CACHE_DIR` and `TMPDIR` there. This is the disk layout [`p5en-h200-cuda-fixes.md`](../vllm-setup/p5en-h200-cuda-fixes.md) prescribes, not an invention of this skill.
+3. If the root disk is tight and no large volume exists, it warns and tells the user to attach one; it does not install vLLM into a volume that cannot hold it.
+
+`tmpfs` is deliberately excluded from that search: `/dev/shm` can advertise a terabyte, but it is RAM. **Tell the user when the venv gets relocated, and that the ephemeral NVMe is wiped on instance stop** -- weights re-download after a restart, which is the right trade for a serving box but a surprise if unannounced.
+
+Two GPU cases the script distinguishes, and you should repeat the distinction to the user:
+
+- **No NVIDIA hardware** -- CPU-only instance. The GPU stack is skipped; everything else still applies. This is a perfectly good machine for driving Bedrock-hosted models (Paths 1 and 2); it just cannot self-host (Path 3).
+- **NVIDIA hardware present but `nvidia-smi` does not work** -- the driver is missing. Do *not* try to install vLLM: it will fail. Tell the user the driver needs installing first (the Deep Learning AMI ships one), then re-run.
+
+## Step 2 -- Announce the plan, loudly
+
+Before installing anything, tell the user in your own message:
+
+- **how many components** will be installed and **what each one is for** (the script prints the reason per line -- do not drop it),
+- **what is being skipped and why** ("no GPU on this instance, so vLLM, nvtop and nvitop are skipped"),
+- **anything that needs sudo** -- the script warns up front when apt packages are planned and passwordless sudo is unavailable, because that turns an unattended run into one that stalls on a password prompt,
+- **any advisory it printed** (disk, NVSwitch hardware).
+
+Do not skip this because the script already printed it. The user asked to be told what is about to be installed, and the script's output may be scrolled off or buffered.
+
+## Step 3 -- Install
+
+```bash
+./.claude/skills/setup-machine/setup-machine.sh --install --yes
+```
+
+Use `--yes` when you have already relayed the plan and the user has agreed; drop it to make the script prompt for itself. Other flags:
+
+| Flag | Effect |
+| --- | --- |
+| `--git-name "Full Name"` | the `user.name` for the global git identity |
+| `--git-email "you@example.com"` | the `user.email` for the global git identity |
+| `--skip-gpu` | never install the GPU stack, even on a GPU box (useful when the box only drives Bedrock) |
+| `--with-omp` | also install the `omp` agent (third-party `curl \| sh` installer) |
+| `--with-kiro` | also install `kiro-cli` (third-party `curl \| bash` installer; needs an interactive `kiro-cli login` afterwards) |
+| `VLLM_ENV=/path/vllm-env` | pin the vLLM venv location; overrides the automatic volume choice below |
+
+`omp` and `kiro-cli` are **opt-in** because both ship third-party pipe-to-shell installers and kiro additionally requires an interactive sign-in. Offer them; do not add them unasked.
+
+### Ask the user for their git identity
+
+If `git config --global user.name` / `user.email` are unset, the script plans a `git identity` component -- and **refuses to install it without both `--git-name` and `--git-email`**. That is deliberate: a guessed identity is baked into every commit the machine makes and rewriting history to fix it is far worse than one question. So **ask the user for their name and email** before the install step, and pass them through:
+
+```bash
+./.claude/skills/setup-machine/setup-machine.sh --install --yes \
+    --git-name "Full Name" --git-email "you@example.com"
+```
+
+Never infer these from the shell user, the hostname, an existing commit, or a `~/.gitconfig` in another checkout. If the user declines to give them, run the install anyway -- every other component proceeds and `git identity` is simply reported as failed, which is honest.
+
+The script echoes `[done] (n/total) <component> -- INSTALLED` as each one lands, and **keeps going after a failure** so one broken component does not block the rest. It is idempotent: re-running after a partial failure only does what remains.
+
+What it installs, and why the repo needs it:
+
+| Component | Why |
+| --- | --- |
+| `git` | clones the target repo each benchmark task runs against |
+| git identity | `user.name` / `user.email`, without which any commit the machine makes fails outright; **must be supplied by the user**, never guessed |
+| `gh` (GitHub CLI) | AGENTS.md's workflow is branch + PR, which `gh pr create` drives; also how issues and CI runs are read. Installed from GitHub's own apt repo and keyring so future `apt upgrade`s stay signature-verified |
+| Python 3.10+ | the harness, judge and plot scripts are 3.10+ (installed via `uv python` -- the system Python is left alone) |
+| `uv` | the repo's package manager; AGENTS.md forbids using `pip` directly |
+| Node.js 22+ | `claude`, `codex` and `pi` are npm packages, and pi needs >= 22 |
+| `claude` | the default harness -- the runner shells out to `claude -p` |
+| `codex` | the judge -- `codex_judge.py` scores artifacts with `codex exec` |
+| `pi` | the second harness (`--agent pi`), which produced most published results |
+| AWS CLI | Bedrock credentials and the pre-flight identity check |
+| pre-commit + hook | CI fails on unformatted Python; the hook makes formatting mechanical |
+| `benchmarks/.venv` | `uv sync` in the harness project |
+| `self-hosted/vllm/.venv` | `uv sync` in the client project (openai, duckdb, ...) |
+| **vLLM** *(GPU only)* | serves the open-weight model for the self-hosted path (Path 3) |
+| **nvtop** *(GPU only)* | live per-GPU utilization TUI while a benchmark runs |
+| **nvitop** *(GPU only)* | per-process GPU view: which PID holds which slice of VRAM |
+
+vLLM is **not** installed inline -- the script delegates to [`self-hosted/vllm/scripts/vllm-install.sh`](../../../self-hosted/vllm/scripts/vllm-install.sh), the vetted installer that also handles the two Deep Learning AMI fixes (`python3.12-dev` + `build-essential` for the Triton JIT). Never reimplement that here.
+
+## Step 4 -- Summarize
+
+Relay the script's final summary: one row per component with `ALREADY PRESENT` / `INSTALLED` / `SKIPPED` / `FAILED`, the GPU verdict, and then the next steps. Call out four things explicitly, because they are the ones that bite later:
+
+1. **A new shell is needed** for freshly installed CLIs to resolve (or `export PATH=$HOME/.local/bin:$PATH`).
+2. **Installing `claude` and `codex` does not wire them to Amazon Bedrock.** An unconfigured `codex` ignores perfectly healthy AWS credentials and 401s against `api.openai.com` partway into a run. Point at [benchmarks/docs/agent-cli-bedrock-setup.md](../../../benchmarks/docs/agent-cli-bedrock-setup.md) and offer to walk it.
+3. **Installing `gh` does not authenticate it.** `gh auth login` is interactive (browser or token) and cannot be scripted from here, so `gh pr create` fails until the user runs it.
+4. **The runner config is not created by this skill.** `cp benchmarks/config/runner.example.yaml benchmarks/config/runner.yaml` and edit it.
+
+If anything reported `FAILED`, say which component and what the error was, and offer to re-run (idempotent) or fix it by hand. Do not report the machine as ready while a component is failed.
+
+Verify the result rather than assuming it:
+
+```bash
+cd benchmarks && uv run python -m unittest discover -s tests
+cd self-hosted/vllm && uv run python -m unittest discover -s tests
+```
+
+A green suite means the project is genuinely usable, not just installed. Use `unittest`, not `pytest`: the suites are stdlib `unittest` and that is what [.github/workflows/test.yml](../../../.github/workflows/test.yml) runs. `pytest` is not in either project's dev dependencies, so `uv run pytest` fails on a correctly set-up machine -- do not report that as a setup failure.
+
+## What this skill does NOT do
+
+- It does not configure any CLI's credentials or model routing (see [agent-cli-bedrock-setup.md](../../../benchmarks/docs/agent-cli-bedrock-setup.md) and [kiro-cli-setup.md](../../../docs/kiro-cli-setup.md)).
+- It does not serve a model -- that is the [`vllm-setup`](../vllm-setup/SKILL.md) skill, which this skill's GPU step only prepares the ground for.
+- It does not run a benchmark -- that is [`benchmark`](../benchmark/SKILL.md).
+- It does not install NVIDIA drivers. If the hardware is there but `nvidia-smi` is not, say so and stop.

--- a/.claude/skills/setup-machine/setup-machine.sh
+++ b/.claude/skills/setup-machine/setup-machine.sh
@@ -1,0 +1,782 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# setup-machine.sh -- inspect this instance and install everything this repo
+# needs in order to run, including the GPU stack when a GPU is present.
+#
+# Two modes:
+#   --check    (default) detect only. Prints the machine facts, what is already
+#              present, and the exact install plan. Changes nothing.
+#   --install  run that plan: install every missing component, echoing each one
+#              as it completes, then print a summary table and next steps.
+#
+# Installed on EVERY instance (the core the harness needs):
+#   git (+ a configured user.name/user.email), the GitHub CLI (gh), python3
+#   >= 3.10, Node.js >= 22, uv, the claude / codex / pi CLIs, the AWS CLI,
+#   pre-commit plus the repo hook, and a synced virtualenv for each of the two
+#   uv projects (benchmarks/ and self-hosted/vllm/).
+#
+# Installed ONLY when an NVIDIA GPU is present (skipped loudly otherwise):
+#   vLLM (via self-hosted/vllm/scripts/vllm-install.sh), nvtop, nvitop.
+#
+# Usage:
+#   ./setup-machine.sh                       # detect and print the plan
+#   ./setup-machine.sh --install             # install the plan (prompts once)
+#   ./setup-machine.sh --install --yes       # install without prompting
+#   ./setup-machine.sh --install --skip-gpu  # core only, even on a GPU box
+#   ./setup-machine.sh --install --with-omp --with-kiro
+#   ./setup-machine.sh --help
+#
+# Flags:
+#   --check       detect only (default)
+#   --install     perform the installs
+#   --yes         do not prompt for confirmation
+#   --skip-gpu    never install the GPU stack, even on a GPU instance
+#   --with-omp    also install the omp agent (third-party 'curl | sh' installer)
+#   --with-kiro   also install kiro-cli (third-party 'curl | bash' installer;
+#                 needs an interactive 'kiro-cli login' afterwards)
+#   --git-name    global git user.name  (or the GIT_USER_NAME env var)
+#   --git-email   global git user.email (or the GIT_USER_EMAIL env var)
+#
+# git's global user.name/user.email are what gh and every commit attribute work
+# to. This script never invents them: supply both, or it reports the identity as
+# still needing to be set and tells you the two commands.
+#
+# Idempotent: anything already present is reported and left alone, so re-running
+# after a partial failure only does what is left.
+#
+# Installing a CLI is NOT the same as wiring it to Amazon Bedrock. See
+# benchmarks/docs/agent-cli-bedrock-setup.md for that step; this script prints
+# the reminder at the end and never edits your CLI config.
+# ---------------------------------------------------------------------------
+
+# uv and everything `uv tool install` places go in ~/.local/bin, which a shell
+# started before the install does not have on PATH. Without this, a second run
+# re-detects those as missing and reinstalls them.
+#
+# APPENDED, not prepended, on purpose: this script invokes curl, dpkg, tee and
+# apt-get under sudo, and a user-writable directory ahead of the system paths
+# would let anything dropped in ~/.local/bin shadow those. Appending still finds
+# uv and the uv-installed tools, which exist nowhere else.
+export PATH="$PATH:$HOME/.local/bin"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BENCHMARKS_DIR="$REPO_ROOT/benchmarks"
+VLLM_DIR="$REPO_ROOT/self-hosted/vllm"
+VLLM_ENV_EXPLICIT="no"
+[[ -n "${VLLM_ENV:-}" ]] && VLLM_ENV_EXPLICIT="yes"
+VLLM_ENV="${VLLM_ENV:-$HOME/vllm-env}"
+
+# vLLM plus its torch/CUDA wheels need roughly this much room before any model
+# weights are downloaded. The p5en root volume is small, which is exactly the
+# case p5en-h200-cuda-fixes.md tells you to move onto the NVMe.
+VLLM_MIN_FREE_GB=40
+
+# The Deep Learning AMI mounts its large ephemeral NVMe here.
+DLAMI_NVME="/opt/dlami/nvme"
+
+MIN_PYTHON="3.10"
+MIN_NODE="22"
+
+MODE="check"
+ASSUME_YES="no"
+SKIP_GPU="no"
+WITH_OMP="no"
+WITH_KIRO="no"
+GIT_USER_NAME="${GIT_USER_NAME:-}"
+GIT_USER_EMAIL="${GIT_USER_EMAIL:-}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; BLUE='\033[0;34m'
+BOLD='\033[1m'; RESET='\033[0m'
+info()   { echo -e "${BLUE}[info]${RESET}  $1"; }
+ok()     { echo -e "${GREEN}[ok]${RESET}    $1"; }
+done_()  { echo -e "${GREEN}${BOLD}[done]${RESET}  $1"; }
+warn()   { echo -e "${YELLOW}[warn]${RESET}  $1"; }
+die()    { echo -e "${RED}[fail]${RESET}  $1" >&2; exit 1; }
+header() { echo -e "\n${BOLD}=== $1 ===${RESET}"; }
+rule()   { echo -e "${BOLD}=======================================================================${RESET}"; }
+
+# Component registry. Every component has a label, a one-line reason it is
+# needed, and a state filled in by detect(): present | plan | skip | manual.
+COMP_ORDER=()
+declare -A COMP_LABEL=()
+declare -A COMP_WHY=()
+declare -A COMP_STATE=()
+declare -A COMP_DETAIL=()
+
+GPU_PRESENT="no"
+GPU_SUMMARY="none detected"
+GPU_COUNT=0
+INSTANCE_TYPE=""
+BIG_VOLUME=""
+VLLM_ENV_NOTE=""
+NEEDS_SUDO="no"
+INSTALLED_COUNT=0
+FAILED_COUNT=0
+
+
+_register() {
+    local key="$1" label="$2" why="$3"
+    COMP_ORDER+=("$key")
+    COMP_LABEL["$key"]="$label"
+    COMP_WHY["$key"]="$why"
+    COMP_STATE["$key"]="plan"
+    COMP_DETAIL["$key"]=""
+}
+
+
+_mark() {
+    local key="$1" state="$2" detail="${3:-}"
+    COMP_STATE["$key"]="$state"
+    COMP_DETAIL["$key"]="$detail"
+}
+
+
+# True when $1 (found version) is >= $2 (minimum version).
+_version_ge() {
+    printf '%s\n%s\n' "$2" "$1" | sort -V -C
+}
+
+
+_have() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+
+_is_apt_system() {
+    _have apt-get
+}
+
+
+_sudo_available() {
+    _have sudo && sudo -n true 2>/dev/null
+}
+
+
+# Install a global npm package, falling back to sudo when the global prefix is
+# root-owned (the usual case for a NodeSource install).
+_npm_global() {
+    local pkg="$1"
+    if npm install -g "$pkg"; then
+        return 0
+    fi
+    warn "global npm install failed unprivileged; retrying with sudo"
+    sudo npm install -g "$pkg"
+}
+
+
+_apt_install() {
+    local pkg="$1"
+    _is_apt_system || die "$pkg needs an apt-based distribution; install it manually."
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "$pkg"
+}
+
+
+# Die unless an option that takes a value actually got one. Called directly (not
+# in a command substitution) so that `die` exits the script rather than a subshell.
+_require_value() {
+    local flag="$1" value="$2"
+    if [[ -z "$value" || "$value" == -* ]]; then
+        die "$flag requires a value (e.g. $flag 'Your Name')"
+    fi
+}
+
+
+_parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --check)     MODE="check" ;;
+            --install)   MODE="install" ;;
+            --yes|-y)    ASSUME_YES="yes" ;;
+            --skip-gpu)  SKIP_GPU="yes" ;;
+            --with-omp)  WITH_OMP="yes" ;;
+            --with-kiro) WITH_KIRO="yes" ;;
+            # Reject a missing or flag-shaped value rather than silently storing
+            # "--install" as somebody's name, and rather than letting a bare
+            # `shift` past the end abort the script with a naked exit 1.
+            --git-name)  _require_value "$1" "${2:-}"; GIT_USER_NAME="$2";  shift ;;
+            --git-email) _require_value "$1" "${2:-}"; GIT_USER_EMAIL="$2"; shift ;;
+            -h|--help)   sed -n '5,45p' "$0" | sed 's/^# \{0,1\}//; s/^#$//'; exit 0 ;;
+            *)           die "unknown argument '$1' (try --help)" ;;
+        esac
+        shift
+    done
+}
+
+
+_report_machine() {
+    header "Step 1 - What machine is this"
+    local kernel distro cpus mem disk instance
+    kernel="$(uname -sr)"
+    distro="$( { grep -m1 '^PRETTY_NAME=' /etc/os-release 2>/dev/null || echo 'PRETTY_NAME=unknown'; } | cut -d'"' -f2)"
+    cpus="$(nproc 2>/dev/null || echo '?')"
+    mem="$(free -h 2>/dev/null | awk '/^Mem:/{print $2}' || echo '?')"
+    disk="$(df -h "$REPO_ROOT" 2>/dev/null | tail -1 | awk '{print $4" free of "$2}')"
+    echo "  OS          : $distro ($kernel)"
+    echo "  CPU / RAM   : ${cpus} vCPU, ${mem} RAM"
+    echo "  Disk        : ${disk:-unknown} (at $REPO_ROOT)"
+
+    # EC2 instance type, best effort via IMDSv2. A non-EC2 box just prints n/a.
+    local token=""
+    token="$(curl -sf -m 2 -X PUT 'http://169.254.169.254/latest/api/token' \
+        -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' 2>/dev/null || true)"
+    if [[ -n "$token" ]]; then
+        instance="$(curl -sf -m 2 -H "X-aws-ec2-metadata-token: $token" \
+            'http://169.254.169.254/latest/meta-data/instance-type' 2>/dev/null || true)"
+    fi
+    INSTANCE_TYPE="${instance:-}"
+    echo "  EC2 instance: ${INSTANCE_TYPE:-n/a (not an EC2 instance, or IMDS unreachable)}"
+    _detect_gpu
+    echo "  GPU         : $GPU_SUMMARY"
+}
+
+
+_detect_gpu() {
+    if _have nvidia-smi && nvidia-smi -L >/dev/null 2>&1 && [[ -n "$(nvidia-smi -L 2>/dev/null)" ]]; then
+        GPU_PRESENT="yes"
+        local count name driver
+        count="$(nvidia-smi -L | wc -l | xargs)"
+        GPU_COUNT="$count"
+        name="$(nvidia-smi --query-gpu=name --format=csv,noheader | awk 'NR==1' | xargs)"
+        driver="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | awk 'NR==1' | xargs)"
+        GPU_SUMMARY="${count}x ${name} (driver ${driver})"
+        return
+    fi
+    if _have lspci && lspci 2>/dev/null | grep -qi 'nvidia'; then
+        GPU_SUMMARY="NVIDIA hardware present but no working nvidia-smi -- driver not installed"
+        return
+    fi
+    GPU_SUMMARY="none detected (CPU-only instance)"
+}
+
+
+_detect_core() {
+    _register git "git" "clone the target repos each benchmark task runs against"
+    if _have git; then
+        _mark git present "$(git --version | awk '{print $3}')"
+    fi
+
+    _register python "python3 >= $MIN_PYTHON" "the harness, judge and plot scripts are Python 3.10+"
+    if _have python3; then
+        local pyver
+        pyver="$(python3 -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])' 2>/dev/null || echo 0)"
+        if _version_ge "$pyver" "$MIN_PYTHON"; then
+            _mark python present "$pyver"
+        else
+            _mark python plan "found $pyver, need >= $MIN_PYTHON"
+        fi
+    fi
+
+    _register gitconfig "git identity" "gh and every commit need a global user.name/user.email"
+    local git_name git_email
+    git_name="$(git config --global user.name 2>/dev/null || true)"
+    git_email="$(git config --global user.email 2>/dev/null || true)"
+    if [[ -n "$git_name" && -n "$git_email" ]]; then
+        _mark gitconfig present "$git_name <$git_email>"
+    elif [[ -n "$GIT_USER_NAME" && -n "$GIT_USER_EMAIL" ]]; then
+        _mark gitconfig plan "will set: $GIT_USER_NAME <$GIT_USER_EMAIL>"
+    else
+        _mark gitconfig plan "NEEDS --git-name and --git-email (ask the user; never invent them)"
+    fi
+
+    _register gh "gh (GitHub CLI)" "opening the PRs this repo's workflow requires, and gh label list"
+    if _have gh; then
+        _mark gh present "$(gh --version 2>/dev/null | awk 'NR==1{print $3}')"
+    fi
+
+    _register uv "uv" "the repo's package manager -- AGENTS.md forbids using pip directly"
+    if _have uv; then
+        _mark uv present "$(uv --version 2>/dev/null | awk '{print $2}')"
+    fi
+
+    _register node "Node.js >= $MIN_NODE" "the claude, codex and pi CLIs are npm packages (pi needs Node >= 22)"
+    if _have node; then
+        local nodever nodemajor
+        nodever="$(node -v 2>/dev/null | sed 's/^v//')"
+        nodemajor="${nodever%%.*}"
+        if [[ -n "$nodemajor" ]] && (( nodemajor >= MIN_NODE )); then
+            _mark node present "$nodever"
+        else
+            _mark node plan "found $nodever, need >= $MIN_NODE"
+        fi
+    fi
+
+    _register claude "claude (Claude Code)" "the default harness: the runner shells out to 'claude -p'"
+    if _have claude; then _mark claude present "$(claude --version 2>/dev/null | awk 'NR==1')"; fi
+
+    _register codex "codex" "the judge: codex_judge.py scores artifacts with 'codex exec'"
+    if _have codex; then _mark codex present "$(codex --version 2>/dev/null | awk 'NR==1')"; fi
+
+    _register pi "pi (pi coding agent)" "the second harness (--agent pi), used for most published results"
+    if _have pi; then _mark pi present "$(pi --version 2>/dev/null | awk 'NR==1')"; fi
+
+    _register aws "AWS CLI" "Bedrock credentials and the pre-flight identity check"
+    if _have aws; then _mark aws present "$(aws --version 2>&1 | awk '{print $1}')"; fi
+
+    _register precommit "pre-commit + repo hook" "CI fails on unformatted Python; the hook formats on every commit"
+    if _have pre-commit && [[ -f "$REPO_ROOT/.git/hooks/pre-commit" ]]; then
+        _mark precommit present "$(pre-commit --version 2>/dev/null | awk '{print $2}')"
+    fi
+
+    _register venv_benchmarks "benchmarks/ venv (uv sync)" "the harness project's dependencies (pydantic, matplotlib, ...)"
+    if [[ -x "$BENCHMARKS_DIR/.venv/bin/python" ]]; then _mark venv_benchmarks present "$BENCHMARKS_DIR/.venv"; fi
+
+    _register venv_vllm "self-hosted/vllm/ venv (uv sync)" "the client project's dependencies (openai, duckdb, ...)"
+    if [[ -x "$VLLM_DIR/.venv/bin/python" ]]; then _mark venv_vllm present "$VLLM_DIR/.venv"; fi
+
+    if [[ "$WITH_OMP" == "yes" ]]; then
+        _register omp "omp (oh-my-pi)" "optional third harness (--agent omp), requested with --with-omp"
+        if _have omp; then _mark omp present "$(omp --version 2>/dev/null | awk 'NR==1')"; fi
+    fi
+    if [[ "$WITH_KIRO" == "yes" ]]; then
+        _register kiro "kiro-cli" "optional fourth harness (--agent kiro), requested with --with-kiro"
+        if _have kiro-cli; then _mark kiro present "$(kiro-cli --version 2>/dev/null | awk 'NR==1')"; fi
+    fi
+}
+
+
+_detect_gpu_stack() {
+    _register nvtop "nvtop" "live per-GPU utilization TUI while a benchmark runs"
+    _register nvitop "nvitop" "per-process GPU view: which PID holds which slice of VRAM"
+    _register vllm "vLLM (in $VLLM_ENV)" "serves the open-weight model for the self-hosted path (Path 3)"
+
+    if [[ "$GPU_PRESENT" != "yes" || "$SKIP_GPU" == "yes" ]]; then
+        local reason="no NVIDIA GPU on this instance"
+        if [[ "$SKIP_GPU" == "yes" ]]; then reason="--skip-gpu requested"; fi
+        _mark nvtop skip "$reason"
+        _mark nvitop skip "$reason"
+        _mark vllm skip "$reason"
+        return
+    fi
+
+    if _have nvtop; then _mark nvtop present "$(nvtop --version 2>/dev/null | awk '{print $NF}')"; fi
+    if _have nvitop; then _mark nvitop present "$(nvitop --version 2>/dev/null | awk '{print $NF}')"; fi
+    if [[ -x "$VLLM_ENV/bin/python" ]] && "$VLLM_ENV/bin/python" -c 'import vllm' 2>/dev/null; then
+        _mark vllm present "$("$VLLM_ENV/bin/python" -c 'import vllm; print(vllm.__version__)' 2>/dev/null)"
+    fi
+}
+
+
+# Free GB on the filesystem holding $1 (the nearest existing ancestor).
+_free_gb() {
+    local target="$1"
+    while [[ -n "$target" && ! -d "$target" ]]; do
+        target="$(dirname "$target")"
+    done
+    df -BG --output=avail "$target" 2>/dev/null | tail -1 | tr -dc '0-9'
+}
+
+
+# Largest writable real volume with room for vLLM, or empty if there is none.
+# tmpfs is excluded on purpose: /dev/shm can advertise a terabyte, but it is RAM,
+# and a multi-GB venv written there is a memory leak with a mount point.
+_pick_big_volume() {
+    local avail target best="" best_gb=0
+    while read -r avail target; do
+        [[ -z "${target:-}" ]] && continue
+        avail="${avail%G}"
+        [[ "$avail" =~ ^[0-9]+$ ]] || continue
+        (( avail < VLLM_MIN_FREE_GB )) && continue
+        [[ -w "$target" ]] || continue
+        # The Deep Learning AMI's ephemeral NVMe is what the p5en run-book names,
+        # so prefer it outright rather than by size.
+        if [[ "$target" == "$DLAMI_NVME" ]]; then
+            echo "$target"
+            return 0
+        fi
+        if (( avail > best_gb )); then
+            best_gb="$avail"
+            best="$target"
+        fi
+    done < <(df -BG --output=avail,target -x tmpfs -x devtmpfs -x efivarfs \
+                -x squashfs -x overlay -x iso9660 2>/dev/null | tail -n +2)
+    echo "$best"
+}
+
+
+# The root volume on a GPU AMI is routinely too small for torch + CUDA wheels,
+# let alone weights, while the box has a multi-TB ephemeral NVMe mounted. Move
+# the venv and caches there automatically -- this is the disk layout the p5en
+# run-book prescribes, not an invention.
+_resolve_vllm_env() {
+    [[ "$GPU_PRESENT" == "yes" && "$SKIP_GPU" != "yes" ]] || return 0
+    if [[ "$VLLM_ENV_EXPLICIT" == "yes" ]]; then
+        VLLM_ENV_NOTE="VLLM_ENV was set explicitly; using $VLLM_ENV as given."
+        return 0
+    fi
+    local home_gb
+    home_gb="$(_free_gb "$VLLM_ENV")"
+    [[ -n "$home_gb" ]] || return 0
+    (( home_gb >= VLLM_MIN_FREE_GB )) && return 0
+
+    BIG_VOLUME="$(_pick_big_volume)"
+    if [[ -z "$BIG_VOLUME" ]]; then
+        VLLM_ENV_NOTE="NO_ROOM:${home_gb}"
+        return 0
+    fi
+    local big_gb
+    big_gb="$(_free_gb "$BIG_VOLUME")"
+    VLLM_ENV="$BIG_VOLUME/vllm-env"
+    VLLM_ENV_NOTE="RELOCATED:${home_gb}:${big_gb}"
+}
+
+
+# Hardware-specific warnings the vLLM install would otherwise hit hours later.
+_gpu_advisories() {
+    case "$VLLM_ENV_NOTE" in
+        RELOCATED:*)
+            local home_gb big_gb
+            home_gb="$(echo "$VLLM_ENV_NOTE" | cut -d: -f2)"
+            big_gb="$(echo "$VLLM_ENV_NOTE" | cut -d: -f3)"
+            echo
+            info "DISK: the volume holding \$HOME has only ${home_gb}G free, but this box has a large"
+            info "      volume at $BIG_VOLUME (${big_gb}G free). The vLLM venv and its caches will go"
+            info "      there instead of the root disk:"
+            info "        VLLM_ENV=$VLLM_ENV"
+            info "        UV_CACHE_DIR=$BIG_VOLUME/uv-cache"
+            info "        TMPDIR=$BIG_VOLUME/tmp"
+            info "      This is the disk layout p5en-h200-cuda-fixes.md prescribes. Note the ephemeral"
+            info "      NVMe is WIPED on instance stop/terminate -- weights re-download after a stop."
+            info "      Override with: VLLM_ENV=/your/path $0 --install"
+            ;;
+        NO_ROOM:*)
+            local free_gb
+            free_gb="$(echo "$VLLM_ENV_NOTE" | cut -d: -f2)"
+            echo
+            warn "DISK: only ${free_gb}G free on the volume holding $VLLM_ENV, vLLM plus its torch/CUDA"
+            warn "      wheels want ~${VLLM_MIN_FREE_GB}G before any weights land (a 30B model is another ~57G),"
+            warn "      and no larger volume was found. Attach one, then re-run with:"
+            warn "        VLLM_ENV=/your/large/volume/vllm-env $0 --install"
+            ;;
+    esac
+    if [[ "$INSTANCE_TYPE" == p5* ]] || (( GPU_COUNT >= 8 )); then
+        echo
+        warn "HARDWARE: this looks like an 8-GPU NVSwitch node (${GPU_COUNT}x GPU, ${INSTANCE_TYPE:-unknown type})."
+        warn "      The install scripts were verified on the 4x L40S reference node; this box needs"
+        warn "      extra one-time driver/NVMe/CUDA-JIT fixes documented in:"
+        warn "        $REPO_ROOT/.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md"
+        warn "      Read it before serving a model, or startup fails at KV-cache init."
+    fi
+}
+
+
+_planned_keys() {
+    local key
+    for key in "${COMP_ORDER[@]}"; do
+        if [[ "${COMP_STATE[$key]}" == "plan" ]]; then echo "$key"; fi
+    done
+}
+
+
+_announce_plan() {
+    local planned=() skipped=() present=() key
+    while IFS= read -r key; do [[ -n "$key" ]] && planned+=("$key"); done < <(_planned_keys)
+    for key in "${COMP_ORDER[@]}"; do
+        case "${COMP_STATE[$key]}" in
+            skip)    skipped+=("$key") ;;
+            present) present+=("$key") ;;
+        esac
+    done
+
+    header "Step 2 - Already present"
+    if (( ${#present[@]} == 0 )); then
+        echo "  (nothing -- this is a bare machine)"
+    else
+        for key in "${present[@]}"; do
+            printf '  %-28s %s\n' "${COMP_LABEL[$key]}" "${COMP_DETAIL[$key]}"
+        done
+    fi
+
+    echo
+    rule
+    if (( ${#planned[@]} == 0 )); then
+        echo -e "${BOLD} INSTALL PLAN -- nothing to install, this machine is ready${RESET}"
+    else
+        echo -e "${BOLD} INSTALL PLAN -- ${#planned[@]} component(s) WILL BE INSTALLED${RESET}"
+    fi
+    rule
+    local i=1
+    for key in "${planned[@]}"; do
+        printf ' %2d. %-28s %s\n' "$i" "${COMP_LABEL[$key]}" "${COMP_WHY[$key]}"
+        if [[ -n "${COMP_DETAIL[$key]}" ]]; then printf '     %-28s (%s)\n' "" "${COMP_DETAIL[$key]}"; fi
+        i=$((i + 1))
+    done
+    if (( ${#skipped[@]} > 0 )); then
+        echo
+        echo -e "${BOLD} SKIPPED (${COMP_DETAIL[${skipped[0]}]}):${RESET}"
+        for key in "${skipped[@]}"; do
+            printf '     %-28s %s\n' "${COMP_LABEL[$key]}" "${COMP_WHY[$key]}"
+        done
+    fi
+    rule
+
+    if [[ "$GPU_PRESENT" == "yes" && "$SKIP_GPU" != "yes" ]]; then
+        _gpu_advisories
+    fi
+
+    if [[ "$WITH_OMP" != "yes" || "$WITH_KIRO" != "yes" ]]; then
+        echo
+        info "Optional harnesses NOT in this plan (both ship third-party 'curl | sh' installers,"
+        info "so they are opt-in): re-run with --with-omp and/or --with-kiro to include them."
+        info "On a shared node, review an installer before running it (docs/kiro-cli-setup.md):"
+        info "  curl -fsSL https://cli.kiro.dev/install -o /tmp/kiro-install.sh && less /tmp/kiro-install.sh"
+    fi
+
+    # Warn about sudo up front rather than stalling on a password prompt mid-run.
+    for key in "${planned[@]}"; do
+        case "$key" in
+            node|nvtop|aws|vllm|gh) NEEDS_SUDO="yes" ;;
+        esac
+    done
+    if [[ "$NEEDS_SUDO" == "yes" ]] && ! _sudo_available; then
+        echo
+        warn "Part of this plan needs sudo (apt packages) and passwordless sudo is NOT available."
+        warn "You will be prompted for a password, so do not run this unattended."
+    fi
+}
+
+
+_install_git()      { _apt_install git; }
+_install_aws()      { _apt_install awscli; }
+_install_nvtop()    { _apt_install nvtop; }
+
+
+_install_python() {
+    # uv can supply an interpreter without touching the system Python.
+    _have uv || _install_uv
+    uv python install "3.12"
+}
+
+
+_install_uv() {
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # Appended for the same reason as the export at the top of this file.
+    export PATH="$PATH:$HOME/.local/bin"
+    _have uv || die "uv installed but not on PATH; add \$HOME/.local/bin to PATH and re-run."
+    uv tool update-shell >/dev/null 2>&1 || true
+}
+
+
+_install_node() {
+    _is_apt_system || die "Node >= $MIN_NODE must be installed manually on this distribution."
+    # Canonical vendor domain over HTTPS, as a literal: never build the URL of a
+    # script that is about to run as root. No 'sudo -E' either -- the installer
+    # does not need the caller's environment, so do not hand it to a root shell.
+    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+}
+
+
+# GitHub's own apt repository, verified by their signing key. Preferred over a
+# pipe-to-shell installer: apt checks the signature on every future upgrade too.
+_install_gh() {
+    _is_apt_system || die "gh must be installed manually on this distribution: https://github.com/cli/cli#installation"
+    sudo mkdir -p -m 755 /etc/apt/keyrings
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+    sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y gh
+}
+
+
+# Never guess an identity: a wrong name/email is baked into every commit the
+# machine makes, and rewriting that later is a history rewrite.
+_install_gitconfig() {
+    if [[ -z "$GIT_USER_NAME" || -z "$GIT_USER_EMAIL" ]]; then
+        die "git identity not supplied. Re-run with: --git-name 'Your Name' --git-email you@example.com"
+    fi
+    git config --global user.name "$GIT_USER_NAME"
+    git config --global user.email "$GIT_USER_EMAIL"
+    ok "git identity set: $(git config --global user.name) <$(git config --global user.email)>"
+}
+
+
+_install_claude()   { _npm_global "@anthropic-ai/claude-code"; }
+_install_codex()    { _npm_global "@openai/codex"; }
+_install_pi()       { _npm_global "@earendil-works/pi-coding-agent"; }
+_install_omp()      { curl -fsSL https://omp.sh/install | sh; }
+_install_kiro()     { curl -fsSL https://cli.kiro.dev/install | bash; }
+_install_nvitop()   { uv tool install nvitop; }
+
+
+_install_precommit() {
+    _have pre-commit || uv tool install pre-commit
+    ( cd "$REPO_ROOT" && "$(command -v pre-commit || echo "$HOME/.local/bin/pre-commit")" install )
+}
+
+
+_install_venv_benchmarks() { ( cd "$BENCHMARKS_DIR" && uv sync ); }
+_install_venv_vllm()       { ( cd "$VLLM_DIR" && uv sync ); }
+
+
+_install_vllm() {
+    local installer="$VLLM_DIR/scripts/vllm-install.sh"
+    [[ -x "$installer" ]] || die "vLLM installer not found or not executable: $installer"
+    if [[ -n "$BIG_VOLUME" ]]; then
+        mkdir -p "$BIG_VOLUME/uv-cache" "$BIG_VOLUME/tmp"
+        export UV_CACHE_DIR="$BIG_VOLUME/uv-cache"
+        export TMPDIR="$BIG_VOLUME/tmp"
+        info "Caches redirected to $BIG_VOLUME (uv-cache, tmp) to keep the root disk clear."
+    fi
+    export VLLM_ENV
+    info "Delegating to $installer (the vetted installer: build deps, venv, vLLM, gpustat)."
+    info "VLLM_ENV=$VLLM_ENV"
+    "$installer"
+}
+
+
+_install_one() {
+    local key="$1"
+    case "$key" in
+        git)              _install_git ;;
+        gitconfig)        _install_gitconfig ;;
+        gh)               _install_gh ;;
+        python)           _install_python ;;
+        uv)               _install_uv ;;
+        node)             _install_node ;;
+        claude)           _install_claude ;;
+        codex)            _install_codex ;;
+        pi)               _install_pi ;;
+        aws)              _install_aws ;;
+        precommit)        _install_precommit ;;
+        venv_benchmarks)  _install_venv_benchmarks ;;
+        venv_vllm)        _install_venv_vllm ;;
+        omp)              _install_omp ;;
+        kiro)             _install_kiro ;;
+        nvtop)            _install_nvtop ;;
+        nvitop)           _install_nvitop ;;
+        vllm)             _install_vllm ;;
+        *)                die "no installer defined for '$key'" ;;
+    esac
+}
+
+
+_confirm() {
+    if [[ "$ASSUME_YES" == "yes" ]]; then return 0; fi
+    echo
+    read -r -p "Proceed with the install plan above? [y/N] " reply
+    [[ "$reply" =~ ^[Yy]$ ]] || { info "Nothing installed. Re-run with --install --yes to skip this prompt."; exit 0; }
+}
+
+
+_run_installs() {
+    local planned=() key
+    while IFS= read -r key; do [[ -n "$key" ]] && planned+=("$key"); done < <(_planned_keys)
+    if (( ${#planned[@]} == 0 )); then
+        header "Step 3 - Install"
+        ok "Nothing to install; every component is already present."
+        return
+    fi
+
+    _confirm
+    header "Step 3 - Install (${#planned[@]} component(s))"
+    local total="${#planned[@]}" i=1
+    for key in "${planned[@]}"; do
+        echo
+        echo -e "${BOLD}--- (${i}/${total}) installing ${COMP_LABEL[$key]} ---${RESET}"
+        # Keep going after a failure so one broken component does not block the
+        # rest; the summary reports exactly which ones failed.
+        if _install_one "$key"; then
+            _mark "$key" installed "installed by this run"
+            done_ "(${i}/${total}) ${COMP_LABEL[$key]} -- INSTALLED"
+            INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
+        else
+            _mark "$key" failed "install failed -- see the output above"
+            warn "(${i}/${total}) ${COMP_LABEL[$key]} -- FAILED (continuing)"
+            FAILED_COUNT=$((FAILED_COUNT + 1))
+        fi
+        i=$((i + 1))
+    done
+}
+
+
+_state_plain() {
+    case "$1" in
+        present)   echo "ALREADY PRESENT" ;;
+        installed) echo "INSTALLED" ;;
+        plan)      echo "TO INSTALL" ;;
+        skip)      echo "SKIPPED" ;;
+        failed)    echo "FAILED" ;;
+        *)         echo "$1" ;;
+    esac
+}
+
+
+_state_color() {
+    case "$1" in
+        present|installed) echo "$GREEN" ;;
+        plan)              echo "$YELLOW" ;;
+        skip)              echo "$BLUE" ;;
+        failed)            echo "$RED" ;;
+        *)                 echo "$RESET" ;;
+    esac
+}
+
+
+_summarize() {
+    echo
+    rule
+    if [[ "$MODE" == "check" ]]; then
+        echo -e "${BOLD} SUMMARY -- detection only, nothing was changed${RESET}"
+    else
+        echo -e "${BOLD} SUMMARY -- ${INSTALLED_COUNT} installed, ${FAILED_COUNT} failed${RESET}"
+    fi
+    rule
+    local key
+    for key in "${COMP_ORDER[@]}"; do
+        printf ' %-30s %b%-16s%b %s\n' \
+            "${COMP_LABEL[$key]}" "$(_state_color "${COMP_STATE[$key]}")" \
+            "$(_state_plain "${COMP_STATE[$key]}")" "$RESET" "${COMP_DETAIL[$key]}"
+    done
+    rule
+    echo "  GPU stack (vLLM, nvtop, nvitop): $( [[ "$GPU_PRESENT" == "yes" && "$SKIP_GPU" != "yes" ]] && echo 'INCLUDED -- GPU detected' || echo 'SKIPPED -- no GPU on this instance' )"
+    echo "  Machine: $GPU_SUMMARY"
+
+    header "Next steps"
+    if [[ "$MODE" == "check" ]]; then
+        echo "  1. Re-run with --install to apply the plan above."
+    else
+        if (( FAILED_COUNT > 0 )); then echo "  0. Re-run this script to retry the FAILED component(s); it is idempotent."; fi
+        echo "  1. Open a new shell (or 'export PATH=\$HOME/.local/bin:\$PATH') so newly installed CLIs resolve."
+    fi
+    echo "  2. Wire 'claude' and 'codex' to Amazon Bedrock (codex must be >= 0.144 for the native"
+    echo "     amazon-bedrock provider; 'codex --version' to confirm)"
+    echo "     -- installing them does NOT configure them, and an unconfigured codex silently"
+    echo "     calls api.openai.com and 401s mid-run:"
+    echo "       $REPO_ROOT/benchmarks/docs/agent-cli-bedrock-setup.md"
+    echo "  3. Authenticate the GitHub CLI (interactive, cannot be scripted): gh auth login"
+    echo "  4. Create your runner config:  cp $BENCHMARKS_DIR/config/runner.example.yaml $BENCHMARKS_DIR/config/runner.yaml"
+    echo "  5. Smoke-test the harness:     cd $BENCHMARKS_DIR && uv run python -m unittest discover -s tests"
+    echo "     (stdlib unittest, which is what CI runs -- pytest is not a declared dependency)"
+    if [[ "$GPU_PRESENT" == "yes" && "$SKIP_GPU" != "yes" ]]; then
+        echo "  6. Serve a model: read $VLLM_DIR/models/<model>.md first, then self-hosted/vllm/scripts/vllm-serve.sh"
+    fi
+    if [[ "$WITH_KIRO" == "yes" ]]; then
+        echo "  7. kiro-cli needs an interactive sign-in: 'kiro-cli login' (see docs/kiro-cli-setup.md)"
+    fi
+    echo
+}
+
+
+main() {
+    _parse_args "$@"
+    echo -e "${BOLD}setup-machine.sh -- dependency check for $REPO_ROOT${RESET}"
+    echo "Mode: $MODE"
+    _report_machine
+    _resolve_vllm_env
+    _detect_core
+    _detect_gpu_stack
+    _announce_plan
+    if [[ "$MODE" == "install" ]]; then _run_installs; fi
+    _summarize
+    if (( FAILED_COUNT > 0 )); then exit 1; fi
+    exit 0
+}
+
+main "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,19 @@ This repository benchmarks how well LLMs perform real agentic coding tasks with 
 
 The harness drives the full flow: pre-flight checks, running the benchmark over a dataset, and scoring the resulting artifacts with a judge.
 
+### First step on a new machine
+
+Before running or debugging a benchmark on a box you have not used before, run the **`setup-machine` skill** -- it is the first step of onboarding this repo onto new hardware:
+
+```bash
+.claude/skills/setup-machine/setup-machine.sh --check     # report only, install nothing
+.claude/skills/setup-machine/setup-machine.sh --install --git-name "..." --git-email "..."
+```
+
+It inspects the instance, names every missing dependency and why the repo needs it, installs them, and prints a summary. The GPU stack (vLLM, nvtop, nvitop) is included only when a GPU is actually present, and on a box with a small root disk the vLLM venv and its caches are placed on the large ephemeral NVMe. Full details: [.claude/skills/setup-machine/SKILL.md](.claude/skills/setup-machine/SKILL.md).
+
+`--check` on its own is also the fast answer to "why is `uv` / `claude` / `codex` not found". Installing the CLIs does **not** wire them to Bedrock -- that is a separate step ([benchmarks/docs/agent-cli-bedrock-setup.md](benchmarks/docs/agent-cli-bedrock-setup.md)).
+
 ## Agent behavior
 
 ### Do not explore proactively
@@ -54,7 +67,7 @@ When a task is unscoped, the source worth reading lives under `benchmarks/` and 
 │   │   ├── runner_config.py      # RunnerConfig Pydantic model (config source of truth)
 │   │   ├── codex_judge.py        # scores artifacts (the judge)
 │   │   └── plot_*.py             # result charts
-│   ├── tests/                    # pytest suite for the harness
+│   ├── tests/                    # unittest suite for the harness
 │   └── docs/                     # harness-specific docs
 ├── self-hosted/                  # vLLM self-hosting path on EC2 (Path 3)
 │   └── vllm/                     # its own uv project
@@ -64,9 +77,9 @@ When a task is unscoped, the source worth reading lives under `benchmarks/` and 
 │       ├── config/               # serving config
 │       ├── models/               # model docs
 │       ├── pricing.json          # instance pricing for cost derivation
-│       └── tests/                # pytest suite
+│       └── tests/                # unittest suite
 ├── docs/                         # cross-cutting docs: results, comparisons, methodology, slides
-├── .claude/skills/               # repo skills (benchmark, swe/swe2/swe3, throughput, vllm-setup, security-check)
+├── .claude/skills/               # repo skills (setup-machine, benchmark, swe/swe2/swe3, throughput, vllm-setup, security-check)
 └── .github/                      # CI workflows and repo metadata
 ```
 
@@ -93,10 +106,10 @@ uv run bandit -r src/
 uv run mypy src/
 
 # Tests
-uv run pytest
+uv run python -m unittest discover -s tests
 
 # All checks in one line
-uv run ruff check --fix . && uv run ruff format . && uv run bandit -r src/ && uv run mypy src/ && uv run pytest
+uv run ruff check --fix . && uv run ruff format . && uv run bandit -r src/ && uv run mypy src/ && uv run python -m unittest discover -s tests
 ```
 
 After editing a single Python file, run `uv run python -m py_compile <filename>`, then `uv run ruff format <filename>`, then `uv run ruff check --fix <filename>`. After editing a shell script, run `bash -n <filename>`.
@@ -246,20 +259,23 @@ def process_data(data: dict) -> dict:
 
 ## Testing
 
-- Use `pytest` as the primary framework, with `pytest-cov` for coverage.
+- Use the standard library's `unittest` as the test framework. Both projects' suites are `unittest`, and [.github/workflows/test.yml](.github/workflows/test.yml) runs them with `uv run python -m unittest discover -s tests`. Neither project declares `pytest`, so `uv run pytest` fails on a correctly set-up machine -- do not reach for it, and do not add it without agreeing the dependency first.
 - Follow the AAA pattern (Arrange, Act, Assert); one assertion per test where possible.
-- Use descriptive test names, fixtures for shared data, and mock external dependencies.
+- Use descriptive test names, `setUp`/helper methods for shared fixtures, and `unittest.mock` for external dependencies.
 - Test both happy paths and error cases.
 - Run the full test suite before submitting a PR and after major features or refactors. A PR with failing tests should never be merged.
 
 ```python
-class TestFeatureName:
+import unittest
+
+
+class TestFeatureName(unittest.TestCase):
     def test_happy_path(self):
         result = function_under_test({"key": "value"})
-        assert result["status"] == "success"
+        self.assertEqual(result["status"], "success")
 
     def test_error_handling(self):
-        with pytest.raises(ValueError, match="Invalid input"):
+        with self.assertRaisesRegex(ValueError, "Invalid input"):
             function_under_test(None)
 ```
 
@@ -487,6 +503,7 @@ Read the doc that covers what you are about to do rather than rediscovering it. 
 
 **Machine setup -- do this before any benchmark run:**
 
+- [.claude/skills/setup-machine/SKILL.md](.claude/skills/setup-machine/SKILL.md) -- the `setup-machine` skill: inspects the instance, reports every missing dependency, and installs it (adding vLLM, nvtop and nvitop only when a GPU is present). Start here on a fresh box; `setup-machine.sh --check` alone is a fast answer to "why is `uv` / `claude` / `codex` not found".
 - [benchmarks/docs/agent-cli-bedrock-setup.md](benchmarks/docs/agent-cli-bedrock-setup.md) -- wiring `codex` (the judge) and `claude` to Amazon Bedrock. **Working AWS credentials are not sufficient**: an unconfigured `codex` ignores them and 401s against `api.openai.com`, so prove it with a real call before starting a long run.
 - [docs/kiro-cli-setup.md](docs/kiro-cli-setup.md) -- kiro-cli's own sign-in and its credit-based cost basis.
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ This is option 2 above -- building your own frontier on your own code. It is a f
 
 ## Prerequisites
 
+> **On a fresh machine, start with the [`/setup-machine` skill](.claude/skills/setup-machine/SKILL.md).** It inspects the box, prints exactly what it will install and why, installs it, and summarizes -- so you do not have to work through the list below by hand. It also installs the GPU stack (vLLM, nvtop, nvitop) only when a GPU is actually present, and puts the vLLM venv and its caches on the large ephemeral NVMe when the root disk is too small.
+
 - An **AWS account** with [Amazon Bedrock model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enabled for the models you want (Paths 1 and 2).
 - **AWS credentials** configured locally (`aws configure`, an IAM role, or AWS SSO).
 - **[Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)** installed.
@@ -227,7 +229,20 @@ This is option 2 above -- building your own frontier on your own code. It is a f
 
 ## Get started
 
-1. **Set up the harness** (its own isolated virtual environment):
+1. **Set up the machine -- do this first on any new box.** Run the **`/setup-machine` skill** from Claude Code (or its script directly). It reports what the instance is, lists every missing dependency with the reason each one is needed, installs them, and prints a summary table:
+
+   ```bash
+   # Dry run: report only, install nothing
+   .claude/skills/setup-machine/setup-machine.sh --check
+
+   # Install everything missing (git identity is required, never guessed)
+   .claude/skills/setup-machine/setup-machine.sh --install \
+       --git-name "Your Name" --git-email "you@example.com"
+   ```
+
+   Add `--with-omp` / `--with-kiro` to include those two harnesses (opt-in: both ship third-party install scripts, and kiro-cli needs an interactive sign-in). See [.claude/skills/setup-machine/SKILL.md](.claude/skills/setup-machine/SKILL.md) for the full component list and flags.
+
+2. **Set up the harness** (its own isolated virtual environment):
 
    ```bash
    cd benchmarks
@@ -235,7 +250,9 @@ This is option 2 above -- building your own frontier on your own code. It is a f
    cp config/runner.example.yaml config/runner.yaml
    ```
 
-2. **Run a benchmark.** The fastest way is the **`/benchmark` skill** from Claude Code, which drives the whole flow interactively -- pre-flight checks, the harness run over a dataset, and the judge -- for any of the three paths. It even manages the vLLM server and metrics collector for the self-hosted path:
+3. **Wire the agent CLIs to Amazon Bedrock.** Installing `claude` and `codex` does not configure them -- an unconfigured `codex` silently calls `api.openai.com` and 401s mid-run. Follow [benchmarks/docs/agent-cli-bedrock-setup.md](benchmarks/docs/agent-cli-bedrock-setup.md).
+
+4. **Run a benchmark.** The fastest way is the **`/benchmark` skill** from Claude Code, which drives the whole flow interactively -- pre-flight checks, the harness run over a dataset, and the judge -- for any of the three paths. It even manages the vLLM server and metrics collector for the self-hosted path:
 
    ```
    /benchmark provider=vllm model=qwen3.6-35b dataset=dataset/mcp-gateway-registry.yaml
@@ -243,12 +260,12 @@ This is option 2 above -- building your own frontier on your own code. It is a f
 
    Prefer a script? The same flow runs headless via [benchmarks/scripts/run-e2e-benchmark.sh](benchmarks/scripts/run-e2e-benchmark.sh) (`--provider bedrock|litellm|vllm --model ... --dataset ...`).
 
-3. **Pick a path and follow its guide** for the setup details each one needs -- every guide ends with a copy-pasteable run command:
+5. **Pick a path and follow its guide** for the setup details each one needs -- every guide ends with a copy-pasteable run command:
    - [Path 1 - Anthropic models directly on Amazon Bedrock](benchmarks/docs/path-anthropic-on-bedrock.md)
    - [Path 2 - open-weight models on Amazon Bedrock via a LiteLLM proxy](benchmarks/docs/path-open-weight-on-bedrock-litellm.md)
    - [Path 3 - self-hosted open-weight models on EC2 with vLLM](benchmarks/docs/path-self-hosted-vllm.md)
 
-4. **Read the shared mechanics** once (they apply to every path): the [harness reference](benchmarks/docs/harness-reference.md) covers the dataset format, the runner config, running the benchmark, the metrics file, and the judge.
+6. **Read the shared mechanics** once (they apply to every path): the [harness reference](benchmarks/docs/harness-reference.md) covers the dataset format, the runner config, running the benchmark, the metrics file, and the judge.
 
 For Path 3 you must first stand up the vLLM server itself -- see [self-hosted/vllm/README.md](self-hosted/vllm/README.md) (or let the `/benchmark` skill start it for you).
 
@@ -266,8 +283,10 @@ claude-code-multi-model/
 ├── .github/                   Issue and pull-request templates
 ├── .claude/                   ← Claude Code skills shipped with the repo
 │   └── skills/
+│       ├── setup-machine/     /setup-machine — inspect a fresh box, install every dependency (start here)
 │       ├── benchmark/         /benchmark — run one end-to-end benchmark (service + harness + judge)
-│       ├── swe/               /swe — drive a model through a SWE task on any repo
+│       ├── swe/, swe2/, swe3/ /swe* — drive a model through a SWE task on any repo (swe3 is the default)
+│       ├── throughput/        /throughput — sweep a served model's throughput
 │       ├── security-check/    /security-check — Cipher security review + fix before any commit
 │       └── vllm-setup/        /vllm-setup — stand up the EC2 vLLM server (Path 3)
 ├── benchmarks/                ← The benchmark harness and results
@@ -294,6 +313,7 @@ Where to read more, by topic:
 
 | Document | What it covers |
 |----------|----------------|
+| [.claude/skills/setup-machine/SKILL.md](.claude/skills/setup-machine/SKILL.md) | **Start here on a new machine.** What `/setup-machine` inspects and installs, why each component is needed, where the vLLM venv lands on a small root disk, and what it deliberately does not do. |
 | [docs/results-swe3.md](docs/results-swe3.md) / [docs/results-swe2.md](docs/results-swe2.md) | Full benchmark results per skill: task-by-task tables, per-model leaderboard, cost/quality frontier, hardware, and what the data says. |
 | [docs/vision.md](docs/vision.md) | The north star: a cost-aware harness that routes each task (and each phase) to the right model on the frontier -- frontier / workhorse / budget -- switching automatically. |
 | [benchmarks/README.md](benchmarks/README.md) | The benchmark harness landing page: the three hosting paths, how a run works, and how to reproduce the results above. |


### PR DESCRIPTION
## Summary

Onboarding this repo onto a new machine meant reading the pre-flight checks in `run-e2e-benchmark.sh` and installing a dozen things by hand, discovering each missing one as a command-not-found partway into a benchmark run. This PR adds a `setup-machine` skill that does it in one step: it reports what the instance is, names every missing dependency **with the reason the repo needs it**, installs them, and prints a summary table.

```bash
.claude/skills/setup-machine/setup-machine.sh --check     # report only, install nothing
.claude/skills/setup-machine/setup-machine.sh --install --yes \
    --git-name "Your Name" --git-email "you@example.com"
```

## What it installs

Core, on every instance: `git` plus a global git identity, `gh`, Python 3.10+ (via `uv python`, leaving the system Python alone), Node.js 22+, `uv`, the `claude` / `codex` / `pi` CLIs, the AWS CLI, `pre-commit` plus the repo hook, and a synced venv for each of the two `uv` projects.

GPU only: **vLLM, nvtop, nvitop**. With at least one GPU visible to `nvidia-smi` those three are in the plan; without one they are reported as `SKIPPED`, never silently dropped, and never installed on a CPU-only box where they are useless. The script also distinguishes "no NVIDIA hardware" from "hardware present but the driver is missing" and refuses to attempt vLLM in the second case, because it would fail.

vLLM itself is **delegated** to `self-hosted/vllm/scripts/vllm-install.sh`, the vetted installer that already handles the two Deep Learning AMI fixes, rather than reimplemented here.

`omp` and `kiro-cli` are opt-in via `--with-omp` / `--with-kiro`.

## Where the vLLM venv lands

A GPU AMI's root disk is routinely ~29G, which does not hold torch and the CUDA wheels, let alone weights -- while the same box has a multi-TB ephemeral NVMe mounted. Rather than failing partway through a download, the script resolves this: an explicit `VLLM_ENV` always wins; otherwise, if `$HOME`'s volume has under 40G free, it puts the venv, `UV_CACHE_DIR` and `TMPDIR` on the large volume, preferring `/opt/dlami/nvme` by name exactly as `p5en-h200-cuda-fixes.md` prescribes. It reports the relocation and notes that the ephemeral NVMe is wiped on instance stop. `tmpfs` is excluded from that search because `/dev/shm` can advertise a terabyte but is RAM. If the root disk is tight and no large volume exists, it warns and stops rather than installing into a volume that cannot hold it.

## Security notes

This is a privileged script -- it runs `sudo apt-get`, writes to `/etc/apt/`, and pipes vendor installers into a shell -- so the design points are worth stating:

- **`gh` does not use pipe-to-shell.** It installs from GitHub's own apt repo and keyring, so apt verifies signatures on every future upgrade too.
- **Every installer URL is a literal on a canonical vendor domain.** No URL is assembled from a variable (pattern R5).
- **`$HOME/.local/bin` is appended to PATH, not prepended.** The script invokes `curl`, `dpkg`, `tee` and `apt-get` under `sudo`; a user-writable directory ahead of the system paths could shadow them. Appending still resolves `uv` and the uv-installed tools, which exist nowhere else.
- **`omp` and `kiro-cli` are opt-in** because both ship third-party pipe-to-shell installers and kiro additionally needs an interactive sign-in. The script prints a download-then-review path for each.
- **The git identity is never guessed.** `--git-name` / `--git-email` are required for that component; a wrong name/email is baked into every commit the machine makes, and fixing it later is a history rewrite. Those flags also reject a missing or flag-shaped value, so `--git-name --install` fails loudly instead of configuring a `user.name` of `--install`.
- **IMDSv2 is used only for the instance type**, never the credentials path.

## AGENTS.md test-framework correction

AGENTS.md documented `pytest` for tests, but `pytest` is not a declared dependency in either project: the suites are stdlib `unittest` and CI runs `uv run python -m unittest discover -s tests` (`.github/workflows/test.yml`). Following AGENTS.md therefore produced a spurious setup failure on a correctly provisioned machine. The commands, the example test, and the framework guidance are corrected, and the guidance now warns that `uv run pytest` fails.

## Documentation

The skill is documented as the **first step on a new machine** in both `README.md` (Prerequisites note, Get started step 1, documentation map) and `AGENTS.md` (a new "First step on a new machine" subsection under the project overview). A step was also added to `README.md`'s Get started for wiring the CLIs to Bedrock, since installing them does not configure them and an unconfigured `codex` silently calls `api.openai.com` and 401s mid-run. The stale skills tree in `README.md` is brought up to date (it was missing `setup-machine`, `swe2`, `swe3` and `throughput`).

## Testing

- `bash -n setup-machine.sh` clean.
- Run end to end on a **p5en.48xlarge (8x H200, driver 595.71.05)**: installed the full core plus the GPU stack, relocated the vLLM venv to `/opt/dlami/nvme` (the NVMe absorbed 7.7G while root moved only 16G -> 18G), and re-ran to confirm idempotency -- the second run correctly reported everything as `ALREADY PRESENT`.
- Flag validation verified: `--git-name` with no value and `--git-email --install` both exit 1 with a clear message; valid values still parse.
- Tool detection verified from a shell **without** `~/.local/bin` on PATH, confirming the appended-PATH change still finds `uv`, `pre-commit` and `nvitop`.
- `benchmarks/`: 296 tests pass. `self-hosted/vllm/`: 18 tests pass. All pre-commit hooks pass.
- `/security-check` (Cipher) run over the diff: **APPROVED WITH CHANGES**, both changes applied (the PATH ordering and the flag-value validation above).
