### PR TITLE
benchmark: omp /swe3 results on mcp-gateway-registry-v2 for the three Anthropic models on Bedrock

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 11,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 59,
+      "notes": "The issue clearly identifies dependency drift, names projects and Dockerfiles, and supplies mostly testable acceptance criteria and non-goals. Its central claim that either `uv sync --frozen` or `--locked` fails for a stale lock is wrong: uv documents that `--frozen` skips freshness checking, while `--locked` performs it.  It also says `Dockerfile.scopes-init` installs `auth_server`, whereas the implementation later calls it a non-Python BusyBox image. No independent task statement was supplied, and repository shell failure prevented confirmation that exactly four lockfiles were missing."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 8,
+      "specificity": 14,
+      "risk_awareness": 10,
+      "total": 46,
+      "notes": "The LLD usefully names dependency roots, workflow integration points, expected files, and the intended build flow. Its load-bearing decision is incorrect because it selects `uv sync --frozen` while asserting stale-lock rejection, which requires `--locked`; `--frozen` uses the existing lock without checking whether it is current.  It also claims locked builds need no package-index network access even though the submitted locks merely reference downloadable distributions, and it does not analyze how `uv sync` differs from the existing requirements-only installation. Several Dockerfiles remain marked TBD or \"to be verified\" while the document simultaneously declares no open questions, so it is not implementation-ready."
+    },
+    "review": {
+      "completeness": 11,
+      "correctness": 7,
+      "specificity": 12,
+      "risk_awareness": 9,
+      "total": 39,
+      "notes": "The strongest findings are the concrete requests to test the registry's subsequent editable install, document lock regeneration, and exercise runtime smoke tests. The review nevertheless approves the core design without catching that `--frozen` does not validate lock freshness, despite that being the feature's principal promised failure mode.  It repeats unsupported claims that lockfiles eliminate build-time network requirements and detect lockfile tampering, and its security and SRE sections largely restate benefits rather than stress the mechanism. The claimed `Dockerfile.registry` line-58 behavior and exact lockfile sizes could not be independently verified because repository command execution failed."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 6,
+      "specificity": 17,
+      "risk_awareness": 14,
+      "total": 52,
+      "notes": "The plan spans lock generation, image builds, stale-lock negatives, CI, compatibility, and a runtime health check with concrete commands. Its key negative oracle is invalid because `uv sync --frozen` is not expected to reject an outdated lock; that behavior belongs to `--locked`.  The mutation appends an array element blindly to the end of `pyproject.toml`, which may only test TOML parsing, and from `auth_server/` it incorrectly references `../../docker/Dockerfile.auth` and `../../` rather than the repository parent. It builds only auth and registry images, merely checks package names rather than locked versions, and includes destructive cleanup with `git reset --hard`."
+    },
+    "implementation": {
+      "completeness": 9,
+      "correctness": 5,
+      "specificity": 15,
+      "risk_awareness": 6,
+      "total": 35,
+      "notes": "The patch summary describes four generated locks, two Dockerfile conversions, workflow triggers, CI validation, and an optional hook, so it implements part of the stated design. It misses other package-installing images implied by the acceptance criteria while claiming no deviations, and its use of `uv sync --frozen` does not provide the advertised stale-lock failure.  The visible pre-commit command swallows every validation failure with `|| true`, and its hunk also deletes the existing shell-hook `exclude: ^(docker/|scripts/setup/)`, creating unrelated behavior change. Full applicability and generated-lock consistency could not be checked because the submitted diff was truncated and the repository shell failed before executing `git apply --check`."
+    }
+  },
+  "task_score": 46.2,
+  "verdict": "The submission is concrete and broad but is undermined by choosing `--frozen` for a requirement that needs `--locked`, incomplete Docker coverage, and an implementation hook that cannot fail.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:35:38.002565Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 898272,
+      "cached_input_tokens": 730750,
+      "cache_write_input_tokens": 128925,
+      "output_tokens": 9592,
+      "reasoning_output_tokens": 7542
+    },
+    "duration_ms": 150928
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "docker",
+    "build",
+    "uv",
+    "dependencies",
+    "reproducibility",
+    "ci",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 94.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 314,
+    "output_tokens": 29614,
+    "cache_read_tokens": 3811741,
+    "cache_write_tokens": 67885,
+    "total_tokens": 3909554,
+    "total_cost_usd": 0.61441435,
+    "latency_seconds": 313.7,
+    "num_turns": 52,
+    "generation_tokens_per_sec": 94.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 314,
+  "output_tokens": 29614,
+  "latency_seconds": 313.7,
+  "num_turns": 52,
+  "total_cost_usd": 0.61441435,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3811741,
+  "cache_creation_tokens": 67885,
+  "run_started_at": "2026-08-30T19:47:14.553739Z",
+  "run_ended_at": "2026-08-30T19:52:28.281692Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 314,
+    "output_tokens": 29614,
+    "cache_read_tokens": 3811741,
+    "cache_write_tokens": 67885,
+    "total_tokens": 3909554,
+    "total_cost_usd": 0.61441435,
+    "latency_seconds": 313.7,
+    "num_turns": 52,
+    "generation_tokens_per_sec": 94.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "build-docker-images-from-uv-lock",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 11,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 59,
+        "notes": "The issue clearly identifies dependency drift, names projects and Dockerfiles, and supplies mostly testable acceptance criteria and non-goals. Its central claim that either `uv sync --frozen` or `--locked` fails for a stale lock is wrong: uv documents that `--frozen` skips freshness checking, while `--locked` performs it.  It also says `Dockerfile.scopes-init` installs `auth_server`, whereas the implementation later calls it a non-Python BusyBox image. No independent task statement was supplied, and repository shell failure prevented confirmation that exactly four lockfiles were missing."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 8,
+        "specificity": 14,
+        "risk_awareness": 10,
+        "total": 46,
+        "notes": "The LLD usefully names dependency roots, workflow integration points, expected files, and the intended build flow. Its load-bearing decision is incorrect because it selects `uv sync --frozen` while asserting stale-lock rejection, which requires `--locked`; `--frozen` uses the existing lock without checking whether it is current.  It also claims locked builds need no package-index network access even though the submitted locks merely reference downloadable distributions, and it does not analyze how `uv sync` differs from the existing requirements-only installation. Several Dockerfiles remain marked TBD or \"to be verified\" while the document simultaneously declares no open questions, so it is not implementation-ready."
+      },
+      "review": {
+        "completeness": 11,
+        "correctness": 7,
+        "specificity": 12,
+        "risk_awareness": 9,
+        "total": 39,
+        "notes": "The strongest findings are the concrete requests to test the registry's subsequent editable install, document lock regeneration, and exercise runtime smoke tests. The review nevertheless approves the core design without catching that `--frozen` does not validate lock freshness, despite that being the feature's principal promised failure mode.  It repeats unsupported claims that lockfiles eliminate build-time network requirements and detect lockfile tampering, and its security and SRE sections largely restate benefits rather than stress the mechanism. The claimed `Dockerfile.registry` line-58 behavior and exact lockfile sizes could not be independently verified because repository command execution failed."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 6,
+        "specificity": 17,
+        "risk_awareness": 14,
+        "total": 52,
+        "notes": "The plan spans lock generation, image builds, stale-lock negatives, CI, compatibility, and a runtime health check with concrete commands. Its key negative oracle is invalid because `uv sync --frozen` is not expected to reject an outdated lock; that behavior belongs to `--locked`.  The mutation appends an array element blindly to the end of `pyproject.toml`, which may only test TOML parsing, and from `auth_server/` it incorrectly references `../../docker/Dockerfile.auth` and `../../` rather than the repository parent. It builds only auth and registry images, merely checks package names rather than locked versions, and includes destructive cleanup with `git reset --hard`."
+      },
+      "implementation": {
+        "completeness": 9,
+        "correctness": 5,
+        "specificity": 15,
+        "risk_awareness": 6,
+        "total": 35,
+        "notes": "The patch summary describes four generated locks, two Dockerfile conversions, workflow triggers, CI validation, and an optional hook, so it implements part of the stated design. It misses other package-installing images implied by the acceptance criteria while claiming no deviations, and its use of `uv sync --frozen` does not provide the advertised stale-lock failure.  The visible pre-commit command swallows every validation failure with `|| true`, and its hunk also deletes the existing shell-hook `exclude: ^(docker/|scripts/setup/)`, creating unrelated behavior change. Full applicability and generated-lock consistency could not be checked because the submitted diff was truncated and the repository shell failed before executing `git apply --check`."
+      }
+    },
+    "task_score": 46.2,
+    "verdict": "The submission is concrete and broad but is undermined by choosing `--frozen` for a requirement that needs `--locked`, incomplete Docker coverage, and an implementation hook that cannot fail.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:35:38.002565Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 898272,
+        "cached_input_tokens": 730750,
+        "cache_write_input_tokens": 128925,
+        "output_tokens": 9592,
+        "reasoning_output_tokens": 7542
+      },
+      "duration_ms": 150928
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 13,
+      "total": 67,
+      "notes": "The issue clearly identifies five flags, explicit exclusions, and mostly testable acceptance criteria. Its largest defect is an internal contradiction: the root cause says configure_egress_auth already accepts custom parameters, while the implementation notes and submitted diff add those parameters. The client diff's original signature supports the latter account, making the former materially inaccurate. Partial-update behavior and issue #1601 could not be verified, and no independent task statement was supplied."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 13,
+      "specificity": 22,
+      "risk_awareness": 12,
+      "total": 67,
+      "notes": "The LLD provides concrete changes for cmd_egress_configure, RegistryClient.configure_egress_auth, argparse flags, and request-body keys, closely matching the submitted patch. Its largest flaw is treating omission of fields as proven partial-update semantics without showing that the POST route merges omitted values with persisted configuration before validation. The design also asserts logging, storage, defaults, and deployment behavior without demonstrating those paths. Local repository execution failed before commands ran, so cited line numbers and server-side claims could not be independently confirmed."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 8,
+      "specificity": 13,
+      "risk_awareness": 7,
+      "total": 41,
+      "notes": "The review offers some concrete checks around argparse choices, optional parameters, documentation, and release notes. Its largest deficiency is unanimous approval without challenging the design's unproven partial-update assumption, which is central to the proposed behavior. It further claims resolve_provider verifies reachability and trust, that non-custom providers produce a specific 400 response, and that fields are indexed, without supporting evidence. It marks default clarification as resolved even though the displayed LLD docstring does not document the post_body default."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 7,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 53,
+      "notes": "The plan covers help output, enum rejection, request fields, omission behavior, integration, and persistence with concrete expected values. However, its unit test mocks client.session.post while the submitted implementation shows configure_egress_auth calling self._make_request, so it may observe the wrong interface. Test 1.1.3 never invokes parsing or asserts anything, and the request-body expression can yield None when the call has one positional argument despite a json keyword. The plan also assumes unverified partial-update and non-custom-provider error behavior while declaring backward compatibility not applicable instead of testing it."
+    },
+    "implementation": {
+      "completeness": 15,
+      "correctness": 17,
+      "specificity": 18,
+      "risk_awareness": 8,
+      "total": 58,
+      "notes": "The submitted code coherently adds all five argparse flags, forwards them through cmd_egress_configure, extends configure_egress_auth, and conditionally adds the corresponding request keys. The largest defect is that implementation.md claims a three-file, 232-line patch including 186 lines of tests, while the actual diff contains only the two production files and approximately 46 additions. The summary also says verification was not executed but later claims unit tests pass, and it overstates unproven partial-update semantics. Patch applicability and repository conventions could not be independently confirmed because the read-only executor failed before running git apply --check or source inspection."
+    }
+  },
+  "task_score": 57.2,
+  "verdict": "The core production diff is plausible and focused, but unsupported update semantics, defective test designs, absent promised tests, and contradictory implementation claims substantially limit confidence.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:37:45.762774Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 265341,
+      "cached_input_tokens": 171390,
+      "cache_write_input_tokens": 35465,
+      "output_tokens": 10634,
+      "reasoning_output_tokens": 8564
+    },
+    "duration_ms": 127748
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "cli",
+    "python",
+    "egress-auth",
+    "oauth",
+    "api-parity",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 4.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 40,
+    "output_tokens": 1603,
+    "cache_read_tokens": 708803,
+    "cache_write_tokens": 7453,
+    "total_tokens": 717899,
+    "total_cost_usd": 0.08825155000000001,
+    "latency_seconds": 334.1,
+    "num_turns": 60,
+    "generation_tokens_per_sec": 4.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 40,
+  "output_tokens": 1603,
+  "latency_seconds": 334.1,
+  "num_turns": 60,
+  "total_cost_usd": 0.08825155000000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 708803,
+  "cache_creation_tokens": 7453,
+  "run_started_at": "2026-08-30T19:59:12.437408Z",
+  "run_ended_at": "2026-08-30T20:04:46.521434Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 40,
+    "output_tokens": 1603,
+    "cache_read_tokens": 708803,
+    "cache_write_tokens": 7453,
+    "total_tokens": 717899,
+    "total_cost_usd": 0.08825155000000001,
+    "latency_seconds": 334.1,
+    "num_turns": 60,
+    "generation_tokens_per_sec": 4.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "cli-custom-egress-oauth-provider-flags",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 13,
+        "total": 67,
+        "notes": "The issue clearly identifies five flags, explicit exclusions, and mostly testable acceptance criteria. Its largest defect is an internal contradiction: the root cause says configure_egress_auth already accepts custom parameters, while the implementation notes and submitted diff add those parameters. The client diff's original signature supports the latter account, making the former materially inaccurate. Partial-update behavior and issue #1601 could not be verified, and no independent task statement was supplied."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 13,
+        "specificity": 22,
+        "risk_awareness": 12,
+        "total": 67,
+        "notes": "The LLD provides concrete changes for cmd_egress_configure, RegistryClient.configure_egress_auth, argparse flags, and request-body keys, closely matching the submitted patch. Its largest flaw is treating omission of fields as proven partial-update semantics without showing that the POST route merges omitted values with persisted configuration before validation. The design also asserts logging, storage, defaults, and deployment behavior without demonstrating those paths. Local repository execution failed before commands ran, so cited line numbers and server-side claims could not be independently confirmed."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 8,
+        "specificity": 13,
+        "risk_awareness": 7,
+        "total": 41,
+        "notes": "The review offers some concrete checks around argparse choices, optional parameters, documentation, and release notes. Its largest deficiency is unanimous approval without challenging the design's unproven partial-update assumption, which is central to the proposed behavior. It further claims resolve_provider verifies reachability and trust, that non-custom providers produce a specific 400 response, and that fields are indexed, without supporting evidence. It marks default clarification as resolved even though the displayed LLD docstring does not document the post_body default."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 7,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 53,
+        "notes": "The plan covers help output, enum rejection, request fields, omission behavior, integration, and persistence with concrete expected values. However, its unit test mocks client.session.post while the submitted implementation shows configure_egress_auth calling self._make_request, so it may observe the wrong interface. Test 1.1.3 never invokes parsing or asserts anything, and the request-body expression can yield None when the call has one positional argument despite a json keyword. The plan also assumes unverified partial-update and non-custom-provider error behavior while declaring backward compatibility not applicable instead of testing it."
+      },
+      "implementation": {
+        "completeness": 15,
+        "correctness": 17,
+        "specificity": 18,
+        "risk_awareness": 8,
+        "total": 58,
+        "notes": "The submitted code coherently adds all five argparse flags, forwards them through cmd_egress_configure, extends configure_egress_auth, and conditionally adds the corresponding request keys. The largest defect is that implementation.md claims a three-file, 232-line patch including 186 lines of tests, while the actual diff contains only the two production files and approximately 46 additions. The summary also says verification was not executed but later claims unit tests pass, and it overstates unproven partial-update semantics. Patch applicability and repository conventions could not be independently confirmed because the read-only executor failed before running git apply --check or source inspection."
+      }
+    },
+    "task_score": 57.2,
+    "verdict": "The core production diff is plausible and focused, but unsupported update semantics, defective test designs, absent promised tests, and contradictory implementation claims substantially limit confidence.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:37:45.762774Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 265341,
+        "cached_input_tokens": 171390,
+        "cache_write_input_tokens": 35465,
+        "output_tokens": 10634,
+        "reasoning_output_tokens": 8564
+      },
+      "duration_ms": 127748
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 76,
+      "notes": "The issue clearly defines the hardcoded timeout problem, backward-compatible default, explicit non-goals, and mostly testable acceptance criteria. The submitted source context supports the named Settings field, auth_server/server.py call site, admin configuration entry, and deployment surfaces. Its largest gap is failure semantics: it does not decide whether values below five seconds reject startup or are silently floored, and it treats an HTTPX timeout as a simple total-call deadline. No independent task statement establishes that admin exposure, every deployment surface, or the five-second minimum was actually required."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 11,
+      "specificity": 20,
+      "risk_awareness": 12,
+      "total": 60,
+      "notes": "The LLD is unusually concrete about files, configuration names, defaults, call flow, and deployment wiring. However, it names a nonexistent _BASIC_CONFIG_ENTRIES integration point where the patch context shows CONFIG_GROUPS, and its proposed Helm stringData/quote change conflicts with the repository's data/b64enc pattern. The ge=5.0 Settings constraint can reject startup before the reader's flooring or invalid-environment fallback executes, leaving the central validation behavior internally inconsistent. It also omits tests and unified-parameter-reference.md from its final modified-file list and gives little treatment to resource retention, surrounding proxy deadlines, observability, or rollback."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 7,
+      "specificity": 13,
+      "risk_awareness": 6,
+      "total": 36,
+      "notes": "The review offers a few concrete follow-ups, including invalid-value testing, startup logging, and timeout metrics. Its largest deficiency is unanimous approval despite material design contradictions around startup validation, environment fallback, the config symbol, and Helm encoding. It incorrectly describes HTTPX as raising TimeoutError and rationalizes storing a non-secret timeout in a Secret rather than simply recognizing the repository's existing convention. It does not examine prolonged resource occupancy, outer load-balancer timeouts, missing documentation/tests, or the unresolved reject-versus-floor behavior."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 5,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 46,
+      "notes": "The plan provides concrete expected values for defaults, overrides, boundaries, invalid input, and deployment-file wiring. Its tests are pytest-style functions using monkeypatch and caplog, but the prescribed unittest discovery command will not discover those top-level functions. Reader tests also mutate the environment around a module-level Settings singleton, so later overrides do not exercise the claimed fallback, while an invalid environment value can fail Settings construction before the reader is callable. The supposed integration test is code inspection, the slow-upstream scenarios lack an executable server and precise 504 oracle, and the boundary scenario accepts either of two incompatible outcomes."
+    },
+    "implementation": {
+      "completeness": 8,
+      "correctness": 1,
+      "specificity": 9,
+      "risk_awareness": 3,
+      "total": 21,
+      "notes": "The patch broadly covers Settings, three Compose files, Helm, Terraform, admin configuration, and the HTTPX call site. Its auth_server/server.py hunk removes the existing try statement while leaving the replacement async with line indented beneath no enclosing block, producing invalid Python and making the implementation unusable. It also supplies no tests and omits unified-parameter-reference.md despite both being acceptance criteria, while implementation.md incorrectly claims nothing was omitted or deviated from the LLD. Several deployment edits match their surrounding repository patterns, but the summary neither detects the fatal control-flow edit nor acknowledges the validation and fallback risks."
+    }
+  },
+  "task_score": 47.8,
+  "verdict": "The submission has a strong issue and detailed design surface, but internally inconsistent validation, ineffective tests, and a syntax-breaking implementation patch prevent it from being mergeable.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:39:34.281576Z",
+    "repo_ref": "1.25.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 180314,
+      "cached_input_tokens": 83178,
+      "cache_write_input_tokens": 28124,
+      "output_tokens": 9373,
+      "reasoning_output_tokens": 7973
+    },
+    "duration_ms": 108507
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.25.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "config",
+    "auth-server",
+    "httpx",
+    "proxy",
+    "timeouts",
+    "fixed-in-1.26.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 82.1,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 583,
+    "output_tokens": 31202,
+    "cache_read_tokens": 9695101,
+    "cache_write_tokens": 278577,
+    "total_tokens": 10005463,
+    "total_cost_usd": 1.4743243500000003,
+    "latency_seconds": 380.2,
+    "num_turns": 97,
+    "generation_tokens_per_sec": 82.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 583,
+  "output_tokens": 31202,
+  "latency_seconds": 380.2,
+  "num_turns": 97,
+  "total_cost_usd": 1.4743243500000003,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 9695101,
+  "cache_creation_tokens": 278577,
+  "run_started_at": "2026-08-30T20:23:23.722277Z",
+  "run_ended_at": "2026-08-30T20:29:43.922726Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 583,
+    "output_tokens": 31202,
+    "cache_read_tokens": 9695101,
+    "cache_write_tokens": 278577,
+    "total_tokens": 10005463,
+    "total_cost_usd": 1.4743243500000003,
+    "latency_seconds": 380.2,
+    "num_turns": 97,
+    "generation_tokens_per_sec": 82.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-mcp-proxy-upstream-timeout",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 76,
+        "notes": "The issue clearly defines the hardcoded timeout problem, backward-compatible default, explicit non-goals, and mostly testable acceptance criteria. The submitted source context supports the named Settings field, auth_server/server.py call site, admin configuration entry, and deployment surfaces. Its largest gap is failure semantics: it does not decide whether values below five seconds reject startup or are silently floored, and it treats an HTTPX timeout as a simple total-call deadline. No independent task statement establishes that admin exposure, every deployment surface, or the five-second minimum was actually required."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 11,
+        "specificity": 20,
+        "risk_awareness": 12,
+        "total": 60,
+        "notes": "The LLD is unusually concrete about files, configuration names, defaults, call flow, and deployment wiring. However, it names a nonexistent _BASIC_CONFIG_ENTRIES integration point where the patch context shows CONFIG_GROUPS, and its proposed Helm stringData/quote change conflicts with the repository's data/b64enc pattern. The ge=5.0 Settings constraint can reject startup before the reader's flooring or invalid-environment fallback executes, leaving the central validation behavior internally inconsistent. It also omits tests and unified-parameter-reference.md from its final modified-file list and gives little treatment to resource retention, surrounding proxy deadlines, observability, or rollback."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 7,
+        "specificity": 13,
+        "risk_awareness": 6,
+        "total": 36,
+        "notes": "The review offers a few concrete follow-ups, including invalid-value testing, startup logging, and timeout metrics. Its largest deficiency is unanimous approval despite material design contradictions around startup validation, environment fallback, the config symbol, and Helm encoding. It incorrectly describes HTTPX as raising TimeoutError and rationalizes storing a non-secret timeout in a Secret rather than simply recognizing the repository's existing convention. It does not examine prolonged resource occupancy, outer load-balancer timeouts, missing documentation/tests, or the unresolved reject-versus-floor behavior."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 5,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 46,
+        "notes": "The plan provides concrete expected values for defaults, overrides, boundaries, invalid input, and deployment-file wiring. Its tests are pytest-style functions using monkeypatch and caplog, but the prescribed unittest discovery command will not discover those top-level functions. Reader tests also mutate the environment around a module-level Settings singleton, so later overrides do not exercise the claimed fallback, while an invalid environment value can fail Settings construction before the reader is callable. The supposed integration test is code inspection, the slow-upstream scenarios lack an executable server and precise 504 oracle, and the boundary scenario accepts either of two incompatible outcomes."
+      },
+      "implementation": {
+        "completeness": 8,
+        "correctness": 1,
+        "specificity": 9,
+        "risk_awareness": 3,
+        "total": 21,
+        "notes": "The patch broadly covers Settings, three Compose files, Helm, Terraform, admin configuration, and the HTTPX call site. Its auth_server/server.py hunk removes the existing try statement while leaving the replacement async with line indented beneath no enclosing block, producing invalid Python and making the implementation unusable. It also supplies no tests and omits unified-parameter-reference.md despite both being acceptance criteria, while implementation.md incorrectly claims nothing was omitted or deviated from the LLD. Several deployment edits match their surrounding repository patterns, but the summary neither detects the fatal control-flow edit nor acknowledges the validation and fallback risks."
+      }
+    },
+    "task_score": 47.8,
+    "verdict": "The submission has a strong issue and detailed design surface, but internally inconsistent validation, ineffective tests, and a syntax-breaking implementation patch prevent it from being mergeable.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:39:34.281576Z",
+      "repo_ref": "1.25.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 180314,
+        "cached_input_tokens": 83178,
+        "cache_write_input_tokens": 28124,
+        "output_tokens": 9373,
+        "reasoning_output_tokens": 7973
+      },
+      "duration_ms": 108507
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-ui-title",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 77,
+      "notes": "The issue clearly defines runtime title resolution, deployment surfaces, testable acceptance criteria, and explicit non-goals. Its largest weakness is ambiguity: registry-only behavior changes when UI_TITLE is unset despite the blanket backward-compatibility criterion, while admin-panel support is simultaneously optional and required if present. The submitted diff confirms that Settings, get_config, useRegistryConfig, Layout, and the named Compose files are genuine integration points. No independent task statement exists, and Issue #984 plus the claim that the title is hardcoded in multiple files could not be independently verified."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 20,
+      "risk_awareness": 13,
+      "total": 63,
+      "notes": "The LLD provides unusually concrete data flow, defaults, interfaces, deployment mappings, and implementation snippets. Its largest deficiency is incorrect or incomplete integration detail: it proposes @router.get(\"/api/config\") although the real diff shows the existing route is @router.get(\"\") under a router prefix, and it omits the required Terraform module-variable pass-through. It also inconsistently describes startup caching while its proposed implementation derives the value per request, and applies a 100-character limit only to Terraform. Exact Terraform and Helm path structure could not be independently verified because repository command execution failed before running."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 10,
+      "specificity": 16,
+      "risk_awareness": 12,
+      "total": 51,
+      "notes": "The review raises concrete topics including frontend fallback behavior, caching, Compose drift, XSS rendering, validation, and observability. It nevertheless misses the LLD's incorrect route decorator, absent Terraform module plumbing, and inconsistent validation, then incorrectly concludes that every acceptance criterion is resolved. Pixel's claimed undefined-render problem ignores the LLD's existing || fallback and recommends DEFAULT_CONFIG even though the shown hook does not export it. The claimed cache lifetime could not be verified, and several reviewer approvals are unsupported assertions rather than repository-grounded analysis."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 11,
+      "specificity": 19,
+      "risk_awareness": 15,
+      "total": 62,
+      "notes": "The plan gives concrete setup, actions, and expected title values across explicit, unset, empty-string, fallback, Docker, Terraform, Helm, and end-to-end scenarios. Its largest weakness is reliance on manual inspection and grep presence checks, with no backend unit tests or frontend type-check/build command that would reliably catch source-level regressions. Test 2.3 would correctly catch the patch's deletion of asset_lifecycle_statuses, but the cache test's claim that browser reloads make no request and the feature-flag oracle rely on unstated defaults. Commands such as python -m registry, npm start, Kubernetes labels, and service names could not be verified against the repository."
+    },
+    "implementation": {
+      "completeness": 8,
+      "correctness": 5,
+      "specificity": 12,
+      "risk_awareness": 5,
+      "total": 30,
+      "notes": "The patch covers the Settings field, title derivation, config response, frontend type/default/rendering, documentation, and three Compose variants. It explicitly omits required Terraform and Helm plumbing and the present admin configuration integration, so it does not implement the promised three-surface feature. More seriously, the Layout hunk replaces the existing version/setVersion state declaration rather than adding the hook alongside it, while config_routes.py silently deletes asset_lifecycle_statuses from the public response. The summary contradicts these omissions by claiming all deployment surfaces are covered, and git apply applicability could not be independently checked because repository command execution failed before running."
+    }
+  },
+  "task_score": 56.6,
+  "verdict": "The submission has a strong, specific problem definition and useful test matrix, but the implementation is incomplete and introduces two serious regressions while the design review fails to catch them.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:41:55.714866Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 268703,
+      "cached_input_tokens": 202111,
+      "cache_write_input_tokens": 35730,
+      "output_tokens": 11569,
+      "reasoning_output_tokens": 9681
+    },
+    "duration_ms": 141421
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "configurable-ui-title",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "ui",
+    "react",
+    "config",
+    "branding",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 83.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 547,
+    "output_tokens": 31103,
+    "cache_read_tokens": 8017745,
+    "cache_write_tokens": 260830,
+    "total_tokens": 8310225,
+    "total_cost_usd": 1.2838740000000004,
+    "latency_seconds": 370.8,
+    "num_turns": 91,
+    "generation_tokens_per_sec": 83.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 547,
+  "output_tokens": 31103,
+  "latency_seconds": 370.8,
+  "num_turns": 91,
+  "total_cost_usd": 1.2838740000000004,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 8017745,
+  "cache_creation_tokens": 260830,
+  "run_started_at": "2026-08-30T20:17:09.871386Z",
+  "run_ended_at": "2026-08-30T20:23:20.717296Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 547,
+    "output_tokens": 31103,
+    "cache_read_tokens": 8017745,
+    "cache_write_tokens": 260830,
+    "total_tokens": 8310225,
+    "total_cost_usd": 1.2838740000000004,
+    "latency_seconds": 370.8,
+    "num_turns": 91,
+    "generation_tokens_per_sec": 83.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-ui-title",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 77,
+        "notes": "The issue clearly defines runtime title resolution, deployment surfaces, testable acceptance criteria, and explicit non-goals. Its largest weakness is ambiguity: registry-only behavior changes when UI_TITLE is unset despite the blanket backward-compatibility criterion, while admin-panel support is simultaneously optional and required if present. The submitted diff confirms that Settings, get_config, useRegistryConfig, Layout, and the named Compose files are genuine integration points. No independent task statement exists, and Issue #984 plus the claim that the title is hardcoded in multiple files could not be independently verified."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 20,
+        "risk_awareness": 13,
+        "total": 63,
+        "notes": "The LLD provides unusually concrete data flow, defaults, interfaces, deployment mappings, and implementation snippets. Its largest deficiency is incorrect or incomplete integration detail: it proposes @router.get(\"/api/config\") although the real diff shows the existing route is @router.get(\"\") under a router prefix, and it omits the required Terraform module-variable pass-through. It also inconsistently describes startup caching while its proposed implementation derives the value per request, and applies a 100-character limit only to Terraform. Exact Terraform and Helm path structure could not be independently verified because repository command execution failed before running."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 10,
+        "specificity": 16,
+        "risk_awareness": 12,
+        "total": 51,
+        "notes": "The review raises concrete topics including frontend fallback behavior, caching, Compose drift, XSS rendering, validation, and observability. It nevertheless misses the LLD's incorrect route decorator, absent Terraform module plumbing, and inconsistent validation, then incorrectly concludes that every acceptance criterion is resolved. Pixel's claimed undefined-render problem ignores the LLD's existing || fallback and recommends DEFAULT_CONFIG even though the shown hook does not export it. The claimed cache lifetime could not be verified, and several reviewer approvals are unsupported assertions rather than repository-grounded analysis."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 11,
+        "specificity": 19,
+        "risk_awareness": 15,
+        "total": 62,
+        "notes": "The plan gives concrete setup, actions, and expected title values across explicit, unset, empty-string, fallback, Docker, Terraform, Helm, and end-to-end scenarios. Its largest weakness is reliance on manual inspection and grep presence checks, with no backend unit tests or frontend type-check/build command that would reliably catch source-level regressions. Test 2.3 would correctly catch the patch's deletion of asset_lifecycle_statuses, but the cache test's claim that browser reloads make no request and the feature-flag oracle rely on unstated defaults. Commands such as python -m registry, npm start, Kubernetes labels, and service names could not be verified against the repository."
+      },
+      "implementation": {
+        "completeness": 8,
+        "correctness": 5,
+        "specificity": 12,
+        "risk_awareness": 5,
+        "total": 30,
+        "notes": "The patch covers the Settings field, title derivation, config response, frontend type/default/rendering, documentation, and three Compose variants. It explicitly omits required Terraform and Helm plumbing and the present admin configuration integration, so it does not implement the promised three-surface feature. More seriously, the Layout hunk replaces the existing version/setVersion state declaration rather than adding the hook alongside it, while config_routes.py silently deletes asset_lifecycle_statuses from the public response. The summary contradicts these omissions by claiming all deployment surfaces are covered, and git apply applicability could not be independently checked because repository command execution failed before running."
+      }
+    },
+    "task_score": 56.6,
+    "verdict": "The submission has a strong, specific problem definition and useful test matrix, but the implementation is incomplete and introduces two serious regressions while the design review fails to catch them.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:41:55.714866Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 268703,
+        "cached_input_tokens": 202111,
+        "cache_write_input_tokens": 35730,
+        "output_tokens": 11569,
+        "reasoning_output_tokens": 9681
+      },
+      "duration_ms": 141421
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 17,
+      "total": 75,
+      "notes": "The issue clearly defines the browser-versus-M2M problem, six claimed endpoints, testable outcomes, and useful non-goals. Its paths and existing dependency names agree with the supplied diff contexts for agent, skill, server, and virtual-server routes. The largest deficiency is that it requires all six endpoints to use the new dependency, while the later design and implementation deliberately exempt /internal/toggle. No independent task statement establishes the six-endpoint scope, and issue #891 could not be verified from the available repository evidence."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 13,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 65,
+      "notes": "The LLD is unusually concrete about files, route symbols, dependency signatures, form handling, and expected status behavior, and those locations align with the patch contexts. Its largest unresolved decision is endpoint coverage: it promises uniform treatment of six endpoints but leaves /internal/toggle as a TODO and ultimately excludes it. More importantly, CSRF bypass is selected from any Bearer-prefixed header rather than from the authentication method successfully chosen by enhanced_auth or nginx_proxied_auth, so the claimed auth precedence is not demonstrated. The assertions of zero breaking changes and reliable M2M detection could not be established from the available surrounding auth implementation."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 12,
+      "specificity": 18,
+      "risk_awareness": 17,
+      "total": 64,
+      "notes": "The review identifies concrete concerns including repeated form parsing, mixed bearer-and-session requests, incomplete endpoint auditing, and observability. It correctly focuses attention on toggle_service_api form fields and the unresolved /internal/toggle decision. Its largest failure is accepting the unproven claim that a client-controlled Authorization header cannot be spoofed and resolving mixed authentication by documentation rather than verifying which credential the auth dependency actually accepts. It also claims configuration-based rollback despite the LLD adding no flag, and its HMAC-SHA512 statement about validate_csrf_token is unsupported by the submitted source."
+    },
+    "testing": {
+      "completeness": 12,
+      "correctness": 4,
+      "specificity": 14,
+      "risk_awareness": 15,
+      "total": 45,
+      "notes": "The plan recognizes the important categories: bearer bypass, session rejection, token binding, mixed credentials, compatibility, and form parsing. However, several constructed URLs duplicate prefixes—for example TEST_AGENT_PATH is /agents/test-agent and is appended to /agents—and the agent test submits enabled as form data even though the supplied FastAPI signature declares an unannotated scalar parameter. Most positive tests merely assert status is not 403, allowing authentication, validation, routing, or server failures to pass, while /internal/toggle receives no test despite the claimed six-endpoint scope. The proposed unittest discovery command would not collect the shown module-level pytest tests, and the bearer-auth overrides, persistent fixtures, and executable registration body are not specified."
+    },
+    "implementation": {
+      "completeness": 13,
+      "correctness": 14,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 56,
+      "notes": "The patch concretely adds verify_csrf_token_if_session_based and wires it into the five externally described agent, skill, server, server-API, and virtual-server handlers shown by the diff. It does not add the dependency to /internal/toggle or add any tests, contradicting both the issue acceptance criteria and the summary's claim that all six endpoints were updated with no deviations. The largest technical risk is that bypass depends solely on a Bearer-prefixed header rather than confirmed bearer authentication, while requests with neither a session nor bearer header also pass this dependency. The summary additionally claims form behavior was tested despite saying verification was not executed; clean application and surrounding unused-import behavior could not be independently verified because local repository execution failed at the sandbox boundary."
+    }
+  },
+  "task_score": 61.0,
+  "verdict": "The submission presents a concrete and mostly coherent design, but unreliable tests, contradictory endpoint coverage, and an unverified header-based CSRF bypass materially limit confidence in the implementation.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:45:55.696607Z",
+    "repo_ref": "v1.0.20",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 383973,
+      "cached_input_tokens": 230153,
+      "cache_write_input_tokens": 86166,
+      "output_tokens": 17691,
+      "reasoning_output_tokens": 15532
+    },
+    "duration_ms": 239970
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.20",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "csrf",
+    "authentication",
+    "api",
+    "fastapi",
+    "m2m",
+    "fixed-in-1.0.21"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 86.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 494,
+    "output_tokens": 34690,
+    "cache_read_tokens": 6542505,
+    "cache_write_tokens": 226178,
+    "total_tokens": 6803867,
+    "total_cost_usd": 1.110917,
+    "latency_seconds": 400.2,
+    "num_turns": 82,
+    "generation_tokens_per_sec": 86.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 494,
+  "output_tokens": 34690,
+  "latency_seconds": 400.2,
+  "num_turns": 82,
+  "total_cost_usd": 1.110917,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 6542505,
+  "cache_creation_tokens": 226178,
+  "run_started_at": "2026-08-30T20:10:26.181560Z",
+  "run_ended_at": "2026-08-30T20:17:06.437213Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 494,
+    "output_tokens": 34690,
+    "cache_read_tokens": 6542505,
+    "cache_write_tokens": 226178,
+    "total_tokens": 6803867,
+    "total_cost_usd": 1.110917,
+    "latency_seconds": 400.2,
+    "num_turns": 82,
+    "generation_tokens_per_sec": 86.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "consistent-csrf-across-toggle-endpoints",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 17,
+        "total": 75,
+        "notes": "The issue clearly defines the browser-versus-M2M problem, six claimed endpoints, testable outcomes, and useful non-goals. Its paths and existing dependency names agree with the supplied diff contexts for agent, skill, server, and virtual-server routes. The largest deficiency is that it requires all six endpoints to use the new dependency, while the later design and implementation deliberately exempt /internal/toggle. No independent task statement establishes the six-endpoint scope, and issue #891 could not be verified from the available repository evidence."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 13,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 65,
+        "notes": "The LLD is unusually concrete about files, route symbols, dependency signatures, form handling, and expected status behavior, and those locations align with the patch contexts. Its largest unresolved decision is endpoint coverage: it promises uniform treatment of six endpoints but leaves /internal/toggle as a TODO and ultimately excludes it. More importantly, CSRF bypass is selected from any Bearer-prefixed header rather than from the authentication method successfully chosen by enhanced_auth or nginx_proxied_auth, so the claimed auth precedence is not demonstrated. The assertions of zero breaking changes and reliable M2M detection could not be established from the available surrounding auth implementation."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 12,
+        "specificity": 18,
+        "risk_awareness": 17,
+        "total": 64,
+        "notes": "The review identifies concrete concerns including repeated form parsing, mixed bearer-and-session requests, incomplete endpoint auditing, and observability. It correctly focuses attention on toggle_service_api form fields and the unresolved /internal/toggle decision. Its largest failure is accepting the unproven claim that a client-controlled Authorization header cannot be spoofed and resolving mixed authentication by documentation rather than verifying which credential the auth dependency actually accepts. It also claims configuration-based rollback despite the LLD adding no flag, and its HMAC-SHA512 statement about validate_csrf_token is unsupported by the submitted source."
+      },
+      "testing": {
+        "completeness": 12,
+        "correctness": 4,
+        "specificity": 14,
+        "risk_awareness": 15,
+        "total": 45,
+        "notes": "The plan recognizes the important categories: bearer bypass, session rejection, token binding, mixed credentials, compatibility, and form parsing. However, several constructed URLs duplicate prefixes—for example TEST_AGENT_PATH is /agents/test-agent and is appended to /agents—and the agent test submits enabled as form data even though the supplied FastAPI signature declares an unannotated scalar parameter. Most positive tests merely assert status is not 403, allowing authentication, validation, routing, or server failures to pass, while /internal/toggle receives no test despite the claimed six-endpoint scope. The proposed unittest discovery command would not collect the shown module-level pytest tests, and the bearer-auth overrides, persistent fixtures, and executable registration body are not specified."
+      },
+      "implementation": {
+        "completeness": 13,
+        "correctness": 14,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 56,
+        "notes": "The patch concretely adds verify_csrf_token_if_session_based and wires it into the five externally described agent, skill, server, server-API, and virtual-server handlers shown by the diff. It does not add the dependency to /internal/toggle or add any tests, contradicting both the issue acceptance criteria and the summary's claim that all six endpoints were updated with no deviations. The largest technical risk is that bypass depends solely on a Bearer-prefixed header rather than confirmed bearer authentication, while requests with neither a session nor bearer header also pass this dependency. The summary additionally claims form behavior was tested despite saying verification was not executed; clean application and surrounding unused-import behavior could not be independently verified because local repository execution failed at the sandbox boundary."
+      }
+    },
+    "task_score": 61.0,
+    "verdict": "The submission presents a concrete and mostly coherent design, but unreliable tests, contradictory endpoint coverage, and an unverified header-based CSRF bypass materially limit confidence in the implementation.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:45:55.696607Z",
+      "repo_ref": "v1.0.20",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 383973,
+        "cached_input_tokens": 230153,
+        "cache_write_input_tokens": 86166,
+        "output_tokens": 17691,
+        "reasoning_output_tokens": 15532
+      },
+      "duration_ms": 239970
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 77,
+      "notes": "The issue gives concrete, testable criteria for initial state, reset behavior, omitted-field handling, and explicit opt-in, with clear exclusions for edit and authorization flows. Its largest flaw is claiming full backward compatibility while changing the backend behavior for API callers that omit create_in_idp from true to false. The submitted patch context corroborates the existing true defaults in IAMGroups.tsx and management_routes.py. The production-frequency claims and issue #916 relationship could not be independently verified, and no separate task statement was supplied."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 13,
+      "total": 67,
+      "notes": "The LLD names concrete files, state setters, payload fields, and backend logic, and the submitted diff corroborates the cited createInIdp and create_in_idp locations. It contradicts itself by declaring backend changes beyond documentation a non-goal while prescribing a runtime backend default change. Its proposed reset test merely clicks the checkbox twice rather than submitting successfully and exercising resetForm, leaving a stated requirement untested. It also understates the compatibility and rollback implications for API clients that omit the field, while logging and test-infrastructure claims could not be independently verified."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 13,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 54,
+      "notes": "The review provides actionable observations about verifying hook mocks, testing reset through a successful submission, and aligning the backend fallback. Its largest deficiency is approving the design despite identifying the exact missing reset test and failing to recognize that changing an omitted-field default changes behavior for existing API callers. The implementation's second test confirms this concern: it only toggles the checkbox manually and never invokes form submission or resetForm. Repeated claims of zero deployment risk, no operational impact, and full compatibility are insufficiently defended and could not be validated against repository tests or callers."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 8,
+      "total": 44,
+      "notes": "The plan spans frontend, API, compatibility, manual UX, and end-to-end checks, with concrete payloads and expected states. Most API scripts only assert HTTP 200 and do not verify whether a group was absent from or present in the identity provider, so they can pass while the central behavior is broken. The purported reset unit test only checks two user clicks, fixed group names lack cleanup or idempotency handling, and the plan contradicts itself by claiming no IdP state is modified while explicitly creating create_in_idp=true groups. The authentication endpoint, /api/v1/management routes, Docker test target, and response schemas could not be independently verified because repository shell access failed before command execution."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 19,
+      "risk_awareness": 12,
+      "total": 65,
+      "notes": "The patch directly changes both frontend defaults in IAMGroups.tsx and the backend fallback and docstring in management_routes.py, so the core requested behavior is represented end to end. Its largest defect is test coverage: none of the three tests submits a group or exercises resetForm, despite the summary claiming the LLD was fully realized, and two tests largely duplicate ordinary checkbox toggling. The third test also contains a contradictory comment about an unchecked final state while correctly asserting checked after three clicks, and the backend omission behavior has no automated regression test. Patch applicability and the mocked hook paths could not be independently confirmed because the read-only shell sandbox failed before git apply --check or source inspection could run."
+    }
+  },
+  "task_score": 61.4,
+  "verdict": "The submission defines and implements the core default flip clearly, but weak reset and backend-contract testing plus an unaddressed omitted-field compatibility change materially limit confidence.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:48:31.078208Z",
+    "repo_ref": "v1.0.21",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 280124,
+      "cached_input_tokens": 196412,
+      "cache_write_input_tokens": 34383,
+      "output_tokens": 11483,
+      "reasoning_output_tokens": 9445
+    },
+    "duration_ms": 155370
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.21",
+  "complexity": "low",
+  "tags": [
+    "ui",
+    "react",
+    "iam",
+    "groups",
+    "ux",
+    "fixed-in-1.0.22"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 95.1,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 339,
+    "output_tokens": 29801,
+    "cache_read_tokens": 3852580,
+    "cache_write_tokens": 121733,
+    "total_tokens": 4004453,
+    "total_cost_usd": 0.6867682499999999,
+    "latency_seconds": 313.4,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 95.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 339,
+  "output_tokens": 29801,
+  "latency_seconds": 313.4,
+  "num_turns": 56,
+  "total_cost_usd": 0.6867682499999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3852580,
+  "cache_creation_tokens": 121733,
+  "run_started_at": "2026-08-30T19:41:58.204229Z",
+  "run_ended_at": "2026-08-30T19:47:11.579492Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 339,
+    "output_tokens": 29801,
+    "cache_read_tokens": 3852580,
+    "cache_write_tokens": 121733,
+    "total_tokens": 4004453,
+    "total_cost_usd": 0.6867682499999999,
+    "latency_seconds": 313.4,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 95.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "default-create-in-idp-checkbox-unchecked",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 77,
+        "notes": "The issue gives concrete, testable criteria for initial state, reset behavior, omitted-field handling, and explicit opt-in, with clear exclusions for edit and authorization flows. Its largest flaw is claiming full backward compatibility while changing the backend behavior for API callers that omit create_in_idp from true to false. The submitted patch context corroborates the existing true defaults in IAMGroups.tsx and management_routes.py. The production-frequency claims and issue #916 relationship could not be independently verified, and no separate task statement was supplied."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 13,
+        "total": 67,
+        "notes": "The LLD names concrete files, state setters, payload fields, and backend logic, and the submitted diff corroborates the cited createInIdp and create_in_idp locations. It contradicts itself by declaring backend changes beyond documentation a non-goal while prescribing a runtime backend default change. Its proposed reset test merely clicks the checkbox twice rather than submitting successfully and exercising resetForm, leaving a stated requirement untested. It also understates the compatibility and rollback implications for API clients that omit the field, while logging and test-infrastructure claims could not be independently verified."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 13,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 54,
+        "notes": "The review provides actionable observations about verifying hook mocks, testing reset through a successful submission, and aligning the backend fallback. Its largest deficiency is approving the design despite identifying the exact missing reset test and failing to recognize that changing an omitted-field default changes behavior for existing API callers. The implementation's second test confirms this concern: it only toggles the checkbox manually and never invokes form submission or resetForm. Repeated claims of zero deployment risk, no operational impact, and full compatibility are insufficiently defended and could not be validated against repository tests or callers."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 8,
+        "total": 44,
+        "notes": "The plan spans frontend, API, compatibility, manual UX, and end-to-end checks, with concrete payloads and expected states. Most API scripts only assert HTTP 200 and do not verify whether a group was absent from or present in the identity provider, so they can pass while the central behavior is broken. The purported reset unit test only checks two user clicks, fixed group names lack cleanup or idempotency handling, and the plan contradicts itself by claiming no IdP state is modified while explicitly creating create_in_idp=true groups. The authentication endpoint, /api/v1/management routes, Docker test target, and response schemas could not be independently verified because repository shell access failed before command execution."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 19,
+        "risk_awareness": 12,
+        "total": 65,
+        "notes": "The patch directly changes both frontend defaults in IAMGroups.tsx and the backend fallback and docstring in management_routes.py, so the core requested behavior is represented end to end. Its largest defect is test coverage: none of the three tests submits a group or exercises resetForm, despite the summary claiming the LLD was fully realized, and two tests largely duplicate ordinary checkbox toggling. The third test also contains a contradictory comment about an unchecked final state while correctly asserting checked after three clicks, and the backend omission behavior has no automated regression test. Patch applicability and the mocked hook paths could not be independently confirmed because the read-only shell sandbox failed before git apply --check or source inspection could run."
+      }
+    },
+    "task_score": 61.4,
+    "verdict": "The submission defines and implements the core default flip clearly, but weak reset and backend-contract testing plus an unaddressed omitted-field compatibility change materially limit confidence.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:48:31.078208Z",
+      "repo_ref": "v1.0.21",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 280124,
+        "cached_input_tokens": 196412,
+        "cache_write_input_tokens": 34383,
+        "output_tokens": 11483,
+        "reasoning_output_tokens": 9445
+      },
+      "duration_ms": 155370
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 87,
+      "notes": "The issue gives a crisp end-to-end scope, testable acceptance criteria, and useful exclusions covering repository verification and non-GitHub hosts. Its named integration points, including translate_skill_url, _parse_skill_md_content, Dashboard.tsx, and both skill modals, agree with the submitted patch contexts. The largest gap is ambiguity around repeated parsing and whether an existing manually entered repository_url should be cleared, preserved, or overwritten. No independent task statement was supplied, so the expanded UI and enterprise-host scope cannot be confirmed beyond the internally consistent artifacts and repository metadata."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 76,
+      "notes": "The design is unusually concrete about files, symbols, data flow, optional response behavior, and conditional modal rendering. Its integration points match the patch contexts for _parse_skill_md_content, parse_skill_md, handleParseSkillMd, SkillCard, and SemanticSearchResults. The central correctness defect is that its algorithm reconstructs the original hostname for raw.githubusercontent.com while its own example requires https://github.com/org/repo, leaving a contradictory load-bearing decision. Its malformed-input guarantee is also incomplete because the resulting implementation accesses parsed.hostname outside the try block, and it does not address stale form values or enterprise instances using non-default ports."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 10,
+      "specificity": 15,
+      "risk_awareness": 11,
+      "total": 52,
+      "notes": "The review provides concrete recommendations for malformed inputs, enterprise cases, null handling, and conditional links rather than merely issuing approvals. It nevertheless misses the LLD's direct contradiction between preserving raw.githubusercontent.com and promising a github.com repository root, then incorrectly states that both URL shapes are handled correctly. Pixel's request for additional auto-fill feedback overlooks the existing success toast visible beside the Dashboard.tsx state update, while Sage incorrectly suggests a guarded optional property would still fail TypeScript strict null checks. The security approval is overconfident because the accepted schemes and precise trust semantics of _is_github_hostname are not established in the review."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 11,
+      "specificity": 16,
+      "risk_awareness": 15,
+      "total": 60,
+      "notes": "The plan has useful concrete oracles for blob and raw derivation, editable auto-fill, modal link targets, old records, and backward-compatible JSON responses. Its main flaw is presenting malformed, short-path, and GitLab cases as helper tests while invoking the parse endpoint, whose service constructs the result only after fetching the supplied URL; the illustrative URLs can therefore fail retrieval before repository_url is observable. The enterprise case has no executable mock setup, TOKEN is undefined, and the proposed tests under tests/unit and tests/integration have neither repository test commands nor concrete test files. It also lacks a direct derive_repository_url unit test and a repeated-parse case that would expose stale repository form state."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 13,
+      "specificity": 19,
+      "risk_awareness": 10,
+      "total": 61,
+      "notes": "The patch covers every stated layer: URL utility, service result, API response, frontend type, Dashboard auto-fill, and both modal implementations. The largest defect is in derive_repository_url: its raw branch returns f\"{scheme}://{hostname}/{org}/{repo}\", producing a raw.githubusercontent.com URL rather than the promised github.com repository root when called directly. Additionally, parsed.hostname is evaluated outside the exception handler, Dashboard preserves a previous repository_url when the new result is null, and no automated tests accompany the change. The summary therefore overstates that there are no deviations and that malformed inputs always return None; local git apply verification could not be completed because the provided shell sandbox failed before executing repository commands."
+    }
+  },
+  "task_score": 67.2,
+  "verdict": "The submission is well-scoped and largely implementation-ready, but its raw-URL derivation contract is internally inconsistent and the review and test plan fail to expose several concrete edge-path defects.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:51:22.380333Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 261755,
+      "cached_input_tokens": 215285,
+      "cache_write_input_tokens": 46134,
+      "output_tokens": 9284,
+      "reasoning_output_tokens": 7202
+    },
+    "duration_ms": 171290
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "skills",
+    "ui",
+    "react",
+    "api",
+    "ux",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 89.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 406,
+    "output_tokens": 29963,
+    "cache_read_tokens": 5313855,
+    "cache_write_tokens": 161765,
+    "total_tokens": 5505989,
+    "total_cost_usd": 0.8838127499999999,
+    "latency_seconds": 334.3,
+    "num_turns": 68,
+    "generation_tokens_per_sec": 89.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 406,
+  "output_tokens": 29963,
+  "latency_seconds": 334.3,
+  "num_turns": 68,
+  "total_cost_usd": 0.8838127499999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 5313855,
+  "cache_creation_tokens": 161765,
+  "run_started_at": "2026-08-30T20:04:49.186247Z",
+  "run_ended_at": "2026-08-30T20:10:23.508344Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 406,
+    "output_tokens": 29963,
+    "cache_read_tokens": 5313855,
+    "cache_write_tokens": 161765,
+    "total_tokens": 5505989,
+    "total_cost_usd": 0.8838127499999999,
+    "latency_seconds": 334.3,
+    "num_turns": 68,
+    "generation_tokens_per_sec": 89.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "derive-repo-url-from-skill-md",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 87,
+        "notes": "The issue gives a crisp end-to-end scope, testable acceptance criteria, and useful exclusions covering repository verification and non-GitHub hosts. Its named integration points, including translate_skill_url, _parse_skill_md_content, Dashboard.tsx, and both skill modals, agree with the submitted patch contexts. The largest gap is ambiguity around repeated parsing and whether an existing manually entered repository_url should be cleared, preserved, or overwritten. No independent task statement was supplied, so the expanded UI and enterprise-host scope cannot be confirmed beyond the internally consistent artifacts and repository metadata."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 76,
+        "notes": "The design is unusually concrete about files, symbols, data flow, optional response behavior, and conditional modal rendering. Its integration points match the patch contexts for _parse_skill_md_content, parse_skill_md, handleParseSkillMd, SkillCard, and SemanticSearchResults. The central correctness defect is that its algorithm reconstructs the original hostname for raw.githubusercontent.com while its own example requires https://github.com/org/repo, leaving a contradictory load-bearing decision. Its malformed-input guarantee is also incomplete because the resulting implementation accesses parsed.hostname outside the try block, and it does not address stale form values or enterprise instances using non-default ports."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 10,
+        "specificity": 15,
+        "risk_awareness": 11,
+        "total": 52,
+        "notes": "The review provides concrete recommendations for malformed inputs, enterprise cases, null handling, and conditional links rather than merely issuing approvals. It nevertheless misses the LLD's direct contradiction between preserving raw.githubusercontent.com and promising a github.com repository root, then incorrectly states that both URL shapes are handled correctly. Pixel's request for additional auto-fill feedback overlooks the existing success toast visible beside the Dashboard.tsx state update, while Sage incorrectly suggests a guarded optional property would still fail TypeScript strict null checks. The security approval is overconfident because the accepted schemes and precise trust semantics of _is_github_hostname are not established in the review."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 11,
+        "specificity": 16,
+        "risk_awareness": 15,
+        "total": 60,
+        "notes": "The plan has useful concrete oracles for blob and raw derivation, editable auto-fill, modal link targets, old records, and backward-compatible JSON responses. Its main flaw is presenting malformed, short-path, and GitLab cases as helper tests while invoking the parse endpoint, whose service constructs the result only after fetching the supplied URL; the illustrative URLs can therefore fail retrieval before repository_url is observable. The enterprise case has no executable mock setup, TOKEN is undefined, and the proposed tests under tests/unit and tests/integration have neither repository test commands nor concrete test files. It also lacks a direct derive_repository_url unit test and a repeated-parse case that would expose stale repository form state."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 13,
+        "specificity": 19,
+        "risk_awareness": 10,
+        "total": 61,
+        "notes": "The patch covers every stated layer: URL utility, service result, API response, frontend type, Dashboard auto-fill, and both modal implementations. The largest defect is in derive_repository_url: its raw branch returns f\"{scheme}://{hostname}/{org}/{repo}\", producing a raw.githubusercontent.com URL rather than the promised github.com repository root when called directly. Additionally, parsed.hostname is evaluated outside the exception handler, Dashboard preserves a previous repository_url when the new result is null, and no automated tests accompany the change. The summary therefore overstates that there are no deviations and that malformed inputs always return None; local git apply verification could not be completed because the provided shell sandbox failed before executing repository commands."
+      }
+    },
+    "task_score": 67.2,
+    "verdict": "The submission is well-scoped and largely implementation-ready, but its raw-URL derivation contract is internally inconsistent and the review and test plan fail to expose several concrete edge-path defects.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:51:22.380333Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 261755,
+        "cached_input_tokens": 215285,
+        "cache_write_input_tokens": 46134,
+        "output_tokens": 9284,
+        "reasoning_output_tokens": 7202
+      },
+      "duration_ms": 171290
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 81,
+      "notes": "The issue clearly identifies both scripts, the verify_setup() failure, operator impact, non-goals, and testable exit-code and lint outcomes. Its GROUPS diagnosis and proposed scalar rename agree with the submitted diff and established Bash behavior. The largest gap is that grep -q \"$TARGET_GROUP\" performs regex substring matching rather than exact group-name membership, despite the acceptance criterion claiming correct membership verification. No independent task statement exists, and the local repository runner failed before execution, so the cited line numbers, issue #1570, and dependency versions could not be independently verified."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 75,
+      "notes": "The LLD gives concrete changes for both named files and its function bodies align with the submitted patch's curl, jq, mapper, and verification flow. It correctly uses a separately declared local scalar, which is compatible with Bash 3.2 and avoids the special GROUPS array behavior. Its main technical deficiency is declaring grep -q correct without addressing exact-line, fixed-string, or leading-hyphen cases; its reserved-variable search list also conflates readonly and merely special or assignable Bash variables. The diagram's claim that failure occurs without printing output conflicts with its own echo statements preceding the assignment, and repository-level file and call-site claims remained unverifiable because local commands could not start."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 14,
+      "specificity": 16,
+      "risk_awareness": 11,
+      "total": 55,
+      "notes": "The review references the actual variable, both scripts, Bash-version portability, wrapper behavior, and transient curl failures rather than remaining wholly generic. Its largest weakness is unanimous approval with no substantive finding, including the incorrect assertion that grep -q \"$TARGET_GROUP\" is a fully correct membership test. It also says only two lines change per script, while each submitted hunk has five additions and three deletions, including three renamed references. Shellcheck compliance and repository integration were asserted rather than demonstrated, and could not be independently verified after the repository command runner failed."
+    },
+    "testing": {
+      "completeness": 12,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 7,
+      "total": 42,
+      "notes": "The plan supplies concrete syntax, lint, scoping, and source-inspection commands for both scripts, with several explicit expected strings. Its central deficiency is that it promises mocked API testing but implements no functional mock, exit-code execution, failure-path test, mapper-negative case, or exact group-membership oracle. The SC2178 section contradicts itself by accepting both grep status 0 and 1, and the double-quoted SERVICE_ACCOUNT_GROUPS=\\\\$(curl pattern can invoke command substitution instead of matching a literal assignment. Its hard-coded /tmp/swe-clone-fix-reserved-groups-var-in-service-account-script path does not match the submitted repository working directory, and it does not test the acceptance claim that no other reserved assignments remain."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 76,
+      "notes": "The patch consistently renames the assignment, output reference, and membership-check reference in both submitted verify_setup() hunks, and adds a separately scoped local variable. That change directly removes the special GROUPS assignment failure and preserves multiline jq output in a scalar, so it implements the core fix end to end. The residual correctness risk is regex substring matching instead of exact group membership, while the summary incorrectly reports +2/-2 per file and net-zero change even though each shown hunk is +5/-3. The evaluator could not run git apply --check or inspect the real files because the read-only command runner failed before execution, so the baseline commit, index hashes, syntax-check claim, and patch applicability remain independently unverified rather than treated as candidate defects."
+    }
+  },
+  "task_score": 65.8,
+  "verdict": "The core two-script Bash fix is small and likely effective, but the review and testing artifacts miss an exact-membership flaw and provide little executable behavioral verification.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:53:14.855175Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 174296,
+      "cached_input_tokens": 109992,
+      "cache_write_input_tokens": 30123,
+      "output_tokens": 9890,
+      "reasoning_output_tokens": 8050
+    },
+    "duration_ms": 112463
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "bash",
+    "keycloak",
+    "setup-scripts",
+    "shellcheck",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 99.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 141,
+    "output_tokens": 15669,
+    "cache_read_tokens": 1348297,
+    "cache_write_tokens": 41978,
+    "total_tokens": 1406085,
+    "total_cost_usd": 0.2657882,
+    "latency_seconds": 158.0,
+    "num_turns": 23,
+    "generation_tokens_per_sec": 99.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 141,
+  "output_tokens": 15669,
+  "latency_seconds": 158.0,
+  "num_turns": 23,
+  "total_cost_usd": 0.2657882,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 1348297,
+  "cache_creation_tokens": 41978,
+  "run_started_at": "2026-08-30T19:56:30.573569Z",
+  "run_ended_at": "2026-08-30T19:59:08.595852Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 141,
+    "output_tokens": 15669,
+    "cache_read_tokens": 1348297,
+    "cache_write_tokens": 41978,
+    "total_tokens": 1406085,
+    "total_cost_usd": 0.2657882,
+    "latency_seconds": 158.0,
+    "num_turns": 23,
+    "generation_tokens_per_sec": 99.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "fix-reserved-groups-var-in-service-account-script",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 81,
+        "notes": "The issue clearly identifies both scripts, the verify_setup() failure, operator impact, non-goals, and testable exit-code and lint outcomes. Its GROUPS diagnosis and proposed scalar rename agree with the submitted diff and established Bash behavior. The largest gap is that grep -q \"$TARGET_GROUP\" performs regex substring matching rather than exact group-name membership, despite the acceptance criterion claiming correct membership verification. No independent task statement exists, and the local repository runner failed before execution, so the cited line numbers, issue #1570, and dependency versions could not be independently verified."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 75,
+        "notes": "The LLD gives concrete changes for both named files and its function bodies align with the submitted patch's curl, jq, mapper, and verification flow. It correctly uses a separately declared local scalar, which is compatible with Bash 3.2 and avoids the special GROUPS array behavior. Its main technical deficiency is declaring grep -q correct without addressing exact-line, fixed-string, or leading-hyphen cases; its reserved-variable search list also conflates readonly and merely special or assignable Bash variables. The diagram's claim that failure occurs without printing output conflicts with its own echo statements preceding the assignment, and repository-level file and call-site claims remained unverifiable because local commands could not start."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 14,
+        "specificity": 16,
+        "risk_awareness": 11,
+        "total": 55,
+        "notes": "The review references the actual variable, both scripts, Bash-version portability, wrapper behavior, and transient curl failures rather than remaining wholly generic. Its largest weakness is unanimous approval with no substantive finding, including the incorrect assertion that grep -q \"$TARGET_GROUP\" is a fully correct membership test. It also says only two lines change per script, while each submitted hunk has five additions and three deletions, including three renamed references. Shellcheck compliance and repository integration were asserted rather than demonstrated, and could not be independently verified after the repository command runner failed."
+      },
+      "testing": {
+        "completeness": 12,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 7,
+        "total": 42,
+        "notes": "The plan supplies concrete syntax, lint, scoping, and source-inspection commands for both scripts, with several explicit expected strings. Its central deficiency is that it promises mocked API testing but implements no functional mock, exit-code execution, failure-path test, mapper-negative case, or exact group-membership oracle. The SC2178 section contradicts itself by accepting both grep status 0 and 1, and the double-quoted SERVICE_ACCOUNT_GROUPS=\\\\$(curl pattern can invoke command substitution instead of matching a literal assignment. Its hard-coded /tmp/swe-clone-fix-reserved-groups-var-in-service-account-script path does not match the submitted repository working directory, and it does not test the acceptance claim that no other reserved assignments remain."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 76,
+        "notes": "The patch consistently renames the assignment, output reference, and membership-check reference in both submitted verify_setup() hunks, and adds a separately scoped local variable. That change directly removes the special GROUPS assignment failure and preserves multiline jq output in a scalar, so it implements the core fix end to end. The residual correctness risk is regex substring matching instead of exact group membership, while the summary incorrectly reports +2/-2 per file and net-zero change even though each shown hunk is +5/-3. The evaluator could not run git apply --check or inspect the real files because the read-only command runner failed before execution, so the baseline commit, index hashes, syntax-check claim, and patch applicability remain independently unverified rather than treated as candidate defects."
+      }
+    },
+    "task_score": 65.8,
+    "verdict": "The core two-script Bash fix is small and likely effective, but the review and testing artifacts miss an exact-membership flaw and provide little executable behavioral verification.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:53:14.855175Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 174296,
+        "cached_input_tokens": 109992,
+        "cache_write_input_tokens": 30123,
+        "output_tokens": 9890,
+        "reasoning_output_tokens": 8050
+      },
+      "duration_ms": 112463
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 73,
+      "notes": "The issue provides concrete visibility criteria for every claimed viewFilter value and clearly limits changes to the existing button. Its largest deficiency is adding Agents-tab behavior not established by the task identifier, despite acknowledging that tab has no dedicated add button. The virtual, skills, servers, and discover expectations are directly testable, while the claim that agents should lose Register is insufficiently justified. Repository inspection was unavailable because the read-only command wrapper failed before execution, so issue #793 and the stated button labels could not be independently verified."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 13,
+      "total": 70,
+      "notes": "The LLD commits to an exact Dashboard.tsx render condition, names relevant handlers, and explains the resulting tab behavior. The positive allowlist changes Agents-tab behavior and suppresses Register for any future filter value, neither of which is addressed as a compatibility decision. The submitted patch context is internally consistent with the named handleRegisterServer button and neighboring handleRefreshHealth control. Exact line numbers, component claims, and symbols could not be independently checked, and the stated zero new lines contradicts the proposed conditional wrapper."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 12,
+      "specificity": 14,
+      "risk_awareness": 8,
+      "total": 47,
+      "notes": "The review's strongest point is identifying Discover-tab visibility as an unresolved UX question and suggesting accessibility and visual checks. It nevertheless approves the design without resolving that question or examining why Agents loses its only described registration action. Claims about existing permission checks and zero security or operational risk are unsupported by the shown change. The unanimous persona approvals do not catch the allowlist's effect on future filters or the task-title scope mismatch."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 13,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 64,
+      "notes": "The plan covers all five claimed tab states, repeated navigation, absence from the DOM, and preservation of click behavior. Its main weakness is that the click oracle permits either /servers/register or an unspecified modal, while npm test or yarn test is offered without confirming repository scripts. The visibility assertions for Register, Add Skill, and Add Virtual Server are concrete, but most procedures remain manual rather than repository-native automated tests. It also codifies the questionable Agents-tab behavior instead of testing preservation of existing access there."
+    },
+    "implementation": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 19,
+      "risk_awareness": 10,
+      "total": 59,
+      "notes": "The shown JSX patch is focused and syntactically coherent, and it fully implements the submitted LLD's servers-or-discover allowlist. Its largest defect is hiding Register on Agents and every unknown future filter even though the task identifier only establishes hiding it on Virtual and Skills. The target path, handleRegisterServer call, button markup, and surrounding handleRefreshHealth context are precise, but git apply --check could not be run because the local command wrapper failed before execution. The summary overstates completeness and reports +2/-8 despite the displayed diff containing nine added and seven removed lines."
+    }
+  },
+  "task_score": 62.6,
+  "verdict": "The submission is specific and internally coherent, but it fails to justify the material Agents-tab behavior change and its repository claims could not be independently verified.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:55:05.401856Z",
+    "repo_ref": "v1.0.18",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 146282,
+      "cached_input_tokens": 82712,
+      "cache_write_input_tokens": 23729,
+      "output_tokens": 9512,
+      "reasoning_output_tokens": 7704
+    },
+    "duration_ms": 110535
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.18",
+  "complexity": "trivial",
+  "tags": [
+    "ui",
+    "react",
+    "dashboard",
+    "ux",
+    "fixed-in-v1.0.19"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 94.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 151,
+    "output_tokens": 14380,
+    "cache_read_tokens": 1666326,
+    "cache_write_tokens": 55457,
+    "total_tokens": 1736314,
+    "total_cost_usd": 0.30800485,
+    "latency_seconds": 152.6,
+    "num_turns": 25,
+    "generation_tokens_per_sec": 94.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 151,
+  "output_tokens": 14380,
+  "latency_seconds": 152.6,
+  "num_turns": 25,
+  "total_cost_usd": 0.30800485,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 1666326,
+  "cache_creation_tokens": 55457,
+  "run_started_at": "2026-08-30T21:11:29.249483Z",
+  "run_ended_at": "2026-08-30T21:14:01.866359Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 151,
+    "output_tokens": 14380,
+    "cache_read_tokens": 1666326,
+    "cache_write_tokens": 55457,
+    "total_tokens": 1736314,
+    "total_cost_usd": 0.30800485,
+    "latency_seconds": 152.6,
+    "num_turns": 25,
+    "generation_tokens_per_sec": 94.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "hide-register-button-on-virtual-and-skills-tabs",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 73,
+        "notes": "The issue provides concrete visibility criteria for every claimed viewFilter value and clearly limits changes to the existing button. Its largest deficiency is adding Agents-tab behavior not established by the task identifier, despite acknowledging that tab has no dedicated add button. The virtual, skills, servers, and discover expectations are directly testable, while the claim that agents should lose Register is insufficiently justified. Repository inspection was unavailable because the read-only command wrapper failed before execution, so issue #793 and the stated button labels could not be independently verified."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 13,
+        "total": 70,
+        "notes": "The LLD commits to an exact Dashboard.tsx render condition, names relevant handlers, and explains the resulting tab behavior. The positive allowlist changes Agents-tab behavior and suppresses Register for any future filter value, neither of which is addressed as a compatibility decision. The submitted patch context is internally consistent with the named handleRegisterServer button and neighboring handleRefreshHealth control. Exact line numbers, component claims, and symbols could not be independently checked, and the stated zero new lines contradicts the proposed conditional wrapper."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 12,
+        "specificity": 14,
+        "risk_awareness": 8,
+        "total": 47,
+        "notes": "The review's strongest point is identifying Discover-tab visibility as an unresolved UX question and suggesting accessibility and visual checks. It nevertheless approves the design without resolving that question or examining why Agents loses its only described registration action. Claims about existing permission checks and zero security or operational risk are unsupported by the shown change. The unanimous persona approvals do not catch the allowlist's effect on future filters or the task-title scope mismatch."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 13,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 64,
+        "notes": "The plan covers all five claimed tab states, repeated navigation, absence from the DOM, and preservation of click behavior. Its main weakness is that the click oracle permits either /servers/register or an unspecified modal, while npm test or yarn test is offered without confirming repository scripts. The visibility assertions for Register, Add Skill, and Add Virtual Server are concrete, but most procedures remain manual rather than repository-native automated tests. It also codifies the questionable Agents-tab behavior instead of testing preservation of existing access there."
+      },
+      "implementation": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 19,
+        "risk_awareness": 10,
+        "total": 59,
+        "notes": "The shown JSX patch is focused and syntactically coherent, and it fully implements the submitted LLD's servers-or-discover allowlist. Its largest defect is hiding Register on Agents and every unknown future filter even though the task identifier only establishes hiding it on Virtual and Skills. The target path, handleRegisterServer call, button markup, and surrounding handleRefreshHealth context are precise, but git apply --check could not be run because the local command wrapper failed before execution. The summary overstates completeness and reports +2/-8 despite the displayed diff containing nine added and seven removed lines."
+      }
+    },
+    "task_score": 62.6,
+    "verdict": "The submission is specific and internally coherent, but it fails to justify the material Agents-tab behavior change and its repository claims could not be independently verified.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:55:05.401856Z",
+      "repo_ref": "v1.0.18",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 146282,
+        "cached_input_tokens": 82712,
+        "cache_write_input_tokens": 23729,
+        "output_tokens": 9512,
+        "reasoning_output_tokens": 7704
+      },
+      "duration_ms": 110535
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 73,
+      "notes": "The issue precisely identifies the endpoint, environment variable, expected response fields, testable acceptance cases, and explicit exclusions. Its largest flaw is claiming unchanged behavior whenever the override is unset, although its proposed resolver checks an operator hint before auto-detection, so the AWS_REGION acceptance case is not unconditional. The submitted endpoint context is internally consistent with the stated raw-detection root cause. The cited repository lines, .env.example value, and related issue numbers could not be independently verified because the local command sandbox failed before executing read-only commands."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 12,
+      "total": 65,
+      "notes": "The LLD gives concrete files, symbols, response fields, control flow, and an implementation-ready code change. It overstates backward compatibility and `_resolve_cloud()` safety while acknowledging that the resolver can query an operator hint before reaching cached detection, introducing different unset-override behavior and potential I/O. It also leaves import placement unresolved and promises tests in its change estimate despite specifying no actual implementation file for them. Repository line numbers, exception handling, validators, and conventions could not be independently confirmed because local inspection commands could not start."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 12,
+      "specificity": 17,
+      "risk_awareness": 12,
+      "total": 57,
+      "notes": "The review usefully elevates regression tests, asks about resolver latency, and recommends searching for other raw-detection callers. It nevertheless approves full backward compatibility without confronting the operator-hint branch, and incorrectly says repeated calls with an explicit override use the cached fallback cascade even though that branch should return before detection. Its import-location finding remains speculative, while the revised-design section claims resolution although the implementation retains the inline import. The actual repository import conventions and caller set could not be verified due the unavailable local command sandbox."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 9,
+      "specificity": 20,
+      "risk_awareness": 13,
+      "total": 60,
+      "notes": "The plan supplies concrete override-precedence and fallback scenarios with exact response oracles across functional, unit, deployment, and UI levels. The proposed unit tests mock `_resolve_cloud()` to return each expected answer, making the settings patches irrelevant and failing to test the real override or detection behavior. It also calls the endpoint POST in prerequisites but GET everywhere else, changes an environment variable during the UI scenario without restarting settings, and provides unverified Helm and IMDS configuration names. No operator-hint test is included even though the chosen resolver adds that branch, and the implementation patch adds none of these tests."
+    },
+    "implementation": {
+      "completeness": 13,
+      "correctness": 17,
+      "specificity": 19,
+      "risk_awareness": 10,
+      "total": 59,
+      "notes": "The central diff is focused and internally coherent: it replaces the raw detector import with `_resolve_cloud()` and awaits it from the existing asynchronous endpoint. It omits every promised regression test despite tests being an acceptance criterion and a must-fix review item, so the summary's claims of fully realizing the LLD and having no follow-ups are false. Calling the full resolver can also change unset-override behavior through operator hints and additional I/O, undermining the asserted complete backward compatibility. The stated +4/-4 net-zero statistics contradict the displayed diff's +11/-7 net-four hunk, and actual patch applicability could not be confirmed because read-only git commands failed before execution."
+    }
+  },
+  "task_score": 62.8,
+  "verdict": "The submission identifies and implements the likely core fix precisely, but missing regression tests and an unexamined operator-hint behavior change materially weaken its completeness and backward-compatibility claims.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:57:17.410232Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 235200,
+      "cached_input_tokens": 170425,
+      "cache_write_input_tokens": 32802,
+      "output_tokens": 9930,
+      "reasoning_output_tokens": 8073
+    },
+    "duration_ms": 132000
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "telemetry",
+    "api",
+    "ui",
+    "deployment",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 100.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1224,
+    "output_tokens": 23757,
+    "cache_read_tokens": 2881961,
+    "cache_write_tokens": 71580,
+    "total_tokens": 2978522,
+    "total_cost_usd": 0.49768010000000007,
+    "latency_seconds": 235.5,
+    "num_turns": 39,
+    "generation_tokens_per_sec": 100.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1224,
+  "output_tokens": 23757,
+  "latency_seconds": 235.5,
+  "num_turns": 39,
+  "total_cost_usd": 0.49768010000000007,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2881961,
+  "cache_creation_tokens": 71580,
+  "run_started_at": "2026-08-30T19:52:31.242505Z",
+  "run_ended_at": "2026-08-30T19:56:26.750883Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1224,
+    "output_tokens": 23757,
+    "cache_read_tokens": 2881961,
+    "cache_write_tokens": 71580,
+    "total_tokens": 2978522,
+    "total_cost_usd": 0.49768010000000007,
+    "latency_seconds": 235.5,
+    "num_turns": 39,
+    "generation_tokens_per_sec": 100.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "honor-cloud-provider-override-in-ui",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 73,
+        "notes": "The issue precisely identifies the endpoint, environment variable, expected response fields, testable acceptance cases, and explicit exclusions. Its largest flaw is claiming unchanged behavior whenever the override is unset, although its proposed resolver checks an operator hint before auto-detection, so the AWS_REGION acceptance case is not unconditional. The submitted endpoint context is internally consistent with the stated raw-detection root cause. The cited repository lines, .env.example value, and related issue numbers could not be independently verified because the local command sandbox failed before executing read-only commands."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 12,
+        "total": 65,
+        "notes": "The LLD gives concrete files, symbols, response fields, control flow, and an implementation-ready code change. It overstates backward compatibility and `_resolve_cloud()` safety while acknowledging that the resolver can query an operator hint before reaching cached detection, introducing different unset-override behavior and potential I/O. It also leaves import placement unresolved and promises tests in its change estimate despite specifying no actual implementation file for them. Repository line numbers, exception handling, validators, and conventions could not be independently confirmed because local inspection commands could not start."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 12,
+        "specificity": 17,
+        "risk_awareness": 12,
+        "total": 57,
+        "notes": "The review usefully elevates regression tests, asks about resolver latency, and recommends searching for other raw-detection callers. It nevertheless approves full backward compatibility without confronting the operator-hint branch, and incorrectly says repeated calls with an explicit override use the cached fallback cascade even though that branch should return before detection. Its import-location finding remains speculative, while the revised-design section claims resolution although the implementation retains the inline import. The actual repository import conventions and caller set could not be verified due the unavailable local command sandbox."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 9,
+        "specificity": 20,
+        "risk_awareness": 13,
+        "total": 60,
+        "notes": "The plan supplies concrete override-precedence and fallback scenarios with exact response oracles across functional, unit, deployment, and UI levels. The proposed unit tests mock `_resolve_cloud()` to return each expected answer, making the settings patches irrelevant and failing to test the real override or detection behavior. It also calls the endpoint POST in prerequisites but GET everywhere else, changes an environment variable during the UI scenario without restarting settings, and provides unverified Helm and IMDS configuration names. No operator-hint test is included even though the chosen resolver adds that branch, and the implementation patch adds none of these tests."
+      },
+      "implementation": {
+        "completeness": 13,
+        "correctness": 17,
+        "specificity": 19,
+        "risk_awareness": 10,
+        "total": 59,
+        "notes": "The central diff is focused and internally coherent: it replaces the raw detector import with `_resolve_cloud()` and awaits it from the existing asynchronous endpoint. It omits every promised regression test despite tests being an acceptance criterion and a must-fix review item, so the summary's claims of fully realizing the LLD and having no follow-ups are false. Calling the full resolver can also change unset-override behavior through operator hints and additional I/O, undermining the asserted complete backward compatibility. The stated +4/-4 net-zero statistics contradict the displayed diff's +11/-7 net-four hunk, and actual patch applicability could not be confirmed because read-only git commands failed before execution."
+      }
+    },
+    "task_score": 62.8,
+    "verdict": "The submission identifies and implements the likely core fix precisely, but missing regression tests and an unexamined operator-hint behavior change materially weaken its completeness and backward-compatibility claims.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T21:57:17.410232Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 235200,
+        "cached_input_tokens": 170425,
+        "cache_write_input_tokens": 32802,
+        "output_tokens": 9930,
+        "reasoning_output_tokens": 8073
+      },
+      "duration_ms": 132000
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 78,
+      "notes": "The issue clearly defines opt-in configuration, refresh, secret masking, compatibility, deployment, documentation, and explicit non-goals. The submitted baseline context confirms the relevant embeddings settings and LiteLLM integration points. Its largest gap is undefined behavior when static and IdP credentials coexist, plus ambiguity about startup timing and background versus request-time refresh. No independent task statement was supplied, and the asserted issue number and 60-minute token lifetime could not be verified."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 8,
+      "specificity": 19,
+      "risk_awareness": 14,
+      "total": 58,
+      "notes": "The LLD names concrete core files and provides unusually detailed configuration, data-flow, deployment, and observability decisions. Its critical mismatch is designing an async encode path around an existing synchronous LiteLLM call, while an asyncio.Lock does not provide the claimed cross-thread safety. The cross-field field_validator approach is unsound, startup fetching is deferred in the expected running-loop case, and the proposed logging guard merely emits a reminder without preventing credential logging. Repository documentation places ECS environment wiring under terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf rather than the asserted main.tf, and the claimed federation API equivalence was not demonstrated. "
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 9,
+      "specificity": 16,
+      "risk_awareness": 15,
+      "total": 54,
+      "notes": "The review identifies concrete concerns around auth-mode precedence, event-loop handling, endpoint reachability, URL validation, and credential leakage. Its largest deficiency is approving the threading model while missing the fatal field-validation and synchronous-event-loop problems. The proposed logging-guard resolution only logs that headers should not be logged, so it does not resolve the stated security blocker. Claims that deployment surfaces are consistently wired and that the design has no backend blockers are unsupported by the LLD and contradicted by the submitted patch."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 6,
+      "specificity": 15,
+      "risk_awareness": 11,
+      "total": 47,
+      "notes": "The plan broadly covers token refresh, injection, validation, compatibility, deployment rendering, and end-to-end behavior. Several tests are not executable as written: they await synchronous encode, patch litellm.embedding rather than the symbol imported into registry.embeddings.client, and import CONFIG_FIELD_SCHEMAS although the patch shows CONFIG_GROUPS. The secret test initializes the provider before installing its failure mock and inspects only an exception string rather than captured logs, while the logging test merely asserts that a warning message was emitted. The reindex endpoint and Helm value names are unverified, Terraform apply is an excessive validation command, and important malformed-response and concurrent-refresh oracles are absent."
+    },
+    "implementation": {
+      "completeness": 9,
+      "correctness": 4,
+      "specificity": 14,
+      "risk_awareness": 7,
+      "total": 34,
+      "notes": "The patch targets the central settings, factory, repository, UI, and LiteLLM client integration points with a concrete token-provider implementation. Its settings validator fatally rejects a fully populated configuration because info.data lacks the current client_id and later client_secret while validating client_id. LiteLLMClient.encode calls run_until_complete even when the loop is already running, then attempts another loop in the same thread, and asyncio.Lock does not make this synchronous client thread-safe. Deployment wiring, documentation, and tests required by the issue are omitted despite the summary claiming no deviations, and git apply --check could not be independently completed because the available command sandbox failed before process launch."
+    }
+  },
+  "task_score": 54.2,
+  "verdict": "The submission frames the feature well, but the design and patch contain fatal validation and event-loop defects and omit several explicit end-to-end deliverables.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:00:25.645913Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 274423,
+      "cached_input_tokens": 185812,
+      "cache_write_input_tokens": 41565,
+      "output_tokens": 14990,
+      "reasoning_output_tokens": 13228
+    },
+    "duration_ms": 188223
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "high",
+  "tags": [
+    "semantic-search",
+    "embeddings",
+    "oauth",
+    "authentication",
+    "litellm",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 105.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 9185,
+    "output_tokens": 40236,
+    "cache_read_tokens": 4002871,
+    "cache_write_tokens": 90236,
+    "total_tokens": 4142528,
+    "total_cost_usd": 0.7234471,
+    "latency_seconds": 380.4,
+    "num_turns": 44,
+    "generation_tokens_per_sec": 105.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 9185,
+  "output_tokens": 40236,
+  "latency_seconds": 380.4,
+  "num_turns": 44,
+  "total_cost_usd": 0.7234471,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 4002871,
+  "cache_creation_tokens": 90236,
+  "run_started_at": "2026-08-30T21:00:38.573065Z",
+  "run_ended_at": "2026-08-30T21:06:59.001813Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 9185,
+    "output_tokens": 40236,
+    "cache_read_tokens": 4002871,
+    "cache_write_tokens": 90236,
+    "total_tokens": 4142528,
+    "total_cost_usd": 0.7234471,
+    "latency_seconds": 380.4,
+    "num_turns": 44,
+    "generation_tokens_per_sec": 105.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "idp-authenticated-embedding-endpoint",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 78,
+        "notes": "The issue clearly defines opt-in configuration, refresh, secret masking, compatibility, deployment, documentation, and explicit non-goals. The submitted baseline context confirms the relevant embeddings settings and LiteLLM integration points. Its largest gap is undefined behavior when static and IdP credentials coexist, plus ambiguity about startup timing and background versus request-time refresh. No independent task statement was supplied, and the asserted issue number and 60-minute token lifetime could not be verified."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 8,
+        "specificity": 19,
+        "risk_awareness": 14,
+        "total": 58,
+        "notes": "The LLD names concrete core files and provides unusually detailed configuration, data-flow, deployment, and observability decisions. Its critical mismatch is designing an async encode path around an existing synchronous LiteLLM call, while an asyncio.Lock does not provide the claimed cross-thread safety. The cross-field field_validator approach is unsound, startup fetching is deferred in the expected running-loop case, and the proposed logging guard merely emits a reminder without preventing credential logging. Repository documentation places ECS environment wiring under terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf rather than the asserted main.tf, and the claimed federation API equivalence was not demonstrated. "
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 9,
+        "specificity": 16,
+        "risk_awareness": 15,
+        "total": 54,
+        "notes": "The review identifies concrete concerns around auth-mode precedence, event-loop handling, endpoint reachability, URL validation, and credential leakage. Its largest deficiency is approving the threading model while missing the fatal field-validation and synchronous-event-loop problems. The proposed logging-guard resolution only logs that headers should not be logged, so it does not resolve the stated security blocker. Claims that deployment surfaces are consistently wired and that the design has no backend blockers are unsupported by the LLD and contradicted by the submitted patch."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 6,
+        "specificity": 15,
+        "risk_awareness": 11,
+        "total": 47,
+        "notes": "The plan broadly covers token refresh, injection, validation, compatibility, deployment rendering, and end-to-end behavior. Several tests are not executable as written: they await synchronous encode, patch litellm.embedding rather than the symbol imported into registry.embeddings.client, and import CONFIG_FIELD_SCHEMAS although the patch shows CONFIG_GROUPS. The secret test initializes the provider before installing its failure mock and inspects only an exception string rather than captured logs, while the logging test merely asserts that a warning message was emitted. The reindex endpoint and Helm value names are unverified, Terraform apply is an excessive validation command, and important malformed-response and concurrent-refresh oracles are absent."
+      },
+      "implementation": {
+        "completeness": 9,
+        "correctness": 4,
+        "specificity": 14,
+        "risk_awareness": 7,
+        "total": 34,
+        "notes": "The patch targets the central settings, factory, repository, UI, and LiteLLM client integration points with a concrete token-provider implementation. Its settings validator fatally rejects a fully populated configuration because info.data lacks the current client_id and later client_secret while validating client_id. LiteLLMClient.encode calls run_until_complete even when the loop is already running, then attempts another loop in the same thread, and asyncio.Lock does not make this synchronous client thread-safe. Deployment wiring, documentation, and tests required by the issue are omitted despite the summary claiming no deviations, and git apply --check could not be independently completed because the available command sandbox failed before process launch."
+      }
+    },
+    "task_score": 54.2,
+    "verdict": "The submission frames the feature well, but the design and patch contain fatal validation and event-loop defects and omit several explicit end-to-end deliverables.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:00:25.645913Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 274423,
+        "cached_input_tokens": 185812,
+        "cache_write_input_tokens": 41565,
+        "output_tokens": 14990,
+        "reasoning_output_tokens": 13228
+      },
+      "duration_ms": 188223
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 74,
+      "notes": "The issue provides a clear documentation problem, bounded exclusions, and mostly testable acceptance criteria. Its largest deficiency is asserting that exactly 12 videos constitute every repository video without preserving scan output or a source-to-URL inventory, while the independently supplied task statement is absent. The submitted README hunk establishes seven prominent links, and the issue names additional concrete docs paths for the remainder. It does not address ongoing ownership, link rot, or how duplicated source links should remain synchronized."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 16,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 65,
+      "notes": "The LLD identifies concrete files, navigation integration, categories, entry structure, and verification steps appropriate to this small change. It fails to resolve its own open question about retaining README links and omits the issue's required audience-level metadata. The proposed README.md, docs/demo-videos.md, and mkdocs.yml changes align with the submitted patch's actual paths and navigation structure. Claims that docs/index.md is auto-generated, deployment is automatic, and all 12 videos were exhaustively scanned are not substantiated by reproducible repository evidence."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 12,
+      "specificity": 15,
+      "risk_awareness": 13,
+      "total": 54,
+      "notes": "The review surfaces relevant concerns including external-link rot, YAML validation, mobile table rendering, and maintenance of stale videos. Its unanimous approval misses the material mismatch between the issue's required audience metadata and the LLD, treating that requirement as an optional enhancement. The SRE section simultaneously declares zero operational risk and acknowledges that an invalid mkdocs.yml change can affect documentation deployment. Assertions about automatic GitHub Pages deployment, screened public content, and absence of security risk are not verified."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 17,
+      "risk_awareness": 13,
+      "total": 55,
+      "notes": "The plan covers file structure, links, rendering, navigation, deployment, and representative external hosts with concrete commands. Its main weakness is that it never reproduces the required repository-wide video scan or compares an authoritative URL set against the index. Counting lines matching `^\\[Watch` can pass with the wrong videos, the title loop checks only ten phrases and conflates federation entries, and `python -m py_yaml_load` is unsupported. The piped MkDocs commands can report success without checking the build exit status, while the backward-compatibility claim contradicts the patch's removal of several README links."
+    },
+    "implementation": {
+      "completeness": 17,
+      "correctness": 15,
+      "specificity": 19,
+      "risk_awareness": 12,
+      "total": 63,
+      "notes": "The patch implements the core outcome end to end: a five-category page containing 12 direct links, a prominent README index link, and a MkDocs navigation entry. It omits audience-level metadata required by the issue and supplies no durations, yet the summary incorrectly claims complete, deviation-free implementation. The README hunk removes direct OAuth, Dynamic Tool Discovery, and Agent Skills links despite the LLD leaving retention unresolved, and the added contributor recording rules are unsupported scope expansion. The diff is internally coherent, but exhaustive video discovery, description accuracy, external-link validity, and actual patch application could not be independently verified from the available evidence."
+    }
+  },
+  "task_score": 62.2,
+  "verdict": "The submission delivers the central documentation page competently, but unsupported completeness claims, omitted required metadata, weak executable tests, and an uncritical review materially limit confidence.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:03:16.896529Z",
+    "repo_ref": "1.24.3",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 313876,
+      "cached_input_tokens": 195532,
+      "cache_write_input_tokens": 36350,
+      "output_tokens": 14175,
+      "reasoning_output_tokens": 12126
+    },
+    "duration_ms": 171239
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.3",
+  "complexity": "trivial",
+  "tags": [
+    "docs",
+    "markdown",
+    "readme",
+    "discoverability",
+    "fixed-in-1.24.4"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 90.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 261,
+    "output_tokens": 24069,
+    "cache_read_tokens": 3208410,
+    "cache_write_tokens": 68807,
+    "total_tokens": 3301547,
+    "total_cost_usd": 0.52745575,
+    "latency_seconds": 264.9,
+    "num_turns": 43,
+    "generation_tokens_per_sec": 90.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 261,
+  "output_tokens": 24069,
+  "latency_seconds": 264.9,
+  "num_turns": 43,
+  "total_cost_usd": 0.52745575,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3208410,
+  "cache_creation_tokens": 68807,
+  "run_started_at": "2026-08-30T21:07:01.869795Z",
+  "run_ended_at": "2026-08-30T21:11:26.751077Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 261,
+    "output_tokens": 24069,
+    "cache_read_tokens": 3208410,
+    "cache_write_tokens": 68807,
+    "total_tokens": 3301547,
+    "total_cost_usd": 0.52745575,
+    "latency_seconds": 264.9,
+    "num_turns": 43,
+    "generation_tokens_per_sec": 90.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "index-demo-videos-in-one-page",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 74,
+        "notes": "The issue provides a clear documentation problem, bounded exclusions, and mostly testable acceptance criteria. Its largest deficiency is asserting that exactly 12 videos constitute every repository video without preserving scan output or a source-to-URL inventory, while the independently supplied task statement is absent. The submitted README hunk establishes seven prominent links, and the issue names additional concrete docs paths for the remainder. It does not address ongoing ownership, link rot, or how duplicated source links should remain synchronized."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 16,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 65,
+        "notes": "The LLD identifies concrete files, navigation integration, categories, entry structure, and verification steps appropriate to this small change. It fails to resolve its own open question about retaining README links and omits the issue's required audience-level metadata. The proposed README.md, docs/demo-videos.md, and mkdocs.yml changes align with the submitted patch's actual paths and navigation structure. Claims that docs/index.md is auto-generated, deployment is automatic, and all 12 videos were exhaustively scanned are not substantiated by reproducible repository evidence."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 12,
+        "specificity": 15,
+        "risk_awareness": 13,
+        "total": 54,
+        "notes": "The review surfaces relevant concerns including external-link rot, YAML validation, mobile table rendering, and maintenance of stale videos. Its unanimous approval misses the material mismatch between the issue's required audience metadata and the LLD, treating that requirement as an optional enhancement. The SRE section simultaneously declares zero operational risk and acknowledges that an invalid mkdocs.yml change can affect documentation deployment. Assertions about automatic GitHub Pages deployment, screened public content, and absence of security risk are not verified."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 17,
+        "risk_awareness": 13,
+        "total": 55,
+        "notes": "The plan covers file structure, links, rendering, navigation, deployment, and representative external hosts with concrete commands. Its main weakness is that it never reproduces the required repository-wide video scan or compares an authoritative URL set against the index. Counting lines matching `^\\[Watch` can pass with the wrong videos, the title loop checks only ten phrases and conflates federation entries, and `python -m py_yaml_load` is unsupported. The piped MkDocs commands can report success without checking the build exit status, while the backward-compatibility claim contradicts the patch's removal of several README links."
+      },
+      "implementation": {
+        "completeness": 17,
+        "correctness": 15,
+        "specificity": 19,
+        "risk_awareness": 12,
+        "total": 63,
+        "notes": "The patch implements the core outcome end to end: a five-category page containing 12 direct links, a prominent README index link, and a MkDocs navigation entry. It omits audience-level metadata required by the issue and supplies no durations, yet the summary incorrectly claims complete, deviation-free implementation. The README hunk removes direct OAuth, Dynamic Tool Discovery, and Agent Skills links despite the LLD leaving retention unresolved, and the added contributor recording rules are unsupported scope expansion. The diff is internally coherent, but exhaustive video discovery, description accuracy, external-link validity, and actual patch application could not be independently verified from the available evidence."
+      }
+    },
+    "task_score": 62.2,
+    "verdict": "The submission delivers the central documentation page competently, but unsupported completeness claims, omitted required metadata, weak executable tests, and an uncritical review materially limit confidence.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:03:16.896529Z",
+      "repo_ref": "1.24.3",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 313876,
+        "cached_input_tokens": 195532,
+        "cache_write_input_tokens": 36350,
+        "output_tokens": 14175,
+        "reasoning_output_tokens": 12126
+      },
+      "duration_ms": 171239
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 82,
+      "notes": "The issue clearly defines five behaviors, testable acceptance criteria, compatibility defaults, dependencies, and explicit non-goals. Its description aligns with the submitted baseline diff, which shows an unsigned webhook service and a server registration-scan callback. The main weakness is that the proposed lifecycle scope is not grounded in the repository's JSON-backed UI-permission model or accompanied by permission-provisioning criteria.  No independent task statement was supplied, so the asserted customer need and related-issue history remain unverifiable."
+    },
+    "lld": {
+      "completeness": 13,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 11,
+      "total": 47,
+      "notes": "The LLD is concrete about payload shape, signature bytes, configuration, and intended route changes. Its largest deficiency is failure to design how the new permission is defined and granted within the existing scope configuration; merely passing a new action string to a checker does not introduce a usable permission.  It also says invalid statuses are ignored while its filtering pseudocode returns no matches, and its fetch-filter-paginate flow does not resolve the repository's acknowledged paginated fast path. Claimed scanner files and mirrored agent/skill integration could not be verified, and the submitted implementation instead places the only scan hook in `server_routes.py`."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 13,
+      "specificity": 17,
+      "risk_awareness": 18,
+      "total": 64,
+      "notes": "The review's strongest work is identifying duplicate events, incomplete scan-path coverage, replay exposure, metric cardinality, consumer verification, and secret rotation. It nevertheless approves a design without catching its permission-provisioning gap, contradictory invalid-status semantics, or pagination risk. Several resolutions merely promise future documentation or verification while the conclusion incorrectly says they are resolved, and recommending publication of a shared secret on a website or in documentation is unsafe. Dashboard webhook behavior and team ownership are speculative and unsupported by repository evidence."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 5,
+      "specificity": 11,
+      "risk_awareness": 13,
+      "total": 43,
+      "notes": "The plan broadly covers all five features, negative permission cases, compatibility defaults, three asset types, and an end-to-end workflow. Most server registration commands use JSON fields such as `server_path` and `server_url`, whereas repository documentation shows multipart `-F` registration using `path` and `proxy_pass_url`; documented rescan URLs also use a single path separator.  Critical oracles are ineffective: the signature body contains placeholders, the single-status shell expression can pass when no draft result exists, invalid status accepts contradictory outcomes, and several HTTP tests check only curl's process exit code. Metrics, scanner exceptions, filtered pagination totals, webhook-send failure, and real signature verification in the E2E flow are not tested."
+    },
+    "implementation": {
+      "completeness": 8,
+      "correctness": 10,
+      "specificity": 13,
+      "risk_awareness": 8,
+      "total": 39,
+      "notes": "The central webhook change correctly serializes one exact body, computes HMAC-SHA256 over it, and sends those same bytes, while retaining the unsigned default. The patch implements route behavior only for servers, omits agent and skill parity, metrics, permission registration, examples, documentation, and tests, despite initially claiming all five requirements were applied consistently. Its scan event is added only to `_perform_security_scan_on_registration`, although the repository exposes separate manual rescan flows for servers, agents, and skills; scanner exceptions also emit no completion event.  The summary contradicts itself by declaring no LLD deviations before listing major omissions, and local `git apply --check` could not be executed because the provided shell sandbox failed before command execution, leaving exact patch applicability unverified."
+    }
+  },
+  "task_score": 55.0,
+  "verdict": "The submission has a strong, testable issue and useful risk discussion, but the design and partial server-only patch leave permission provisioning, cross-asset coverage, scan failure paths, and executable verification materially incomplete.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:06:18.980415Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 329387,
+      "cached_input_tokens": 228179,
+      "cache_write_input_tokens": 44443,
+      "output_tokens": 12761,
+      "reasoning_output_tokens": 10939
+    },
+    "duration_ms": 182072
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
@@ -1,0 +1,154 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "high",
+  "tags": [
+    "architecture",
+    "security",
+    "api",
+    "webhooks",
+    "hmac",
+    "lifecycle",
+    "permissions",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 86.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 498,
+    "output_tokens": 34523,
+    "cache_read_tokens": 6590831,
+    "cache_write_tokens": 82089,
+    "total_tokens": 6707941,
+    "total_cost_usd": 0.9348073500000003,
+    "latency_seconds": 398.8,
+    "num_turns": 83,
+    "generation_tokens_per_sec": 86.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 498,
+  "output_tokens": 34523,
+  "latency_seconds": 398.8,
+  "num_turns": 83,
+  "total_cost_usd": 0.9348073500000003,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 6590831,
+  "cache_creation_tokens": 82089,
+  "run_started_at": "2026-08-30T20:45:00.744813Z",
+  "run_ended_at": "2026-08-30T20:51:39.540175Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 498,
+    "output_tokens": 34523,
+    "cache_read_tokens": 6590831,
+    "cache_write_tokens": 82089,
+    "total_tokens": 6707941,
+    "total_cost_usd": 0.9348073500000003,
+    "latency_seconds": 398.8,
+    "num_turns": 83,
+    "generation_tokens_per_sec": 86.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "lifecycle-workflow-webhooks",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 82,
+        "notes": "The issue clearly defines five behaviors, testable acceptance criteria, compatibility defaults, dependencies, and explicit non-goals. Its description aligns with the submitted baseline diff, which shows an unsigned webhook service and a server registration-scan callback. The main weakness is that the proposed lifecycle scope is not grounded in the repository's JSON-backed UI-permission model or accompanied by permission-provisioning criteria.  No independent task statement was supplied, so the asserted customer need and related-issue history remain unverifiable."
+      },
+      "lld": {
+        "completeness": 13,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 11,
+        "total": 47,
+        "notes": "The LLD is concrete about payload shape, signature bytes, configuration, and intended route changes. Its largest deficiency is failure to design how the new permission is defined and granted within the existing scope configuration; merely passing a new action string to a checker does not introduce a usable permission.  It also says invalid statuses are ignored while its filtering pseudocode returns no matches, and its fetch-filter-paginate flow does not resolve the repository's acknowledged paginated fast path. Claimed scanner files and mirrored agent/skill integration could not be verified, and the submitted implementation instead places the only scan hook in `server_routes.py`."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 13,
+        "specificity": 17,
+        "risk_awareness": 18,
+        "total": 64,
+        "notes": "The review's strongest work is identifying duplicate events, incomplete scan-path coverage, replay exposure, metric cardinality, consumer verification, and secret rotation. It nevertheless approves a design without catching its permission-provisioning gap, contradictory invalid-status semantics, or pagination risk. Several resolutions merely promise future documentation or verification while the conclusion incorrectly says they are resolved, and recommending publication of a shared secret on a website or in documentation is unsafe. Dashboard webhook behavior and team ownership are speculative and unsupported by repository evidence."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 5,
+        "specificity": 11,
+        "risk_awareness": 13,
+        "total": 43,
+        "notes": "The plan broadly covers all five features, negative permission cases, compatibility defaults, three asset types, and an end-to-end workflow. Most server registration commands use JSON fields such as `server_path` and `server_url`, whereas repository documentation shows multipart `-F` registration using `path` and `proxy_pass_url`; documented rescan URLs also use a single path separator.  Critical oracles are ineffective: the signature body contains placeholders, the single-status shell expression can pass when no draft result exists, invalid status accepts contradictory outcomes, and several HTTP tests check only curl's process exit code. Metrics, scanner exceptions, filtered pagination totals, webhook-send failure, and real signature verification in the E2E flow are not tested."
+      },
+      "implementation": {
+        "completeness": 8,
+        "correctness": 10,
+        "specificity": 13,
+        "risk_awareness": 8,
+        "total": 39,
+        "notes": "The central webhook change correctly serializes one exact body, computes HMAC-SHA256 over it, and sends those same bytes, while retaining the unsigned default. The patch implements route behavior only for servers, omits agent and skill parity, metrics, permission registration, examples, documentation, and tests, despite initially claiming all five requirements were applied consistently. Its scan event is added only to `_perform_security_scan_on_registration`, although the repository exposes separate manual rescan flows for servers, agents, and skills; scanner exceptions also emit no completion event.  The summary contradicts itself by declaring no LLD deviations before listing major omissions, and local `git apply --check` could not be executed because the provided shell sandbox failed before command execution, leaving exact patch applicability unverified."
+      }
+    },
+    "task_score": 55.0,
+    "verdict": "The submission has a strong, testable issue and useful risk discussion, but the design and partial server-only patch leave permission provisioning, cross-asset coverage, scan failure paths, and executable verification materially incomplete.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:06:18.980415Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 329387,
+        "cached_input_tokens": 228179,
+        "cache_write_input_tokens": 44443,
+        "output_tokens": 12761,
+        "reasoning_output_tokens": 10939
+      },
+      "duration_ms": 182072
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 18,
+      "risk_awareness": 15,
+      "total": 61,
+      "notes": "The issue clearly defines the WAF and disclosure problems, explicit non-goals, and mostly testable acceptance criteria. Its largest deficiency is an undefined cross-service handoff: the registry stores the token while the auth server is expected to retrieve it from a different session-store module without a shared-store contract or transfer mechanism. The submitted patch confirms incompatible storage keys, with the registry writing `session_id` and the auth server querying `_id`, while the eventual IdP redirect still contains `id_token_hint`. No independent task statement was supplied, and the claims covering every named provider and unchanged metrics cannot be verified from the issue."
+    },
+    "lld": {
+      "completeness": 10,
+      "correctness": 2,
+      "specificity": 13,
+      "risk_awareness": 8,
+      "total": 33,
+      "notes": "The LLD names concrete files, endpoint parameters, provider branches, fallback behavior, and a single-use session concept. Its core data flow is nonfunctional because `registry/auth/session_store.py` writes the hint to its collection under `session_id`, whereas `auth_server/session_store.py` retrieves from its own collection using `_id`; no inter-service transfer or verified shared collection is designed. It also feeds the resolved token into `logout_params` and `urlencode`, returning a browser redirect to the IdP that still exposes `id_token_hint`, and it stores raw tokens with ISO-string expiration values that MongoDB TTL indexes cannot expire as dates. Claims of existing encryption, automatic cleanup, configuration-free operation, and safe rollback are therefore unsupported or contradicted."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 5,
+      "specificity": 14,
+      "risk_awareness": 10,
+      "total": 39,
+      "notes": "The review's strongest contribution is identifying session-store outage behavior, TTL-index deployment needs, monitoring, and upgrade concerns. It nevertheless approves the design without catching the missing cross-service token transfer, incompatible document keys, plaintext token insertion, string-valued TTL field, or the token's continued presence in the IdP redirect URL. Its assertion that cross-provider leakage is prevented by deletion is unsound because entries are not provider-bound, and it inconsistently describes a 32-byte value as 128 bits when `token_hex(16)` generates 16 random bytes. The claimed TTL blocker is also declared resolved even though neither the LLD nor patch creates a valid index or BSON-date expiration field."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 7,
+      "specificity": 16,
+      "risk_awareness": 12,
+      "total": 50,
+      "notes": "The plan covers URL shape, single use, fallback, local logout, provider behavior, TTL cleanup, and an end-to-end cycle with concrete expected outcomes. The primary oracle checks only the registry-to-auth-server redirect, while the auth-server-to-IdP redirect intentionally contains the token, so it cannot prove the promised absence from browser-visible URLs. Several procedures are unreliable or unsupported: unauthenticated `curl -I /logout` cannot obtain a session-backed ID, navigation performance entries need not expose intermediate redirects, HttpOnly cookies cannot be checked through `document.cookie`, and a 65-second wait is not a reliable MongoDB TTL-monitor bound. The assumed database and collection names, `/api/auth` endpoint, proposed test paths, container names, and unittest command are not established by the submitted repository evidence, and no executable tests accompany the patch."
+    },
+    "implementation": {
+      "completeness": 6,
+      "correctness": 2,
+      "specificity": 12,
+      "risk_awareness": 6,
+      "total": 26,
+      "notes": "The patch is narrowly targeted at the submitted preimage symbols `oauth2_logout`, `logout_handler`, and the two session-store modules, although the claimed `git apply --check` and syntax runs could not be independently verified because repository shell execution failed before commands ran. It does not implement a working token handoff: the registry inserts a document with `session_id`, while the auth server queries its separate store for `_id`, leaving the new auth-server writer and registry reader unused. Even if both modules shared a physical collection, the key mismatch prevents retrieval, and the auth server subsequently constructs a browser `Location` URL containing the resolved token as `id_token_hint`, directly defeating the stated requirement. The patch also stores the token without an encryption helper, writes `expires_at` as an ISO string unsuitable for MongoDB TTL expiration, adds no tests or index migration, and the summary incorrectly calls the implementation complete and identical to the LLD."
+    }
+  },
+  "task_score": 41.8,
+  "verdict": "The submission is detailed and repository-shaped, but its implementation lacks a viable cross-service token transfer and still exposes the ID token in the browser's IdP redirect URL.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:08:29.707077Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 235521,
+      "cached_input_tokens": 171538,
+      "cache_write_input_tokens": 36801,
+      "output_tokens": 11251,
+      "reasoning_output_tokens": 9181
+    },
+    "duration_ms": 130715
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "auth",
+    "oidc",
+    "logout",
+    "security",
+    "waf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 96.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 231,
+    "output_tokens": 23185,
+    "cache_read_tokens": 3754828,
+    "cache_write_tokens": 93083,
+    "total_tokens": 3871327,
+    "total_cost_usd": 0.6079925500000001,
+    "latency_seconds": 239.7,
+    "num_turns": 39,
+    "generation_tokens_per_sec": 96.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 231,
+  "output_tokens": 23185,
+  "latency_seconds": 239.7,
+  "num_turns": 39,
+  "total_cost_usd": 0.6079925500000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3754828,
+  "cache_creation_tokens": 93083,
+  "run_started_at": "2026-08-30T21:29:06.787318Z",
+  "run_ended_at": "2026-08-30T21:33:06.533155Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 231,
+    "output_tokens": 23185,
+    "cache_read_tokens": 3754828,
+    "cache_write_tokens": 93083,
+    "total_tokens": 3871327,
+    "total_cost_usd": 0.6079925500000001,
+    "latency_seconds": 239.7,
+    "num_turns": 39,
+    "generation_tokens_per_sec": 96.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "logout-id-token-hint-out-of-browser-url",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 18,
+        "risk_awareness": 15,
+        "total": 61,
+        "notes": "The issue clearly defines the WAF and disclosure problems, explicit non-goals, and mostly testable acceptance criteria. Its largest deficiency is an undefined cross-service handoff: the registry stores the token while the auth server is expected to retrieve it from a different session-store module without a shared-store contract or transfer mechanism. The submitted patch confirms incompatible storage keys, with the registry writing `session_id` and the auth server querying `_id`, while the eventual IdP redirect still contains `id_token_hint`. No independent task statement was supplied, and the claims covering every named provider and unchanged metrics cannot be verified from the issue."
+      },
+      "lld": {
+        "completeness": 10,
+        "correctness": 2,
+        "specificity": 13,
+        "risk_awareness": 8,
+        "total": 33,
+        "notes": "The LLD names concrete files, endpoint parameters, provider branches, fallback behavior, and a single-use session concept. Its core data flow is nonfunctional because `registry/auth/session_store.py` writes the hint to its collection under `session_id`, whereas `auth_server/session_store.py` retrieves from its own collection using `_id`; no inter-service transfer or verified shared collection is designed. It also feeds the resolved token into `logout_params` and `urlencode`, returning a browser redirect to the IdP that still exposes `id_token_hint`, and it stores raw tokens with ISO-string expiration values that MongoDB TTL indexes cannot expire as dates. Claims of existing encryption, automatic cleanup, configuration-free operation, and safe rollback are therefore unsupported or contradicted."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 5,
+        "specificity": 14,
+        "risk_awareness": 10,
+        "total": 39,
+        "notes": "The review's strongest contribution is identifying session-store outage behavior, TTL-index deployment needs, monitoring, and upgrade concerns. It nevertheless approves the design without catching the missing cross-service token transfer, incompatible document keys, plaintext token insertion, string-valued TTL field, or the token's continued presence in the IdP redirect URL. Its assertion that cross-provider leakage is prevented by deletion is unsound because entries are not provider-bound, and it inconsistently describes a 32-byte value as 128 bits when `token_hex(16)` generates 16 random bytes. The claimed TTL blocker is also declared resolved even though neither the LLD nor patch creates a valid index or BSON-date expiration field."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 7,
+        "specificity": 16,
+        "risk_awareness": 12,
+        "total": 50,
+        "notes": "The plan covers URL shape, single use, fallback, local logout, provider behavior, TTL cleanup, and an end-to-end cycle with concrete expected outcomes. The primary oracle checks only the registry-to-auth-server redirect, while the auth-server-to-IdP redirect intentionally contains the token, so it cannot prove the promised absence from browser-visible URLs. Several procedures are unreliable or unsupported: unauthenticated `curl -I /logout` cannot obtain a session-backed ID, navigation performance entries need not expose intermediate redirects, HttpOnly cookies cannot be checked through `document.cookie`, and a 65-second wait is not a reliable MongoDB TTL-monitor bound. The assumed database and collection names, `/api/auth` endpoint, proposed test paths, container names, and unittest command are not established by the submitted repository evidence, and no executable tests accompany the patch."
+      },
+      "implementation": {
+        "completeness": 6,
+        "correctness": 2,
+        "specificity": 12,
+        "risk_awareness": 6,
+        "total": 26,
+        "notes": "The patch is narrowly targeted at the submitted preimage symbols `oauth2_logout`, `logout_handler`, and the two session-store modules, although the claimed `git apply --check` and syntax runs could not be independently verified because repository shell execution failed before commands ran. It does not implement a working token handoff: the registry inserts a document with `session_id`, while the auth server queries its separate store for `_id`, leaving the new auth-server writer and registry reader unused. Even if both modules shared a physical collection, the key mismatch prevents retrieval, and the auth server subsequently constructs a browser `Location` URL containing the resolved token as `id_token_hint`, directly defeating the stated requirement. The patch also stores the token without an encryption helper, writes `expires_at` as an ISO string unsuitable for MongoDB TTL expiration, adds no tests or index migration, and the summary incorrectly calls the implementation complete and identical to the LLD."
+      }
+    },
+    "task_score": 41.8,
+    "verdict": "The submission is detailed and repository-shaped, but its implementation lacks a viable cross-service token transfer and still exposes the ID token in the browser's IdP redirect URL.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:08:29.707077Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 235521,
+        "cached_input_tokens": 171538,
+        "cache_write_input_tokens": 36801,
+        "output_tokens": 11251,
+        "reasoning_output_tokens": 9181
+      },
+      "duration_ms": 130715
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 79,
+      "notes": "The issue clearly defines the early-version-check problem, user impact, testable outcomes, and explicit non-goals. Its target is consistent with the submitted baseline hunk, where Phase 1 only runs `python3 --version` and emits `PYTHON_OK` or `PYTHON_FAIL`. The largest gap is failure-policy detail when project metadata cannot be read or parsed. No independent task statement was supplied, so the claimed downstream failure behavior could not be verified."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 4,
+      "specificity": 19,
+      "risk_awareness": 7,
+      "total": 47,
+      "notes": "The LLD names the relevant skill file, metadata source, result codes, messages, integration points, and proposed flow. Its quoted second heredoc prevents `$INSTALLED_VERSION` and `$REQUIRED_VERSION` from expanding, so `packaging.version.parse()` receives literal dollar-prefixed strings and the compliant path cannot succeed. It also assumes `packaging` and an older-Python `toml` fallback are installed before dependency setup, and its regex does not handle all PEP 440 constraints as claimed. Error branches are discussed, but the design misses these bootstrap and parsing risks and does not concretely implement its proposed richer log entry."
+    },
+    "review": {
+      "completeness": 8,
+      "correctness": 2,
+      "specificity": 11,
+      "risk_awareness": 4,
+      "total": 25,
+      "notes": "The review identifies version-constraint parsing as a relevant concern and ties recommendations to the proposed code. It incorrectly declares that concern resolved and explicitly praises the quoted heredoc, overlooking that the same quoting disables the variable expansion required by the comparison script. It also accepts unsupported claims that project dependencies are available to the prerequisite interpreter and that the regex handles all valid PEP 440 formats. Five unanimous approvals therefore miss multiple release-blocking defects and provide little effective design stress."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 5,
+      "specificity": 14,
+      "risk_awareness": 17,
+      "total": 55,
+      "notes": "The plan covers compliant, obsolete, missing-interpreter, malformed-metadata, remediation, compatibility, and end-to-end scenarios with useful output oracles. Its only substantially inlined test repeats the quoted-heredoc bug and therefore cannot produce the expected `PYTHON_OK`, while many other invocations remain `[run check code]` placeholders. Expected nonzero exit codes also disagree with the skill snippet, whose failure branches end with successful `echo` commands rather than `exit 1`. The table-preservation test would catch the patch's missing `PYTHON_FAIL` row, but the plan is not directly executable enough to provide reliable regression coverage."
+    },
+    "implementation": {
+      "completeness": 7,
+      "correctness": 1,
+      "specificity": 14,
+      "risk_awareness": 4,
+      "total": 26,
+      "notes": "The patch targets the submitted Phase 1 Python check and adds focused parsing, comparison, messaging, and remediation changes. However, the quoted comparison heredoc passes literal `$INSTALLED_VERSION` and `$REQUIRED_VERSION` strings to `packaging.version.parse()`, so every installed interpreter reaches `PYTHON_VERSION_FAIL`; additionally, `packaging` is not guaranteed in the system interpreter before dependency installation. The diff replaces rather than preserves the `PYTHON_FAIL` remediation row and leaves the generic log instruction unchanged, contradicting the summary's claims that both rows and mismatch logging were implemented. An independent `git apply --check` could not be completed because the repository command runner failed before executing, but the diff itself contains these decisive functional defects."
+    }
+  },
+  "task_score": 46.4,
+  "verdict": "The issue is strong and the test coverage is broad in intent, but the design, review, and patch all miss a heredoc expansion bug that makes the core feature fail for every installed Python version.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:09:54.809862Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 117852,
+      "cached_input_tokens": 75475,
+      "cache_write_input_tokens": 27732,
+      "output_tokens": 6382,
+      "reasoning_output_tokens": 4996
+    },
+    "duration_ms": 85091
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "setup",
+    "skill",
+    "developer-experience",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 87.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 432,
+    "output_tokens": 33768,
+    "cache_read_tokens": 6316284,
+    "cache_write_tokens": 95422,
+    "total_tokens": 6445906,
+    "total_cost_usd": 0.9201778999999999,
+    "latency_seconds": 384.7,
+    "num_turns": 72,
+    "generation_tokens_per_sec": 87.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 432,
+  "output_tokens": 33768,
+  "latency_seconds": 384.7,
+  "num_turns": 72,
+  "total_cost_usd": 0.9201778999999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 6316284,
+  "cache_creation_tokens": 95422,
+  "run_started_at": "2026-08-30T21:18:00.596812Z",
+  "run_ended_at": "2026-08-30T21:24:25.319831Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 432,
+    "output_tokens": 33768,
+    "cache_read_tokens": 6316284,
+    "cache_write_tokens": 95422,
+    "total_tokens": 6445906,
+    "total_cost_usd": 0.9201778999999999,
+    "latency_seconds": 384.7,
+    "num_turns": 72,
+    "generation_tokens_per_sec": 87.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "macos-setup-python-version-precheck",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 79,
+        "notes": "The issue clearly defines the early-version-check problem, user impact, testable outcomes, and explicit non-goals. Its target is consistent with the submitted baseline hunk, where Phase 1 only runs `python3 --version` and emits `PYTHON_OK` or `PYTHON_FAIL`. The largest gap is failure-policy detail when project metadata cannot be read or parsed. No independent task statement was supplied, so the claimed downstream failure behavior could not be verified."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 4,
+        "specificity": 19,
+        "risk_awareness": 7,
+        "total": 47,
+        "notes": "The LLD names the relevant skill file, metadata source, result codes, messages, integration points, and proposed flow. Its quoted second heredoc prevents `$INSTALLED_VERSION` and `$REQUIRED_VERSION` from expanding, so `packaging.version.parse()` receives literal dollar-prefixed strings and the compliant path cannot succeed. It also assumes `packaging` and an older-Python `toml` fallback are installed before dependency setup, and its regex does not handle all PEP 440 constraints as claimed. Error branches are discussed, but the design misses these bootstrap and parsing risks and does not concretely implement its proposed richer log entry."
+      },
+      "review": {
+        "completeness": 8,
+        "correctness": 2,
+        "specificity": 11,
+        "risk_awareness": 4,
+        "total": 25,
+        "notes": "The review identifies version-constraint parsing as a relevant concern and ties recommendations to the proposed code. It incorrectly declares that concern resolved and explicitly praises the quoted heredoc, overlooking that the same quoting disables the variable expansion required by the comparison script. It also accepts unsupported claims that project dependencies are available to the prerequisite interpreter and that the regex handles all valid PEP 440 formats. Five unanimous approvals therefore miss multiple release-blocking defects and provide little effective design stress."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 5,
+        "specificity": 14,
+        "risk_awareness": 17,
+        "total": 55,
+        "notes": "The plan covers compliant, obsolete, missing-interpreter, malformed-metadata, remediation, compatibility, and end-to-end scenarios with useful output oracles. Its only substantially inlined test repeats the quoted-heredoc bug and therefore cannot produce the expected `PYTHON_OK`, while many other invocations remain `[run check code]` placeholders. Expected nonzero exit codes also disagree with the skill snippet, whose failure branches end with successful `echo` commands rather than `exit 1`. The table-preservation test would catch the patch's missing `PYTHON_FAIL` row, but the plan is not directly executable enough to provide reliable regression coverage."
+      },
+      "implementation": {
+        "completeness": 7,
+        "correctness": 1,
+        "specificity": 14,
+        "risk_awareness": 4,
+        "total": 26,
+        "notes": "The patch targets the submitted Phase 1 Python check and adds focused parsing, comparison, messaging, and remediation changes. However, the quoted comparison heredoc passes literal `$INSTALLED_VERSION` and `$REQUIRED_VERSION` strings to `packaging.version.parse()`, so every installed interpreter reaches `PYTHON_VERSION_FAIL`; additionally, `packaging` is not guaranteed in the system interpreter before dependency installation. The diff replaces rather than preserves the `PYTHON_FAIL` remediation row and leaves the generic log instruction unchanged, contradicting the summary's claims that both rows and mismatch logging were implemented. An independent `git apply --check` could not be completed because the repository command runner failed before executing, but the diff itself contains these decisive functional defects."
+      }
+    },
+    "task_score": 46.4,
+    "verdict": "The issue is strong and the test coverage is broad in intent, but the design, review, and patch all miss a heredoc expansion bug that makes the core feature fail for every installed Python version.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:09:54.809862Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 117852,
+        "cached_input_tokens": 75475,
+        "cache_write_input_tokens": 27732,
+        "output_tokens": 6382,
+        "reasoning_output_tokens": 4996
+      },
+      "duration_ms": 85091
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 78,
+      "notes": "The issue clearly identifies `_create_location_block`, the intended trailing-slash behavior, client compatibility, scope, and testable config output. Its `/a` versus registered `/api` collision example is technically misleading because nginx chooses the longest matching prefix, so `/api` already wins that pairing.  The bare-path criterion is internally inconsistent: `/server-name/` is required not to silently match, yet the proposed `location /server-name/` necessarily matches it. No independent task statement was supplied, and the claimed source line could not be independently inspected because the local command sandbox failed before execution."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 73,
+      "notes": "The LLD is unusually concrete about `registry/core/nginx_service.py`, `_create_location_block`, normalization, generated output, compatibility, and edge cases. Its largest deficiency is unsupported certainty: it declares full compatibility and automatic migration while leaving bare `/server-name/` behavior unresolved and not identifying the exact event that rerenders persisted configuration. The proposed normalization changes only `location_path`; other construction using raw `path`, such as the asserted mcp-proxy URI, may still produce doubled slashes for `/server/` input. Claims that `_NGINX_AGENT_PATH_SAFE` validates every MCP path and that `_create_agent_location_block` is the applicable reference could not be independently verified."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 13,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 61,
+      "notes": "The review provides prioritized test, rollout, validation, and documentation recommendations tied to named symbols and scenarios. However, its five personas mostly ratify the LLD and fail to catch the contradictory `/server-name/` acceptance criterion or the ineffective `/a` plus `/api` collision premise. It also accepts unsupported claims about complete path validation, unchanged monitoring, automatic regeneration, and full backward compatibility. The strongest actionable finding is the demand for explicit trailing-slash assertions, but the review does not require a real nginx routing oracle."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 19,
+      "risk_awareness": 14,
+      "total": 61,
+      "notes": "The plan supplies concrete fixtures, inputs, expected generated strings, transport coverage, normalization cases, and proposed deployment checks. Several purported compatibility and collision tests contain only comments after asserting config text, so they cannot prove request routing, and no test covers the issue's `/server-name/` behavior. The command `python -m unittest discover` is mismatched with the shown pytest-style functions and fixtures, while the proposed `python -m registry.core.nginx_service.NginxConfigService.generate_config_async(...)` invocation is not a valid way to call a class method. The live test also accepts an ambiguous `200 or other` result and assumes registration endpoints and payloads that could not be verified."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 20,
+      "risk_awareness": 13,
+      "total": 67,
+      "notes": "The patch directly changes `registry/core/nginx_service.py::_create_location_block`, updates nine existing assertions, and adds focused normalization and generated-block tests, so it implements the central trailing-slash change. Its collision test verifies only two strings and proxy targets, not nginx matching, and the patch does not implement or test explicit handling for bare `/server-name/` despite claiming every acceptance criterion is met. Normalizing only `location_path` may leave raw-path uses producing doubled proxy URI slashes for already-suffixed inputs, and the summary's `_NGINX_AGENT_PATH_SAFE` and render-layer sanitization assurances are unverified. The hunk context is internally consistent with the submitted artifacts, but `git apply --check` and repository test execution could not be performed because the read-only shell sandbox failed before running commands."
+    }
+  },
+  "task_score": 68.0,
+  "verdict": "The submission identifies and implements the central one-line routing fix, but it overstates completeness because its key collision evidence is not a routing test and bare-path, normalization, validation, and regeneration behavior remain insufficiently established.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:12:41.543683Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 260699,
+      "cached_input_tokens": 176950,
+      "cache_write_input_tokens": 41783,
+      "output_tokens": 12970,
+      "reasoning_output_tokens": 11048
+    },
+    "duration_ms": 166722
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "medium",
+  "tags": [
+    "bug",
+    "security",
+    "nginx",
+    "routing",
+    "auth",
+    "python",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 3.2,
+  "token_accounting_warning": "[task=nginx-location-trailing-slash-route-hijack] TOKEN ACCOUNTING SUSPECT: 982 output tokens over 57 turns = 17.2/turn, below the 20 floor. An agent making edits emits hundreds per turn, so the omp usage is likely being read from one scope instead of summed across all of them (see the pi per-message usage bug, issue #99). Scores, turns, and latency are unaffected and still valid -- but DO NOT publish the token or cost columns from this run without re-checking the extractor.",
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 17,
+    "output_tokens": 982,
+    "cache_read_tokens": 126626,
+    "cache_write_tokens": 70962,
+    "total_tokens": 198587,
+    "total_cost_usd": 0.10629210000000001,
+    "latency_seconds": 308.4,
+    "num_turns": 57,
+    "generation_tokens_per_sec": 3.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 17,
+  "output_tokens": 982,
+  "latency_seconds": 308.4,
+  "num_turns": 57,
+  "total_cost_usd": 0.10629210000000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 126626,
+  "cache_creation_tokens": 70962,
+  "run_started_at": "2026-08-30T20:29:46.892776Z",
+  "run_ended_at": "2026-08-30T20:34:55.296333Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 17,
+    "output_tokens": 982,
+    "cache_read_tokens": 126626,
+    "cache_write_tokens": 70962,
+    "total_tokens": 198587,
+    "total_cost_usd": 0.10629210000000001,
+    "latency_seconds": 308.4,
+    "num_turns": 57,
+    "generation_tokens_per_sec": 3.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "nginx-location-trailing-slash-route-hijack",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 78,
+        "notes": "The issue clearly identifies `_create_location_block`, the intended trailing-slash behavior, client compatibility, scope, and testable config output. Its `/a` versus registered `/api` collision example is technically misleading because nginx chooses the longest matching prefix, so `/api` already wins that pairing.  The bare-path criterion is internally inconsistent: `/server-name/` is required not to silently match, yet the proposed `location /server-name/` necessarily matches it. No independent task statement was supplied, and the claimed source line could not be independently inspected because the local command sandbox failed before execution."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 73,
+        "notes": "The LLD is unusually concrete about `registry/core/nginx_service.py`, `_create_location_block`, normalization, generated output, compatibility, and edge cases. Its largest deficiency is unsupported certainty: it declares full compatibility and automatic migration while leaving bare `/server-name/` behavior unresolved and not identifying the exact event that rerenders persisted configuration. The proposed normalization changes only `location_path`; other construction using raw `path`, such as the asserted mcp-proxy URI, may still produce doubled slashes for `/server/` input. Claims that `_NGINX_AGENT_PATH_SAFE` validates every MCP path and that `_create_agent_location_block` is the applicable reference could not be independently verified."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 13,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 61,
+        "notes": "The review provides prioritized test, rollout, validation, and documentation recommendations tied to named symbols and scenarios. However, its five personas mostly ratify the LLD and fail to catch the contradictory `/server-name/` acceptance criterion or the ineffective `/a` plus `/api` collision premise. It also accepts unsupported claims about complete path validation, unchanged monitoring, automatic regeneration, and full backward compatibility. The strongest actionable finding is the demand for explicit trailing-slash assertions, but the review does not require a real nginx routing oracle."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 19,
+        "risk_awareness": 14,
+        "total": 61,
+        "notes": "The plan supplies concrete fixtures, inputs, expected generated strings, transport coverage, normalization cases, and proposed deployment checks. Several purported compatibility and collision tests contain only comments after asserting config text, so they cannot prove request routing, and no test covers the issue's `/server-name/` behavior. The command `python -m unittest discover` is mismatched with the shown pytest-style functions and fixtures, while the proposed `python -m registry.core.nginx_service.NginxConfigService.generate_config_async(...)` invocation is not a valid way to call a class method. The live test also accepts an ambiguous `200 or other` result and assumes registration endpoints and payloads that could not be verified."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 20,
+        "risk_awareness": 13,
+        "total": 67,
+        "notes": "The patch directly changes `registry/core/nginx_service.py::_create_location_block`, updates nine existing assertions, and adds focused normalization and generated-block tests, so it implements the central trailing-slash change. Its collision test verifies only two strings and proxy targets, not nginx matching, and the patch does not implement or test explicit handling for bare `/server-name/` despite claiming every acceptance criterion is met. Normalizing only `location_path` may leave raw-path uses producing doubled proxy URI slashes for already-suffixed inputs, and the summary's `_NGINX_AGENT_PATH_SAFE` and render-layer sanitization assurances are unverified. The hunk context is internally consistent with the submitted artifacts, but `git apply --check` and repository test execution could not be performed because the read-only shell sandbox failed before running commands."
+      }
+    },
+    "task_score": 68.0,
+    "verdict": "The submission identifies and implements the central one-line routing fix, but it overstates completeness because its key collision evidence is not a routing test and bare-path, normalization, validation, and regeneration behavior remain insufficiently established.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:12:41.543683Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 260699,
+        "cached_input_tokens": 176950,
+        "cache_write_input_tokens": 41783,
+        "output_tokens": 12970,
+        "reasoning_output_tokens": 11048
+      },
+      "duration_ms": 166722
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 83,
+      "notes": "The issue clearly identifies the two affected compose variants, expected interpolation behavior, non-goals, and testable acceptance criteria. Its target locations align with the submitted patch contexts around REGISTRY_CONTACT_URL and SECRET_KEY. The weakest point is that the DHI acceptance criterion is vague and the health-check criterion omits the concrete registration interface needed to test it. The related issue number and exact baseline line references could not be independently verified because repository shell execution was unavailable."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The LLD commits to exact files, interpolation syntax, insertion locations, defaults, and the intended configuration lifecycle, which is ample guidance for this small change. The proposed hunks match the implementation's surrounding YAML context and preserve the existing SECRET_KEY and egress configuration ordering. It contains concrete errors: five comment lines plus two variable lines is seven lines per file, not six, and the architecture example incorrectly places a port in SSRF_ALLOWED_HOSTS despite describing hostname-only entries. Claims about docker-compose.dhi.yml, agents/a2a files, server_routes.py, and exact source line numbers could not be independently verified."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 14,
+      "specificity": 12,
+      "risk_awareness": 10,
+      "total": 49,
+      "notes": "The review correctly recognizes the established empty-default pattern and raises useful follow-ups concerning release notes and future compose-file drift. However, the five-persona structure is largely repetitive approval and catches none of the LLD's line-count, hostname-format, or verification weaknesses. Its security analysis misleadingly characterizes an allowlist exception as enabling the mitigation and does not discuss least-privilege risks from broad host or CIDR entries. It also preserves unverified claims about the DHI overlay and application environment readers while asserting that no integration test is required despite an end-to-end acceptance criterion."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 9,
+      "specificity": 14,
+      "risk_awareness": 11,
+      "total": 51,
+      "notes": "The plan covers all three compose variants, empty defaults, static deployment-surface checks, and an end-to-end allowlisted-host scenario with explicit expected values. Its main pass-through tests export the variables in the shell, which overrides .env and therefore does not prove the documented .env workflow; the grep-only default test likewise cannot prove private-address blocking behavior. The end-to-end test lacks a usable network-attached server setup and relies on unverified API paths, payloads, container names, and authentication details. It also overwrites .env without restoring it, mixes Docker and Podman commands, uses stale-container-prone process checks, and asserts an unverified zero registry count for docker-compose.dhi.yml."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 89,
+      "notes": "The patch implements the task directly by adding both empty-default environment pass-throughs to the registry sections of the podman and prebuilt compose variants. Both hunks are internally consistent with their shown YAML context and make no unrelated service, networking, volume, or application changes. The summary accurately reports fourteen added lines, although its verification example incorrectly says a grep for SSRF_ALLOWED_HOSTS outputs both variable lines and its claim of no LLD deviation overlooks the LLD's erroneous line statistics. Independent git apply --check and validation of the stated baseline commit were not possible because the repository shell sandbox failed before command execution."
+    }
+  },
+  "task_score": 69.8,
+  "verdict": "The submission contains a strong issue, a mostly implementation-ready design, and a likely correct minimal patch, but its review is insufficiently adversarial and its testing plan has several commands and oracles that do not validate the claimed .env workflow.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:15:17.622296Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 296791,
+      "cached_input_tokens": 212745,
+      "cache_write_input_tokens": 41678,
+      "output_tokens": 12301,
+      "reasoning_output_tokens": 10251
+    },
+    "duration_ms": 156067
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "docker",
+    "compose",
+    "configuration",
+    "ssrf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 100.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2131,
+    "output_tokens": 23448,
+    "cache_read_tokens": 2361031,
+    "cache_write_tokens": 63510,
+    "total_tokens": 2450120,
+    "total_cost_usd": 0.4348616,
+    "latency_seconds": 232.8,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 100.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2131,
+  "output_tokens": 23448,
+  "latency_seconds": 232.8,
+  "num_turns": 33,
+  "total_cost_usd": 0.4348616,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2361031,
+  "cache_creation_tokens": 63510,
+  "run_started_at": "2026-08-30T21:14:04.844921Z",
+  "run_ended_at": "2026-08-30T21:17:57.612819Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2131,
+    "output_tokens": 23448,
+    "cache_read_tokens": 2361031,
+    "cache_write_tokens": 63510,
+    "total_tokens": 2450120,
+    "total_cost_usd": 0.4348616,
+    "latency_seconds": 232.8,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 100.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "pass-ssrf-allowlist-env-to-registry-container",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 83,
+        "notes": "The issue clearly identifies the two affected compose variants, expected interpolation behavior, non-goals, and testable acceptance criteria. Its target locations align with the submitted patch contexts around REGISTRY_CONTACT_URL and SECRET_KEY. The weakest point is that the DHI acceptance criterion is vague and the health-check criterion omits the concrete registration interface needed to test it. The related issue number and exact baseline line references could not be independently verified because repository shell execution was unavailable."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The LLD commits to exact files, interpolation syntax, insertion locations, defaults, and the intended configuration lifecycle, which is ample guidance for this small change. The proposed hunks match the implementation's surrounding YAML context and preserve the existing SECRET_KEY and egress configuration ordering. It contains concrete errors: five comment lines plus two variable lines is seven lines per file, not six, and the architecture example incorrectly places a port in SSRF_ALLOWED_HOSTS despite describing hostname-only entries. Claims about docker-compose.dhi.yml, agents/a2a files, server_routes.py, and exact source line numbers could not be independently verified."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 14,
+        "specificity": 12,
+        "risk_awareness": 10,
+        "total": 49,
+        "notes": "The review correctly recognizes the established empty-default pattern and raises useful follow-ups concerning release notes and future compose-file drift. However, the five-persona structure is largely repetitive approval and catches none of the LLD's line-count, hostname-format, or verification weaknesses. Its security analysis misleadingly characterizes an allowlist exception as enabling the mitigation and does not discuss least-privilege risks from broad host or CIDR entries. It also preserves unverified claims about the DHI overlay and application environment readers while asserting that no integration test is required despite an end-to-end acceptance criterion."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 9,
+        "specificity": 14,
+        "risk_awareness": 11,
+        "total": 51,
+        "notes": "The plan covers all three compose variants, empty defaults, static deployment-surface checks, and an end-to-end allowlisted-host scenario with explicit expected values. Its main pass-through tests export the variables in the shell, which overrides .env and therefore does not prove the documented .env workflow; the grep-only default test likewise cannot prove private-address blocking behavior. The end-to-end test lacks a usable network-attached server setup and relies on unverified API paths, payloads, container names, and authentication details. It also overwrites .env without restoring it, mixes Docker and Podman commands, uses stale-container-prone process checks, and asserts an unverified zero registry count for docker-compose.dhi.yml."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 89,
+        "notes": "The patch implements the task directly by adding both empty-default environment pass-throughs to the registry sections of the podman and prebuilt compose variants. Both hunks are internally consistent with their shown YAML context and make no unrelated service, networking, volume, or application changes. The summary accurately reports fourteen added lines, although its verification example incorrectly says a grep for SSRF_ALLOWED_HOSTS outputs both variable lines and its claim of no LLD deviation overlooks the LLD's erroneous line statistics. Independent git apply --check and validation of the stated baseline commit were not possible because the repository shell sandbox failed before command execution."
+      }
+    },
+    "task_score": 69.8,
+    "verdict": "The submission contains a strong issue, a mostly implementation-ready design, and a likely correct minimal patch, but its review is insufficiently adversarial and its testing plan has several commands and oracles that do not validate the claimed .env workflow.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:15:17.622296Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 296791,
+        "cached_input_tokens": 212745,
+        "cache_write_input_tokens": 41678,
+        "output_tokens": 12301,
+        "reasoning_output_tokens": 10251
+      },
+      "duration_ms": 156067
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 73,
+      "notes": "The issue provides concrete acceptance criteria for target-aware enforcement, early quarantine denial, status 403, headers, administrative management, and compatibility. Its largest defect is asserting both reuse of existing membership storage and target quarantine through that storage, while the LLD later acknowledges memberships are caller-centric and requires a new collection. The published repository overview distinguishes fail-open rate-limit availability behavior from fail-closed quarantine membership checks, whereas the issue broadly demands fail-closed behavior for both axes.  No independent task statement was supplied, so the exact authority of issue #1504 and several UI and deployment requirements could not be verified."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 7,
+      "specificity": 13,
+      "risk_awareness": 13,
+      "total": 47,
+      "notes": "The LLD names relevant files and considers identity collisions, early denial, administrative bypass, caching, rollout, and observability. Its central design is unstable: target quarantine alternates among memberships, definitions, and a dedicated collection, while caller_target alternates between a composite counter subject and an exact-pair definition model. The submitted source context defines CALLER_TYPE_USER and CALLER_TYPE_AGENT, but the design repeatedly uses client identities and the patch queries user/client prefixes, creating an integration mismatch. Claims about cache TTLs, latency, indexes, existing API capabilities, UI reuse, and nginx conditional status behavior were not substantiated by verifiable baseline source."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 11,
+      "specificity": 17,
+      "risk_awareness": 17,
+      "total": 60,
+      "notes": "The review usefully identifies caller-type collisions, empty identities, delimiter ambiguity, indexing, cache invalidation, auditability, and compromised-admin risk. It misses more fundamental defects, including the unresolved target-quarantine storage model, the issue's stated minimum limit of one versus proposed zero-valued definitions, and the lack of a credible 403-preservation path through nginx. Its claim that critical fixes are resolved is contradicted by examples that still omit caller type and by audit logging merely being deferred. Several approvals rely on unverified repository claims such as a 0.25-second timeout, 30-second caches, and existing UI behavior."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 7,
+      "specificity": 15,
+      "risk_awareness": 11,
+      "total": 49,
+      "notes": "The plan covers independent target quotas, quarantine, administrative behavior, compatibility, headers, malformed identities, deployment surface, and combined gates with concrete expected statuses. Several tests have invalid or self-contradictory oracles: the independence test exhausts both targets, the quarantine counter test deletes all memberships and then expects throttling, and the ordering test gives every gate the same window. Target-quarantine commands are absent from the patch, multiple token variables and helpers are undefined, and the end-to-end script prints success without failing on mismatched responses. DocumentDB failure, cache propagation, counter non-consumption, and real unit-level gate ordering remain unimplemented or unverifiable despite being listed as covered."
+    },
+    "implementation": {
+      "completeness": 5,
+      "correctness": 4,
+      "specificity": 10,
+      "risk_awareness": 5,
+      "total": 24,
+      "notes": "The summary honestly states that the patch is only a data-layer phase, but consequently it implements no caller_target enforcement, quarantine denial, API or CLI management, startup seeding, immutability, UI support, or tests. Concrete defects include querying user/client prefixes despite importing user/agent constants, never calling ensure_quarantine_groups, and catching every exception from target-quarantine insertion as a successful duplicate. The proposed zero-valued quarantine definitions conflict with the issue's stated configuration floor of one, while quarantine headers still retain X-RateLimit-Throttled and no code creates quarantine decisions. Patch applicability could not be independently confirmed because the provided read-only shell failed before executing git apply --check, leaving exact baseline fit as a material evidence gap."
+    }
+  },
+  "task_score": 50.6,
+  "verdict": "The submission frames the problem well and surfaces useful risks, but its design remains contradictory and the partial implementation neither enforces the feature nor provides a reliable foundation for completing it.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:17:38.172315Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 334318,
+      "cached_input_tokens": 256456,
+      "cache_write_input_tokens": 49959,
+      "output_tokens": 11105,
+      "reasoning_output_tokens": 9303
+    },
+    "duration_ms": 140538
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "high",
+  "tags": [
+    "rate-limiting",
+    "security",
+    "auth-server",
+    "api",
+    "operations",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 92.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 484,
+    "output_tokens": 49025,
+    "cache_read_tokens": 7424029,
+    "cache_write_tokens": 194506,
+    "total_tokens": 7668044,
+    "total_cost_usd": 1.2311444000000005,
+    "latency_seconds": 532.9,
+    "num_turns": 81,
+    "generation_tokens_per_sec": 92.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 484,
+  "output_tokens": 49025,
+  "latency_seconds": 532.9,
+  "num_turns": 81,
+  "total_cost_usd": 1.2311444000000005,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 7424029,
+  "cache_creation_tokens": 194506,
+  "run_started_at": "2026-08-30T20:51:42.531188Z",
+  "run_ended_at": "2026-08-30T21:00:35.419713Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 484,
+    "output_tokens": 49025,
+    "cache_read_tokens": 7424029,
+    "cache_write_tokens": 194506,
+    "total_tokens": 7668044,
+    "total_cost_usd": 1.2311444000000005,
+    "latency_seconds": 532.9,
+    "num_turns": 81,
+    "generation_tokens_per_sec": 92.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "per-caller-per-target-rate-limits-and-quarantine",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 73,
+        "notes": "The issue provides concrete acceptance criteria for target-aware enforcement, early quarantine denial, status 403, headers, administrative management, and compatibility. Its largest defect is asserting both reuse of existing membership storage and target quarantine through that storage, while the LLD later acknowledges memberships are caller-centric and requires a new collection. The published repository overview distinguishes fail-open rate-limit availability behavior from fail-closed quarantine membership checks, whereas the issue broadly demands fail-closed behavior for both axes.  No independent task statement was supplied, so the exact authority of issue #1504 and several UI and deployment requirements could not be verified."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 7,
+        "specificity": 13,
+        "risk_awareness": 13,
+        "total": 47,
+        "notes": "The LLD names relevant files and considers identity collisions, early denial, administrative bypass, caching, rollout, and observability. Its central design is unstable: target quarantine alternates among memberships, definitions, and a dedicated collection, while caller_target alternates between a composite counter subject and an exact-pair definition model. The submitted source context defines CALLER_TYPE_USER and CALLER_TYPE_AGENT, but the design repeatedly uses client identities and the patch queries user/client prefixes, creating an integration mismatch. Claims about cache TTLs, latency, indexes, existing API capabilities, UI reuse, and nginx conditional status behavior were not substantiated by verifiable baseline source."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 11,
+        "specificity": 17,
+        "risk_awareness": 17,
+        "total": 60,
+        "notes": "The review usefully identifies caller-type collisions, empty identities, delimiter ambiguity, indexing, cache invalidation, auditability, and compromised-admin risk. It misses more fundamental defects, including the unresolved target-quarantine storage model, the issue's stated minimum limit of one versus proposed zero-valued definitions, and the lack of a credible 403-preservation path through nginx. Its claim that critical fixes are resolved is contradicted by examples that still omit caller type and by audit logging merely being deferred. Several approvals rely on unverified repository claims such as a 0.25-second timeout, 30-second caches, and existing UI behavior."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 7,
+        "specificity": 15,
+        "risk_awareness": 11,
+        "total": 49,
+        "notes": "The plan covers independent target quotas, quarantine, administrative behavior, compatibility, headers, malformed identities, deployment surface, and combined gates with concrete expected statuses. Several tests have invalid or self-contradictory oracles: the independence test exhausts both targets, the quarantine counter test deletes all memberships and then expects throttling, and the ordering test gives every gate the same window. Target-quarantine commands are absent from the patch, multiple token variables and helpers are undefined, and the end-to-end script prints success without failing on mismatched responses. DocumentDB failure, cache propagation, counter non-consumption, and real unit-level gate ordering remain unimplemented or unverifiable despite being listed as covered."
+      },
+      "implementation": {
+        "completeness": 5,
+        "correctness": 4,
+        "specificity": 10,
+        "risk_awareness": 5,
+        "total": 24,
+        "notes": "The summary honestly states that the patch is only a data-layer phase, but consequently it implements no caller_target enforcement, quarantine denial, API or CLI management, startup seeding, immutability, UI support, or tests. Concrete defects include querying user/client prefixes despite importing user/agent constants, never calling ensure_quarantine_groups, and catching every exception from target-quarantine insertion as a successful duplicate. The proposed zero-valued quarantine definitions conflict with the issue's stated configuration floor of one, while quarantine headers still retain X-RateLimit-Throttled and no code creates quarantine decisions. Patch applicability could not be independently confirmed because the provided read-only shell failed before executing git apply --check, leaving exact baseline fit as a material evidence gap."
+      }
+    },
+    "task_score": 50.6,
+    "verdict": "The submission frames the problem well and surfaces useful risks, but its design remains contradictory and the partial implementation neither enforces the feature nor provides a reliable foundation for completing it.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:17:38.172315Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 334318,
+        "cached_input_tokens": 256456,
+        "cache_write_input_tokens": 49959,
+        "output_tokens": 11105,
+        "reasoning_output_tokens": 9303
+      },
+      "duration_ms": 140538
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 4,
+      "specificity": 17,
+      "risk_awareness": 7,
+      "total": 46,
+      "notes": "The issue has clear scope, named variables, non-goals, and testable outcomes such as eliminating duplicate assignments and backup files. Its central solution is incorrect: GNU sed documents the optional in-place suffix as attached to -i, so a separate empty argument is parsed as an operand rather than a portable suffix.  The submitted diff corroborates the existence of ten static deletion calls and one dynamic ENV_VAR_NAME call, but the issue's claim that sourcing duplicate assignments reads the first value conflicts with normal shell behavior, where the later assignment replaces the earlier one.  With no independent task statement and unavailable local shell inspection, the asserted auth-server crash-loop, exact baseline lines, and related issue number could not be independently verified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 2,
+      "specificity": 17,
+      "risk_awareness": 6,
+      "total": 43,
+      "notes": "The LLD is unusually concrete about build_and_run.sh, the five static secret blocks, the dynamic token block, error propagation, alternatives, and intended tests. The load-bearing design is nevertheless invalid because sed -i '' is not a single cross-platform invocation under GNU sed's documented option syntax.  The submitted patch context supports several cited symbols, including handle_error, ENV_VAR_NAME, and the eleven existing sed calls, but the LLD also rejects Python as a new dependency despite showing that these blocks already invoke python3. Its risk analysis misses the resulting Linux regression, incorrectly declares full backward compatibility, and leaves no open question for the unresolved GNU/BSD command difference."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 2,
+      "specificity": 10,
+      "risk_awareness": 6,
+      "total": 28,
+      "notes": "The review does identify two concrete concerns: newly visible failures may affect automation, and validation is needed on both operating-system families. Its unanimous approval misses the design's decisive flaw, repeatedly asserting that sed -i '' behaves identically on GNU and BSD despite GNU's documented attached optional-argument syntax.  Recommendations about the dynamic call, comments, release notes, and macOS testing are specific, but the frontend and security sections add little substantive pressure testing. Claims about available macOS CI, dependent automation, and shell-scripting guidelines remain unverified, while the verdict incorrectly labels the change backward compatible."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 2,
+      "specificity": 14,
+      "risk_awareness": 8,
+      "total": 40,
+      "notes": "The plan covers cross-platform behavior, all named secrets, dynamic keys, existing values, failure visibility, backup files, and deployment-level checks. Its foundational Linux test executes the invalid sed -i '' form, so the plan would expose rather than validate the proposed portability claim under GNU sed.  The repeat-run test is also internally wrong: its second deletion removes only an empty SECRET_KEY assignment, so appending NEW_VALUE2 after a nonempty prior value produces two entries rather than the asserted one. Several sections are pseudo-code or instructions to extract logic, the chmod 444 failure setup is unreliable for rename-based in-place editing, and the claimed health endpoint and optional skip-docker flag could not be verified."
+    },
+    "implementation": {
+      "completeness": 7,
+      "correctness": 0,
+      "specificity": 12,
+      "risk_awareness": 4,
+      "total": 23,
+      "notes": "The diff text attempts all eleven advertised replacements and consistently removes error suppression from both static and dynamic deletion paths. It does not implement a portable command: on GNU sed, the separate empty argument does not serve as the optional -i suffix, making the Linux compatibility and no-breaking-change claims false.  The patch headers target /tmp/original.sh and /tmp/modified.sh rather than build_and_run.sh, so the documented git apply command cannot reliably modify the intended repository file as submitted. Exact baseline applicability could not be dry-run because the local shell sandbox failed to initialize, but the malformed target paths and incorrect GNU behavior independently make the implementation unusable."
+    }
+  },
+  "task_score": 36.0,
+  "verdict": "The artifacts are detailed and repository-shaped, but the proposed command is not portable to GNU sed and the submitted patch does not even target build_and_run.sh, invalidating the design, tests, and implementation.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:19:36.234698Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 222691,
+      "cached_input_tokens": 135583,
+      "cache_write_input_tokens": 34368,
+      "output_tokens": 9382,
+      "reasoning_output_tokens": 7419
+    },
+    "duration_ms": 118051
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "portability",
+    "macos",
+    "secrets",
+    "setup",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 88.3,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 282,
+    "output_tokens": 24332,
+    "cache_read_tokens": 3212279,
+    "cache_write_tokens": 60451,
+    "total_tokens": 3297344,
+    "total_cost_usd": 0.5187336499999999,
+    "latency_seconds": 275.5,
+    "num_turns": 46,
+    "generation_tokens_per_sec": 88.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 282,
+  "output_tokens": 24332,
+  "latency_seconds": 275.5,
+  "num_turns": 46,
+  "total_cost_usd": 0.5187336499999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3212279,
+  "cache_creation_tokens": 60451,
+  "run_started_at": "2026-08-30T21:24:28.280212Z",
+  "run_ended_at": "2026-08-30T21:29:03.804226Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 282,
+    "output_tokens": 24332,
+    "cache_read_tokens": 3212279,
+    "cache_write_tokens": 60451,
+    "total_tokens": 3297344,
+    "total_cost_usd": 0.5187336499999999,
+    "latency_seconds": 275.5,
+    "num_turns": 46,
+    "generation_tokens_per_sec": 88.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "portable-env-secret-generation-in-build-script",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 4,
+        "specificity": 17,
+        "risk_awareness": 7,
+        "total": 46,
+        "notes": "The issue has clear scope, named variables, non-goals, and testable outcomes such as eliminating duplicate assignments and backup files. Its central solution is incorrect: GNU sed documents the optional in-place suffix as attached to -i, so a separate empty argument is parsed as an operand rather than a portable suffix.  The submitted diff corroborates the existence of ten static deletion calls and one dynamic ENV_VAR_NAME call, but the issue's claim that sourcing duplicate assignments reads the first value conflicts with normal shell behavior, where the later assignment replaces the earlier one.  With no independent task statement and unavailable local shell inspection, the asserted auth-server crash-loop, exact baseline lines, and related issue number could not be independently verified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 2,
+        "specificity": 17,
+        "risk_awareness": 6,
+        "total": 43,
+        "notes": "The LLD is unusually concrete about build_and_run.sh, the five static secret blocks, the dynamic token block, error propagation, alternatives, and intended tests. The load-bearing design is nevertheless invalid because sed -i '' is not a single cross-platform invocation under GNU sed's documented option syntax.  The submitted patch context supports several cited symbols, including handle_error, ENV_VAR_NAME, and the eleven existing sed calls, but the LLD also rejects Python as a new dependency despite showing that these blocks already invoke python3. Its risk analysis misses the resulting Linux regression, incorrectly declares full backward compatibility, and leaves no open question for the unresolved GNU/BSD command difference."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 2,
+        "specificity": 10,
+        "risk_awareness": 6,
+        "total": 28,
+        "notes": "The review does identify two concrete concerns: newly visible failures may affect automation, and validation is needed on both operating-system families. Its unanimous approval misses the design's decisive flaw, repeatedly asserting that sed -i '' behaves identically on GNU and BSD despite GNU's documented attached optional-argument syntax.  Recommendations about the dynamic call, comments, release notes, and macOS testing are specific, but the frontend and security sections add little substantive pressure testing. Claims about available macOS CI, dependent automation, and shell-scripting guidelines remain unverified, while the verdict incorrectly labels the change backward compatible."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 2,
+        "specificity": 14,
+        "risk_awareness": 8,
+        "total": 40,
+        "notes": "The plan covers cross-platform behavior, all named secrets, dynamic keys, existing values, failure visibility, backup files, and deployment-level checks. Its foundational Linux test executes the invalid sed -i '' form, so the plan would expose rather than validate the proposed portability claim under GNU sed.  The repeat-run test is also internally wrong: its second deletion removes only an empty SECRET_KEY assignment, so appending NEW_VALUE2 after a nonempty prior value produces two entries rather than the asserted one. Several sections are pseudo-code or instructions to extract logic, the chmod 444 failure setup is unreliable for rename-based in-place editing, and the claimed health endpoint and optional skip-docker flag could not be verified."
+      },
+      "implementation": {
+        "completeness": 7,
+        "correctness": 0,
+        "specificity": 12,
+        "risk_awareness": 4,
+        "total": 23,
+        "notes": "The diff text attempts all eleven advertised replacements and consistently removes error suppression from both static and dynamic deletion paths. It does not implement a portable command: on GNU sed, the separate empty argument does not serve as the optional -i suffix, making the Linux compatibility and no-breaking-change claims false.  The patch headers target /tmp/original.sh and /tmp/modified.sh rather than build_and_run.sh, so the documented git apply command cannot reliably modify the intended repository file as submitted. Exact baseline applicability could not be dry-run because the local shell sandbox failed to initialize, but the malformed target paths and incorrect GNU behavior independently make the implementation unusable."
+      }
+    },
+    "task_score": 36.0,
+    "verdict": "The artifacts are detailed and repository-shaped, but the proposed command is not portable to GNU sed and the submitted patch does not even target build_and_run.sh, invalidating the design, tests, and implementation.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:19:36.234698Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 222691,
+        "cached_input_tokens": 135583,
+        "cache_write_input_tokens": 34368,
+        "output_tokens": 9382,
+        "reasoning_output_tokens": 7419
+      },
+      "duration_ms": 118051
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "registration-admission-control-gate",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 80,
+      "notes": "The issue clearly defines synchronous, fail-closed admission behavior, enumerates seven create/update routes, and supplies testable acceptance criteria and non-goals. Its largest gap is security treatment of transmitting full asset payloads, including TLS, sensitive fields, response sanitization, and malformed gate responses. Off-by-default behavior and explicit timeout, denial, and deployment requirements make the intended compatibility boundary concrete despite the absent independent task statement. The claims that httpx is already available and that the named deployment surfaces are exhaustive were not substantiated by the submission."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 11,
+      "specificity": 17,
+      "risk_awareness": 13,
+      "total": 57,
+      "notes": "The LLD names route files, service methods, configuration fields, payload structure, and persistence boundaries, making it substantially more actionable than a generic architecture. Its critical integration decisions remain inconsistent: it alternates between lifespan/global initialization and dependency creation, claims unavailable gates produce 503 while its route examples do not translate the service's generic exceptions, and catches asyncio.TimeoutError rather than HTTPX's timeout exception type. It identifies multiple server entry points, yet the eventual patch contains only one server-route gate hunk, demonstrating that the endpoint inventory was not converted into an enforceable implementation map. Latency and fail-closed behavior are discussed, but sensitive payload disclosure, malformed or oversized responses, TLS enforcement, and concrete rollback validation receive inadequate treatment."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 13,
+      "specificity": 17,
+      "risk_awareness": 16,
+      "total": 62,
+      "notes": "The review surfaces useful concrete issues including URL validation, error-message leakage, token handling, HTTP-client dependency verification, and service initialization consistency. Its largest weakness is that it records those findings as resolved or non-blocking without updating the LLD or verifying the implementation. The submitted patch still lacks URL validation and secret documentation and modifies only one server route, contradicting the review's claims that configuration propagation is sound and all concerns are addressed. It also misses the most consequential bypass risk from ungated internal and update routes and does not examine exposure of complete asset payloads to the external service."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 15,
+      "risk_awareness": 12,
+      "total": 50,
+      "notes": "The plan provides concrete expected status codes, gate-call payload assertions, persistence checks, disabled-mode coverage, and allow, deny, timeout, and unreachable scenarios. Its largest defect is executability: it invokes tests/test_admission_gate.py tests that the patch never adds, does not explain how the localhost mock server is started, and includes invalid JSON examples containing comments or ellipses. It omits server-update coverage, malformed 200 responses, non-403 error statuses, authorization-header verification, configuration validation, and payload confidentiality checks. The checklist also calls the functional set nine tests while enumerating twelve, and several claimed repository commands and deployment paths remain unverified."
+    },
+    "implementation": {
+      "completeness": 8,
+      "correctness": 9,
+      "specificity": 13,
+      "risk_awareness": 7,
+      "total": 37,
+      "notes": "The patch concretely adds settings, an asynchronous gate client, and checks at five call sites: two agent routes, one server route, and two skill routes. The largest defect is a security bypass: no hunk gates the internal server registration or server update route, while no deployment configuration or executable tests are added despite explicit requirements. The summary falsely claims internal registration and all endpoints are covered, says there are no LLD deviations despite changing initialization strategy, and reports security-review resolutions that the code does not implement. Patched paths fail closed, but the code sends full payloads to an unvalidated URL, surfaces raw 403 bodies, and catches asyncio.TimeoutError instead of HTTPX's timeout exception; independent git-apply verification was unavailable in the read-only execution environment."
+    }
+  },
+  "task_score": 57.2,
+  "verdict": "The submission has a strong issue and useful design detail, but the implementation remains materially incomplete because server admission paths can bypass the gate and promised deployment, validation, and test work is absent.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:21:41.494121Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 259771,
+      "cached_input_tokens": 192580,
+      "cache_write_input_tokens": 35169,
+      "output_tokens": 11183,
+      "reasoning_output_tokens": 9744
+    },
+    "duration_ms": 125247
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "registration-admission-control-gate",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "architecture",
+    "api",
+    "fastapi",
+    "webhooks",
+    "admission-control",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 95.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 310,
+    "output_tokens": 28826,
+    "cache_read_tokens": 4037485,
+    "cache_write_tokens": 77663,
+    "total_tokens": 4144284,
+    "total_cost_usd": 0.6452672500000001,
+    "latency_seconds": 301.3,
+    "num_turns": 52,
+    "generation_tokens_per_sec": 95.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 310,
+  "output_tokens": 28826,
+  "latency_seconds": 301.3,
+  "num_turns": 52,
+  "total_cost_usd": 0.6452672500000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 4037485,
+  "cache_creation_tokens": 77663,
+  "run_started_at": "2026-08-30T20:34:57.963863Z",
+  "run_ended_at": "2026-08-30T20:39:59.265011Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 310,
+    "output_tokens": 28826,
+    "cache_read_tokens": 4037485,
+    "cache_write_tokens": 77663,
+    "total_tokens": 4144284,
+    "total_cost_usd": 0.6452672500000001,
+    "latency_seconds": 301.3,
+    "num_turns": 52,
+    "generation_tokens_per_sec": 95.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "registration-admission-control-gate",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 80,
+        "notes": "The issue clearly defines synchronous, fail-closed admission behavior, enumerates seven create/update routes, and supplies testable acceptance criteria and non-goals. Its largest gap is security treatment of transmitting full asset payloads, including TLS, sensitive fields, response sanitization, and malformed gate responses. Off-by-default behavior and explicit timeout, denial, and deployment requirements make the intended compatibility boundary concrete despite the absent independent task statement. The claims that httpx is already available and that the named deployment surfaces are exhaustive were not substantiated by the submission."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 11,
+        "specificity": 17,
+        "risk_awareness": 13,
+        "total": 57,
+        "notes": "The LLD names route files, service methods, configuration fields, payload structure, and persistence boundaries, making it substantially more actionable than a generic architecture. Its critical integration decisions remain inconsistent: it alternates between lifespan/global initialization and dependency creation, claims unavailable gates produce 503 while its route examples do not translate the service's generic exceptions, and catches asyncio.TimeoutError rather than HTTPX's timeout exception type. It identifies multiple server entry points, yet the eventual patch contains only one server-route gate hunk, demonstrating that the endpoint inventory was not converted into an enforceable implementation map. Latency and fail-closed behavior are discussed, but sensitive payload disclosure, malformed or oversized responses, TLS enforcement, and concrete rollback validation receive inadequate treatment."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 13,
+        "specificity": 17,
+        "risk_awareness": 16,
+        "total": 62,
+        "notes": "The review surfaces useful concrete issues including URL validation, error-message leakage, token handling, HTTP-client dependency verification, and service initialization consistency. Its largest weakness is that it records those findings as resolved or non-blocking without updating the LLD or verifying the implementation. The submitted patch still lacks URL validation and secret documentation and modifies only one server route, contradicting the review's claims that configuration propagation is sound and all concerns are addressed. It also misses the most consequential bypass risk from ungated internal and update routes and does not examine exposure of complete asset payloads to the external service."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 15,
+        "risk_awareness": 12,
+        "total": 50,
+        "notes": "The plan provides concrete expected status codes, gate-call payload assertions, persistence checks, disabled-mode coverage, and allow, deny, timeout, and unreachable scenarios. Its largest defect is executability: it invokes tests/test_admission_gate.py tests that the patch never adds, does not explain how the localhost mock server is started, and includes invalid JSON examples containing comments or ellipses. It omits server-update coverage, malformed 200 responses, non-403 error statuses, authorization-header verification, configuration validation, and payload confidentiality checks. The checklist also calls the functional set nine tests while enumerating twelve, and several claimed repository commands and deployment paths remain unverified."
+      },
+      "implementation": {
+        "completeness": 8,
+        "correctness": 9,
+        "specificity": 13,
+        "risk_awareness": 7,
+        "total": 37,
+        "notes": "The patch concretely adds settings, an asynchronous gate client, and checks at five call sites: two agent routes, one server route, and two skill routes. The largest defect is a security bypass: no hunk gates the internal server registration or server update route, while no deployment configuration or executable tests are added despite explicit requirements. The summary falsely claims internal registration and all endpoints are covered, says there are no LLD deviations despite changing initialization strategy, and reports security-review resolutions that the code does not implement. Patched paths fail closed, but the code sends full payloads to an unvalidated URL, surfaces raw 403 bodies, and catches asyncio.TimeoutError instead of HTTPX's timeout exception; independent git-apply verification was unavailable in the read-only execution environment."
+      }
+    },
+    "task_score": 57.2,
+    "verdict": "The submission has a strong issue and useful design detail, but the implementation remains materially incomplete because server admission paths can bypass the gate and promised deployment, validation, and test work is absent.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:21:41.494121Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 259771,
+        "cached_input_tokens": 192580,
+        "cache_write_input_tokens": 35169,
+        "output_tokens": 11183,
+        "reasoning_output_tokens": 9744
+      },
+      "duration_ms": 125247
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/run-summary.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/run-summary.json
@@ -1,0 +1,1438 @@
+{
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry-v2",
+  "provider": "bedrock",
+  "ref": null,
+  "refs": [
+    "1.23.0",
+    "1.24.3",
+    "1.24.7",
+    "1.25.0",
+    "1.27.1",
+    "1.28.0",
+    "v1.0.18",
+    "v1.0.19",
+    "v1.0.20",
+    "v1.0.21"
+  ],
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T21:35:38.002565Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 898272,
+      "cached_input_tokens": 730750,
+      "cache_write_input_tokens": 128925,
+      "output_tokens": 9592,
+      "reasoning_output_tokens": 7542
+    },
+    "duration_ms": 150928
+  },
+  "num_tasks": 21,
+  "num_scored": 21,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 56.18,
+  "mean_cost_usd_excl_failed": 0.69,
+  "tasks": [
+    {
+      "task": "pass-ssrf-allowlist-env-to-registry-container",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 33,
+      "input_tokens": 2131,
+      "output_tokens": 23448,
+      "total_tokens": 2450120,
+      "latency_seconds": 232.8,
+      "total_cost_usd": 0.4348616,
+      "result_subtype": "success",
+      "task_score": 69.8,
+      "cache_read_tokens": 2361031,
+      "cache_write_tokens": 63510,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 100.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 83,
+          "notes": "The issue clearly identifies the two affected compose variants, expected interpolation behavior, non-goals, and testable acceptance criteria. Its target locations align with the submitted patch contexts around REGISTRY_CONTACT_URL and SECRET_KEY. The weakest point is that the DHI acceptance criterion is vague and the health-check criterion omits the concrete registration interface needed to test it. The related issue number and exact baseline line references could not be independently verified because repository shell execution was unavailable."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The LLD commits to exact files, interpolation syntax, insertion locations, defaults, and the intended configuration lifecycle, which is ample guidance for this small change. The proposed hunks match the implementation's surrounding YAML context and preserve the existing SECRET_KEY and egress configuration ordering. It contains concrete errors: five comment lines plus two variable lines is seven lines per file, not six, and the architecture example incorrectly places a port in SSRF_ALLOWED_HOSTS despite describing hostname-only entries. Claims about docker-compose.dhi.yml, agents/a2a files, server_routes.py, and exact source line numbers could not be independently verified."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 14,
+          "specificity": 12,
+          "risk_awareness": 10,
+          "total": 49,
+          "notes": "The review correctly recognizes the established empty-default pattern and raises useful follow-ups concerning release notes and future compose-file drift. However, the five-persona structure is largely repetitive approval and catches none of the LLD's line-count, hostname-format, or verification weaknesses. Its security analysis misleadingly characterizes an allowlist exception as enabling the mitigation and does not discuss least-privilege risks from broad host or CIDR entries. It also preserves unverified claims about the DHI overlay and application environment readers while asserting that no integration test is required despite an end-to-end acceptance criterion."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 9,
+          "specificity": 14,
+          "risk_awareness": 11,
+          "total": 51,
+          "notes": "The plan covers all three compose variants, empty defaults, static deployment-surface checks, and an end-to-end allowlisted-host scenario with explicit expected values. Its main pass-through tests export the variables in the shell, which overrides .env and therefore does not prove the documented .env workflow; the grep-only default test likewise cannot prove private-address blocking behavior. The end-to-end test lacks a usable network-attached server setup and relies on unverified API paths, payloads, container names, and authentication details. It also overwrites .env without restoring it, mixes Docker and Podman commands, uses stale-container-prone process checks, and asserts an unverified zero registry count for docker-compose.dhi.yml."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 89,
+          "notes": "The patch implements the task directly by adding both empty-default environment pass-throughs to the registry sections of the podman and prebuilt compose variants. Both hunks are internally consistent with their shown YAML context and make no unrelated service, networking, volume, or application changes. The summary accurately reports fourteen added lines, although its verification example incorrectly says a grep for SSRF_ALLOWED_HOSTS outputs both variable lines and its claim of no LLD deviation overlooks the LLD's erroneous line statistics. Independent git apply --check and validation of the stated baseline commit were not possible because the repository shell sandbox failed before command execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "nginx-location-trailing-slash-route-hijack",
+      "complexity": "medium",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 57,
+      "input_tokens": 17,
+      "output_tokens": 982,
+      "total_tokens": 198587,
+      "latency_seconds": 308.4,
+      "total_cost_usd": 0.10629210000000001,
+      "result_subtype": "success",
+      "task_score": 68.0,
+      "cache_read_tokens": 126626,
+      "cache_write_tokens": 70962,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 3.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 78,
+          "notes": "The issue clearly identifies `_create_location_block`, the intended trailing-slash behavior, client compatibility, scope, and testable config output. Its `/a` versus registered `/api` collision example is technically misleading because nginx chooses the longest matching prefix, so `/api` already wins that pairing.  The bare-path criterion is internally inconsistent: `/server-name/` is required not to silently match, yet the proposed `location /server-name/` necessarily matches it. No independent task statement was supplied, and the claimed source line could not be independently inspected because the local command sandbox failed before execution."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 73,
+          "notes": "The LLD is unusually concrete about `registry/core/nginx_service.py`, `_create_location_block`, normalization, generated output, compatibility, and edge cases. Its largest deficiency is unsupported certainty: it declares full compatibility and automatic migration while leaving bare `/server-name/` behavior unresolved and not identifying the exact event that rerenders persisted configuration. The proposed normalization changes only `location_path`; other construction using raw `path`, such as the asserted mcp-proxy URI, may still produce doubled slashes for `/server/` input. Claims that `_NGINX_AGENT_PATH_SAFE` validates every MCP path and that `_create_agent_location_block` is the applicable reference could not be independently verified."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 13,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 61,
+          "notes": "The review provides prioritized test, rollout, validation, and documentation recommendations tied to named symbols and scenarios. However, its five personas mostly ratify the LLD and fail to catch the contradictory `/server-name/` acceptance criterion or the ineffective `/a` plus `/api` collision premise. It also accepts unsupported claims about complete path validation, unchanged monitoring, automatic regeneration, and full backward compatibility. The strongest actionable finding is the demand for explicit trailing-slash assertions, but the review does not require a real nginx routing oracle."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 61,
+          "notes": "The plan supplies concrete fixtures, inputs, expected generated strings, transport coverage, normalization cases, and proposed deployment checks. Several purported compatibility and collision tests contain only comments after asserting config text, so they cannot prove request routing, and no test covers the issue's `/server-name/` behavior. The command `python -m unittest discover` is mismatched with the shown pytest-style functions and fixtures, while the proposed `python -m registry.core.nginx_service.NginxConfigService.generate_config_async(...)` invocation is not a valid way to call a class method. The live test also accepts an ambiguous `200 or other` result and assumes registration endpoints and payloads that could not be verified."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 67,
+          "notes": "The patch directly changes `registry/core/nginx_service.py::_create_location_block`, updates nine existing assertions, and adds focused normalization and generated-block tests, so it implements the central trailing-slash change. Its collision test verifies only two strings and proxy targets, not nginx matching, and the patch does not implement or test explicit handling for bare `/server-name/` despite claiming every acceptance criterion is met. Normalizing only `location_path` may leave raw-path uses producing doubled proxy URI slashes for already-suffixed inputs, and the summary's `_NGINX_AGENT_PATH_SAFE` and render-layer sanitization assurances are unverified. The hunk context is internally consistent with the submitted artifacts, but `git apply --check` and repository test execution could not be performed because the read-only shell sandbox failed before running commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "derive-repo-url-from-skill-md",
+      "complexity": "medium",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 68,
+      "input_tokens": 406,
+      "output_tokens": 29963,
+      "total_tokens": 5505989,
+      "latency_seconds": 334.3,
+      "total_cost_usd": 0.8838127499999999,
+      "result_subtype": "success",
+      "task_score": 67.2,
+      "cache_read_tokens": 5313855,
+      "cache_write_tokens": 161765,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 89.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 87,
+          "notes": "The issue gives a crisp end-to-end scope, testable acceptance criteria, and useful exclusions covering repository verification and non-GitHub hosts. Its named integration points, including translate_skill_url, _parse_skill_md_content, Dashboard.tsx, and both skill modals, agree with the submitted patch contexts. The largest gap is ambiguity around repeated parsing and whether an existing manually entered repository_url should be cleared, preserved, or overwritten. No independent task statement was supplied, so the expanded UI and enterprise-host scope cannot be confirmed beyond the internally consistent artifacts and repository metadata."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The design is unusually concrete about files, symbols, data flow, optional response behavior, and conditional modal rendering. Its integration points match the patch contexts for _parse_skill_md_content, parse_skill_md, handleParseSkillMd, SkillCard, and SemanticSearchResults. The central correctness defect is that its algorithm reconstructs the original hostname for raw.githubusercontent.com while its own example requires https://github.com/org/repo, leaving a contradictory load-bearing decision. Its malformed-input guarantee is also incomplete because the resulting implementation accesses parsed.hostname outside the try block, and it does not address stale form values or enterprise instances using non-default ports."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 10,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 52,
+          "notes": "The review provides concrete recommendations for malformed inputs, enterprise cases, null handling, and conditional links rather than merely issuing approvals. It nevertheless misses the LLD's direct contradiction between preserving raw.githubusercontent.com and promising a github.com repository root, then incorrectly states that both URL shapes are handled correctly. Pixel's request for additional auto-fill feedback overlooks the existing success toast visible beside the Dashboard.tsx state update, while Sage incorrectly suggests a guarded optional property would still fail TypeScript strict null checks. The security approval is overconfident because the accepted schemes and precise trust semantics of _is_github_hostname are not established in the review."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 11,
+          "specificity": 16,
+          "risk_awareness": 15,
+          "total": 60,
+          "notes": "The plan has useful concrete oracles for blob and raw derivation, editable auto-fill, modal link targets, old records, and backward-compatible JSON responses. Its main flaw is presenting malformed, short-path, and GitLab cases as helper tests while invoking the parse endpoint, whose service constructs the result only after fetching the supplied URL; the illustrative URLs can therefore fail retrieval before repository_url is observable. The enterprise case has no executable mock setup, TOKEN is undefined, and the proposed tests under tests/unit and tests/integration have neither repository test commands nor concrete test files. It also lacks a direct derive_repository_url unit test and a repeated-parse case that would expose stale repository form state."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 13,
+          "specificity": 19,
+          "risk_awareness": 10,
+          "total": 61,
+          "notes": "The patch covers every stated layer: URL utility, service result, API response, frontend type, Dashboard auto-fill, and both modal implementations. The largest defect is in derive_repository_url: its raw branch returns f\"{scheme}://{hostname}/{org}/{repo}\", producing a raw.githubusercontent.com URL rather than the promised github.com repository root when called directly. Additionally, parsed.hostname is evaluated outside the exception handler, Dashboard preserves a previous repository_url when the new result is null, and no automated tests accompany the change. The summary therefore overstates that there are no deviations and that malformed inputs always return None; local git apply verification could not be completed because the provided shell sandbox failed before executing repository commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "fix-reserved-groups-var-in-service-account-script",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 23,
+      "input_tokens": 141,
+      "output_tokens": 15669,
+      "total_tokens": 1406085,
+      "latency_seconds": 158.0,
+      "total_cost_usd": 0.2657882,
+      "result_subtype": "success",
+      "task_score": 65.8,
+      "cache_read_tokens": 1348297,
+      "cache_write_tokens": 41978,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 99.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 81,
+          "notes": "The issue clearly identifies both scripts, the verify_setup() failure, operator impact, non-goals, and testable exit-code and lint outcomes. Its GROUPS diagnosis and proposed scalar rename agree with the submitted diff and established Bash behavior. The largest gap is that grep -q \"$TARGET_GROUP\" performs regex substring matching rather than exact group-name membership, despite the acceptance criterion claiming correct membership verification. No independent task statement exists, and the local repository runner failed before execution, so the cited line numbers, issue #1570, and dependency versions could not be independently verified."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 75,
+          "notes": "The LLD gives concrete changes for both named files and its function bodies align with the submitted patch's curl, jq, mapper, and verification flow. It correctly uses a separately declared local scalar, which is compatible with Bash 3.2 and avoids the special GROUPS array behavior. Its main technical deficiency is declaring grep -q correct without addressing exact-line, fixed-string, or leading-hyphen cases; its reserved-variable search list also conflates readonly and merely special or assignable Bash variables. The diagram's claim that failure occurs without printing output conflicts with its own echo statements preceding the assignment, and repository-level file and call-site claims remained unverifiable because local commands could not start."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 14,
+          "specificity": 16,
+          "risk_awareness": 11,
+          "total": 55,
+          "notes": "The review references the actual variable, both scripts, Bash-version portability, wrapper behavior, and transient curl failures rather than remaining wholly generic. Its largest weakness is unanimous approval with no substantive finding, including the incorrect assertion that grep -q \"$TARGET_GROUP\" is a fully correct membership test. It also says only two lines change per script, while each submitted hunk has five additions and three deletions, including three renamed references. Shellcheck compliance and repository integration were asserted rather than demonstrated, and could not be independently verified after the repository command runner failed."
+        },
+        "testing": {
+          "completeness": 12,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 7,
+          "total": 42,
+          "notes": "The plan supplies concrete syntax, lint, scoping, and source-inspection commands for both scripts, with several explicit expected strings. Its central deficiency is that it promises mocked API testing but implements no functional mock, exit-code execution, failure-path test, mapper-negative case, or exact group-membership oracle. The SC2178 section contradicts itself by accepting both grep status 0 and 1, and the double-quoted SERVICE_ACCOUNT_GROUPS=\\\\$(curl pattern can invoke command substitution instead of matching a literal assignment. Its hard-coded /tmp/swe-clone-fix-reserved-groups-var-in-service-account-script path does not match the submitted repository working directory, and it does not test the acceptance claim that no other reserved assignments remain."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 76,
+          "notes": "The patch consistently renames the assignment, output reference, and membership-check reference in both submitted verify_setup() hunks, and adds a separately scoped local variable. That change directly removes the special GROUPS assignment failure and preserves multiline jq output in a scalar, so it implements the core fix end to end. The residual correctness risk is regex substring matching instead of exact group membership, while the summary incorrectly reports +2/-2 per file and net-zero change even though each shown hunk is +5/-3. The evaluator could not run git apply --check or inspect the real files because the read-only command runner failed before execution, so the baseline commit, index hashes, syntax-check claim, and patch applicability remain independently unverified rather than treated as candidate defects."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "honor-cloud-provider-override-in-ui",
+      "complexity": "low",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 39,
+      "input_tokens": 1224,
+      "output_tokens": 23757,
+      "total_tokens": 2978522,
+      "latency_seconds": 235.5,
+      "total_cost_usd": 0.49768010000000007,
+      "result_subtype": "success",
+      "task_score": 62.8,
+      "cache_read_tokens": 2881961,
+      "cache_write_tokens": 71580,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 100.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 73,
+          "notes": "The issue precisely identifies the endpoint, environment variable, expected response fields, testable acceptance cases, and explicit exclusions. Its largest flaw is claiming unchanged behavior whenever the override is unset, although its proposed resolver checks an operator hint before auto-detection, so the AWS_REGION acceptance case is not unconditional. The submitted endpoint context is internally consistent with the stated raw-detection root cause. The cited repository lines, .env.example value, and related issue numbers could not be independently verified because the local command sandbox failed before executing read-only commands."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 12,
+          "total": 65,
+          "notes": "The LLD gives concrete files, symbols, response fields, control flow, and an implementation-ready code change. It overstates backward compatibility and `_resolve_cloud()` safety while acknowledging that the resolver can query an operator hint before reaching cached detection, introducing different unset-override behavior and potential I/O. It also leaves import placement unresolved and promises tests in its change estimate despite specifying no actual implementation file for them. Repository line numbers, exception handling, validators, and conventions could not be independently confirmed because local inspection commands could not start."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 12,
+          "specificity": 17,
+          "risk_awareness": 12,
+          "total": 57,
+          "notes": "The review usefully elevates regression tests, asks about resolver latency, and recommends searching for other raw-detection callers. It nevertheless approves full backward compatibility without confronting the operator-hint branch, and incorrectly says repeated calls with an explicit override use the cached fallback cascade even though that branch should return before detection. Its import-location finding remains speculative, while the revised-design section claims resolution although the implementation retains the inline import. The actual repository import conventions and caller set could not be verified due the unavailable local command sandbox."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 9,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 60,
+          "notes": "The plan supplies concrete override-precedence and fallback scenarios with exact response oracles across functional, unit, deployment, and UI levels. The proposed unit tests mock `_resolve_cloud()` to return each expected answer, making the settings patches irrelevant and failing to test the real override or detection behavior. It also calls the endpoint POST in prerequisites but GET everywhere else, changes an environment variable during the UI scenario without restarting settings, and provides unverified Helm and IMDS configuration names. No operator-hint test is included even though the chosen resolver adds that branch, and the implementation patch adds none of these tests."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 17,
+          "specificity": 19,
+          "risk_awareness": 10,
+          "total": 59,
+          "notes": "The central diff is focused and internally coherent: it replaces the raw detector import with `_resolve_cloud()` and awaits it from the existing asynchronous endpoint. It omits every promised regression test despite tests being an acceptance criterion and a must-fix review item, so the summary's claims of fully realizing the LLD and having no follow-ups are false. Calling the full resolver can also change unset-override behavior through operator hints and additional I/O, undermining the asserted complete backward compatibility. The stated +4/-4 net-zero statistics contradict the displayed diff's +11/-7 net-four hunk, and actual patch applicability could not be confirmed because read-only git commands failed before execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "hide-register-button-on-virtual-and-skills-tabs",
+      "complexity": "trivial",
+      "ref": "v1.0.18",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 25,
+      "input_tokens": 151,
+      "output_tokens": 14380,
+      "total_tokens": 1736314,
+      "latency_seconds": 152.6,
+      "total_cost_usd": 0.30800485,
+      "result_subtype": "success",
+      "task_score": 62.6,
+      "cache_read_tokens": 1666326,
+      "cache_write_tokens": 55457,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 94.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 73,
+          "notes": "The issue provides concrete visibility criteria for every claimed viewFilter value and clearly limits changes to the existing button. Its largest deficiency is adding Agents-tab behavior not established by the task identifier, despite acknowledging that tab has no dedicated add button. The virtual, skills, servers, and discover expectations are directly testable, while the claim that agents should lose Register is insufficiently justified. Repository inspection was unavailable because the read-only command wrapper failed before execution, so issue #793 and the stated button labels could not be independently verified."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 13,
+          "total": 70,
+          "notes": "The LLD commits to an exact Dashboard.tsx render condition, names relevant handlers, and explains the resulting tab behavior. The positive allowlist changes Agents-tab behavior and suppresses Register for any future filter value, neither of which is addressed as a compatibility decision. The submitted patch context is internally consistent with the named handleRegisterServer button and neighboring handleRefreshHealth control. Exact line numbers, component claims, and symbols could not be independently checked, and the stated zero new lines contradicts the proposed conditional wrapper."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 12,
+          "specificity": 14,
+          "risk_awareness": 8,
+          "total": 47,
+          "notes": "The review's strongest point is identifying Discover-tab visibility as an unresolved UX question and suggesting accessibility and visual checks. It nevertheless approves the design without resolving that question or examining why Agents loses its only described registration action. Claims about existing permission checks and zero security or operational risk are unsupported by the shown change. The unanimous persona approvals do not catch the allowlist's effect on future filters or the task-title scope mismatch."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 13,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 64,
+          "notes": "The plan covers all five claimed tab states, repeated navigation, absence from the DOM, and preservation of click behavior. Its main weakness is that the click oracle permits either /servers/register or an unspecified modal, while npm test or yarn test is offered without confirming repository scripts. The visibility assertions for Register, Add Skill, and Add Virtual Server are concrete, but most procedures remain manual rather than repository-native automated tests. It also codifies the questionable Agents-tab behavior instead of testing preservation of existing access there."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 19,
+          "risk_awareness": 10,
+          "total": 59,
+          "notes": "The shown JSX patch is focused and syntactically coherent, and it fully implements the submitted LLD's servers-or-discover allowlist. Its largest defect is hiding Register on Agents and every unknown future filter even though the task identifier only establishes hiding it on Virtual and Skills. The target path, handleRegisterServer call, button markup, and surrounding handleRefreshHealth context are precise, but git apply --check could not be run because the local command wrapper failed before execution. The summary overstates completeness and reports +2/-8 despite the displayed diff containing nine added and seven removed lines."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "index-demo-videos-in-one-page",
+      "complexity": "trivial",
+      "ref": "1.24.3",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 43,
+      "input_tokens": 261,
+      "output_tokens": 24069,
+      "total_tokens": 3301547,
+      "latency_seconds": 264.9,
+      "total_cost_usd": 0.52745575,
+      "result_subtype": "success",
+      "task_score": 62.2,
+      "cache_read_tokens": 3208410,
+      "cache_write_tokens": 68807,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 90.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 74,
+          "notes": "The issue provides a clear documentation problem, bounded exclusions, and mostly testable acceptance criteria. Its largest deficiency is asserting that exactly 12 videos constitute every repository video without preserving scan output or a source-to-URL inventory, while the independently supplied task statement is absent. The submitted README hunk establishes seven prominent links, and the issue names additional concrete docs paths for the remainder. It does not address ongoing ownership, link rot, or how duplicated source links should remain synchronized."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 16,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 65,
+          "notes": "The LLD identifies concrete files, navigation integration, categories, entry structure, and verification steps appropriate to this small change. It fails to resolve its own open question about retaining README links and omits the issue's required audience-level metadata. The proposed README.md, docs/demo-videos.md, and mkdocs.yml changes align with the submitted patch's actual paths and navigation structure. Claims that docs/index.md is auto-generated, deployment is automatic, and all 12 videos were exhaustively scanned are not substantiated by reproducible repository evidence."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 12,
+          "specificity": 15,
+          "risk_awareness": 13,
+          "total": 54,
+          "notes": "The review surfaces relevant concerns including external-link rot, YAML validation, mobile table rendering, and maintenance of stale videos. Its unanimous approval misses the material mismatch between the issue's required audience metadata and the LLD, treating that requirement as an optional enhancement. The SRE section simultaneously declares zero operational risk and acknowledges that an invalid mkdocs.yml change can affect documentation deployment. Assertions about automatic GitHub Pages deployment, screened public content, and absence of security risk are not verified."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 17,
+          "risk_awareness": 13,
+          "total": 55,
+          "notes": "The plan covers file structure, links, rendering, navigation, deployment, and representative external hosts with concrete commands. Its main weakness is that it never reproduces the required repository-wide video scan or compares an authoritative URL set against the index. Counting lines matching `^\\[Watch` can pass with the wrong videos, the title loop checks only ten phrases and conflates federation entries, and `python -m py_yaml_load` is unsupported. The piped MkDocs commands can report success without checking the build exit status, while the backward-compatibility claim contradicts the patch's removal of several README links."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 15,
+          "specificity": 19,
+          "risk_awareness": 12,
+          "total": 63,
+          "notes": "The patch implements the core outcome end to end: a five-category page containing 12 direct links, a prominent README index link, and a MkDocs navigation entry. It omits audience-level metadata required by the issue and supplies no durations, yet the summary incorrectly claims complete, deviation-free implementation. The README hunk removes direct OAuth, Dynamic Tool Discovery, and Agent Skills links despite the LLD leaving retention unresolved, and the added contributor recording rules are unsupported scope expansion. The diff is internally coherent, but exhaustive video discovery, description accuracy, external-link validity, and actual patch application could not be independently verified from the available evidence."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "default-create-in-idp-checkbox-unchecked",
+      "complexity": "low",
+      "ref": "v1.0.21",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 339,
+      "output_tokens": 29801,
+      "total_tokens": 4004453,
+      "latency_seconds": 313.4,
+      "total_cost_usd": 0.6867682499999999,
+      "result_subtype": "success",
+      "task_score": 61.4,
+      "cache_read_tokens": 3852580,
+      "cache_write_tokens": 121733,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 95.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 77,
+          "notes": "The issue gives concrete, testable criteria for initial state, reset behavior, omitted-field handling, and explicit opt-in, with clear exclusions for edit and authorization flows. Its largest flaw is claiming full backward compatibility while changing the backend behavior for API callers that omit create_in_idp from true to false. The submitted patch context corroborates the existing true defaults in IAMGroups.tsx and management_routes.py. The production-frequency claims and issue #916 relationship could not be independently verified, and no separate task statement was supplied."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 13,
+          "total": 67,
+          "notes": "The LLD names concrete files, state setters, payload fields, and backend logic, and the submitted diff corroborates the cited createInIdp and create_in_idp locations. It contradicts itself by declaring backend changes beyond documentation a non-goal while prescribing a runtime backend default change. Its proposed reset test merely clicks the checkbox twice rather than submitting successfully and exercising resetForm, leaving a stated requirement untested. It also understates the compatibility and rollback implications for API clients that omit the field, while logging and test-infrastructure claims could not be independently verified."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 13,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 54,
+          "notes": "The review provides actionable observations about verifying hook mocks, testing reset through a successful submission, and aligning the backend fallback. Its largest deficiency is approving the design despite identifying the exact missing reset test and failing to recognize that changing an omitted-field default changes behavior for existing API callers. The implementation's second test confirms this concern: it only toggles the checkbox manually and never invokes form submission or resetForm. Repeated claims of zero deployment risk, no operational impact, and full compatibility are insufficiently defended and could not be validated against repository tests or callers."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 8,
+          "total": 44,
+          "notes": "The plan spans frontend, API, compatibility, manual UX, and end-to-end checks, with concrete payloads and expected states. Most API scripts only assert HTTP 200 and do not verify whether a group was absent from or present in the identity provider, so they can pass while the central behavior is broken. The purported reset unit test only checks two user clicks, fixed group names lack cleanup or idempotency handling, and the plan contradicts itself by claiming no IdP state is modified while explicitly creating create_in_idp=true groups. The authentication endpoint, /api/v1/management routes, Docker test target, and response schemas could not be independently verified because repository shell access failed before command execution."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 19,
+          "risk_awareness": 12,
+          "total": 65,
+          "notes": "The patch directly changes both frontend defaults in IAMGroups.tsx and the backend fallback and docstring in management_routes.py, so the core requested behavior is represented end to end. Its largest defect is test coverage: none of the three tests submits a group or exercises resetForm, despite the summary claiming the LLD was fully realized, and two tests largely duplicate ordinary checkbox toggling. The third test also contains a contradictory comment about an unchecked final state while correctly asserting checked after three clicks, and the backend omission behavior has no automated regression test. Patch applicability and the mocked hook paths could not be independently confirmed because the read-only shell sandbox failed before git apply --check or source inspection could run."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "consistent-csrf-across-toggle-endpoints",
+      "complexity": "medium",
+      "ref": "v1.0.20",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 82,
+      "input_tokens": 494,
+      "output_tokens": 34690,
+      "total_tokens": 6803867,
+      "latency_seconds": 400.2,
+      "total_cost_usd": 1.110917,
+      "result_subtype": "success",
+      "task_score": 61.0,
+      "cache_read_tokens": 6542505,
+      "cache_write_tokens": 226178,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 86.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 75,
+          "notes": "The issue clearly defines the browser-versus-M2M problem, six claimed endpoints, testable outcomes, and useful non-goals. Its paths and existing dependency names agree with the supplied diff contexts for agent, skill, server, and virtual-server routes. The largest deficiency is that it requires all six endpoints to use the new dependency, while the later design and implementation deliberately exempt /internal/toggle. No independent task statement establishes the six-endpoint scope, and issue #891 could not be verified from the available repository evidence."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 13,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 65,
+          "notes": "The LLD is unusually concrete about files, route symbols, dependency signatures, form handling, and expected status behavior, and those locations align with the patch contexts. Its largest unresolved decision is endpoint coverage: it promises uniform treatment of six endpoints but leaves /internal/toggle as a TODO and ultimately excludes it. More importantly, CSRF bypass is selected from any Bearer-prefixed header rather than from the authentication method successfully chosen by enhanced_auth or nginx_proxied_auth, so the claimed auth precedence is not demonstrated. The assertions of zero breaking changes and reliable M2M detection could not be established from the available surrounding auth implementation."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 18,
+          "risk_awareness": 17,
+          "total": 64,
+          "notes": "The review identifies concrete concerns including repeated form parsing, mixed bearer-and-session requests, incomplete endpoint auditing, and observability. It correctly focuses attention on toggle_service_api form fields and the unresolved /internal/toggle decision. Its largest failure is accepting the unproven claim that a client-controlled Authorization header cannot be spoofed and resolving mixed authentication by documentation rather than verifying which credential the auth dependency actually accepts. It also claims configuration-based rollback despite the LLD adding no flag, and its HMAC-SHA512 statement about validate_csrf_token is unsupported by the submitted source."
+        },
+        "testing": {
+          "completeness": 12,
+          "correctness": 4,
+          "specificity": 14,
+          "risk_awareness": 15,
+          "total": 45,
+          "notes": "The plan recognizes the important categories: bearer bypass, session rejection, token binding, mixed credentials, compatibility, and form parsing. However, several constructed URLs duplicate prefixes\u2014for example TEST_AGENT_PATH is /agents/test-agent and is appended to /agents\u2014and the agent test submits enabled as form data even though the supplied FastAPI signature declares an unannotated scalar parameter. Most positive tests merely assert status is not 403, allowing authentication, validation, routing, or server failures to pass, while /internal/toggle receives no test despite the claimed six-endpoint scope. The proposed unittest discovery command would not collect the shown module-level pytest tests, and the bearer-auth overrides, persistent fixtures, and executable registration body are not specified."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 56,
+          "notes": "The patch concretely adds verify_csrf_token_if_session_based and wires it into the five externally described agent, skill, server, server-API, and virtual-server handlers shown by the diff. It does not add the dependency to /internal/toggle or add any tests, contradicting both the issue acceptance criteria and the summary's claim that all six endpoints were updated with no deviations. The largest technical risk is that bypass depends solely on a Bearer-prefixed header rather than confirmed bearer authentication, while requests with neither a session nor bearer header also pass this dependency. The summary additionally claims form behavior was tested despite saying verification was not executed; clean application and surrounding unused-import behavior could not be independently verified because local repository execution failed at the sandbox boundary."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "cli-custom-egress-oauth-provider-flags",
+      "complexity": "low",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 60,
+      "input_tokens": 40,
+      "output_tokens": 1603,
+      "total_tokens": 717899,
+      "latency_seconds": 334.1,
+      "total_cost_usd": 0.08825155000000001,
+      "result_subtype": "success",
+      "task_score": 57.2,
+      "cache_read_tokens": 708803,
+      "cache_write_tokens": 7453,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 4.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 13,
+          "total": 67,
+          "notes": "The issue clearly identifies five flags, explicit exclusions, and mostly testable acceptance criteria. Its largest defect is an internal contradiction: the root cause says configure_egress_auth already accepts custom parameters, while the implementation notes and submitted diff add those parameters. The client diff's original signature supports the latter account, making the former materially inaccurate. Partial-update behavior and issue #1601 could not be verified, and no independent task statement was supplied."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 13,
+          "specificity": 22,
+          "risk_awareness": 12,
+          "total": 67,
+          "notes": "The LLD provides concrete changes for cmd_egress_configure, RegistryClient.configure_egress_auth, argparse flags, and request-body keys, closely matching the submitted patch. Its largest flaw is treating omission of fields as proven partial-update semantics without showing that the POST route merges omitted values with persisted configuration before validation. The design also asserts logging, storage, defaults, and deployment behavior without demonstrating those paths. Local repository execution failed before commands ran, so cited line numbers and server-side claims could not be independently confirmed."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 13,
+          "risk_awareness": 7,
+          "total": 41,
+          "notes": "The review offers some concrete checks around argparse choices, optional parameters, documentation, and release notes. Its largest deficiency is unanimous approval without challenging the design's unproven partial-update assumption, which is central to the proposed behavior. It further claims resolve_provider verifies reachability and trust, that non-custom providers produce a specific 400 response, and that fields are indexed, without supporting evidence. It marks default clarification as resolved even though the displayed LLD docstring does not document the post_body default."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 7,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 53,
+          "notes": "The plan covers help output, enum rejection, request fields, omission behavior, integration, and persistence with concrete expected values. However, its unit test mocks client.session.post while the submitted implementation shows configure_egress_auth calling self._make_request, so it may observe the wrong interface. Test 1.1.3 never invokes parsing or asserts anything, and the request-body expression can yield None when the call has one positional argument despite a json keyword. The plan also assumes unverified partial-update and non-custom-provider error behavior while declaring backward compatibility not applicable instead of testing it."
+        },
+        "implementation": {
+          "completeness": 15,
+          "correctness": 17,
+          "specificity": 18,
+          "risk_awareness": 8,
+          "total": 58,
+          "notes": "The submitted code coherently adds all five argparse flags, forwards them through cmd_egress_configure, extends configure_egress_auth, and conditionally adds the corresponding request keys. The largest defect is that implementation.md claims a three-file, 232-line patch including 186 lines of tests, while the actual diff contains only the two production files and approximately 46 additions. The summary also says verification was not executed but later claims unit tests pass, and it overstates unproven partial-update semantics. Patch applicability and repository conventions could not be independently confirmed because the read-only executor failed before running git apply --check or source inspection."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "registration-admission-control-gate",
+      "complexity": "high",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 52,
+      "input_tokens": 310,
+      "output_tokens": 28826,
+      "total_tokens": 4144284,
+      "latency_seconds": 301.3,
+      "total_cost_usd": 0.6452672500000001,
+      "result_subtype": "success",
+      "task_score": 57.2,
+      "cache_read_tokens": 4037485,
+      "cache_write_tokens": 77663,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 95.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 80,
+          "notes": "The issue clearly defines synchronous, fail-closed admission behavior, enumerates seven create/update routes, and supplies testable acceptance criteria and non-goals. Its largest gap is security treatment of transmitting full asset payloads, including TLS, sensitive fields, response sanitization, and malformed gate responses. Off-by-default behavior and explicit timeout, denial, and deployment requirements make the intended compatibility boundary concrete despite the absent independent task statement. The claims that httpx is already available and that the named deployment surfaces are exhaustive were not substantiated by the submission."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 17,
+          "risk_awareness": 13,
+          "total": 57,
+          "notes": "The LLD names route files, service methods, configuration fields, payload structure, and persistence boundaries, making it substantially more actionable than a generic architecture. Its critical integration decisions remain inconsistent: it alternates between lifespan/global initialization and dependency creation, claims unavailable gates produce 503 while its route examples do not translate the service's generic exceptions, and catches asyncio.TimeoutError rather than HTTPX's timeout exception type. It identifies multiple server entry points, yet the eventual patch contains only one server-route gate hunk, demonstrating that the endpoint inventory was not converted into an enforceable implementation map. Latency and fail-closed behavior are discussed, but sensitive payload disclosure, malformed or oversized responses, TLS enforcement, and concrete rollback validation receive inadequate treatment."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 13,
+          "specificity": 17,
+          "risk_awareness": 16,
+          "total": 62,
+          "notes": "The review surfaces useful concrete issues including URL validation, error-message leakage, token handling, HTTP-client dependency verification, and service initialization consistency. Its largest weakness is that it records those findings as resolved or non-blocking without updating the LLD or verifying the implementation. The submitted patch still lacks URL validation and secret documentation and modifies only one server route, contradicting the review's claims that configuration propagation is sound and all concerns are addressed. It also misses the most consequential bypass risk from ungated internal and update routes and does not examine exposure of complete asset payloads to the external service."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 50,
+          "notes": "The plan provides concrete expected status codes, gate-call payload assertions, persistence checks, disabled-mode coverage, and allow, deny, timeout, and unreachable scenarios. Its largest defect is executability: it invokes tests/test_admission_gate.py tests that the patch never adds, does not explain how the localhost mock server is started, and includes invalid JSON examples containing comments or ellipses. It omits server-update coverage, malformed 200 responses, non-403 error statuses, authorization-header verification, configuration validation, and payload confidentiality checks. The checklist also calls the functional set nine tests while enumerating twelve, and several claimed repository commands and deployment paths remain unverified."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 9,
+          "specificity": 13,
+          "risk_awareness": 7,
+          "total": 37,
+          "notes": "The patch concretely adds settings, an asynchronous gate client, and checks at five call sites: two agent routes, one server route, and two skill routes. The largest defect is a security bypass: no hunk gates the internal server registration or server update route, while no deployment configuration or executable tests are added despite explicit requirements. The summary falsely claims internal registration and all endpoints are covered, says there are no LLD deviations despite changing initialization strategy, and reports security-review resolutions that the code does not implement. Patched paths fail closed, but the code sends full payloads to an unvalidated URL, surfaces raw 403 bodies, and catches asyncio.TimeoutError instead of HTTPX's timeout exception; independent git-apply verification was unavailable in the read-only execution environment."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-ui-title",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 91,
+      "input_tokens": 547,
+      "output_tokens": 31103,
+      "total_tokens": 8310225,
+      "latency_seconds": 370.8,
+      "total_cost_usd": 1.2838740000000004,
+      "result_subtype": "success",
+      "task_score": 56.6,
+      "cache_read_tokens": 8017745,
+      "cache_write_tokens": 260830,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 83.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 77,
+          "notes": "The issue clearly defines runtime title resolution, deployment surfaces, testable acceptance criteria, and explicit non-goals. Its largest weakness is ambiguity: registry-only behavior changes when UI_TITLE is unset despite the blanket backward-compatibility criterion, while admin-panel support is simultaneously optional and required if present. The submitted diff confirms that Settings, get_config, useRegistryConfig, Layout, and the named Compose files are genuine integration points. No independent task statement exists, and Issue #984 plus the claim that the title is hardcoded in multiple files could not be independently verified."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 63,
+          "notes": "The LLD provides unusually concrete data flow, defaults, interfaces, deployment mappings, and implementation snippets. Its largest deficiency is incorrect or incomplete integration detail: it proposes @router.get(\"/api/config\") although the real diff shows the existing route is @router.get(\"\") under a router prefix, and it omits the required Terraform module-variable pass-through. It also inconsistently describes startup caching while its proposed implementation derives the value per request, and applies a 100-character limit only to Terraform. Exact Terraform and Helm path structure could not be independently verified because repository command execution failed before running."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 10,
+          "specificity": 16,
+          "risk_awareness": 12,
+          "total": 51,
+          "notes": "The review raises concrete topics including frontend fallback behavior, caching, Compose drift, XSS rendering, validation, and observability. It nevertheless misses the LLD's incorrect route decorator, absent Terraform module plumbing, and inconsistent validation, then incorrectly concludes that every acceptance criterion is resolved. Pixel's claimed undefined-render problem ignores the LLD's existing || fallback and recommends DEFAULT_CONFIG even though the shown hook does not export it. The claimed cache lifetime could not be verified, and several reviewer approvals are unsupported assertions rather than repository-grounded analysis."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 15,
+          "total": 62,
+          "notes": "The plan gives concrete setup, actions, and expected title values across explicit, unset, empty-string, fallback, Docker, Terraform, Helm, and end-to-end scenarios. Its largest weakness is reliance on manual inspection and grep presence checks, with no backend unit tests or frontend type-check/build command that would reliably catch source-level regressions. Test 2.3 would correctly catch the patch's deletion of asset_lifecycle_statuses, but the cache test's claim that browser reloads make no request and the feature-flag oracle rely on unstated defaults. Commands such as python -m registry, npm start, Kubernetes labels, and service names could not be verified against the repository."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 5,
+          "specificity": 12,
+          "risk_awareness": 5,
+          "total": 30,
+          "notes": "The patch covers the Settings field, title derivation, config response, frontend type/default/rendering, documentation, and three Compose variants. It explicitly omits required Terraform and Helm plumbing and the present admin configuration integration, so it does not implement the promised three-surface feature. More seriously, the Layout hunk replaces the existing version/setVersion state declaration rather than adding the hook alongside it, while config_routes.py silently deletes asset_lifecycle_statuses from the public response. The summary contradicts these omissions by claiming all deployment surfaces are covered, and git apply applicability could not be independently checked because repository command execution failed before running."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "lifecycle-workflow-webhooks",
+      "complexity": "high",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 83,
+      "input_tokens": 498,
+      "output_tokens": 34523,
+      "total_tokens": 6707941,
+      "latency_seconds": 398.8,
+      "total_cost_usd": 0.9348073500000003,
+      "result_subtype": "success",
+      "task_score": 55.0,
+      "cache_read_tokens": 6590831,
+      "cache_write_tokens": 82089,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 86.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 82,
+          "notes": "The issue clearly defines five behaviors, testable acceptance criteria, compatibility defaults, dependencies, and explicit non-goals. Its description aligns with the submitted baseline diff, which shows an unsigned webhook service and a server registration-scan callback. The main weakness is that the proposed lifecycle scope is not grounded in the repository's JSON-backed UI-permission model or accompanied by permission-provisioning criteria.  No independent task statement was supplied, so the asserted customer need and related-issue history remain unverifiable."
+        },
+        "lld": {
+          "completeness": 13,
+          "correctness": 8,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 47,
+          "notes": "The LLD is concrete about payload shape, signature bytes, configuration, and intended route changes. Its largest deficiency is failure to design how the new permission is defined and granted within the existing scope configuration; merely passing a new action string to a checker does not introduce a usable permission.  It also says invalid statuses are ignored while its filtering pseudocode returns no matches, and its fetch-filter-paginate flow does not resolve the repository's acknowledged paginated fast path. Claimed scanner files and mirrored agent/skill integration could not be verified, and the submitted implementation instead places the only scan hook in `server_routes.py`."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 13,
+          "specificity": 17,
+          "risk_awareness": 18,
+          "total": 64,
+          "notes": "The review's strongest work is identifying duplicate events, incomplete scan-path coverage, replay exposure, metric cardinality, consumer verification, and secret rotation. It nevertheless approves a design without catching its permission-provisioning gap, contradictory invalid-status semantics, or pagination risk. Several resolutions merely promise future documentation or verification while the conclusion incorrectly says they are resolved, and recommending publication of a shared secret on a website or in documentation is unsafe. Dashboard webhook behavior and team ownership are speculative and unsupported by repository evidence."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 5,
+          "specificity": 11,
+          "risk_awareness": 13,
+          "total": 43,
+          "notes": "The plan broadly covers all five features, negative permission cases, compatibility defaults, three asset types, and an end-to-end workflow. Most server registration commands use JSON fields such as `server_path` and `server_url`, whereas repository documentation shows multipart `-F` registration using `path` and `proxy_pass_url`; documented rescan URLs also use a single path separator.  Critical oracles are ineffective: the signature body contains placeholders, the single-status shell expression can pass when no draft result exists, invalid status accepts contradictory outcomes, and several HTTP tests check only curl's process exit code. Metrics, scanner exceptions, filtered pagination totals, webhook-send failure, and real signature verification in the E2E flow are not tested."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 10,
+          "specificity": 13,
+          "risk_awareness": 8,
+          "total": 39,
+          "notes": "The central webhook change correctly serializes one exact body, computes HMAC-SHA256 over it, and sends those same bytes, while retaining the unsigned default. The patch implements route behavior only for servers, omits agent and skill parity, metrics, permission registration, examples, documentation, and tests, despite initially claiming all five requirements were applied consistently. Its scan event is added only to `_perform_security_scan_on_registration`, although the repository exposes separate manual rescan flows for servers, agents, and skills; scanner exceptions also emit no completion event.  The summary contradicts itself by declaring no LLD deviations before listing major omissions, and local `git apply --check` could not be executed because the provided shell sandbox failed before command execution, leaving exact patch applicability unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "idp-authenticated-embedding-endpoint",
+      "complexity": "high",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 44,
+      "input_tokens": 9185,
+      "output_tokens": 40236,
+      "total_tokens": 4142528,
+      "latency_seconds": 380.4,
+      "total_cost_usd": 0.7234471,
+      "result_subtype": "success",
+      "task_score": 54.2,
+      "cache_read_tokens": 4002871,
+      "cache_write_tokens": 90236,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 105.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 78,
+          "notes": "The issue clearly defines opt-in configuration, refresh, secret masking, compatibility, deployment, documentation, and explicit non-goals. The submitted baseline context confirms the relevant embeddings settings and LiteLLM integration points. Its largest gap is undefined behavior when static and IdP credentials coexist, plus ambiguity about startup timing and background versus request-time refresh. No independent task statement was supplied, and the asserted issue number and 60-minute token lifetime could not be verified."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 8,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 58,
+          "notes": "The LLD names concrete core files and provides unusually detailed configuration, data-flow, deployment, and observability decisions. Its critical mismatch is designing an async encode path around an existing synchronous LiteLLM call, while an asyncio.Lock does not provide the claimed cross-thread safety. The cross-field field_validator approach is unsound, startup fetching is deferred in the expected running-loop case, and the proposed logging guard merely emits a reminder without preventing credential logging. Repository documentation places ECS environment wiring under terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf rather than the asserted main.tf, and the claimed federation API equivalence was not demonstrated. "
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 16,
+          "risk_awareness": 15,
+          "total": 54,
+          "notes": "The review identifies concrete concerns around auth-mode precedence, event-loop handling, endpoint reachability, URL validation, and credential leakage. Its largest deficiency is approving the threading model while missing the fatal field-validation and synchronous-event-loop problems. The proposed logging-guard resolution only logs that headers should not be logged, so it does not resolve the stated security blocker. Claims that deployment surfaces are consistently wired and that the design has no backend blockers are unsupported by the LLD and contradicted by the submitted patch."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 6,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 47,
+          "notes": "The plan broadly covers token refresh, injection, validation, compatibility, deployment rendering, and end-to-end behavior. Several tests are not executable as written: they await synchronous encode, patch litellm.embedding rather than the symbol imported into registry.embeddings.client, and import CONFIG_FIELD_SCHEMAS although the patch shows CONFIG_GROUPS. The secret test initializes the provider before installing its failure mock and inspects only an exception string rather than captured logs, while the logging test merely asserts that a warning message was emitted. The reindex endpoint and Helm value names are unverified, Terraform apply is an excessive validation command, and important malformed-response and concurrent-refresh oracles are absent."
+        },
+        "implementation": {
+          "completeness": 9,
+          "correctness": 4,
+          "specificity": 14,
+          "risk_awareness": 7,
+          "total": 34,
+          "notes": "The patch targets the central settings, factory, repository, UI, and LiteLLM client integration points with a concrete token-provider implementation. Its settings validator fatally rejects a fully populated configuration because info.data lacks the current client_id and later client_secret while validating client_id. LiteLLMClient.encode calls run_until_complete even when the loop is already running, then attempts another loop in the same thread, and asyncio.Lock does not make this synchronous client thread-safe. Deployment wiring, documentation, and tests required by the issue are omitted despite the summary claiming no deviations, and git apply --check could not be independently completed because the available command sandbox failed before process launch."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "per-caller-per-target-rate-limits-and-quarantine",
+      "complexity": "high",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 81,
+      "input_tokens": 484,
+      "output_tokens": 49025,
+      "total_tokens": 7668044,
+      "latency_seconds": 532.9,
+      "total_cost_usd": 1.2311444000000005,
+      "result_subtype": "success",
+      "task_score": 50.6,
+      "cache_read_tokens": 7424029,
+      "cache_write_tokens": 194506,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 92.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 73,
+          "notes": "The issue provides concrete acceptance criteria for target-aware enforcement, early quarantine denial, status 403, headers, administrative management, and compatibility. Its largest defect is asserting both reuse of existing membership storage and target quarantine through that storage, while the LLD later acknowledges memberships are caller-centric and requires a new collection. The published repository overview distinguishes fail-open rate-limit availability behavior from fail-closed quarantine membership checks, whereas the issue broadly demands fail-closed behavior for both axes.  No independent task statement was supplied, so the exact authority of issue #1504 and several UI and deployment requirements could not be verified."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 7,
+          "specificity": 13,
+          "risk_awareness": 13,
+          "total": 47,
+          "notes": "The LLD names relevant files and considers identity collisions, early denial, administrative bypass, caching, rollout, and observability. Its central design is unstable: target quarantine alternates among memberships, definitions, and a dedicated collection, while caller_target alternates between a composite counter subject and an exact-pair definition model. The submitted source context defines CALLER_TYPE_USER and CALLER_TYPE_AGENT, but the design repeatedly uses client identities and the patch queries user/client prefixes, creating an integration mismatch. Claims about cache TTLs, latency, indexes, existing API capabilities, UI reuse, and nginx conditional status behavior were not substantiated by verifiable baseline source."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 17,
+          "risk_awareness": 17,
+          "total": 60,
+          "notes": "The review usefully identifies caller-type collisions, empty identities, delimiter ambiguity, indexing, cache invalidation, auditability, and compromised-admin risk. It misses more fundamental defects, including the unresolved target-quarantine storage model, the issue's stated minimum limit of one versus proposed zero-valued definitions, and the lack of a credible 403-preservation path through nginx. Its claim that critical fixes are resolved is contradicted by examples that still omit caller type and by audit logging merely being deferred. Several approvals rely on unverified repository claims such as a 0.25-second timeout, 30-second caches, and existing UI behavior."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 7,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 49,
+          "notes": "The plan covers independent target quotas, quarantine, administrative behavior, compatibility, headers, malformed identities, deployment surface, and combined gates with concrete expected statuses. Several tests have invalid or self-contradictory oracles: the independence test exhausts both targets, the quarantine counter test deletes all memberships and then expects throttling, and the ordering test gives every gate the same window. Target-quarantine commands are absent from the patch, multiple token variables and helpers are undefined, and the end-to-end script prints success without failing on mismatched responses. DocumentDB failure, cache propagation, counter non-consumption, and real unit-level gate ordering remain unimplemented or unverifiable despite being listed as covered."
+        },
+        "implementation": {
+          "completeness": 5,
+          "correctness": 4,
+          "specificity": 10,
+          "risk_awareness": 5,
+          "total": 24,
+          "notes": "The summary honestly states that the patch is only a data-layer phase, but consequently it implements no caller_target enforcement, quarantine denial, API or CLI management, startup seeding, immutability, UI support, or tests. Concrete defects include querying user/client prefixes despite importing user/agent constants, never calling ensure_quarantine_groups, and catching every exception from target-quarantine insertion as a successful duplicate. The proposed zero-valued quarantine definitions conflict with the issue's stated configuration floor of one, while quarantine headers still retain X-RateLimit-Throttled and no code creates quarantine decisions. Patch applicability could not be independently confirmed because the provided read-only shell failed before executing git apply --check, leaving exact baseline fit as a material evidence gap."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "server-side-oauth-token-storage",
+      "complexity": "high",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 30,
+      "input_tokens": 14408,
+      "output_tokens": 31052,
+      "total_tokens": 2828289,
+      "latency_seconds": 295.8,
+      "total_cost_usd": 0.66474085,
+      "result_subtype": "success",
+      "task_score": 50.0,
+      "cache_read_tokens": 2594316,
+      "cache_write_tokens": 188513,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 105.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 69,
+          "notes": "The issue clearly states the cookie-size problem, measurable acceptance criteria, explicit exclusions, expiry, revocation, and the no-per-request-read constraint. Its largest deficiency is presenting an invented access/refresh-token reference design and `/oauth2/tokens` API as settled requirements despite the absence of an independent task statement. Repository release evidence describes the eventual design as an opaque session ID referencing a server-side record containing username, groups, and encrypted `id_token`, with existing sessions invalidated, which conflicts with several compatibility and data-model claims here.  The asserted typical token sizes, two-kilobyte target, and exact endpoint contract could not be independently verified."
+        },
+        "lld": {
+          "completeness": 13,
+          "correctness": 6,
+          "specificity": 15,
+          "risk_awareness": 11,
+          "total": 45,
+          "notes": "The LLD identifies concrete files, callback and validation integration points, data flow, ownership filtering, encryption, TTL indexing, and operational concerns. Its central design is internally inconsistent: one section persists an automatically generated key in MongoDB and fails closed, while the configuration and implementation sections generate an ephemeral key, log it, and explicitly warn it will be lost; the displayed model is also structurally malformed around the `id` field and omits `user_id`. Repository release evidence instead uses an `oauth_sessions` store, HKDF derivation from `SECRET_KEY`, and an opaque cookie session ID, contradicting the LLD's claimed established storage and compatibility model.  Material symbols such as `validate_session_cookie`, `get_database`, the cited line ranges, and the proposed `request.app.state.db` wiring could not be verified from the unavailable local shell."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 20,
+          "total": 70,
+          "notes": "The review's strongest work is identifying concrete failure modes around ephemeral encryption keys, TTL deletion lag, staged rollout, expiry alignment, decryption errors, logging, and revocation. Its largest defect is the final claim that all blockers were integrated: the LLD still lacks the promised feature flag, revoke-all endpoint design, metrics integration, and consistent persistent-key behavior. Several recommendations are weak or arbitrary, including a redundant post-query ownership assertion, a 100GB alert threshold without workload evidence, and dual cookie storage that preserves the original size problem. Repository release evidence confirms that key derivation, migration behavior, and forced logout were material concerns, supporting the review's focus but not its declaration that the design was ready. "
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 5,
+          "specificity": 15,
+          "risk_awareness": 12,
+          "total": 46,
+          "notes": "The plan covers storage, retrieval, unauthorized access, cookie size, legacy sessions, index creation, deployment, expiry, key changes, and concurrency. Many proposed tests cannot produce their stated oracle: callback requests use fake authorization codes and states without defining a mock, header parsing omits `curl -i`, signed cookies cannot be validated by simply grepping decoded JSON, and JWT decodability does not prove encryption round-trip equality. The cross-user test extracts a `token_reference` that the response does not contain and calls an unimplemented GET-by-reference endpoint, while the no-database-read check relies on an unverified log path and generic text matching. Its legacy-cookie expectation also conflicts with repository release behavior that rejects pre-migration sessions and requires reauthentication, and revocation lacks a concrete executable test despite being an acceptance criterion. "
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 2,
+          "specificity": 10,
+          "risk_awareness": 4,
+          "total": 20,
+          "notes": "The patch contains concrete AES-GCM encryption, scoped MongoDB queries, TTL-index creation, and revocation repository methods. It does not implement the feature end to end: every hunk adds a new file, while `server.py`, the OAuth callback, application startup, route registration, configuration, and tests remain untouched; the summary admits these are implementer follow-ups while simultaneously claiming the tokens were moved and there were no LLD deviations. `token_endpoints.py` cannot be imported because `app`, `Request`, `HTTPException`, `logger`, `validate_session_cookie`, and repository imports are undefined, and `OAuthTokenDocument(id=...)` conflicts with the `_id` alias without enabling field-name population; the DELETE handler also returns the default 200 rather than its promised 204. The implementation retains the critical ephemeral-key behavior and logs the generated secret, contrary to the reviewed persistent-key design, while repository release evidence shows a materially different integrated session-store implementation. "
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-mcp-proxy-upstream-timeout",
+      "complexity": "medium",
+      "ref": "1.25.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 97,
+      "input_tokens": 583,
+      "output_tokens": 31202,
+      "total_tokens": 10005463,
+      "latency_seconds": 380.2,
+      "total_cost_usd": 1.4743243500000003,
+      "result_subtype": "success",
+      "task_score": 47.8,
+      "cache_read_tokens": 9695101,
+      "cache_write_tokens": 278577,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 82.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 76,
+          "notes": "The issue clearly defines the hardcoded timeout problem, backward-compatible default, explicit non-goals, and mostly testable acceptance criteria. The submitted source context supports the named Settings field, auth_server/server.py call site, admin configuration entry, and deployment surfaces. Its largest gap is failure semantics: it does not decide whether values below five seconds reject startup or are silently floored, and it treats an HTTPX timeout as a simple total-call deadline. No independent task statement establishes that admin exposure, every deployment surface, or the five-second minimum was actually required."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 60,
+          "notes": "The LLD is unusually concrete about files, configuration names, defaults, call flow, and deployment wiring. However, it names a nonexistent _BASIC_CONFIG_ENTRIES integration point where the patch context shows CONFIG_GROUPS, and its proposed Helm stringData/quote change conflicts with the repository's data/b64enc pattern. The ge=5.0 Settings constraint can reject startup before the reader's flooring or invalid-environment fallback executes, leaving the central validation behavior internally inconsistent. It also omits tests and unified-parameter-reference.md from its final modified-file list and gives little treatment to resource retention, surrounding proxy deadlines, observability, or rollback."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 13,
+          "risk_awareness": 6,
+          "total": 36,
+          "notes": "The review offers a few concrete follow-ups, including invalid-value testing, startup logging, and timeout metrics. Its largest deficiency is unanimous approval despite material design contradictions around startup validation, environment fallback, the config symbol, and Helm encoding. It incorrectly describes HTTPX as raising TimeoutError and rationalizes storing a non-secret timeout in a Secret rather than simply recognizing the repository's existing convention. It does not examine prolonged resource occupancy, outer load-balancer timeouts, missing documentation/tests, or the unresolved reject-versus-floor behavior."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 5,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 46,
+          "notes": "The plan provides concrete expected values for defaults, overrides, boundaries, invalid input, and deployment-file wiring. Its tests are pytest-style functions using monkeypatch and caplog, but the prescribed unittest discovery command will not discover those top-level functions. Reader tests also mutate the environment around a module-level Settings singleton, so later overrides do not exercise the claimed fallback, while an invalid environment value can fail Settings construction before the reader is callable. The supposed integration test is code inspection, the slow-upstream scenarios lack an executable server and precise 504 oracle, and the boundary scenario accepts either of two incompatible outcomes."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 1,
+          "specificity": 9,
+          "risk_awareness": 3,
+          "total": 21,
+          "notes": "The patch broadly covers Settings, three Compose files, Helm, Terraform, admin configuration, and the HTTPX call site. Its auth_server/server.py hunk removes the existing try statement while leaving the replacement async with line indented beneath no enclosing block, producing invalid Python and making the implementation unusable. It also supplies no tests and omits unified-parameter-reference.md despite both being acceptance criteria, while implementation.md incorrectly claims nothing was omitted or deviated from the LLD. Several deployment edits match their surrounding repository patterns, but the summary neither detects the fatal control-flow edit nor acknowledges the validation and fallback risks."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "macos-setup-python-version-precheck",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 72,
+      "input_tokens": 432,
+      "output_tokens": 33768,
+      "total_tokens": 6445906,
+      "latency_seconds": 384.7,
+      "total_cost_usd": 0.9201778999999999,
+      "result_subtype": "success",
+      "task_score": 46.4,
+      "cache_read_tokens": 6316284,
+      "cache_write_tokens": 95422,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 87.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 79,
+          "notes": "The issue clearly defines the early-version-check problem, user impact, testable outcomes, and explicit non-goals. Its target is consistent with the submitted baseline hunk, where Phase 1 only runs `python3 --version` and emits `PYTHON_OK` or `PYTHON_FAIL`. The largest gap is failure-policy detail when project metadata cannot be read or parsed. No independent task statement was supplied, so the claimed downstream failure behavior could not be verified."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 4,
+          "specificity": 19,
+          "risk_awareness": 7,
+          "total": 47,
+          "notes": "The LLD names the relevant skill file, metadata source, result codes, messages, integration points, and proposed flow. Its quoted second heredoc prevents `$INSTALLED_VERSION` and `$REQUIRED_VERSION` from expanding, so `packaging.version.parse()` receives literal dollar-prefixed strings and the compliant path cannot succeed. It also assumes `packaging` and an older-Python `toml` fallback are installed before dependency setup, and its regex does not handle all PEP 440 constraints as claimed. Error branches are discussed, but the design misses these bootstrap and parsing risks and does not concretely implement its proposed richer log entry."
+        },
+        "review": {
+          "completeness": 8,
+          "correctness": 2,
+          "specificity": 11,
+          "risk_awareness": 4,
+          "total": 25,
+          "notes": "The review identifies version-constraint parsing as a relevant concern and ties recommendations to the proposed code. It incorrectly declares that concern resolved and explicitly praises the quoted heredoc, overlooking that the same quoting disables the variable expansion required by the comparison script. It also accepts unsupported claims that project dependencies are available to the prerequisite interpreter and that the regex handles all valid PEP 440 formats. Five unanimous approvals therefore miss multiple release-blocking defects and provide little effective design stress."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 5,
+          "specificity": 14,
+          "risk_awareness": 17,
+          "total": 55,
+          "notes": "The plan covers compliant, obsolete, missing-interpreter, malformed-metadata, remediation, compatibility, and end-to-end scenarios with useful output oracles. Its only substantially inlined test repeats the quoted-heredoc bug and therefore cannot produce the expected `PYTHON_OK`, while many other invocations remain `[run check code]` placeholders. Expected nonzero exit codes also disagree with the skill snippet, whose failure branches end with successful `echo` commands rather than `exit 1`. The table-preservation test would catch the patch's missing `PYTHON_FAIL` row, but the plan is not directly executable enough to provide reliable regression coverage."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 1,
+          "specificity": 14,
+          "risk_awareness": 4,
+          "total": 26,
+          "notes": "The patch targets the submitted Phase 1 Python check and adds focused parsing, comparison, messaging, and remediation changes. However, the quoted comparison heredoc passes literal `$INSTALLED_VERSION` and `$REQUIRED_VERSION` strings to `packaging.version.parse()`, so every installed interpreter reaches `PYTHON_VERSION_FAIL`; additionally, `packaging` is not guaranteed in the system interpreter before dependency installation. The diff replaces rather than preserves the `PYTHON_FAIL` remediation row and leaves the generic log instruction unchanged, contradicting the summary's claims that both rows and mismatch logging were implemented. An independent `git apply --check` could not be completed because the repository command runner failed before executing, but the diff itself contains these decisive functional defects."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "build-docker-images-from-uv-lock",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 52,
+      "input_tokens": 314,
+      "output_tokens": 29614,
+      "total_tokens": 3909554,
+      "latency_seconds": 313.7,
+      "total_cost_usd": 0.61441435,
+      "result_subtype": "success",
+      "task_score": 46.2,
+      "cache_read_tokens": 3811741,
+      "cache_write_tokens": 67885,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 94.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 59,
+          "notes": "The issue clearly identifies dependency drift, names projects and Dockerfiles, and supplies mostly testable acceptance criteria and non-goals. Its central claim that either `uv sync --frozen` or `--locked` fails for a stale lock is wrong: uv documents that `--frozen` skips freshness checking, while `--locked` performs it.  It also says `Dockerfile.scopes-init` installs `auth_server`, whereas the implementation later calls it a non-Python BusyBox image. No independent task statement was supplied, and repository shell failure prevented confirmation that exactly four lockfiles were missing."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 14,
+          "risk_awareness": 10,
+          "total": 46,
+          "notes": "The LLD usefully names dependency roots, workflow integration points, expected files, and the intended build flow. Its load-bearing decision is incorrect because it selects `uv sync --frozen` while asserting stale-lock rejection, which requires `--locked`; `--frozen` uses the existing lock without checking whether it is current.  It also claims locked builds need no package-index network access even though the submitted locks merely reference downloadable distributions, and it does not analyze how `uv sync` differs from the existing requirements-only installation. Several Dockerfiles remain marked TBD or \"to be verified\" while the document simultaneously declares no open questions, so it is not implementation-ready."
+        },
+        "review": {
+          "completeness": 11,
+          "correctness": 7,
+          "specificity": 12,
+          "risk_awareness": 9,
+          "total": 39,
+          "notes": "The strongest findings are the concrete requests to test the registry's subsequent editable install, document lock regeneration, and exercise runtime smoke tests. The review nevertheless approves the core design without catching that `--frozen` does not validate lock freshness, despite that being the feature's principal promised failure mode.  It repeats unsupported claims that lockfiles eliminate build-time network requirements and detect lockfile tampering, and its security and SRE sections largely restate benefits rather than stress the mechanism. The claimed `Dockerfile.registry` line-58 behavior and exact lockfile sizes could not be independently verified because repository command execution failed."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 6,
+          "specificity": 17,
+          "risk_awareness": 14,
+          "total": 52,
+          "notes": "The plan spans lock generation, image builds, stale-lock negatives, CI, compatibility, and a runtime health check with concrete commands. Its key negative oracle is invalid because `uv sync --frozen` is not expected to reject an outdated lock; that behavior belongs to `--locked`.  The mutation appends an array element blindly to the end of `pyproject.toml`, which may only test TOML parsing, and from `auth_server/` it incorrectly references `../../docker/Dockerfile.auth` and `../../` rather than the repository parent. It builds only auth and registry images, merely checks package names rather than locked versions, and includes destructive cleanup with `git reset --hard`."
+        },
+        "implementation": {
+          "completeness": 9,
+          "correctness": 5,
+          "specificity": 15,
+          "risk_awareness": 6,
+          "total": 35,
+          "notes": "The patch summary describes four generated locks, two Dockerfile conversions, workflow triggers, CI validation, and an optional hook, so it implements part of the stated design. It misses other package-installing images implied by the acceptance criteria while claiming no deviations, and its use of `uv sync --frozen` does not provide the advertised stale-lock failure.  The visible pre-commit command swallows every validation failure with `|| true`, and its hunk also deletes the existing shell-hook `exclude: ^(docker/|scripts/setup/)`, creating unrelated behavior change. Full applicability and generated-lock consistency could not be checked because the submitted diff was truncated and the repository shell failed before executing `git apply --check`."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "logout-id-token-hint-out-of-browser-url",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 39,
+      "input_tokens": 231,
+      "output_tokens": 23185,
+      "total_tokens": 3871327,
+      "latency_seconds": 239.7,
+      "total_cost_usd": 0.6079925500000001,
+      "result_subtype": "success",
+      "task_score": 41.8,
+      "cache_read_tokens": 3754828,
+      "cache_write_tokens": 93083,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 96.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 15,
+          "total": 61,
+          "notes": "The issue clearly defines the WAF and disclosure problems, explicit non-goals, and mostly testable acceptance criteria. Its largest deficiency is an undefined cross-service handoff: the registry stores the token while the auth server is expected to retrieve it from a different session-store module without a shared-store contract or transfer mechanism. The submitted patch confirms incompatible storage keys, with the registry writing `session_id` and the auth server querying `_id`, while the eventual IdP redirect still contains `id_token_hint`. No independent task statement was supplied, and the claims covering every named provider and unchanged metrics cannot be verified from the issue."
+        },
+        "lld": {
+          "completeness": 10,
+          "correctness": 2,
+          "specificity": 13,
+          "risk_awareness": 8,
+          "total": 33,
+          "notes": "The LLD names concrete files, endpoint parameters, provider branches, fallback behavior, and a single-use session concept. Its core data flow is nonfunctional because `registry/auth/session_store.py` writes the hint to its collection under `session_id`, whereas `auth_server/session_store.py` retrieves from its own collection using `_id`; no inter-service transfer or verified shared collection is designed. It also feeds the resolved token into `logout_params` and `urlencode`, returning a browser redirect to the IdP that still exposes `id_token_hint`, and it stores raw tokens with ISO-string expiration values that MongoDB TTL indexes cannot expire as dates. Claims of existing encryption, automatic cleanup, configuration-free operation, and safe rollback are therefore unsupported or contradicted."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 5,
+          "specificity": 14,
+          "risk_awareness": 10,
+          "total": 39,
+          "notes": "The review's strongest contribution is identifying session-store outage behavior, TTL-index deployment needs, monitoring, and upgrade concerns. It nevertheless approves the design without catching the missing cross-service token transfer, incompatible document keys, plaintext token insertion, string-valued TTL field, or the token's continued presence in the IdP redirect URL. Its assertion that cross-provider leakage is prevented by deletion is unsound because entries are not provider-bound, and it inconsistently describes a 32-byte value as 128 bits when `token_hex(16)` generates 16 random bytes. The claimed TTL blocker is also declared resolved even though neither the LLD nor patch creates a valid index or BSON-date expiration field."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 16,
+          "risk_awareness": 12,
+          "total": 50,
+          "notes": "The plan covers URL shape, single use, fallback, local logout, provider behavior, TTL cleanup, and an end-to-end cycle with concrete expected outcomes. The primary oracle checks only the registry-to-auth-server redirect, while the auth-server-to-IdP redirect intentionally contains the token, so it cannot prove the promised absence from browser-visible URLs. Several procedures are unreliable or unsupported: unauthenticated `curl -I /logout` cannot obtain a session-backed ID, navigation performance entries need not expose intermediate redirects, HttpOnly cookies cannot be checked through `document.cookie`, and a 65-second wait is not a reliable MongoDB TTL-monitor bound. The assumed database and collection names, `/api/auth` endpoint, proposed test paths, container names, and unittest command are not established by the submitted repository evidence, and no executable tests accompany the patch."
+        },
+        "implementation": {
+          "completeness": 6,
+          "correctness": 2,
+          "specificity": 12,
+          "risk_awareness": 6,
+          "total": 26,
+          "notes": "The patch is narrowly targeted at the submitted preimage symbols `oauth2_logout`, `logout_handler`, and the two session-store modules, although the claimed `git apply --check` and syntax runs could not be independently verified because repository shell execution failed before commands ran. It does not implement a working token handoff: the registry inserts a document with `session_id`, while the auth server queries its separate store for `_id`, leaving the new auth-server writer and registry reader unused. Even if both modules shared a physical collection, the key mismatch prevents retrieval, and the auth server subsequently constructs a browser `Location` URL containing the resolved token as `id_token_hint`, directly defeating the stated requirement. The patch also stores the token without an encryption helper, writes `expires_at` as an ISO string unsuitable for MongoDB TTL expiration, adds no tests or index migration, and the summary incorrectly calls the implementation complete and identical to the LLD."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "portable-env-secret-generation-in-build-script",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 46,
+      "input_tokens": 282,
+      "output_tokens": 24332,
+      "total_tokens": 3297344,
+      "latency_seconds": 275.5,
+      "total_cost_usd": 0.5187336499999999,
+      "result_subtype": "success",
+      "task_score": 36.0,
+      "cache_read_tokens": 3212279,
+      "cache_write_tokens": 60451,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 88.3,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 4,
+          "specificity": 17,
+          "risk_awareness": 7,
+          "total": 46,
+          "notes": "The issue has clear scope, named variables, non-goals, and testable outcomes such as eliminating duplicate assignments and backup files. Its central solution is incorrect: GNU sed documents the optional in-place suffix as attached to -i, so a separate empty argument is parsed as an operand rather than a portable suffix.  The submitted diff corroborates the existence of ten static deletion calls and one dynamic ENV_VAR_NAME call, but the issue's claim that sourcing duplicate assignments reads the first value conflicts with normal shell behavior, where the later assignment replaces the earlier one.  With no independent task statement and unavailable local shell inspection, the asserted auth-server crash-loop, exact baseline lines, and related issue number could not be independently verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 2,
+          "specificity": 17,
+          "risk_awareness": 6,
+          "total": 43,
+          "notes": "The LLD is unusually concrete about build_and_run.sh, the five static secret blocks, the dynamic token block, error propagation, alternatives, and intended tests. The load-bearing design is nevertheless invalid because sed -i '' is not a single cross-platform invocation under GNU sed's documented option syntax.  The submitted patch context supports several cited symbols, including handle_error, ENV_VAR_NAME, and the eleven existing sed calls, but the LLD also rejects Python as a new dependency despite showing that these blocks already invoke python3. Its risk analysis misses the resulting Linux regression, incorrectly declares full backward compatibility, and leaves no open question for the unresolved GNU/BSD command difference."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 2,
+          "specificity": 10,
+          "risk_awareness": 6,
+          "total": 28,
+          "notes": "The review does identify two concrete concerns: newly visible failures may affect automation, and validation is needed on both operating-system families. Its unanimous approval misses the design's decisive flaw, repeatedly asserting that sed -i '' behaves identically on GNU and BSD despite GNU's documented attached optional-argument syntax.  Recommendations about the dynamic call, comments, release notes, and macOS testing are specific, but the frontend and security sections add little substantive pressure testing. Claims about available macOS CI, dependent automation, and shell-scripting guidelines remain unverified, while the verdict incorrectly labels the change backward compatible."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 2,
+          "specificity": 14,
+          "risk_awareness": 8,
+          "total": 40,
+          "notes": "The plan covers cross-platform behavior, all named secrets, dynamic keys, existing values, failure visibility, backup files, and deployment-level checks. Its foundational Linux test executes the invalid sed -i '' form, so the plan would expose rather than validate the proposed portability claim under GNU sed.  The repeat-run test is also internally wrong: its second deletion removes only an empty SECRET_KEY assignment, so appending NEW_VALUE2 after a nonempty prior value produces two entries rather than the asserted one. Several sections are pseudo-code or instructions to extract logic, the chmod 444 failure setup is unreliable for rename-based in-place editing, and the claimed health endpoint and optional skip-docker flag could not be verified."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 0,
+          "specificity": 12,
+          "risk_awareness": 4,
+          "total": 23,
+          "notes": "The diff text attempts all eleven advertised replacements and consistently removes error suppression from both static and dynamic deletion paths. It does not implement a portable command: on GNU sed, the separate empty argument does not serve as the optional -i suffix, making the Linux compatibility and no-breaking-change claims false.  The patch headers target /tmp/original.sh and /tmp/modified.sh rather than build_and_run.sh, so the documented git apply command cannot reliably modify the intended repository file as submitted. Exact baseline applicability could not be dry-run because the local shell sandbox failed to initialize, but the malformed target paths and incorrect GNU behavior independently make the implementation unusable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-30"
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 15,
+      "total": 69,
+      "notes": "The issue clearly states the cookie-size problem, measurable acceptance criteria, explicit exclusions, expiry, revocation, and the no-per-request-read constraint. Its largest deficiency is presenting an invented access/refresh-token reference design and `/oauth2/tokens` API as settled requirements despite the absence of an independent task statement. Repository release evidence describes the eventual design as an opaque session ID referencing a server-side record containing username, groups, and encrypted `id_token`, with existing sessions invalidated, which conflicts with several compatibility and data-model claims here.  The asserted typical token sizes, two-kilobyte target, and exact endpoint contract could not be independently verified."
+    },
+    "lld": {
+      "completeness": 13,
+      "correctness": 6,
+      "specificity": 15,
+      "risk_awareness": 11,
+      "total": 45,
+      "notes": "The LLD identifies concrete files, callback and validation integration points, data flow, ownership filtering, encryption, TTL indexing, and operational concerns. Its central design is internally inconsistent: one section persists an automatically generated key in MongoDB and fails closed, while the configuration and implementation sections generate an ephemeral key, log it, and explicitly warn it will be lost; the displayed model is also structurally malformed around the `id` field and omits `user_id`. Repository release evidence instead uses an `oauth_sessions` store, HKDF derivation from `SECRET_KEY`, and an opaque cookie session ID, contradicting the LLD's claimed established storage and compatibility model.  Material symbols such as `validate_session_cookie`, `get_database`, the cited line ranges, and the proposed `request.app.state.db` wiring could not be verified from the unavailable local shell."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 18,
+      "risk_awareness": 20,
+      "total": 70,
+      "notes": "The review's strongest work is identifying concrete failure modes around ephemeral encryption keys, TTL deletion lag, staged rollout, expiry alignment, decryption errors, logging, and revocation. Its largest defect is the final claim that all blockers were integrated: the LLD still lacks the promised feature flag, revoke-all endpoint design, metrics integration, and consistent persistent-key behavior. Several recommendations are weak or arbitrary, including a redundant post-query ownership assertion, a 100GB alert threshold without workload evidence, and dual cookie storage that preserves the original size problem. Repository release evidence confirms that key derivation, migration behavior, and forced logout were material concerns, supporting the review's focus but not its declaration that the design was ready. "
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 5,
+      "specificity": 15,
+      "risk_awareness": 12,
+      "total": 46,
+      "notes": "The plan covers storage, retrieval, unauthorized access, cookie size, legacy sessions, index creation, deployment, expiry, key changes, and concurrency. Many proposed tests cannot produce their stated oracle: callback requests use fake authorization codes and states without defining a mock, header parsing omits `curl -i`, signed cookies cannot be validated by simply grepping decoded JSON, and JWT decodability does not prove encryption round-trip equality. The cross-user test extracts a `token_reference` that the response does not contain and calls an unimplemented GET-by-reference endpoint, while the no-database-read check relies on an unverified log path and generic text matching. Its legacy-cookie expectation also conflicts with repository release behavior that rejects pre-migration sessions and requires reauthentication, and revocation lacks a concrete executable test despite being an acceptance criterion. "
+    },
+    "implementation": {
+      "completeness": 4,
+      "correctness": 2,
+      "specificity": 10,
+      "risk_awareness": 4,
+      "total": 20,
+      "notes": "The patch contains concrete AES-GCM encryption, scoped MongoDB queries, TTL-index creation, and revocation repository methods. It does not implement the feature end to end: every hunk adds a new file, while `server.py`, the OAuth callback, application startup, route registration, configuration, and tests remain untouched; the summary admits these are implementer follow-ups while simultaneously claiming the tokens were moved and there were no LLD deviations. `token_endpoints.py` cannot be imported because `app`, `Request`, `HTTPException`, `logger`, `validate_session_cookie`, and repository imports are undefined, and `OAuthTokenDocument(id=...)` conflicts with the `_id` alias without enabling field-name population; the DELETE handler also returns the default 200 rather than its promised 204. The implementation retains the critical ephemeral-key behavior and logs the generated secret, contrary to the reviewed persistent-key design, while repository release evidence shows a materially different integrated session-store implementation. "
+    }
+  },
+  "task_score": 50.0,
+  "verdict": "The submission has a strong issue and useful risk review, but the contradictory LLD, largely non-executable tests, and non-integrated implementation prevent it from delivering the requested feature.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-30T22:23:42.346037Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 373634,
+      "cached_input_tokens": 277688,
+      "cache_write_input_tokens": 42451,
+      "output_tokens": 10187,
+      "reasoning_output_tokens": 7879
+    },
+    "duration_ms": 120840
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-haiku-4-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "high",
+  "tags": [
+    "authentication",
+    "oauth",
+    "session",
+    "mongodb",
+    "encryption",
+    "auth-server",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "model_slug": "claude-haiku-4-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 105.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 14408,
+    "output_tokens": 31052,
+    "cache_read_tokens": 2594316,
+    "cache_write_tokens": 188513,
+    "total_tokens": 2828289,
+    "total_cost_usd": 0.66474085,
+    "latency_seconds": 295.8,
+    "num_turns": 30,
+    "generation_tokens_per_sec": 105.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 14408,
+  "output_tokens": 31052,
+  "latency_seconds": 295.8,
+  "num_turns": 30,
+  "total_cost_usd": 0.66474085,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2594316,
+  "cache_creation_tokens": 188513,
+  "run_started_at": "2026-08-30T20:40:01.982993Z",
+  "run_ended_at": "2026-08-30T20:44:57.796577Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 14408,
+    "output_tokens": 31052,
+    "cache_read_tokens": 2594316,
+    "cache_write_tokens": 188513,
+    "total_tokens": 2828289,
+    "total_cost_usd": 0.66474085,
+    "latency_seconds": 295.8,
+    "num_turns": 30,
+    "generation_tokens_per_sec": 105.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "server-side-oauth-token-storage",
+    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 15,
+        "total": 69,
+        "notes": "The issue clearly states the cookie-size problem, measurable acceptance criteria, explicit exclusions, expiry, revocation, and the no-per-request-read constraint. Its largest deficiency is presenting an invented access/refresh-token reference design and `/oauth2/tokens` API as settled requirements despite the absence of an independent task statement. Repository release evidence describes the eventual design as an opaque session ID referencing a server-side record containing username, groups, and encrypted `id_token`, with existing sessions invalidated, which conflicts with several compatibility and data-model claims here.  The asserted typical token sizes, two-kilobyte target, and exact endpoint contract could not be independently verified."
+      },
+      "lld": {
+        "completeness": 13,
+        "correctness": 6,
+        "specificity": 15,
+        "risk_awareness": 11,
+        "total": 45,
+        "notes": "The LLD identifies concrete files, callback and validation integration points, data flow, ownership filtering, encryption, TTL indexing, and operational concerns. Its central design is internally inconsistent: one section persists an automatically generated key in MongoDB and fails closed, while the configuration and implementation sections generate an ephemeral key, log it, and explicitly warn it will be lost; the displayed model is also structurally malformed around the `id` field and omits `user_id`. Repository release evidence instead uses an `oauth_sessions` store, HKDF derivation from `SECRET_KEY`, and an opaque cookie session ID, contradicting the LLD's claimed established storage and compatibility model.  Material symbols such as `validate_session_cookie`, `get_database`, the cited line ranges, and the proposed `request.app.state.db` wiring could not be verified from the unavailable local shell."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 18,
+        "risk_awareness": 20,
+        "total": 70,
+        "notes": "The review's strongest work is identifying concrete failure modes around ephemeral encryption keys, TTL deletion lag, staged rollout, expiry alignment, decryption errors, logging, and revocation. Its largest defect is the final claim that all blockers were integrated: the LLD still lacks the promised feature flag, revoke-all endpoint design, metrics integration, and consistent persistent-key behavior. Several recommendations are weak or arbitrary, including a redundant post-query ownership assertion, a 100GB alert threshold without workload evidence, and dual cookie storage that preserves the original size problem. Repository release evidence confirms that key derivation, migration behavior, and forced logout were material concerns, supporting the review's focus but not its declaration that the design was ready. "
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 5,
+        "specificity": 15,
+        "risk_awareness": 12,
+        "total": 46,
+        "notes": "The plan covers storage, retrieval, unauthorized access, cookie size, legacy sessions, index creation, deployment, expiry, key changes, and concurrency. Many proposed tests cannot produce their stated oracle: callback requests use fake authorization codes and states without defining a mock, header parsing omits `curl -i`, signed cookies cannot be validated by simply grepping decoded JSON, and JWT decodability does not prove encryption round-trip equality. The cross-user test extracts a `token_reference` that the response does not contain and calls an unimplemented GET-by-reference endpoint, while the no-database-read check relies on an unverified log path and generic text matching. Its legacy-cookie expectation also conflicts with repository release behavior that rejects pre-migration sessions and requires reauthentication, and revocation lacks a concrete executable test despite being an acceptance criterion. "
+      },
+      "implementation": {
+        "completeness": 4,
+        "correctness": 2,
+        "specificity": 10,
+        "risk_awareness": 4,
+        "total": 20,
+        "notes": "The patch contains concrete AES-GCM encryption, scoped MongoDB queries, TTL-index creation, and revocation repository methods. It does not implement the feature end to end: every hunk adds a new file, while `server.py`, the OAuth callback, application startup, route registration, configuration, and tests remain untouched; the summary admits these are implementer follow-ups while simultaneously claiming the tokens were moved and there were no LLD deviations. `token_endpoints.py` cannot be imported because `app`, `Request`, `HTTPException`, `logger`, `validate_session_cookie`, and repository imports are undefined, and `OAuthTokenDocument(id=...)` conflicts with the `_id` alias without enabling field-name population; the DELETE handler also returns the default 200 rather than its promised 204. The implementation retains the critical ephemeral-key behavior and logs the generated secret, contrary to the reviewed persistent-key design, while repository release evidence shows a materially different integrated session-store implementation. "
+      }
+    },
+    "task_score": 50.0,
+    "verdict": "The submission has a strong issue and useful risk review, but the contradictory LLD, largely non-executable tests, and non-integrated implementation prevent it from delivering the requested feature.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-30T22:23:42.346037Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 373634,
+        "cached_input_tokens": 277688,
+        "cache_write_input_tokens": 42451,
+        "output_tokens": 10187,
+        "reasoning_output_tokens": 7879
+      },
+      "duration_ms": 120840
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 86,
+      "notes": "The strongest aspect is the concrete problem statement, naming the affected Dockerfiles, missing lockfiles, CPU PyTorch handling, CI gate, and explicit exclusions. Acceptance criteria include actionable commands such as the docker grep and uv lock checks, plus runtime and security oracles. The largest deficiency is that the promised reproducibility remains incomplete for MCP images with out-of-lock PyTorch, while dropping torchvision conflicts with the stated unchanged image behavior. No independent task statement was supplied, so the candidate-defined exclusions cannot be fully validated against external requirements."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 86,
+      "notes": "The LLD makes unusually concrete decisions around uv sync --locked, --no-dev, --inexact, the explicit PyTorch index, and --no-deps for the editable registry install. It identifies real integration points including pyproject.toml, uv.lock, five Dockerfiles, build contexts, CI, and regression tests. Its largest weakness is knowingly retaining an unpinned PyTorch installation in two MCP images while claiming locked, reproducible image dependencies; it also changes local development to CPU PyTorch and removes torchvision. Exact timing, package-delta, and build-context claims could not all be independently verified because the submitted patch was truncated and local shell execution was unavailable."
+    },
+    "review": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 23,
+      "total": 89,
+      "notes": "The review surfaces concrete defects with consequences, especially the unconstrained editable install, unsafe shell discovery loop, CUDA-size risk, missing rollback unit, and insufficient embeddings coverage. Its proposed regression test does not actually enforce the claimed future invariant because it checks a fixed list of five Dockerfiles rather than scanning every Dockerfile under docker/. The review also accepts the out-of-lock MCP PyTorch installation after merely documenting it, making the final approval more generous than the reproducibility goal warrants. Claims such as byte-identical frontend assets and measured lock-check timings were not independently verifiable from the available repository access."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 79,
+      "notes": "The plan has strong behavioral oracles for stale locks, CPU-only torch, absence of CUDA and development packages, embeddings operation, health endpoints, rollback, and repeated-build dependency equality. Several commands are unreliable: uv sync --extra dev does not select a dependency group, python -m pip may be unavailable in an unseeded uv-created environment, and git diff HEAD~1 does not isolate an uncommitted applied patch. Package-inspection docker run commands also omit an entrypoint override despite the documented image entrypoints, and some deployment checks assert unchanged output without constructing a baseline comparison. The breadth is excellent, but these executable errors materially reduce confidence that the plan can be followed successfully."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 20,
+      "total": 76,
+      "notes": "The visible patch and summary implement the central path: new lockfiles, locked synchronization in five Dockerfiles, an explicit CPU PyTorch source, a stale-lock workflow, and a targeted regression test. The largest defect is that Dockerfile.mcp-server and Dockerfile.mcp-server-cpu deliberately retain an unpinned, hash-free PyTorch install through --inexact, while the registry image also drops torchvision despite the unchanged-content objective. The regression test's hardcoded Dockerfile list will not catch the sixth-Dockerfile scenario it claims to prevent, and repository-controlled paths remain unescaped when emitted into workflow annotations and Markdown. The complete diff could not be apply-checked because the submission truncates it, and repository release notes later document that clean locked builds required pinning uv, confirming the acknowledged unpinned-tool risk. "
+    }
+  },
+  "task_score": 83.2,
+  "verdict": "This is strong, repository-specific work with excellent design analysis, but incomplete dependency reproducibility and multiple faulty test commands keep it below excellent overall.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T13:44:40.580582Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 1039324,
+      "cached_input_tokens": 831145,
+      "cache_write_input_tokens": 149492,
+      "output_tokens": 12505,
+      "reasoning_output_tokens": 10539
+    },
+    "duration_ms": 321725
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "docker",
+    "build",
+    "uv",
+    "dependencies",
+    "reproducibility",
+    "ci",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 72.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 3513,
+    "output_tokens": 102397,
+    "cache_read_tokens": 15707008,
+    "cache_write_tokens": 250489,
+    "total_tokens": 16063407,
+    "total_cost_usd": 11.99655025,
+    "latency_seconds": 1421.8,
+    "num_turns": 79,
+    "generation_tokens_per_sec": 72.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 3513,
+  "output_tokens": 102397,
+  "latency_seconds": 1421.8,
+  "num_turns": 79,
+  "total_cost_usd": 11.99655025,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 15707008,
+  "cache_creation_tokens": 250489,
+  "run_started_at": "2026-08-31T06:22:47.335185Z",
+  "run_ended_at": "2026-08-31T06:46:29.125550Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 3513,
+    "output_tokens": 102397,
+    "cache_read_tokens": 15707008,
+    "cache_write_tokens": 250489,
+    "total_tokens": 16063407,
+    "total_cost_usd": 11.99655025,
+    "latency_seconds": 1421.8,
+    "num_turns": 79,
+    "generation_tokens_per_sec": 72.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "build-docker-images-from-uv-lock",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 86,
+        "notes": "The strongest aspect is the concrete problem statement, naming the affected Dockerfiles, missing lockfiles, CPU PyTorch handling, CI gate, and explicit exclusions. Acceptance criteria include actionable commands such as the docker grep and uv lock checks, plus runtime and security oracles. The largest deficiency is that the promised reproducibility remains incomplete for MCP images with out-of-lock PyTorch, while dropping torchvision conflicts with the stated unchanged image behavior. No independent task statement was supplied, so the candidate-defined exclusions cannot be fully validated against external requirements."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 86,
+        "notes": "The LLD makes unusually concrete decisions around uv sync --locked, --no-dev, --inexact, the explicit PyTorch index, and --no-deps for the editable registry install. It identifies real integration points including pyproject.toml, uv.lock, five Dockerfiles, build contexts, CI, and regression tests. Its largest weakness is knowingly retaining an unpinned PyTorch installation in two MCP images while claiming locked, reproducible image dependencies; it also changes local development to CPU PyTorch and removes torchvision. Exact timing, package-delta, and build-context claims could not all be independently verified because the submitted patch was truncated and local shell execution was unavailable."
+      },
+      "review": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 23,
+        "total": 89,
+        "notes": "The review surfaces concrete defects with consequences, especially the unconstrained editable install, unsafe shell discovery loop, CUDA-size risk, missing rollback unit, and insufficient embeddings coverage. Its proposed regression test does not actually enforce the claimed future invariant because it checks a fixed list of five Dockerfiles rather than scanning every Dockerfile under docker/. The review also accepts the out-of-lock MCP PyTorch installation after merely documenting it, making the final approval more generous than the reproducibility goal warrants. Claims such as byte-identical frontend assets and measured lock-check timings were not independently verifiable from the available repository access."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 79,
+        "notes": "The plan has strong behavioral oracles for stale locks, CPU-only torch, absence of CUDA and development packages, embeddings operation, health endpoints, rollback, and repeated-build dependency equality. Several commands are unreliable: uv sync --extra dev does not select a dependency group, python -m pip may be unavailable in an unseeded uv-created environment, and git diff HEAD~1 does not isolate an uncommitted applied patch. Package-inspection docker run commands also omit an entrypoint override despite the documented image entrypoints, and some deployment checks assert unchanged output without constructing a baseline comparison. The breadth is excellent, but these executable errors materially reduce confidence that the plan can be followed successfully."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 20,
+        "total": 76,
+        "notes": "The visible patch and summary implement the central path: new lockfiles, locked synchronization in five Dockerfiles, an explicit CPU PyTorch source, a stale-lock workflow, and a targeted regression test. The largest defect is that Dockerfile.mcp-server and Dockerfile.mcp-server-cpu deliberately retain an unpinned, hash-free PyTorch install through --inexact, while the registry image also drops torchvision despite the unchanged-content objective. The regression test's hardcoded Dockerfile list will not catch the sixth-Dockerfile scenario it claims to prevent, and repository-controlled paths remain unescaped when emitted into workflow annotations and Markdown. The complete diff could not be apply-checked because the submission truncates it, and repository release notes later document that clean locked builds required pinning uv, confirming the acknowledged unpinned-tool risk. "
+      }
+    },
+    "task_score": 83.2,
+    "verdict": "This is strong, repository-specific work with excellent design analysis, but incomplete dependency reproducibility and multiple faulty test commands keep it below excellent overall.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T13:44:40.580582Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 1039324,
+        "cached_input_tokens": 831145,
+        "cache_write_input_tokens": 149492,
+        "output_tokens": 12505,
+        "reasoning_output_tokens": 10539
+      },
+      "duration_ms": 321725
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 24,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 91,
+      "notes": "The issue provides unusually concrete acceptance criteria, including exact flags, exit codes, omission semantics, compatibility cases, and explicit non-goals. Its largest factual weakness is the claim that curl is the only existing configuration path, which conflicts with its own evidence that Dashboard.tsx sends the two mandatory custom-provider URLs. The cited cmd_egress_configure, configure_egress_auth, EgressConfigRequest, and TokenEndpointAuthStyle integration points align consistently across the submitted artifacts. No independent task statement was supplied, so scope coverage can only be judged from the task identifier, repository context, and internally consistent evidence."
+    },
+    "lld": {
+      "completeness": 24,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 24,
+      "total": 94,
+      "notes": "The LLD commits to exact signature ordering, request-body gates, parser choices, validation ownership, file changes, compatibility behavior, and documentation updates. It correctly identifies the load-bearing full-declaration behavior of the route and preserves target_audience's positional slot by appending the five parameters. A limited inconsistency remains because it says the flags apply only to oauth_user plus custom while the proposed command silently forwards them for provider custom in other modes, and its environment-variable secret examples still expose the expanded secret through process argv. The design explicitly covers SSRF authority, enum drift, UI overwrite risk, response visibility, rollback, and the missing custom_resource model field."
+    },
+    "review": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 24,
+      "total": 93,
+      "notes": "The review finds concrete defects rather than merely approving the design, especially the original positional-parameter misbinding, normalization constraint, and duplicated-enum drift risk. Each major finding states a consequence and a specific resolution subsequently reflected in the revised LLD and patch. Its largest omission is that it does not directly challenge the issue's false curl-only claim despite noting that the server-edit modal already sends both required URLs. The claimed pre-revision LLD cannot be independently compared with the submitted revised version, but the resolved decisions are concrete and technically coherent."
+    },
+    "testing": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 89,
+      "notes": "The plan covers parser behavior, client body shape, positional compatibility, all modes, negative validation, documentation, live operation, and an actual OAuth flow with specific commands and expected states. Its principal correctness flaw is section 1.3.3 suggesting that a consent redirect can confirm basic_header persistence, although token-endpoint authentication style is exercised during token exchange, not authorization redirect construction. The implemented warning test also fails to assert that a warning occurred, and the bad-choice test does not directly prove that client construction was skipped. The plan recognizes SSRF, secret logging, rollback, read-back limitations, and compatibility risks, although expanding an environment variable still leaves the secret visible in process argv."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 89,
+      "notes": "The diff implements the designed path end to end: five parser flags, five appended client parameters, omission-preserving body construction, pre-client URL checks, documentation, and focused tests. The signature keeps target_audience in its existing positional slot, and the body uses is not None so an empty custom_scope_separator is transmitted. The main implementation defect is that the non-custom warning uses truthiness, so an explicitly supplied empty separator is forwarded without the warning promised by the design; one test docstring also incorrectly implies omitted custom fields cannot be cleared despite the documented full-rebuild behavior. The repository shell failed before commands executed, so patch applicability and source-context matching could not be independently confirmed; this is an evidence gap rather than a demonstrated patch failure."
+    }
+  },
+  "task_score": 91.2,
+  "verdict": "This is excellent, implementation-ready work overall, with the largest material limitation being several testing claims and oracles that do not fully prove the behavior they describe.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T13:51:33.803337Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 432807,
+      "cached_input_tokens": 313693,
+      "cache_write_input_tokens": 60863,
+      "output_tokens": 11847,
+      "reasoning_output_tokens": 9983
+    },
+    "duration_ms": 413209
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "cli",
+    "python",
+    "egress-auth",
+    "oauth",
+    "api-parity",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 81.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 15131,
+    "output_tokens": 101277,
+    "cache_read_tokens": 9387795,
+    "cache_write_tokens": 203069,
+    "total_tokens": 9707272,
+    "total_cost_usd": 8.570658750000002,
+    "latency_seconds": 1241.4,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 81.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 15131,
+  "output_tokens": 101277,
+  "latency_seconds": 1241.4,
+  "num_turns": 56,
+  "total_cost_usd": 8.570658750000002,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 9387795,
+  "cache_creation_tokens": 203069,
+  "run_started_at": "2026-08-31T07:15:19.850217Z",
+  "run_ended_at": "2026-08-31T07:36:01.317658Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 15131,
+    "output_tokens": 101277,
+    "cache_read_tokens": 9387795,
+    "cache_write_tokens": 203069,
+    "total_tokens": 9707272,
+    "total_cost_usd": 8.570658750000002,
+    "latency_seconds": 1241.4,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 81.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "cli-custom-egress-oauth-provider-flags",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 24,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 91,
+        "notes": "The issue provides unusually concrete acceptance criteria, including exact flags, exit codes, omission semantics, compatibility cases, and explicit non-goals. Its largest factual weakness is the claim that curl is the only existing configuration path, which conflicts with its own evidence that Dashboard.tsx sends the two mandatory custom-provider URLs. The cited cmd_egress_configure, configure_egress_auth, EgressConfigRequest, and TokenEndpointAuthStyle integration points align consistently across the submitted artifacts. No independent task statement was supplied, so scope coverage can only be judged from the task identifier, repository context, and internally consistent evidence."
+      },
+      "lld": {
+        "completeness": 24,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 24,
+        "total": 94,
+        "notes": "The LLD commits to exact signature ordering, request-body gates, parser choices, validation ownership, file changes, compatibility behavior, and documentation updates. It correctly identifies the load-bearing full-declaration behavior of the route and preserves target_audience's positional slot by appending the five parameters. A limited inconsistency remains because it says the flags apply only to oauth_user plus custom while the proposed command silently forwards them for provider custom in other modes, and its environment-variable secret examples still expose the expanded secret through process argv. The design explicitly covers SSRF authority, enum drift, UI overwrite risk, response visibility, rollback, and the missing custom_resource model field."
+      },
+      "review": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 24,
+        "total": 93,
+        "notes": "The review finds concrete defects rather than merely approving the design, especially the original positional-parameter misbinding, normalization constraint, and duplicated-enum drift risk. Each major finding states a consequence and a specific resolution subsequently reflected in the revised LLD and patch. Its largest omission is that it does not directly challenge the issue's false curl-only claim despite noting that the server-edit modal already sends both required URLs. The claimed pre-revision LLD cannot be independently compared with the submitted revised version, but the resolved decisions are concrete and technically coherent."
+      },
+      "testing": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 89,
+        "notes": "The plan covers parser behavior, client body shape, positional compatibility, all modes, negative validation, documentation, live operation, and an actual OAuth flow with specific commands and expected states. Its principal correctness flaw is section 1.3.3 suggesting that a consent redirect can confirm basic_header persistence, although token-endpoint authentication style is exercised during token exchange, not authorization redirect construction. The implemented warning test also fails to assert that a warning occurred, and the bad-choice test does not directly prove that client construction was skipped. The plan recognizes SSRF, secret logging, rollback, read-back limitations, and compatibility risks, although expanding an environment variable still leaves the secret visible in process argv."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 89,
+        "notes": "The diff implements the designed path end to end: five parser flags, five appended client parameters, omission-preserving body construction, pre-client URL checks, documentation, and focused tests. The signature keeps target_audience in its existing positional slot, and the body uses is not None so an empty custom_scope_separator is transmitted. The main implementation defect is that the non-custom warning uses truthiness, so an explicitly supplied empty separator is forwarded without the warning promised by the design; one test docstring also incorrectly implies omitted custom fields cannot be cleared despite the documented full-rebuild behavior. The repository shell failed before commands executed, so patch applicability and source-context matching could not be independently confirmed; this is an evidence gap rather than a demonstrated patch failure."
+      }
+    },
+    "task_score": 91.2,
+    "verdict": "This is excellent, implementation-ready work overall, with the largest material limitation being several testing claims and oracles that do not fully prove the behavior they describe.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T13:51:33.803337Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 432807,
+        "cached_input_tokens": 313693,
+        "cache_write_input_tokens": 60863,
+        "output_tokens": 11847,
+        "reasoning_output_tokens": 9983
+      },
+      "duration_ms": 413209
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 86,
+      "notes": "The issue precisely identifies the hardcoded AsyncClient timeout, affected proxy path, deployment surfaces, compatibility target, and testable acceptance criteria. The submitted baseline hunk corroborates auth_server/server.py using timeout=30.0 and preserving the existing 504 detail. Its largest weakness is describing the scalar httpx timeout as a strict total-duration ceiling and claiming byte-for-byte default behavior despite adding nginx timeout directives that can alter edge-case timing. No independent task statement was supplied, and issue-number history could not be independently verified."
+    },
+    "lld": {
+      "completeness": 24,
+      "correctness": 16,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 82,
+      "notes": "The LLD is unusually concrete about real files, symbols, configuration surfaces, rollout, observability, and nginx interaction. Its proposed changes align closely with the submitted source hunks for Settings, mcp_proxy, NginxConfigService, Helm, Compose, and Terraform. However, the settings-first helper makes its environment fallback largely unreachable once BaseSettings owns a defaulted field, so malformed deployment environment values can fail model construction before the promised warning and fallback; it also inserts nginx limits into common_settings rather than proving they apply only to the auth-server proxy branch. The design additionally treats httpx and nginx inactivity timeouts as total deadlines, weakening its guarantees about resource bounds and which component always returns the 504."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 78,
+      "notes": "The review finds substantive defects rather than merely approving the design, notably the missing upper bound, nginx's separate timeout, registry-side configuration propagation, and load-balancer limits. Its resolutions are prioritized and map to concrete fields, helpers, tests, and deployment files. It misses the BaseSettings precedence contradiction, the unconditional common_settings scope, and the fact that timeout activity can continue beyond the nominal scalar budget, while incorrectly presenting the ceiling as a complete slow-resource bound. Repository issue-history claims and the assertion that direct-to-8888 is unsupported were not independently verifiable."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 76,
+      "notes": "The plan spans focused unit tests, real route-level httpx assertions, nginx generation, compatibility, deployment rendering, rollback, and end-to-end long-call behavior with concrete expected values. The proposed unit tests meaningfully assert 30.0, 120.0, 35s, 305s, and the unchanged 504 body rather than merely checking execution. Its largest defect is accepting either clamping or startup ValidationError for an out-of-range environment value, which does not pin the issue's promised behavior, while the fallback tests artificially remove the Settings attribute instead of exercising normal configuration loading. It also omits a regression oracle for direct-transport locations and uses inconsistent authentication examples for /api/config between the LLD and testing plan."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 74,
+      "notes": "The patch implements the designed field, resolver, AsyncClient wiring, logging, admin exposure, nginx generation, deployment surfaces, documentation, and targeted tests rather than stopping at the call-site replacement. The auth_server/server.py hunk concretely removes timeout=30.0, passes the resolved value, and preserves the existing JSON 504 detail. The main defects are that malformed environment values can be rejected during Settings construction before the advertised fallback, and that timeout directives are added unconditionally to nginx common_settings, potentially changing direct-transport behavior without a regression test; inactivity semantics also invalidate the claim that the auth-server always times out first. The local sandbox failed before command execution, so git apply --check and independent source inspection were unavailable; applicability is therefore not independently verified, although the submitted paths and hunk contexts are internally consistent."
+    }
+  },
+  "task_score": 79.2,
+  "verdict": "The submission is highly detailed and largely end-to-end, but configuration-precedence semantics and overbroad nginx timeout insertion leave material correctness and regression risks.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T13:53:40.700366Z",
+    "repo_ref": "1.25.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 372683,
+      "cached_input_tokens": 300964,
+      "cache_write_input_tokens": 58726,
+      "output_tokens": 8901,
+      "reasoning_output_tokens": 6720
+    },
+    "duration_ms": 126885
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.25.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "config",
+    "auth-server",
+    "httpx",
+    "proxy",
+    "timeouts",
+    "fixed-in-1.26.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 20606,
+    "output_tokens": 89994,
+    "cache_read_tokens": 12841713,
+    "cache_write_tokens": 215197,
+    "total_tokens": 13167510,
+    "total_cost_usd": 10.118717749999998,
+    "latency_seconds": 1161.9,
+    "num_turns": 73,
+    "generation_tokens_per_sec": 77.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 20606,
+  "output_tokens": 89994,
+  "latency_seconds": 1161.9,
+  "num_turns": 73,
+  "total_cost_usd": 10.118717749999998,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 12841713,
+  "cache_creation_tokens": 215197,
+  "run_started_at": "2026-08-31T08:34:43.709754Z",
+  "run_ended_at": "2026-08-31T08:54:05.583771Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 20606,
+    "output_tokens": 89994,
+    "cache_read_tokens": 12841713,
+    "cache_write_tokens": 215197,
+    "total_tokens": 13167510,
+    "total_cost_usd": 10.118717749999998,
+    "latency_seconds": 1161.9,
+    "num_turns": 73,
+    "generation_tokens_per_sec": 77.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-mcp-proxy-upstream-timeout",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 86,
+        "notes": "The issue precisely identifies the hardcoded AsyncClient timeout, affected proxy path, deployment surfaces, compatibility target, and testable acceptance criteria. The submitted baseline hunk corroborates auth_server/server.py using timeout=30.0 and preserving the existing 504 detail. Its largest weakness is describing the scalar httpx timeout as a strict total-duration ceiling and claiming byte-for-byte default behavior despite adding nginx timeout directives that can alter edge-case timing. No independent task statement was supplied, and issue-number history could not be independently verified."
+      },
+      "lld": {
+        "completeness": 24,
+        "correctness": 16,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 82,
+        "notes": "The LLD is unusually concrete about real files, symbols, configuration surfaces, rollout, observability, and nginx interaction. Its proposed changes align closely with the submitted source hunks for Settings, mcp_proxy, NginxConfigService, Helm, Compose, and Terraform. However, the settings-first helper makes its environment fallback largely unreachable once BaseSettings owns a defaulted field, so malformed deployment environment values can fail model construction before the promised warning and fallback; it also inserts nginx limits into common_settings rather than proving they apply only to the auth-server proxy branch. The design additionally treats httpx and nginx inactivity timeouts as total deadlines, weakening its guarantees about resource bounds and which component always returns the 504."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 78,
+        "notes": "The review finds substantive defects rather than merely approving the design, notably the missing upper bound, nginx's separate timeout, registry-side configuration propagation, and load-balancer limits. Its resolutions are prioritized and map to concrete fields, helpers, tests, and deployment files. It misses the BaseSettings precedence contradiction, the unconditional common_settings scope, and the fact that timeout activity can continue beyond the nominal scalar budget, while incorrectly presenting the ceiling as a complete slow-resource bound. Repository issue-history claims and the assertion that direct-to-8888 is unsupported were not independently verifiable."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 76,
+        "notes": "The plan spans focused unit tests, real route-level httpx assertions, nginx generation, compatibility, deployment rendering, rollback, and end-to-end long-call behavior with concrete expected values. The proposed unit tests meaningfully assert 30.0, 120.0, 35s, 305s, and the unchanged 504 body rather than merely checking execution. Its largest defect is accepting either clamping or startup ValidationError for an out-of-range environment value, which does not pin the issue's promised behavior, while the fallback tests artificially remove the Settings attribute instead of exercising normal configuration loading. It also omits a regression oracle for direct-transport locations and uses inconsistent authentication examples for /api/config between the LLD and testing plan."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 74,
+        "notes": "The patch implements the designed field, resolver, AsyncClient wiring, logging, admin exposure, nginx generation, deployment surfaces, documentation, and targeted tests rather than stopping at the call-site replacement. The auth_server/server.py hunk concretely removes timeout=30.0, passes the resolved value, and preserves the existing JSON 504 detail. The main defects are that malformed environment values can be rejected during Settings construction before the advertised fallback, and that timeout directives are added unconditionally to nginx common_settings, potentially changing direct-transport behavior without a regression test; inactivity semantics also invalidate the claim that the auth-server always times out first. The local sandbox failed before command execution, so git apply --check and independent source inspection were unavailable; applicability is therefore not independently verified, although the submitted paths and hunk contexts are internally consistent."
+      }
+    },
+    "task_score": 79.2,
+    "verdict": "The submission is highly detailed and largely end-to-end, but configuration-precedence semantics and overbroad nginx timeout insertion leave material correctness and regression risks.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T13:53:40.700366Z",
+      "repo_ref": "1.25.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 372683,
+        "cached_input_tokens": 300964,
+        "cache_write_input_tokens": 58726,
+        "output_tokens": 8901,
+        "reasoning_output_tokens": 6720
+      },
+      "duration_ms": 126885
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-ui-title",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 80,
+      "notes": "The issue is unusually concrete, covering backend resolution, four UI occurrences, three deployment surfaces, documentation, tests, and explicit non-goals. Its largest defect is a direct contradiction: registry-only deployments without UI_TITLE intentionally change to \"AI Registry\", while another user story and acceptance criterion promise that deployments without UI_TITLE change nothing. The submitted diff confirms the named Layout.tsx, Login.tsx, Logout.tsx, config routes, and deployment files are the intended change points. No independent task statement establishes the deployment-mode-derived default, so that requirement remains candidate-defined rather than externally verified."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 87,
+      "notes": "The LLD is implementation-ready across Settings, both API paths, React consumers, exports, Docker, Terraform, Helm, documentation, rollout, and rollback. Its main weakness is preserving the issue's incompatible no-change claim; removing UI_TITLE does not restore pre-change registry-only text, and the blank raw System Config field does not directly show the effective value requested by a user story. Concrete decisions such as the conditional Helm environment entry, reserved-name guard, empty-string export semantics, public auth-config payload, and React text-only rendering are reflected in the patch. Exact tag, line-number, and cache-behavior claims could not be independently confirmed because the provided repository shell failed during sandbox initialization."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 86,
+      "notes": "The review finds several consequential design defects, including exporting None, whitespace-only titles, Helm positional-test breakage, duplicate environment names, unbounded public values, and unauthenticated disclosure. Its largest omission is failing to challenge the central backward-compatibility contradiction or the mismatch between showing a raw blank field and promising visibility of the effective title. Findings are prioritized and actionable, and the implementation visibly incorporates B1 through B6 in config.py, deployment.yaml, _helpers.tpl, and auth/routes.py. The reviewed Rev 1 artifact was not supplied, so claims about its exact contents and the asserted exhaustive repository test search are not independently verifiable."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 80,
+      "notes": "The plan covers resolution precedence, malformed input, both APIs, compatibility skew, UI behavior, every deployment surface, rollback, and end-to-end runtime configuration. Its largest weakness is executable reliability: it repeatedly appends to .env without cleanup, calls a Terraform task-definition change a no-op, and describes config/full fields inconsistently as top-level raw data in section 1.1.7 but nested value.display data in section 5.1. Several curl and jq examples display results without asserting status or the promised field values, and no automated React test verifies the header, login, logout, or fallback behavior. The unit-test and Helm regression commands otherwise align closely with the submitted patch and target the highest-risk backend and chart behaviors."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 83,
+      "notes": "The patch implements the feature end to end: Settings normalization and derivation, authenticated and public API exposure, all four UI strings, CONFIG_GROUPS, Docker, Terraform, Helm, documentation, and backend tests. Its largest deficiency is verification coverage and summary accuracy: the added file contains 16 test functions rather than the claimed 18, with no automated frontend, config/full, export-round-trip, warning-log, or Helm test additions. The submitted hunks are internally consistent around Settings.effective_ui_title, get_config, get_auth_config, useRegistryConfig, the conditional Helm entry, and Terraform pass-through, and the implementation honestly excludes static generated bundles. The claimed git apply checks and exact baseline compatibility could not be independently rerun because all repository shell commands failed at sandbox initialization."
+    }
+  },
+  "task_score": 83.2,
+  "verdict": "Strong, highly repository-specific work whose largest limitation is the unresolved contradiction between deployment-mode-aware title changes and the promise that unset UI_TITLE causes no change.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T13:56:57.967611Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 252055,
+      "cached_input_tokens": 182881,
+      "cache_write_input_tokens": 48761,
+      "output_tokens": 13434,
+      "reasoning_output_tokens": 11589
+    },
+    "duration_ms": 197255
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "configurable-ui-title",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "ui",
+    "react",
+    "config",
+    "branding",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 2.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8,
+    "output_tokens": 2264,
+    "cache_read_tokens": 1000703,
+    "cache_write_tokens": 10384,
+    "total_tokens": 1013359,
+    "total_cost_usd": 0.6218915,
+    "latency_seconds": 1123.8,
+    "num_turns": 75,
+    "generation_tokens_per_sec": 2.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 8,
+  "output_tokens": 2264,
+  "latency_seconds": 1123.8,
+  "num_turns": 75,
+  "total_cost_usd": 0.6218915,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 1000703,
+  "cache_creation_tokens": 10384,
+  "run_started_at": "2026-08-31T08:15:56.308191Z",
+  "run_ended_at": "2026-08-31T08:34:40.100555Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8,
+    "output_tokens": 2264,
+    "cache_read_tokens": 1000703,
+    "cache_write_tokens": 10384,
+    "total_tokens": 1013359,
+    "total_cost_usd": 0.6218915,
+    "latency_seconds": 1123.8,
+    "num_turns": 75,
+    "generation_tokens_per_sec": 2.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-ui-title",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 80,
+        "notes": "The issue is unusually concrete, covering backend resolution, four UI occurrences, three deployment surfaces, documentation, tests, and explicit non-goals. Its largest defect is a direct contradiction: registry-only deployments without UI_TITLE intentionally change to \"AI Registry\", while another user story and acceptance criterion promise that deployments without UI_TITLE change nothing. The submitted diff confirms the named Layout.tsx, Login.tsx, Logout.tsx, config routes, and deployment files are the intended change points. No independent task statement establishes the deployment-mode-derived default, so that requirement remains candidate-defined rather than externally verified."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 87,
+        "notes": "The LLD is implementation-ready across Settings, both API paths, React consumers, exports, Docker, Terraform, Helm, documentation, rollout, and rollback. Its main weakness is preserving the issue's incompatible no-change claim; removing UI_TITLE does not restore pre-change registry-only text, and the blank raw System Config field does not directly show the effective value requested by a user story. Concrete decisions such as the conditional Helm environment entry, reserved-name guard, empty-string export semantics, public auth-config payload, and React text-only rendering are reflected in the patch. Exact tag, line-number, and cache-behavior claims could not be independently confirmed because the provided repository shell failed during sandbox initialization."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 86,
+        "notes": "The review finds several consequential design defects, including exporting None, whitespace-only titles, Helm positional-test breakage, duplicate environment names, unbounded public values, and unauthenticated disclosure. Its largest omission is failing to challenge the central backward-compatibility contradiction or the mismatch between showing a raw blank field and promising visibility of the effective title. Findings are prioritized and actionable, and the implementation visibly incorporates B1 through B6 in config.py, deployment.yaml, _helpers.tpl, and auth/routes.py. The reviewed Rev 1 artifact was not supplied, so claims about its exact contents and the asserted exhaustive repository test search are not independently verifiable."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 80,
+        "notes": "The plan covers resolution precedence, malformed input, both APIs, compatibility skew, UI behavior, every deployment surface, rollback, and end-to-end runtime configuration. Its largest weakness is executable reliability: it repeatedly appends to .env without cleanup, calls a Terraform task-definition change a no-op, and describes config/full fields inconsistently as top-level raw data in section 1.1.7 but nested value.display data in section 5.1. Several curl and jq examples display results without asserting status or the promised field values, and no automated React test verifies the header, login, logout, or fallback behavior. The unit-test and Helm regression commands otherwise align closely with the submitted patch and target the highest-risk backend and chart behaviors."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 83,
+        "notes": "The patch implements the feature end to end: Settings normalization and derivation, authenticated and public API exposure, all four UI strings, CONFIG_GROUPS, Docker, Terraform, Helm, documentation, and backend tests. Its largest deficiency is verification coverage and summary accuracy: the added file contains 16 test functions rather than the claimed 18, with no automated frontend, config/full, export-round-trip, warning-log, or Helm test additions. The submitted hunks are internally consistent around Settings.effective_ui_title, get_config, get_auth_config, useRegistryConfig, the conditional Helm entry, and Terraform pass-through, and the implementation honestly excludes static generated bundles. The claimed git apply checks and exact baseline compatibility could not be independently rerun because all repository shell commands failed at sandbox initialization."
+      }
+    },
+    "task_score": 83.2,
+    "verdict": "Strong, highly repository-specific work whose largest limitation is the unresolved contradiction between deployment-mode-aware title changes and the promise that unset UI_TITLE causes no change.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T13:56:57.967611Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 252055,
+        "cached_input_tokens": 182881,
+        "cache_write_input_tokens": 48761,
+        "output_tokens": 13434,
+        "reasoning_output_tokens": 11589
+      },
+      "duration_ms": 197255
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 85,
+      "notes": "The issue provides unusually concrete route inventory, testable rejection cases, non-goals, and downgrade-resistance requirements. Its largest defect is claiming the six routes share equivalent authentication and that bearer requests can succeed on all toggles, while its own table and exclusions identify cookie-only enhanced_auth and header-only validate_internal_auth. The named routes and existing verify_csrf_token_flexible behavior align with the submitted source contexts, but no independent task statement establishes that all six routes were required scope. Security boundaries, mismatched-session tokens, proxy signaling, and backward compatibility are otherwise handled strongly."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 90,
+      "notes": "The LLD is implementation-ready, naming concrete files, dependencies, handler symbols, test-fixture identity overrides, data flow, rollout, rollback, and operator effects. It correctly chooses cookie presence as the relaxing boundary and uses X-Auth-Method only to fail closed. Its main weakness is continuing to describe successful browser and bearer behavior uniformly across six endpoints even though it acknowledges that the form route is cookie-only and the internal route requires an internal JWT; those claims should be framed as CSRF-layer behavior. The submitted diff matches most named integration points, though exact baseline applicability and several line-number claims could not be independently re-executed in the available repository shell."
+    },
+    "review": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 23,
+      "total": 87,
+      "notes": "The review identifies concrete concerns including dependency-override identity, stale-token UX, proxy failure behavior, authorization preservation, and route-set regression coverage. Its most questionable judgment is treating constant-time comparison after successful HMAC verification as a blocking security defect while missing the more direct contradiction about heterogeneous endpoint authentication. It also says the revised design is implemented exactly, but the patch contains no real unauthorized-bearer route test or internal-toggle JWT test promised by the review. The findings are nevertheless prioritized, actionable, and tied to specific files and symbols rather than generic reviewer role-play."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 84,
+      "notes": "The plan supplies concrete requests, expected statuses and bodies, negative cases, dependency semantics, route introspection, rollback checks, and browser workflows. Its largest correctness problem is the checklist assertion that the bearer path returns 200 on all six endpoints, which conflicts with enhanced_auth on POST /api/toggle/{service_path:path} and the internal-JWT requirement on /api/internal/toggle. The patch implements extensive dependency tests and agent-route tests, but not the promised real-route unauthorized-bearer or internal-toggle no-op tests, and the valid-token curl loop exercises only two routes. Commands and paths appear consistent with the submitted repository evidence, but they were not independently executable in the available shell."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 86,
+      "notes": "The patch implements the central design end to end: one conditional dependency, fail-closed proxy signaling, six route declarations, fixture updates, route-set guards, focused tests, and operator documentation. Static inspection shows coherent imports and matching handler contexts for toggle_service_route, internal_toggle_service, toggle_service_api, toggle_agent, toggle_skill, and toggle_virtual_server. The largest deficiency is that it omits the explicitly promised authorization-preservation and actual internal-JWT route tests while the summary overstates exact conformance; only the agent toggle receives real-route CSRF coverage. No obvious production-code bypass or caller break is visible, although the submitted git-apply and execution claims could not be independently rerun in the constrained repository shell."
+    }
+  },
+  "task_score": 86.4,
+  "verdict": "This is strong, repository-specific work with a sound core implementation, limited mainly by repeated overstatement of uniform end-to-end authentication across six heterogeneous routes and missing promised real-route authorization/internal tests.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T14:02:37.663085Z",
+    "repo_ref": "v1.0.20",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 447348,
+      "cached_input_tokens": 354919,
+      "cache_write_input_tokens": 60680,
+      "output_tokens": 13203,
+      "reasoning_output_tokens": 10774
+    },
+    "duration_ms": 339683
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.20",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "csrf",
+    "authentication",
+    "api",
+    "fastapi",
+    "m2m",
+    "fixed-in-1.0.21"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 75.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 7641,
+    "output_tokens": 95550,
+    "cache_read_tokens": 14161427,
+    "cache_write_tokens": 228790,
+    "total_tokens": 14493408,
+    "total_cost_usd": 10.937606,
+    "latency_seconds": 1263.9,
+    "num_turns": 75,
+    "generation_tokens_per_sec": 75.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 7641,
+  "output_tokens": 95550,
+  "latency_seconds": 1263.9,
+  "num_turns": 75,
+  "total_cost_usd": 10.937606,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 14161427,
+  "cache_creation_tokens": 228790,
+  "run_started_at": "2026-08-31T07:54:48.291719Z",
+  "run_ended_at": "2026-08-31T08:15:52.245009Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 7641,
+    "output_tokens": 95550,
+    "cache_read_tokens": 14161427,
+    "cache_write_tokens": 228790,
+    "total_tokens": 14493408,
+    "total_cost_usd": 10.937606,
+    "latency_seconds": 1263.9,
+    "num_turns": 75,
+    "generation_tokens_per_sec": 75.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "consistent-csrf-across-toggle-endpoints",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 85,
+        "notes": "The issue provides unusually concrete route inventory, testable rejection cases, non-goals, and downgrade-resistance requirements. Its largest defect is claiming the six routes share equivalent authentication and that bearer requests can succeed on all toggles, while its own table and exclusions identify cookie-only enhanced_auth and header-only validate_internal_auth. The named routes and existing verify_csrf_token_flexible behavior align with the submitted source contexts, but no independent task statement establishes that all six routes were required scope. Security boundaries, mismatched-session tokens, proxy signaling, and backward compatibility are otherwise handled strongly."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 90,
+        "notes": "The LLD is implementation-ready, naming concrete files, dependencies, handler symbols, test-fixture identity overrides, data flow, rollout, rollback, and operator effects. It correctly chooses cookie presence as the relaxing boundary and uses X-Auth-Method only to fail closed. Its main weakness is continuing to describe successful browser and bearer behavior uniformly across six endpoints even though it acknowledges that the form route is cookie-only and the internal route requires an internal JWT; those claims should be framed as CSRF-layer behavior. The submitted diff matches most named integration points, though exact baseline applicability and several line-number claims could not be independently re-executed in the available repository shell."
+      },
+      "review": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 23,
+        "total": 87,
+        "notes": "The review identifies concrete concerns including dependency-override identity, stale-token UX, proxy failure behavior, authorization preservation, and route-set regression coverage. Its most questionable judgment is treating constant-time comparison after successful HMAC verification as a blocking security defect while missing the more direct contradiction about heterogeneous endpoint authentication. It also says the revised design is implemented exactly, but the patch contains no real unauthorized-bearer route test or internal-toggle JWT test promised by the review. The findings are nevertheless prioritized, actionable, and tied to specific files and symbols rather than generic reviewer role-play."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 84,
+        "notes": "The plan supplies concrete requests, expected statuses and bodies, negative cases, dependency semantics, route introspection, rollback checks, and browser workflows. Its largest correctness problem is the checklist assertion that the bearer path returns 200 on all six endpoints, which conflicts with enhanced_auth on POST /api/toggle/{service_path:path} and the internal-JWT requirement on /api/internal/toggle. The patch implements extensive dependency tests and agent-route tests, but not the promised real-route unauthorized-bearer or internal-toggle no-op tests, and the valid-token curl loop exercises only two routes. Commands and paths appear consistent with the submitted repository evidence, but they were not independently executable in the available shell."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 86,
+        "notes": "The patch implements the central design end to end: one conditional dependency, fail-closed proxy signaling, six route declarations, fixture updates, route-set guards, focused tests, and operator documentation. Static inspection shows coherent imports and matching handler contexts for toggle_service_route, internal_toggle_service, toggle_service_api, toggle_agent, toggle_skill, and toggle_virtual_server. The largest deficiency is that it omits the explicitly promised authorization-preservation and actual internal-JWT route tests while the summary overstates exact conformance; only the agent toggle receives real-route CSRF coverage. No obvious production-code bypass or caller break is visible, although the submitted git-apply and execution claims could not be independently rerun in the constrained repository shell."
+      }
+    },
+    "task_score": 86.4,
+    "verdict": "This is strong, repository-specific work with a sound core implementation, limited mainly by repeated overstatement of uniform end-to-end authentication across six heterogeneous routes and missing promised real-route authorization/internal tests.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T14:02:37.663085Z",
+      "repo_ref": "v1.0.20",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 447348,
+        "cached_input_tokens": 354919,
+        "cache_write_input_tokens": 60680,
+        "output_tokens": 13203,
+        "reasoning_output_tokens": 10774
+      },
+      "duration_ms": 339683
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 91,
+      "notes": "The issue identifies four concrete default sources in IAMGroups.tsx and management_routes.py, then supplies testable UI, payload, reset, JSON, and backend acceptance criteria. Its strongest feature is the explicit boundary around server_routes.py and existing groups, including the compatibility reason for excluding them. The main limitation is that changing the management endpoint's omitted-field behavior remains an API behavior change despite the otherwise narrow UI framing. No independent task statement was supplied, so the issue linkage and requirements beyond the task identifier and internally consistent artifacts could not be independently established."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 24,
+      "total": 91,
+      "notes": "The LLD traces createInIdp through _buildScopeJson, useIAM.createGroup, management_create_group, iam.create_group, and scope_service.import_group, with concrete file changes and test updates. It handles reset behavior, JSON round-tripping, mixed-version deployment, error translation, documentation, rollback, and the deliberately divergent server_routes.py defaults. Its largest defect is the alternatives matrix claiming the chosen approach is backward-compatible for CLI/curl while the design itself documents changed behavior for management-endpoint callers that omit the flag. Exact dependency versions, line references, and repository-wide consumer claims could not be independently rechecked because the read-only shell failed before commands ran."
+    },
+    "review": {
+      "completeness": 24,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 24,
+      "total": 93,
+      "notes": "The review finds concrete flaws rather than merely approving the design: resetForm, EXAMPLE_SCOPE_JSON, inaccessible labeling, seven backend tests, stale documentation, duplicate behavior, release communication, and divergent API defaults. It prioritizes each finding, explains consequences, and maps resolutions back to specific revised LLD steps. The main limitation is that claims such as the management endpoint having no consumer beyond the UI rely on repository grep and cannot establish external callers, while the aggregate verdict understates that several findings were initially mandatory. The cited symbols and patch changes are internally consistent, but the repository-wide grep claims could not be independently rerun."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 88,
+      "notes": "The plan has strong automated oracles for initial unchecked state, false and true payloads, reset-after-cancel, omitted backend flags, IdP error translation, authorization, and MongoDB import. It also covers mixed-version behavior, least-privilege deployment, rollback, accessibility, and both retained legacy defaults. Its largest weakness is that example download/upload behavior remains manual, the registry-list verification is hedged without a concrete MongoDB fallback command, and some grep checks are too broad to be reliable assertions. The commands were explicitly not executed, and their exact compatibility with the checkout could not be independently verified because shell execution was unavailable."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 90,
+      "notes": "The patch implements the design end to end: one frontend default constant, reset and example updates, accessible helper text, backend fallback and docstring changes, focused frontend tests, updated backend tests, and operator documentation. The hunks consistently target IAMGroups.tsx, management_create_group, and the named test cases, while the summary accurately discloses the unchanged server_routes.py defaults and lack of test execution. The largest remaining weakness is incomplete automated coverage for example JSON parsing/download behavior, plus documentation wording that treats omission as unconditionally local-only even though parsing an omitted key preserves the form's current state. A local git apply --check could not be rerun because the read-only shell failed before execution, so applicability is supported by coherent hunk context rather than an independent apply result."
+    }
+  },
+  "task_score": 90.6,
+  "verdict": "This is strong, implementation-ready work with unusually concrete regression coverage, limited chiefly by the intentionally retained opposite defaults on legacy group-creation surfaces and the ambiguity that divergence leaves for API users.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T14:06:47.832859Z",
+    "repo_ref": "v1.0.21",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 440924,
+      "cached_input_tokens": 332029,
+      "cache_write_input_tokens": 59997,
+      "output_tokens": 12791,
+      "reasoning_output_tokens": 10278
+    },
+    "duration_ms": 250158
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.21",
+  "complexity": "low",
+  "tags": [
+    "ui",
+    "react",
+    "iam",
+    "groups",
+    "ux",
+    "fixed-in-1.0.22"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 75.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 7713,
+    "output_tokens": 62118,
+    "cache_read_tokens": 5455152,
+    "cache_write_tokens": 193401,
+    "total_tokens": 5718384,
+    "total_cost_usd": 5.52784725,
+    "latency_seconds": 823.6,
+    "num_turns": 39,
+    "generation_tokens_per_sec": 75.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 7713,
+  "output_tokens": 62118,
+  "latency_seconds": 823.6,
+  "num_turns": 39,
+  "total_cost_usd": 5.52784725,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 5455152,
+  "cache_creation_tokens": 193401,
+  "run_started_at": "2026-08-31T06:09:00.072107Z",
+  "run_ended_at": "2026-08-31T06:22:43.668360Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 7713,
+    "output_tokens": 62118,
+    "cache_read_tokens": 5455152,
+    "cache_write_tokens": 193401,
+    "total_tokens": 5718384,
+    "total_cost_usd": 5.52784725,
+    "latency_seconds": 823.6,
+    "num_turns": 39,
+    "generation_tokens_per_sec": 75.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "default-create-in-idp-checkbox-unchecked",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 91,
+        "notes": "The issue identifies four concrete default sources in IAMGroups.tsx and management_routes.py, then supplies testable UI, payload, reset, JSON, and backend acceptance criteria. Its strongest feature is the explicit boundary around server_routes.py and existing groups, including the compatibility reason for excluding them. The main limitation is that changing the management endpoint's omitted-field behavior remains an API behavior change despite the otherwise narrow UI framing. No independent task statement was supplied, so the issue linkage and requirements beyond the task identifier and internally consistent artifacts could not be independently established."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 24,
+        "total": 91,
+        "notes": "The LLD traces createInIdp through _buildScopeJson, useIAM.createGroup, management_create_group, iam.create_group, and scope_service.import_group, with concrete file changes and test updates. It handles reset behavior, JSON round-tripping, mixed-version deployment, error translation, documentation, rollback, and the deliberately divergent server_routes.py defaults. Its largest defect is the alternatives matrix claiming the chosen approach is backward-compatible for CLI/curl while the design itself documents changed behavior for management-endpoint callers that omit the flag. Exact dependency versions, line references, and repository-wide consumer claims could not be independently rechecked because the read-only shell failed before commands ran."
+      },
+      "review": {
+        "completeness": 24,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 24,
+        "total": 93,
+        "notes": "The review finds concrete flaws rather than merely approving the design: resetForm, EXAMPLE_SCOPE_JSON, inaccessible labeling, seven backend tests, stale documentation, duplicate behavior, release communication, and divergent API defaults. It prioritizes each finding, explains consequences, and maps resolutions back to specific revised LLD steps. The main limitation is that claims such as the management endpoint having no consumer beyond the UI rely on repository grep and cannot establish external callers, while the aggregate verdict understates that several findings were initially mandatory. The cited symbols and patch changes are internally consistent, but the repository-wide grep claims could not be independently rerun."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 88,
+        "notes": "The plan has strong automated oracles for initial unchecked state, false and true payloads, reset-after-cancel, omitted backend flags, IdP error translation, authorization, and MongoDB import. It also covers mixed-version behavior, least-privilege deployment, rollback, accessibility, and both retained legacy defaults. Its largest weakness is that example download/upload behavior remains manual, the registry-list verification is hedged without a concrete MongoDB fallback command, and some grep checks are too broad to be reliable assertions. The commands were explicitly not executed, and their exact compatibility with the checkout could not be independently verified because shell execution was unavailable."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 90,
+        "notes": "The patch implements the design end to end: one frontend default constant, reset and example updates, accessible helper text, backend fallback and docstring changes, focused frontend tests, updated backend tests, and operator documentation. The hunks consistently target IAMGroups.tsx, management_create_group, and the named test cases, while the summary accurately discloses the unchanged server_routes.py defaults and lack of test execution. The largest remaining weakness is incomplete automated coverage for example JSON parsing/download behavior, plus documentation wording that treats omission as unconditionally local-only even though parsing an omitted key preserves the form's current state. A local git apply --check could not be rerun because the read-only shell failed before execution, so applicability is supported by coherent hunk context rather than an independent apply result."
+      }
+    },
+    "task_score": 90.6,
+    "verdict": "This is strong, implementation-ready work with unusually concrete regression coverage, limited chiefly by the intentionally retained opposite defaults on legacy group-creation surfaces and the ambiguity that divergence leaves for API users.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T14:06:47.832859Z",
+      "repo_ref": "v1.0.21",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 440924,
+        "cached_input_tokens": 332029,
+        "cache_write_input_tokens": 59997,
+        "output_tokens": 12791,
+        "reasoning_output_tokens": 10278
+      },
+      "duration_ms": 250158
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 90,
+      "notes": "The issue provides unusually testable acceptance criteria, explicit non-goals, derivation examples, compatibility behavior, and both UI integration paths. The supplied baseline diff contexts corroborate key claims such as SkillInfo and the frontend Skill type lacking repository_url and both modals using View on GitHub. Its largest weakness is the unsupported assertion that most users omit the field, while no independent task statement establishes the full enterprise and semantic-search scope. Exact repository line references could not be independently re-read because shell execution failed at sandbox startup."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 15,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 76,
+      "notes": "The LLD maps the data flow and named integration points in implementation-ready detail, including both SkillInfo construction sites, search metadata, form state, and modal rendering. Its central design error is that _extract_owner_repo validates only the first two segments and path length, so arbitrary GitHub paths such as /org/repo/issues are accepted despite the stated recognized-shapes-only contract. It also claims non-HTTP schemes cannot reach output and that logging is credential-safe, although ftp://github.com/org/repo/blob/main/SKILL.md derives successfully and debug messages interpolate the original credential-bearing URL. Leaving the file search backend unchanged also makes the semantic-search guarantee backend-dependent, and that claim could not be independently resolved through repository execution."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 76,
+      "notes": "The review identifies concrete defects—especially positive owner/repository validation, credential removal from the rendered URL, index staleness, and search-plumbing scope—and records actionable resolutions. Its largest miss is the load-bearing URL-shape flaw: every reviewer endorses taking the first two path segments without checking blob, raw, or SKILL.md structure. The security review also declares logging clean even though derive_repository_url logs the original input URL, which may contain userinfo. The findings are otherwise specific and prioritized, but exact source assertions could not be independently rerun in the unavailable shell."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The plan supplies concrete unit, API, compatibility, UX, build, and end-to-end oracles, with particularly strong credential, port, null-field, and stale-index coverage. It omits the cases that expose the implementation's main defect, such as GitHub /tree or /issues paths and a well-formed ftp://github.com URL; its javascript test has no parsed hostname and therefore proves little about scheme enforcement. The implementation also contains no automated API or component tests, and the E2E instructions delete the skill before the subsequent UI check. The proposed commands and endpoint payloads could not be independently executed because repository command execution was unavailable."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 72,
+      "notes": "The patch implements the design broadly across parsing, listing, search metadata, frontend types, form state, both modals, documentation, and 25 helper tests, with coherent baseline contexts in the submitted diff. The core helper does not actually recognize only supported SKILL.md shapes: any GitHub-like host with three path segments can derive a repository, and a well-formed non-HTTP URL such as ftp://github.com/org/repo/blob/main/SKILL.md also produces an HTTPS result. Debug logging includes the original URL and can expose embedded credentials, while the unchanged file search backend may omit repository_url; neither risk is covered by the added tests. The summary also omits SemanticSearchResults.tsx from its file table and oversells rejection behavior, and git apply --check could not be independently run because the read-only shell failed before command execution."
+    }
+  },
+  "task_score": 78.2,
+  "verdict": "The submission is detailed and largely end-to-end, but its central derivation logic accepts unsupported GitHub paths and non-HTTP URLs, contradicting the stated contract and escaping its otherwise extensive review and tests.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T14:10:46.764263Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 472503,
+      "cached_input_tokens": 389851,
+      "cache_write_input_tokens": 61407,
+      "output_tokens": 10181,
+      "reasoning_output_tokens": 8209
+    },
+    "duration_ms": 238919
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "skills",
+    "ui",
+    "react",
+    "api",
+    "ux",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 72.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6570,
+    "output_tokens": 81511,
+    "cache_read_tokens": 15713435,
+    "cache_write_tokens": 218612,
+    "total_tokens": 16020128,
+    "total_cost_usd": 11.2936675,
+    "latency_seconds": 1118.7,
+    "num_turns": 85,
+    "generation_tokens_per_sec": 72.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 6570,
+  "output_tokens": 81511,
+  "latency_seconds": 1118.7,
+  "num_turns": 85,
+  "total_cost_usd": 11.2936675,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 15713435,
+  "cache_creation_tokens": 218612,
+  "run_started_at": "2026-08-31T07:36:05.554928Z",
+  "run_ended_at": "2026-08-31T07:54:44.276750Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6570,
+    "output_tokens": 81511,
+    "cache_read_tokens": 15713435,
+    "cache_write_tokens": 218612,
+    "total_tokens": 16020128,
+    "total_cost_usd": 11.2936675,
+    "latency_seconds": 1118.7,
+    "num_turns": 85,
+    "generation_tokens_per_sec": 72.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "derive-repo-url-from-skill-md",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 90,
+        "notes": "The issue provides unusually testable acceptance criteria, explicit non-goals, derivation examples, compatibility behavior, and both UI integration paths. The supplied baseline diff contexts corroborate key claims such as SkillInfo and the frontend Skill type lacking repository_url and both modals using View on GitHub. Its largest weakness is the unsupported assertion that most users omit the field, while no independent task statement establishes the full enterprise and semantic-search scope. Exact repository line references could not be independently re-read because shell execution failed at sandbox startup."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 15,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 76,
+        "notes": "The LLD maps the data flow and named integration points in implementation-ready detail, including both SkillInfo construction sites, search metadata, form state, and modal rendering. Its central design error is that _extract_owner_repo validates only the first two segments and path length, so arbitrary GitHub paths such as /org/repo/issues are accepted despite the stated recognized-shapes-only contract. It also claims non-HTTP schemes cannot reach output and that logging is credential-safe, although ftp://github.com/org/repo/blob/main/SKILL.md derives successfully and debug messages interpolate the original credential-bearing URL. Leaving the file search backend unchanged also makes the semantic-search guarantee backend-dependent, and that claim could not be independently resolved through repository execution."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 76,
+        "notes": "The review identifies concrete defects—especially positive owner/repository validation, credential removal from the rendered URL, index staleness, and search-plumbing scope—and records actionable resolutions. Its largest miss is the load-bearing URL-shape flaw: every reviewer endorses taking the first two path segments without checking blob, raw, or SKILL.md structure. The security review also declares logging clean even though derive_repository_url logs the original input URL, which may contain userinfo. The findings are otherwise specific and prioritized, but exact source assertions could not be independently rerun in the unavailable shell."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The plan supplies concrete unit, API, compatibility, UX, build, and end-to-end oracles, with particularly strong credential, port, null-field, and stale-index coverage. It omits the cases that expose the implementation's main defect, such as GitHub /tree or /issues paths and a well-formed ftp://github.com URL; its javascript test has no parsed hostname and therefore proves little about scheme enforcement. The implementation also contains no automated API or component tests, and the E2E instructions delete the skill before the subsequent UI check. The proposed commands and endpoint payloads could not be independently executed because repository command execution was unavailable."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 72,
+        "notes": "The patch implements the design broadly across parsing, listing, search metadata, frontend types, form state, both modals, documentation, and 25 helper tests, with coherent baseline contexts in the submitted diff. The core helper does not actually recognize only supported SKILL.md shapes: any GitHub-like host with three path segments can derive a repository, and a well-formed non-HTTP URL such as ftp://github.com/org/repo/blob/main/SKILL.md also produces an HTTPS result. Debug logging includes the original URL and can expose embedded credentials, while the unchanged file search backend may omit repository_url; neither risk is covered by the added tests. The summary also omits SemanticSearchResults.tsx from its file table and oversells rejection behavior, and git apply --check could not be independently run because the read-only shell failed before command execution."
+      }
+    },
+    "task_score": 78.2,
+    "verdict": "The submission is detailed and largely end-to-end, but its central derivation logic accepts unsupported GitHub paths and non-HTTP URLs, contradicting the stated contract and escaping its otherwise extensive review and tests.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T14:10:46.764263Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 472503,
+        "cached_input_tokens": 389851,
+        "cache_write_input_tokens": 61407,
+        "output_tokens": 10181,
+        "reasoning_output_tokens": 8209
+      },
+      "duration_ms": 238919
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 89,
+      "notes": "The issue precisely identifies the reserved GROUPS assignment, affected functions, expected behavior, exclusions, and testable acceptance criteria. The submitted patch context corroborates the cited GROUPS assignments and loose grep checks in all four named files. Its largest weakness is a minor step-count inconsistency with the LLD, which later describes verify_setup and token generation as steps 9 and 10 rather than 7 and 8. The claimed 91-file sweep, documentation references, and caller behavior could not be independently verified because repository commands failed during sandbox initialization."
+    },
+    "lld": {
+      "completeness": 24,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 24,
+      "total": 94,
+      "notes": "The LLD is unusually implementation-ready: it commits to exact files, functions, variable names, scoping, matching semantics, compatibility constraints, rollout, and rollback behavior. Its split local declaration and assignment correctly avoids masking command-substitution status, while grep -qxF aligns assign_to_group and verify_setup. The main technical weakness is that local scoping itself does not prevent a future collision with another special variable, and failures earlier in curl pipelines remain maskable without pipefail, although that residual risk is disclosed. Repository-wide counts, workflow claims, and exact integration paths could not be independently verified through the unavailable command sandbox."
+    },
+    "review": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 23,
+      "total": 90,
+      "notes": "The review surfaces concrete design defects rather than merely approving it, notably the global-scoping boundary, empty-pattern behavior, absent regression guard, scope expansion, and operational implications. Each material finding has a specific consequence and a documented resolution incorporated into the revised LLD. Its largest deficiency is that several frontend and security assertions about TypeScript command routing and authorization use are presented as verified without evidence available in the submitted diff. The concerns tied directly to CURRENT_GROUPS, ACCOUNT_GROUPS, grep -qxF, and the four patch targets are well supported."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 76,
+      "notes": "The plan broadly covers syntax, shellcheck, reproduction, live Keycloak behavior, idempotency, compatibility, CLI output, and independent server-state checks with concrete expected values. Its largest defect is that the purported negative membership test reruns the full script, which repairs membership and exits 0, then substitutes an isolated grep command instead of exercising verify_setup's red failure branch. The unreachable-Keycloak test fails during token acquisition and therefore cannot catch a combined local assignment inside verify_setup, while the deployment command includes terraform/ despite expecting no diff even though the patch intentionally changes a Terraform script. Several commands also depend on unverified local Keycloak, Terraform/SSM, and macOS environments, and no test was executed."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 89,
+      "notes": "The unified diff implements the stated design end to end across both setup scripts and both list_groups implementations, using function-local replacement variables and exact fixed-string membership checks. The hunk contexts and symbols are internally consistent, preserve the Terraform copy's defensive jq behavior, and introduce no unrelated interface or configuration changes. The largest remaining risk is the absence of an executable regression test or lint gate; additionally, grep lacks -- or -e before the operator-supplied pattern, so a group name beginning with a hyphen can still be misinterpreted as an option. Patch applicability and the claimed pristine-baseline checks could not be independently rerun because the read-only command runner failed before executing git apply --check."
+    }
+  },
+  "task_score": 87.6,
+  "verdict": "This is a strong, carefully scoped fix with an implementation-ready design, but the testing plan does not actually exercise the critical verification-failure branch and contains several misleading command-level assertions.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T14:15:30.114263Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 415337,
+      "cached_input_tokens": 329843,
+      "cache_write_input_tokens": 54678,
+      "output_tokens": 11403,
+      "reasoning_output_tokens": 9549
+    },
+    "duration_ms": 283338
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "bash",
+    "keycloak",
+    "setup-scripts",
+    "shellcheck",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 12059,
+    "output_tokens": 70559,
+    "cache_read_tokens": 5006135,
+    "cache_write_tokens": 163421,
+    "total_tokens": 5252174,
+    "total_cost_usd": 5.348718750000001,
+    "latency_seconds": 911.5,
+    "num_turns": 35,
+    "generation_tokens_per_sec": 77.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 12059,
+  "output_tokens": 70559,
+  "latency_seconds": 911.5,
+  "num_turns": 35,
+  "total_cost_usd": 5.348718750000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 5006135,
+  "cache_creation_tokens": 163421,
+  "run_started_at": "2026-08-31T06:59:56.571384Z",
+  "run_ended_at": "2026-08-31T07:15:08.071356Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 12059,
+    "output_tokens": 70559,
+    "cache_read_tokens": 5006135,
+    "cache_write_tokens": 163421,
+    "total_tokens": 5252174,
+    "total_cost_usd": 5.348718750000001,
+    "latency_seconds": 911.5,
+    "num_turns": 35,
+    "generation_tokens_per_sec": 77.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "fix-reserved-groups-var-in-service-account-script",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 89,
+        "notes": "The issue precisely identifies the reserved GROUPS assignment, affected functions, expected behavior, exclusions, and testable acceptance criteria. The submitted patch context corroborates the cited GROUPS assignments and loose grep checks in all four named files. Its largest weakness is a minor step-count inconsistency with the LLD, which later describes verify_setup and token generation as steps 9 and 10 rather than 7 and 8. The claimed 91-file sweep, documentation references, and caller behavior could not be independently verified because repository commands failed during sandbox initialization."
+      },
+      "lld": {
+        "completeness": 24,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 24,
+        "total": 94,
+        "notes": "The LLD is unusually implementation-ready: it commits to exact files, functions, variable names, scoping, matching semantics, compatibility constraints, rollout, and rollback behavior. Its split local declaration and assignment correctly avoids masking command-substitution status, while grep -qxF aligns assign_to_group and verify_setup. The main technical weakness is that local scoping itself does not prevent a future collision with another special variable, and failures earlier in curl pipelines remain maskable without pipefail, although that residual risk is disclosed. Repository-wide counts, workflow claims, and exact integration paths could not be independently verified through the unavailable command sandbox."
+      },
+      "review": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 23,
+        "total": 90,
+        "notes": "The review surfaces concrete design defects rather than merely approving it, notably the global-scoping boundary, empty-pattern behavior, absent regression guard, scope expansion, and operational implications. Each material finding has a specific consequence and a documented resolution incorporated into the revised LLD. Its largest deficiency is that several frontend and security assertions about TypeScript command routing and authorization use are presented as verified without evidence available in the submitted diff. The concerns tied directly to CURRENT_GROUPS, ACCOUNT_GROUPS, grep -qxF, and the four patch targets are well supported."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 76,
+        "notes": "The plan broadly covers syntax, shellcheck, reproduction, live Keycloak behavior, idempotency, compatibility, CLI output, and independent server-state checks with concrete expected values. Its largest defect is that the purported negative membership test reruns the full script, which repairs membership and exits 0, then substitutes an isolated grep command instead of exercising verify_setup's red failure branch. The unreachable-Keycloak test fails during token acquisition and therefore cannot catch a combined local assignment inside verify_setup, while the deployment command includes terraform/ despite expecting no diff even though the patch intentionally changes a Terraform script. Several commands also depend on unverified local Keycloak, Terraform/SSM, and macOS environments, and no test was executed."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 89,
+        "notes": "The unified diff implements the stated design end to end across both setup scripts and both list_groups implementations, using function-local replacement variables and exact fixed-string membership checks. The hunk contexts and symbols are internally consistent, preserve the Terraform copy's defensive jq behavior, and introduce no unrelated interface or configuration changes. The largest remaining risk is the absence of an executable regression test or lint gate; additionally, grep lacks -- or -e before the operator-supplied pattern, so a group name beginning with a hyphen can still be misinterpreted as an option. Patch applicability and the claimed pristine-baseline checks could not be independently rerun because the read-only command runner failed before executing git apply --check."
+      }
+    },
+    "task_score": 87.6,
+    "verdict": "This is a strong, carefully scoped fix with an implementation-ready design, but the testing plan does not actually exercise the critical verification-failure branch and contains several misleading command-level assertions.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T14:15:30.114263Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 415337,
+        "cached_input_tokens": 329843,
+        "cache_write_input_tokens": 54678,
+        "output_tokens": 11403,
+        "reasoning_output_tokens": 9549
+      },
+      "duration_ms": 283338
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 87,
+      "notes": "The issue gives crisp scope, non-goals, and testable behavior for all six tabs. The submitted patch context supports its central Dashboard.tsx state and button claims. Its assertion that registration is appropriate on External Registries is a reasonable but unestablished product inference given the missing independent task statement. Local repository commands failed before execution with a sandbox loopback error, so cited line numbers and related-file claims could not be independently reverified."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 89,
+      "notes": "The LLD commits to an exact data flow, condition, JSX integration point, compatibility boundary, and rollback approach. The supplied diff implements its named showRegisterButton allowlist and preserves the existing handler and button markup. Minor defects include incorrectly claiming a module-level tab array would allocate each render and inconsistently describing the automated tests as a complete six-tab matrix. Repository-only claims about hooks, feature flags, CI, and surrounding symbols could not be independently checked because the read-only shell sandbox failed."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 85,
+      "notes": "The review surfaces concrete concerns including ambiguous Register selectors, future-tab behavior, layout, permissions, caching, and absent CI enforcement. Its strongest finding correctly separates tab relevance from authorization and requires exact accessible-name matching. It is repetitive and misses that the proposed automated suite never covers the External Registries branch despite emphasizing preservation of that behavior. Claims such as the number of state hooks and exact workflow coverage remained unverifiable because repository inspection was unavailable."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 86,
+      "notes": "The plan provides a concrete six-tab manual matrix, navigation oracles, negative cases, compatibility checks, layout checks, and accessibility coverage. Its exact Register selector and expected /servers/register URL align with the submitted implementation. The automated suite omits External Registries, the populated-data prerequisite conflicts with the later empty-skills scenario, and page-wide claims about exactly one plus-icon button are broader than necessary. Package scripts, proxy settings, helper behavior, and CI commands could not be independently verified due to the shell failure."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 85,
+      "notes": "The code change directly implements the requested behavior with a closed allowlist and preserves the existing registration handler, route, and unrelated header controls. The diff is internally coherent: it adds showRegisterButton beside viewFilter, gates only the header button, and tests both affected tabs plus positive server and agent cases. Its largest gap is the absent External Registries automated assertion while the summary overstates the spec as a complete per-tab matrix; the tests and build were also explicitly not executed. The claimed git apply --check and exact compatibility with the real baseline could not be independently confirmed because every local read-only command failed before execution."
+    }
+  },
+  "task_score": 86.4,
+  "verdict": "This is strong, implementation-ready work for a small UI fix, with the main limitation being incomplete automated coverage of the preserved External Registries behavior and an unavoidable repository-verification gap.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T14:22:31.967070Z",
+    "repo_ref": "v1.0.18",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 333522,
+      "cached_input_tokens": 250126,
+      "cache_write_input_tokens": 44978,
+      "output_tokens": 10849,
+      "reasoning_output_tokens": 8850
+    },
+    "duration_ms": 421840
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.18",
+  "complexity": "trivial",
+  "tags": [
+    "ui",
+    "react",
+    "dashboard",
+    "ux",
+    "fixed-in-v1.0.19"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 74.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 10671,
+    "output_tokens": 47752,
+    "cache_read_tokens": 3912699,
+    "cache_write_tokens": 123869,
+    "total_tokens": 4094991,
+    "total_cost_usd": 3.9776857500000014,
+    "latency_seconds": 642.2,
+    "num_turns": 31,
+    "generation_tokens_per_sec": 74.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 10671,
+  "output_tokens": 47752,
+  "latency_seconds": 642.2,
+  "num_turns": 31,
+  "total_cost_usd": 3.9776857500000014,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3912699,
+  "cache_creation_tokens": 123869,
+  "run_started_at": "2026-08-31T12:08:17.476324Z",
+  "run_ended_at": "2026-08-31T12:18:59.678876Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 10671,
+    "output_tokens": 47752,
+    "cache_read_tokens": 3912699,
+    "cache_write_tokens": 123869,
+    "total_tokens": 4094991,
+    "total_cost_usd": 3.9776857500000014,
+    "latency_seconds": 642.2,
+    "num_turns": 31,
+    "generation_tokens_per_sec": 74.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "hide-register-button-on-virtual-and-skills-tabs",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 87,
+        "notes": "The issue gives crisp scope, non-goals, and testable behavior for all six tabs. The submitted patch context supports its central Dashboard.tsx state and button claims. Its assertion that registration is appropriate on External Registries is a reasonable but unestablished product inference given the missing independent task statement. Local repository commands failed before execution with a sandbox loopback error, so cited line numbers and related-file claims could not be independently reverified."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 89,
+        "notes": "The LLD commits to an exact data flow, condition, JSX integration point, compatibility boundary, and rollback approach. The supplied diff implements its named showRegisterButton allowlist and preserves the existing handler and button markup. Minor defects include incorrectly claiming a module-level tab array would allocate each render and inconsistently describing the automated tests as a complete six-tab matrix. Repository-only claims about hooks, feature flags, CI, and surrounding symbols could not be independently checked because the read-only shell sandbox failed."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 85,
+        "notes": "The review surfaces concrete concerns including ambiguous Register selectors, future-tab behavior, layout, permissions, caching, and absent CI enforcement. Its strongest finding correctly separates tab relevance from authorization and requires exact accessible-name matching. It is repetitive and misses that the proposed automated suite never covers the External Registries branch despite emphasizing preservation of that behavior. Claims such as the number of state hooks and exact workflow coverage remained unverifiable because repository inspection was unavailable."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 86,
+        "notes": "The plan provides a concrete six-tab manual matrix, navigation oracles, negative cases, compatibility checks, layout checks, and accessibility coverage. Its exact Register selector and expected /servers/register URL align with the submitted implementation. The automated suite omits External Registries, the populated-data prerequisite conflicts with the later empty-skills scenario, and page-wide claims about exactly one plus-icon button are broader than necessary. Package scripts, proxy settings, helper behavior, and CI commands could not be independently verified due to the shell failure."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 85,
+        "notes": "The code change directly implements the requested behavior with a closed allowlist and preserves the existing registration handler, route, and unrelated header controls. The diff is internally coherent: it adds showRegisterButton beside viewFilter, gates only the header button, and tests both affected tabs plus positive server and agent cases. Its largest gap is the absent External Registries automated assertion while the summary overstates the spec as a complete per-tab matrix; the tests and build were also explicitly not executed. The claimed git apply --check and exact compatibility with the real baseline could not be independently confirmed because every local read-only command failed before execution."
+      }
+    },
+    "task_score": 86.4,
+    "verdict": "This is strong, implementation-ready work for a small UI fix, with the main limitation being incomplete automated coverage of the preserved External Registries behavior and an unavoidable repository-verification gap.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T14:22:31.967070Z",
+      "repo_ref": "v1.0.18",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 333522,
+        "cached_input_tokens": 250126,
+        "cache_write_input_tokens": 44978,
+        "output_tokens": 10849,
+        "reasoning_output_tokens": 8850
+      },
+      "duration_ms": 421840
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 24,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 92,
+      "notes": "The issue provides unusually concrete scope, testable acceptance criteria, compatibility requirements, and explicit non-goals. It identifies the relevant endpoint, resolver, configuration field, UI consumer, authentication behavior, and documentation surfaces. Its largest flaw is that the proposed log suppression does not cover a cold-cache fallback through `_detect_cloud_provider_with_method()`, which can still log and increment the counter despite the absolute acceptance criterion. No independent task statement was supplied, and sandbox failure prevented independent confirmation of every cited repository line."
+    },
+    "lld": {
+      "completeness": 24,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 90,
+      "notes": "The LLD is implementation-ready, with committed interface changes, precedence, caching, failure handling, documentation, rollout, rollback, and file-level edits. The submitted diff corroborates its central symbols and integration shape: `_resolve_cloud`, `get_telemetry_detection_info`, and the unchanged response keys. Its material error is claiming the display path cannot log, increment metrics, or trigger IMDS when the uncached cascade branch remains unguarded and may execute on the endpoint's first call. Exact baseline paths and line references could not be independently checked because the repository shell sandbox failed before executing read-only commands."
+    },
+    "review": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 90,
+      "notes": "The review finds concrete defects rather than merely approving the design, especially per-request observability noise, documentation drift, hint-read I/O, validation, and missing resolver coverage. Its recommendations are prioritized and tied to specific symbols such as `_log_detection_result`, `_get_operator_cloud_hint`, and `CLOUD_DETECTION_TOTAL`. It nevertheless misses the revised design's cold-cache contradiction and incorrectly accepts blanket claims that the endpoint cannot emit a detection result or trigger an IMDS probe. Repository-level verification of its grep and line-number claims was unavailable due the execution sandbox failure."
+    },
+    "testing": {
+      "completeness": 23,
+      "correctness": 19,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 87,
+      "notes": "The plan supplies exact inputs, response bodies, status codes, compatibility checks, deployment surfaces, UX expectations, and unit-test oracles across override, hint, invalid-value, and unauthenticated cases. The proposed automated tests target the real changed functions and assert exact JSON rather than merely checking successful execution. The largest gap is that no test exercises `log_result=False` with an uncached cascade, so the plan would miss the implementation's remaining log, metric, and possible IMDS side effect; the named short-circuit test also never asserts that the cascade was not called. Token-file paths, service commands, and several operational assumptions could not be independently verified against the checkout."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 83,
+      "notes": "The diff implements the primary behavior end to end: the endpoint awaits `_resolve_cloud(log_result=False)`, preserves the response contract, documents the widened values, and adds focused resolver and endpoint tests. The changes are internally consistent with the LLD and retain `log_result=True` for existing callers by default. The largest defect is that the fallback still calls the logging, cached cascade, so a cold-cache endpoint request can increment `CLOUD_DETECTION_TOTAL`, emit the INFO line, and potentially probe IMDS despite the acceptance criteria and new documentation. The claimed baseline hash and `git apply --check` result could not be independently confirmed because all local shell commands failed before execution; the summary also truthfully states that tests were not run."
+    }
+  },
+  "task_score": 88.4,
+  "verdict": "This is a strong, repository-specific submission whose main limitation is an unhandled cold-cache cascade path that contradicts its observability and no-probe guarantees.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T14:26:50.272270Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 324004,
+      "cached_input_tokens": 244263,
+      "cache_write_input_tokens": 45697,
+      "output_tokens": 8988,
+      "reasoning_output_tokens": 7063
+    },
+    "duration_ms": 258293
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "telemetry",
+    "api",
+    "ui",
+    "deployment",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 80.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 12465,
+    "output_tokens": 64334,
+    "cache_read_tokens": 4356148,
+    "cache_write_tokens": 154489,
+    "total_tokens": 4587436,
+    "total_cost_usd": 4.814305250000001,
+    "latency_seconds": 800.2,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 80.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 12465,
+  "output_tokens": 64334,
+  "latency_seconds": 800.2,
+  "num_turns": 33,
+  "total_cost_usd": 4.814305250000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 4356148,
+  "cache_creation_tokens": 154489,
+  "run_started_at": "2026-08-31T06:46:32.278855Z",
+  "run_ended_at": "2026-08-31T06:59:52.473400Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 12465,
+    "output_tokens": 64334,
+    "cache_read_tokens": 4356148,
+    "cache_write_tokens": 154489,
+    "total_tokens": 4587436,
+    "total_cost_usd": 4.814305250000001,
+    "latency_seconds": 800.2,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 80.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "honor-cloud-provider-override-in-ui",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 24,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 92,
+        "notes": "The issue provides unusually concrete scope, testable acceptance criteria, compatibility requirements, and explicit non-goals. It identifies the relevant endpoint, resolver, configuration field, UI consumer, authentication behavior, and documentation surfaces. Its largest flaw is that the proposed log suppression does not cover a cold-cache fallback through `_detect_cloud_provider_with_method()`, which can still log and increment the counter despite the absolute acceptance criterion. No independent task statement was supplied, and sandbox failure prevented independent confirmation of every cited repository line."
+      },
+      "lld": {
+        "completeness": 24,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 90,
+        "notes": "The LLD is implementation-ready, with committed interface changes, precedence, caching, failure handling, documentation, rollout, rollback, and file-level edits. The submitted diff corroborates its central symbols and integration shape: `_resolve_cloud`, `get_telemetry_detection_info`, and the unchanged response keys. Its material error is claiming the display path cannot log, increment metrics, or trigger IMDS when the uncached cascade branch remains unguarded and may execute on the endpoint's first call. Exact baseline paths and line references could not be independently checked because the repository shell sandbox failed before executing read-only commands."
+      },
+      "review": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 90,
+        "notes": "The review finds concrete defects rather than merely approving the design, especially per-request observability noise, documentation drift, hint-read I/O, validation, and missing resolver coverage. Its recommendations are prioritized and tied to specific symbols such as `_log_detection_result`, `_get_operator_cloud_hint`, and `CLOUD_DETECTION_TOTAL`. It nevertheless misses the revised design's cold-cache contradiction and incorrectly accepts blanket claims that the endpoint cannot emit a detection result or trigger an IMDS probe. Repository-level verification of its grep and line-number claims was unavailable due the execution sandbox failure."
+      },
+      "testing": {
+        "completeness": 23,
+        "correctness": 19,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 87,
+        "notes": "The plan supplies exact inputs, response bodies, status codes, compatibility checks, deployment surfaces, UX expectations, and unit-test oracles across override, hint, invalid-value, and unauthenticated cases. The proposed automated tests target the real changed functions and assert exact JSON rather than merely checking successful execution. The largest gap is that no test exercises `log_result=False` with an uncached cascade, so the plan would miss the implementation's remaining log, metric, and possible IMDS side effect; the named short-circuit test also never asserts that the cascade was not called. Token-file paths, service commands, and several operational assumptions could not be independently verified against the checkout."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 83,
+        "notes": "The diff implements the primary behavior end to end: the endpoint awaits `_resolve_cloud(log_result=False)`, preserves the response contract, documents the widened values, and adds focused resolver and endpoint tests. The changes are internally consistent with the LLD and retain `log_result=True` for existing callers by default. The largest defect is that the fallback still calls the logging, cached cascade, so a cold-cache endpoint request can increment `CLOUD_DETECTION_TOTAL`, emit the INFO line, and potentially probe IMDS despite the acceptance criteria and new documentation. The claimed baseline hash and `git apply --check` result could not be independently confirmed because all local shell commands failed before execution; the summary also truthfully states that tests were not run."
+      }
+    },
+    "task_score": 88.4,
+    "verdict": "This is a strong, repository-specific submission whose main limitation is an unhandled cold-cache cascade path that contradicts its observability and no-probe guarantees.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T14:26:50.272270Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 324004,
+        "cached_input_tokens": 244263,
+        "cache_write_input_tokens": 45697,
+        "output_tokens": 8988,
+        "reasoning_output_tokens": 7063
+      },
+      "duration_ms": 258293
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 85,
+      "notes": "The issue is unusually concrete: it defines opt-in behavior, concurrency, retry bounds, validation, deployment surfaces, non-goals, and testable acceptance criteria. Its repository claims align with the supplied contexts for LiteLLMClient, FederationAuthManager, and search_repository._get_embedding_model. The largest deficiency is that it requires the secret to never appear in an export while later artifacts preserve the existing explicitly confirmed sensitive-export path, and it overlooks permanent _embedding_unavailable latching after a transient token-endpoint failure. No independent task statement was supplied, so the candidate-defined scope cannot be verified beyond the task identifier and repository evidence."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 23,
+      "risk_awareness": 16,
+      "total": 77,
+      "notes": "The LLD is highly repository-specific, naming real integration points such as registry/embeddings/client.py, Settings.__init__, config_routes.CONFIG_GROUPS, and the ECS secret and IAM blocks. It makes clear decisions about token caching, TLS validation, bounded retries, compatibility, deployment, and rollback. Its largest design flaw is that clear_token() and get_token() are separate operations after a 401, so concurrent rejected calls can each clear a newly refreshed token and stampede the IdP; it also explicitly allows token failures to reach _embed_texts() and latch _embedding_unavailable without a recovery strategy. The asserted LiteLLM api_key-to-bearer behavior is not validated end-to-end, and the security analysis misses the entrypoint's unredacted token-URL logging and Terraform secret-state lifecycle."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 78,
+      "notes": "The review identifies many concrete repository-level defects, including the missing ECS IAM grant, the misleading entrypoint warning, TLS enforcement, expires_in coercion, and None-on-token-failure semantics. Recommendations are prioritized and tied to specific design changes rather than generic reviewer approval. Its claim that all blocking issues are resolved is too strong because it misses the concurrent 401 refresh race, permanent embedding-disable latch after transient IdP failure, Terraform's not-configured secret bypass, and unredacted entrypoint URL. It also accepts the privileged sensitive-export behavior without reconciling it with the issue's absolute no-export acceptance criterion."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 74,
+      "notes": "The unit plan has strong, concrete oracles for caching, buffered refresh, failure propagation, secret logging, per-call injection, bounded retry, startup validation, and compatibility. The supplied tests exercise the principal classes and retain the existing embeddings suite unchanged. The E2E harness is not executable as described: ACCEPT and STATE live inside separate stub processes with no control or inspection endpoint, so the plan cannot force revocation, count token requests, or prove the initial Authorization header. It also omits concurrent-401 coverage, expects a no-change Terraform plan despite unconditional new task-definition environment entries, and does not establish that the named search endpoints and config raw_value oracle match the repository."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 71,
+      "notes": "The patch implements the nominal flow end to end across Settings, LiteLLMClient, search_repository, tests, documentation, Compose, Terraform, Helm, and config masking, and its hunks use the expected repository symbols and conventions. The largest code defect is the non-atomic 401 path: concurrent callers can repeatedly clear and remint tokens, violating the promised single-flight behavior; transient token acquisition errors can also trigger the existing permanent _embedding_unavailable latch. Terraform substitutes not-configured when IdP mode is enabled without a client secret, bypassing application fail-fast validation, while the entrypoint logs EMBEDDINGS_IDP_TOKEN_URL without redact_url and the summary overstates unchanged/default behavior. The local sandbox could not execute git apply --check, so forward applicability and test execution remain independently unverified despite coherent submitted hunk context."
+    }
+  },
+  "task_score": 77.0,
+  "verdict": "This is a strong, repository-aware submission whose largest limitation is that its concurrency and failure-lifecycle design does not actually guarantee resilient single-flight token refresh in production.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T15:33:19.603614Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 519651,
+      "cached_input_tokens": 424378,
+      "cache_write_input_tokens": 78385,
+      "output_tokens": 12687,
+      "reasoning_output_tokens": 10900
+    },
+    "duration_ms": 377431
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "high",
+  "tags": [
+    "semantic-search",
+    "embeddings",
+    "oauth",
+    "authentication",
+    "litellm",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 76.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 25453,
+    "output_tokens": 118214,
+    "cache_read_tokens": 26314426,
+    "cache_write_tokens": 297292,
+    "total_tokens": 26755385,
+    "total_cost_usd": 18.097903,
+    "latency_seconds": 1547.6,
+    "num_turns": 113,
+    "generation_tokens_per_sec": 76.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 25453,
+  "output_tokens": 118214,
+  "latency_seconds": 1547.6,
+  "num_turns": 113,
+  "total_cost_usd": 18.097903,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 26314426,
+  "cache_creation_tokens": 297292,
+  "run_started_at": "2026-08-31T11:25:32.772494Z",
+  "run_ended_at": "2026-08-31T11:51:20.375964Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 25453,
+    "output_tokens": 118214,
+    "cache_read_tokens": 26314426,
+    "cache_write_tokens": 297292,
+    "total_tokens": 26755385,
+    "total_cost_usd": 18.097903,
+    "latency_seconds": 1547.6,
+    "num_turns": 113,
+    "generation_tokens_per_sec": 76.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "idp-authenticated-embedding-endpoint",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 85,
+        "notes": "The issue is unusually concrete: it defines opt-in behavior, concurrency, retry bounds, validation, deployment surfaces, non-goals, and testable acceptance criteria. Its repository claims align with the supplied contexts for LiteLLMClient, FederationAuthManager, and search_repository._get_embedding_model. The largest deficiency is that it requires the secret to never appear in an export while later artifacts preserve the existing explicitly confirmed sensitive-export path, and it overlooks permanent _embedding_unavailable latching after a transient token-endpoint failure. No independent task statement was supplied, so the candidate-defined scope cannot be verified beyond the task identifier and repository evidence."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 23,
+        "risk_awareness": 16,
+        "total": 77,
+        "notes": "The LLD is highly repository-specific, naming real integration points such as registry/embeddings/client.py, Settings.__init__, config_routes.CONFIG_GROUPS, and the ECS secret and IAM blocks. It makes clear decisions about token caching, TLS validation, bounded retries, compatibility, deployment, and rollback. Its largest design flaw is that clear_token() and get_token() are separate operations after a 401, so concurrent rejected calls can each clear a newly refreshed token and stampede the IdP; it also explicitly allows token failures to reach _embed_texts() and latch _embedding_unavailable without a recovery strategy. The asserted LiteLLM api_key-to-bearer behavior is not validated end-to-end, and the security analysis misses the entrypoint's unredacted token-URL logging and Terraform secret-state lifecycle."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 78,
+        "notes": "The review identifies many concrete repository-level defects, including the missing ECS IAM grant, the misleading entrypoint warning, TLS enforcement, expires_in coercion, and None-on-token-failure semantics. Recommendations are prioritized and tied to specific design changes rather than generic reviewer approval. Its claim that all blocking issues are resolved is too strong because it misses the concurrent 401 refresh race, permanent embedding-disable latch after transient IdP failure, Terraform's not-configured secret bypass, and unredacted entrypoint URL. It also accepts the privileged sensitive-export behavior without reconciling it with the issue's absolute no-export acceptance criterion."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 74,
+        "notes": "The unit plan has strong, concrete oracles for caching, buffered refresh, failure propagation, secret logging, per-call injection, bounded retry, startup validation, and compatibility. The supplied tests exercise the principal classes and retain the existing embeddings suite unchanged. The E2E harness is not executable as described: ACCEPT and STATE live inside separate stub processes with no control or inspection endpoint, so the plan cannot force revocation, count token requests, or prove the initial Authorization header. It also omits concurrent-401 coverage, expects a no-change Terraform plan despite unconditional new task-definition environment entries, and does not establish that the named search endpoints and config raw_value oracle match the repository."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 71,
+        "notes": "The patch implements the nominal flow end to end across Settings, LiteLLMClient, search_repository, tests, documentation, Compose, Terraform, Helm, and config masking, and its hunks use the expected repository symbols and conventions. The largest code defect is the non-atomic 401 path: concurrent callers can repeatedly clear and remint tokens, violating the promised single-flight behavior; transient token acquisition errors can also trigger the existing permanent _embedding_unavailable latch. Terraform substitutes not-configured when IdP mode is enabled without a client secret, bypassing application fail-fast validation, while the entrypoint logs EMBEDDINGS_IDP_TOKEN_URL without redact_url and the summary overstates unchanged/default behavior. The local sandbox could not execute git apply --check, so forward applicability and test execution remain independently unverified despite coherent submitted hunk context."
+      }
+    },
+    "task_score": 77.0,
+    "verdict": "This is a strong, repository-aware submission whose largest limitation is that its concurrency and failure-lifecycle design does not actually guarantee resilient single-flight token refresh in production.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T15:33:19.603614Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 519651,
+        "cached_input_tokens": 424378,
+        "cache_write_input_tokens": 78385,
+        "output_tokens": 12687,
+        "reasoning_output_tokens": 10900
+      },
+      "duration_ms": 377431
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 88,
+      "notes": "The issue provides unusually testable scope, including 13 exact URLs, required entry points, preservation requirements, and explicit non-goals. Its inventory arithmetic is internally consistent with the cited 24 references, and the patch confirms the claimed broken `docs/index.md` anchor. The largest defect is the contradictory discoverability claim: it calls the virtual-server and ANS recordings effectively single-page discoveries while its own inventory shows additional README links. No independent task statement exists, so requirements beyond the task identifier and artifact consensus remain unverifiable."
+    },
+    "lld": {
+      "completeness": 24,
+      "correctness": 19,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 89,
+      "notes": "The LLD is implementation-ready, naming the four files, exact navigation placement, row assignments, relative-link rules, maintenance workflow, rollback, and external-hosting risks. Its target documents are credible repository components; public source confirms that `docs/mcp-registry-cli.md` and `docs/auth.md` cover the subjects assigned to them. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/mcp-registry-cli.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/auth.md)) The main correctness gaps are that its set-difference scan includes the index itself and excludes Loom, Vimeo, and direct media URLs from URL extraction despite claiming broader coverage. It also incorrectly implies ordinary table links play inline on GitHub and that iframe code executes in the project's own origin."
+    },
+    "review": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 23,
+      "total": 88,
+      "notes": "The review identifies concrete defects involving stale numeric labels, ambiguous partial listings, nav prominence, external hosting, public recordings, and executable completeness checks, then maps each recommendation to a design revision. Its strongest contribution is forcing canonicity and the ordered maintenance workflow rather than merely approving polished prose. It misses the flawed scan semantics and repeats the inaccurate claim that embedded third-party JavaScript would execute in the documentation site's origin. Several findings are disproportionate for a four-file documentation change, but they remain actionable rather than generic role-play."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 17,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 85,
+      "notes": "The plan covers URL-set equality, target existence, rendering, navigation, preservation of historical links, deployment, rollback, negative cases, and concrete reader tasks with explicit oracles. Its largest defect is test 2.1: replacing README line 14 necessarily creates a removed diff line containing every original video URL, so the command cannot produce the promised empty output on the submitted patch. The repository-wide URL set also includes `docs/demo-videos.md`, making the claimed page-only typo guard logically misleading, while the extraction regex omits several formats named by the scan regex. Redundant count, set, and line-specific checks still provide substantial coverage of the actual 13-video change."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 85,
+      "notes": "The patch implements the requested flow end to end: 13 distinct videos are grouped on a new page, existing links remain in the shown diff, the broken resource link is corrected, and MkDocs navigation is updated. The largest code-content defect is the new page's claim that ordinary Markdown links play inline on GitHub and open third-party players in a new tab, neither of which is guaranteed by the link markup used. The summary also says no configuration file changed while explicitly modifying `mkdocs.yml`, and external playback and content descriptions remain manually unverified. The local command runner failed before execution, so the claimed exact-tag `git apply --check` result could not be independently reproduced; public source only corroborates some link targets, not the complete `1.24.3` tree. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/mcp-registry-cli.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/auth.md))"
+    }
+  },
+  "task_score": 87.0,
+  "verdict": "This is a strong, unusually concrete documentation change whose largest limitation is verification correctness: one compatibility command fails by construction, and the implemented page overstates link-rendering behavior.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T15:39:14.788060Z",
+    "repo_ref": "1.24.3",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 342797,
+      "cached_input_tokens": 253592,
+      "cache_write_input_tokens": 45647,
+      "output_tokens": 12289,
+      "reasoning_output_tokens": 10233
+    },
+    "duration_ms": 340546
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.3",
+  "complexity": "trivial",
+  "tags": [
+    "docs",
+    "markdown",
+    "readme",
+    "discoverability",
+    "fixed-in-1.24.4"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 1.1,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4,
+    "output_tokens": 1131,
+    "cache_read_tokens": 414288,
+    "cache_write_tokens": 2049,
+    "total_tokens": 417472,
+    "total_cost_usd": 0.24824524999999997,
+    "latency_seconds": 1011.0,
+    "num_turns": 48,
+    "generation_tokens_per_sec": 1.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4,
+  "output_tokens": 1131,
+  "latency_seconds": 1011.0,
+  "num_turns": 48,
+  "total_cost_usd": 0.24824524999999997,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 414288,
+  "cache_creation_tokens": 2049,
+  "run_started_at": "2026-08-31T11:51:23.572165Z",
+  "run_ended_at": "2026-08-31T12:08:14.640052Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4,
+    "output_tokens": 1131,
+    "cache_read_tokens": 414288,
+    "cache_write_tokens": 2049,
+    "total_tokens": 417472,
+    "total_cost_usd": 0.24824524999999997,
+    "latency_seconds": 1011.0,
+    "num_turns": 48,
+    "generation_tokens_per_sec": 1.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "index-demo-videos-in-one-page",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 88,
+        "notes": "The issue provides unusually testable scope, including 13 exact URLs, required entry points, preservation requirements, and explicit non-goals. Its inventory arithmetic is internally consistent with the cited 24 references, and the patch confirms the claimed broken `docs/index.md` anchor. The largest defect is the contradictory discoverability claim: it calls the virtual-server and ANS recordings effectively single-page discoveries while its own inventory shows additional README links. No independent task statement exists, so requirements beyond the task identifier and artifact consensus remain unverifiable."
+      },
+      "lld": {
+        "completeness": 24,
+        "correctness": 19,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 89,
+        "notes": "The LLD is implementation-ready, naming the four files, exact navigation placement, row assignments, relative-link rules, maintenance workflow, rollback, and external-hosting risks. Its target documents are credible repository components; public source confirms that `docs/mcp-registry-cli.md` and `docs/auth.md` cover the subjects assigned to them. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/mcp-registry-cli.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/auth.md)) The main correctness gaps are that its set-difference scan includes the index itself and excludes Loom, Vimeo, and direct media URLs from URL extraction despite claiming broader coverage. It also incorrectly implies ordinary table links play inline on GitHub and that iframe code executes in the project's own origin."
+      },
+      "review": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 23,
+        "total": 88,
+        "notes": "The review identifies concrete defects involving stale numeric labels, ambiguous partial listings, nav prominence, external hosting, public recordings, and executable completeness checks, then maps each recommendation to a design revision. Its strongest contribution is forcing canonicity and the ordered maintenance workflow rather than merely approving polished prose. It misses the flawed scan semantics and repeats the inaccurate claim that embedded third-party JavaScript would execute in the documentation site's origin. Several findings are disproportionate for a four-file documentation change, but they remain actionable rather than generic role-play."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 17,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 85,
+        "notes": "The plan covers URL-set equality, target existence, rendering, navigation, preservation of historical links, deployment, rollback, negative cases, and concrete reader tasks with explicit oracles. Its largest defect is test 2.1: replacing README line 14 necessarily creates a removed diff line containing every original video URL, so the command cannot produce the promised empty output on the submitted patch. The repository-wide URL set also includes `docs/demo-videos.md`, making the claimed page-only typo guard logically misleading, while the extraction regex omits several formats named by the scan regex. Redundant count, set, and line-specific checks still provide substantial coverage of the actual 13-video change."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 85,
+        "notes": "The patch implements the requested flow end to end: 13 distinct videos are grouped on a new page, existing links remain in the shown diff, the broken resource link is corrected, and MkDocs navigation is updated. The largest code-content defect is the new page's claim that ordinary Markdown links play inline on GitHub and open third-party players in a new tab, neither of which is guaranteed by the link markup used. The summary also says no configuration file changed while explicitly modifying `mkdocs.yml`, and external playback and content descriptions remain manually unverified. The local command runner failed before execution, so the claimed exact-tag `git apply --check` result could not be independently reproduced; public source only corroborates some link targets, not the complete `1.24.3` tree. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/mcp-registry-cli.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/auth.md))"
+      }
+    },
+    "task_score": 87.0,
+    "verdict": "This is a strong, unusually concrete documentation change whose largest limitation is verification correctness: one compatibility command fails by construction, and the implemented page overstates link-rendering behavior.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T15:39:14.788060Z",
+      "repo_ref": "1.24.3",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 342797,
+        "cached_input_tokens": 253592,
+        "cache_write_input_tokens": 45647,
+        "output_tokens": 12289,
+        "reasoning_output_tokens": 10233
+      },
+      "duration_ms": 340546
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 87,
+      "notes": "The issue's strongest aspect is its unusually concrete acceptance contract across webhook payloads, list filtering, registration policy, permissions, observability, documentation, and deployment surfaces. It names real baseline symbols such as `LifecycleStatus`, `webhook_service.py`, the three scan hooks, and the server and agent PUT/PATCH endpoints represented in the patch. Its largest gap is the existing agent batch register/patch/replace surface evidenced by `agent_batch_service` and the batch tests, which is omitted despite claiming the controls cover every agent registration and lifecycle update. The absence of an independent task statement limits external requirement verification, and the claim that leaking only the receiver URL defeats an already-verified bearer token overstates HMAC's incremental protection."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 17,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 80,
+      "notes": "The LLD is highly repository-specific and commits to important decisions including raw `content=` transmission, `model_fields_set` for omitted statuses, filtered-path `total_count`, and gates on PUT as well as PATCH. Its largest correctness defect is `status_change_requested`, which treats an explicitly supplied null or blank status as no change even though `ServerUpdateRequest.status` permits null and the design itself states server PUT previously persisted null, leaving a lifecycle-permission bypass. It also omits the agent batch register, patch, and replace processors, so both the initial-status mandate and lifecycle gate are incomplete for an established API surface. The Terraform design injects the HMAC secret through the ECS plaintext `environment` list while recommending a Secrets Manager reference, which ECS will not resolve without a `secrets.valueFrom` mapping."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 82,
+      "notes": "The review finds several genuine load-bearing defects, especially signing different bytes than those transmitted, PUT bypasses, omitted-status corruption, implicit admin bypass, and inaccurate filtered counts. Findings such as Byte-1, Byte-2, Cipher-2, and Circuit-1 include concrete consequences and actionable resolutions rather than generic role approval. Its largest deficiency is approving the lifecycle gate without noticing the explicit-null bypass or the existing agent batch mutation paths shown by the repository's batch imports and tests. The SRE review also recommends a Secrets Manager reference while overlooking that the proposed ECS task definition places the value in ordinary environment variables."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 72,
+      "notes": "The plan covers unit, compatibility, deployment, functional, and end-to-end levels with strong oracles for exact signed bytes, invalid filters, mandate mismatches, permission denials, and PUT status preservation. Several status-filter checks can pass vacuously without deterministic draft, beta, and active fixtures, while the permission scenarios depend on an undefined `lob-owned` asset and `$CSRF` setup. The receiver is bound to `127.0.0.1` while the container targets `host.docker.internal`, and using an unreachable proxy URL is not a reliable way to force the scanner itself to raise. No tests cover explicit null status updates or agent batch register, patch, and replace, which are the most consequential untested bypasses."
+    },
+    "implementation": {
+      "completeness": 16,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 68,
+      "notes": "The patch substantially implements the design through a centralized `_post_event`, exact-byte HMAC signing, scan summaries, lifecycle helpers, route wiring, scope configuration, metrics, documentation, and deployment parameters. The visible contexts target plausible baseline symbols including `_perform_security_scan_on_registration`, `update_server_endpoint`, `patch_agent`, `update_skill`, and `send_registration_webhook`, but the submission's `git apply --check` claim could not be independently confirmed from the available evidence. The largest defect is incomplete authorization coverage: agent batch register, patch, and replace paths are untouched, and explicit null or blank server status values evade `change_lifecycle_status` because `status_change_requested` returns false. The signing secret is also placed directly in the ECS environment and Terraform state, while the summary overstates backward compatibility despite immediately restricting existing non-admin status changes and requiring manual DocumentDB scope updates."
+    }
+  },
+  "task_score": 77.8,
+  "verdict": "This is a strong and unusually specific submission, but the implementation does not fully enforce the lifecycle boundary because agent batch operations and explicit-null status updates remain bypasses.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T15:46:42.151729Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 439325,
+      "cached_input_tokens": 315251,
+      "cache_write_input_tokens": 85499,
+      "output_tokens": 13481,
+      "reasoning_output_tokens": 11347
+    },
+    "duration_ms": 440339
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
@@ -1,0 +1,154 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "high",
+  "tags": [
+    "architecture",
+    "security",
+    "api",
+    "webhooks",
+    "hmac",
+    "lifecycle",
+    "permissions",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 0.6,
+  "token_accounting_warning": "[task=lifecycle-workflow-webhooks] TOKEN ACCOUNTING SUSPECT: 1,362 output tokens over 173 turns = 7.9/turn, below the 20 floor. An agent making edits emits hundreds per turn, so the omp usage is likely being read from one scope instead of summed across all of them (see the pi per-message usage bug, issue #99). Scores, turns, and latency are unaffected and still valid -- but DO NOT publish the token or cost columns from this run without re-checking the extractor.",
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8,
+    "output_tokens": 1362,
+    "cache_read_tokens": 1649086,
+    "cache_write_tokens": 3514,
+    "total_tokens": 1653970,
+    "total_cost_usd": 0.8805955,
+    "latency_seconds": 2195.4,
+    "num_turns": 173,
+    "generation_tokens_per_sec": 0.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 8,
+  "output_tokens": 1362,
+  "latency_seconds": 2195.4,
+  "num_turns": 173,
+  "total_cost_usd": 0.8805955,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 1649086,
+  "cache_creation_tokens": 3514,
+  "run_started_at": "2026-08-31T10:12:01.916020Z",
+  "run_ended_at": "2026-08-31T10:48:37.391123Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8,
+    "output_tokens": 1362,
+    "cache_read_tokens": 1649086,
+    "cache_write_tokens": 3514,
+    "total_tokens": 1653970,
+    "total_cost_usd": 0.8805955,
+    "latency_seconds": 2195.4,
+    "num_turns": 173,
+    "generation_tokens_per_sec": 0.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "lifecycle-workflow-webhooks",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 87,
+        "notes": "The issue's strongest aspect is its unusually concrete acceptance contract across webhook payloads, list filtering, registration policy, permissions, observability, documentation, and deployment surfaces. It names real baseline symbols such as `LifecycleStatus`, `webhook_service.py`, the three scan hooks, and the server and agent PUT/PATCH endpoints represented in the patch. Its largest gap is the existing agent batch register/patch/replace surface evidenced by `agent_batch_service` and the batch tests, which is omitted despite claiming the controls cover every agent registration and lifecycle update. The absence of an independent task statement limits external requirement verification, and the claim that leaking only the receiver URL defeats an already-verified bearer token overstates HMAC's incremental protection."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 17,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 80,
+        "notes": "The LLD is highly repository-specific and commits to important decisions including raw `content=` transmission, `model_fields_set` for omitted statuses, filtered-path `total_count`, and gates on PUT as well as PATCH. Its largest correctness defect is `status_change_requested`, which treats an explicitly supplied null or blank status as no change even though `ServerUpdateRequest.status` permits null and the design itself states server PUT previously persisted null, leaving a lifecycle-permission bypass. It also omits the agent batch register, patch, and replace processors, so both the initial-status mandate and lifecycle gate are incomplete for an established API surface. The Terraform design injects the HMAC secret through the ECS plaintext `environment` list while recommending a Secrets Manager reference, which ECS will not resolve without a `secrets.valueFrom` mapping."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 82,
+        "notes": "The review finds several genuine load-bearing defects, especially signing different bytes than those transmitted, PUT bypasses, omitted-status corruption, implicit admin bypass, and inaccurate filtered counts. Findings such as Byte-1, Byte-2, Cipher-2, and Circuit-1 include concrete consequences and actionable resolutions rather than generic role approval. Its largest deficiency is approving the lifecycle gate without noticing the explicit-null bypass or the existing agent batch mutation paths shown by the repository's batch imports and tests. The SRE review also recommends a Secrets Manager reference while overlooking that the proposed ECS task definition places the value in ordinary environment variables."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 72,
+        "notes": "The plan covers unit, compatibility, deployment, functional, and end-to-end levels with strong oracles for exact signed bytes, invalid filters, mandate mismatches, permission denials, and PUT status preservation. Several status-filter checks can pass vacuously without deterministic draft, beta, and active fixtures, while the permission scenarios depend on an undefined `lob-owned` asset and `$CSRF` setup. The receiver is bound to `127.0.0.1` while the container targets `host.docker.internal`, and using an unreachable proxy URL is not a reliable way to force the scanner itself to raise. No tests cover explicit null status updates or agent batch register, patch, and replace, which are the most consequential untested bypasses."
+      },
+      "implementation": {
+        "completeness": 16,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 68,
+        "notes": "The patch substantially implements the design through a centralized `_post_event`, exact-byte HMAC signing, scan summaries, lifecycle helpers, route wiring, scope configuration, metrics, documentation, and deployment parameters. The visible contexts target plausible baseline symbols including `_perform_security_scan_on_registration`, `update_server_endpoint`, `patch_agent`, `update_skill`, and `send_registration_webhook`, but the submission's `git apply --check` claim could not be independently confirmed from the available evidence. The largest defect is incomplete authorization coverage: agent batch register, patch, and replace paths are untouched, and explicit null or blank server status values evade `change_lifecycle_status` because `status_change_requested` returns false. The signing secret is also placed directly in the ECS environment and Terraform state, while the summary overstates backward compatibility despite immediately restricting existing non-admin status changes and requiring manual DocumentDB scope updates."
+      }
+    },
+    "task_score": 77.8,
+    "verdict": "This is a strong and unusually specific submission, but the implementation does not fully enforce the lifecycle boundary because agent batch operations and explicit-null status updates remain bypasses.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T15:46:42.151729Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 439325,
+        "cached_input_tokens": 315251,
+        "cache_write_input_tokens": 85499,
+        "output_tokens": 13481,
+        "reasoning_output_tokens": 11347
+      },
+      "duration_ms": 440339
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 80,
+      "notes": "The issue provides unusually concrete scope, compatibility cases, exclusions, and testable acceptance criteria. Its cited logout flow aligns with the submitted diff context around registry/auth/routes.py and auth_server/server.py. The largest flaw is an unresolved contradiction: logout_hint_id remains in an edge-visible browser query string while the criteria require that it never be logged, and the final IdP redirect still carries the ID token through the browser. No independent task statement exists, and the exact baseline line references could not be independently rechecked."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 83,
+      "notes": "The LLD commits to concrete interfaces, storage semantics, mixed-version behavior, metrics, rollout, and named repository integration points. Its design correctly calls for HINT_ID_BYTES = 32, atomic find_one_and_delete, read-time expiry enforcement, and validation at both trust boundaries. Its largest gap is that index-creation failure is treated as recoverable without addressing indefinite retention when the TTL index is absent; it also promises log hygiene without specifying edge query-string redaction. Claims about nginx exposure, Helm reserved names, and pristine baseline applicability could not be independently verified."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 19,
+      "total": 78,
+      "notes": "The review finds several real, actionable defects, especially TTL-sweep lag, unbounded request bodies, read-after-write behavior, and database-query/header validation. Those findings map directly to concrete proposed symbols such as consume_logout_hint, LogoutHintRequest, and _create_logout_hint. Its largest weakness is declaring security finding C3 resolved even though the design deliberately places the bearer handle in an edge-visible URL and introduces no access-log redaction; it also misses the TTL-index initialization failure mode. Assertions that every blocker is resolved and that /internal/* is unreachable were not independently verifiable."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 12,
+      "specificity": 22,
+      "risk_awareness": 19,
+      "total": 74,
+      "notes": "The plan has strong behavior-level oracles for URL shape, compatibility, expiry, concurrency, encryption, metrics, WAF regression, and IdP-session termination. Several tests cannot work in the written sequence: section 1.2.1 consumes HINT_ID before 1.2.2 expects its first use to succeed, and section 1.3.1 deletes the session before 1.3.2 reuses the same cookie. Stopping the shared MongoDB in section 2.5 also prevents registry session resolution rather than isolating a hint-store outage, while the rollback exec command does not persist the environment change. The listed commands and endpoints could not be executed independently, so their repository compatibility remains unverified."
+    },
+    "implementation": {
+      "completeness": 16,
+      "correctness": 3,
+      "specificity": 20,
+      "risk_awareness": 12,
+      "total": 51,
+      "notes": "The patch broadly covers the designed code, configuration, metrics, documentation, and unit-test surfaces, but the core feature is nonfunctional. In auth_server/logout_hint_store.py, generate_hint_id() calls secrets.token_hex(HINT_ID_BYTES), yet HINT_ID_BYTES is never defined, causing every creation attempt and its new tests to fail; the endpoint therefore returns 500 and the registry always falls back to the legacy token URL. Additionally, a failed index creation caches _collection while leaving _indexes_created false, so indexes are never retried and encrypted hints may persist indefinitely without the TTL index. The summary honestly states tests were not run, but its claimed git apply --check result could not be independently reproduced."
+    }
+  },
+  "task_score": 73.2,
+  "verdict": "The design package is detailed and repository-shaped, but the undefined HINT_ID_BYTES makes the submitted implementation’s core back-channel path unusable.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T15:51:08.467393Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 448377,
+      "cached_input_tokens": 360325,
+      "cache_write_input_tokens": 70829,
+      "output_tokens": 10491,
+      "reasoning_output_tokens": 8667
+    },
+    "duration_ms": 260341
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "auth",
+    "oidc",
+    "logout",
+    "security",
+    "waf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 76.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4326,
+    "output_tokens": 101281,
+    "cache_read_tokens": 14208258,
+    "cache_write_tokens": 210251,
+    "total_tokens": 14524116,
+    "total_cost_usd": 10.97185275,
+    "latency_seconds": 1332.9,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 76.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4326,
+  "output_tokens": 101281,
+  "latency_seconds": 1332.9,
+  "num_turns": 80,
+  "total_cost_usd": 10.97185275,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 14208258,
+  "cache_creation_tokens": 210251,
+  "run_started_at": "2026-08-31T13:17:05.373048Z",
+  "run_ended_at": "2026-08-31T13:39:18.314794Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4326,
+    "output_tokens": 101281,
+    "cache_read_tokens": 14208258,
+    "cache_write_tokens": 210251,
+    "total_tokens": 14524116,
+    "total_cost_usd": 10.97185275,
+    "latency_seconds": 1332.9,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 76.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "logout-id-token-hint-out-of-browser-url",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 80,
+        "notes": "The issue provides unusually concrete scope, compatibility cases, exclusions, and testable acceptance criteria. Its cited logout flow aligns with the submitted diff context around registry/auth/routes.py and auth_server/server.py. The largest flaw is an unresolved contradiction: logout_hint_id remains in an edge-visible browser query string while the criteria require that it never be logged, and the final IdP redirect still carries the ID token through the browser. No independent task statement exists, and the exact baseline line references could not be independently rechecked."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 83,
+        "notes": "The LLD commits to concrete interfaces, storage semantics, mixed-version behavior, metrics, rollout, and named repository integration points. Its design correctly calls for HINT_ID_BYTES = 32, atomic find_one_and_delete, read-time expiry enforcement, and validation at both trust boundaries. Its largest gap is that index-creation failure is treated as recoverable without addressing indefinite retention when the TTL index is absent; it also promises log hygiene without specifying edge query-string redaction. Claims about nginx exposure, Helm reserved names, and pristine baseline applicability could not be independently verified."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 19,
+        "total": 78,
+        "notes": "The review finds several real, actionable defects, especially TTL-sweep lag, unbounded request bodies, read-after-write behavior, and database-query/header validation. Those findings map directly to concrete proposed symbols such as consume_logout_hint, LogoutHintRequest, and _create_logout_hint. Its largest weakness is declaring security finding C3 resolved even though the design deliberately places the bearer handle in an edge-visible URL and introduces no access-log redaction; it also misses the TTL-index initialization failure mode. Assertions that every blocker is resolved and that /internal/* is unreachable were not independently verifiable."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 12,
+        "specificity": 22,
+        "risk_awareness": 19,
+        "total": 74,
+        "notes": "The plan has strong behavior-level oracles for URL shape, compatibility, expiry, concurrency, encryption, metrics, WAF regression, and IdP-session termination. Several tests cannot work in the written sequence: section 1.2.1 consumes HINT_ID before 1.2.2 expects its first use to succeed, and section 1.3.1 deletes the session before 1.3.2 reuses the same cookie. Stopping the shared MongoDB in section 2.5 also prevents registry session resolution rather than isolating a hint-store outage, while the rollback exec command does not persist the environment change. The listed commands and endpoints could not be executed independently, so their repository compatibility remains unverified."
+      },
+      "implementation": {
+        "completeness": 16,
+        "correctness": 3,
+        "specificity": 20,
+        "risk_awareness": 12,
+        "total": 51,
+        "notes": "The patch broadly covers the designed code, configuration, metrics, documentation, and unit-test surfaces, but the core feature is nonfunctional. In auth_server/logout_hint_store.py, generate_hint_id() calls secrets.token_hex(HINT_ID_BYTES), yet HINT_ID_BYTES is never defined, causing every creation attempt and its new tests to fail; the endpoint therefore returns 500 and the registry always falls back to the legacy token URL. Additionally, a failed index creation caches _collection while leaving _indexes_created false, so indexes are never retried and encrypted hints may persist indefinitely without the TTL index. The summary honestly states tests were not run, but its claimed git apply --check result could not be independently reproduced."
+      }
+    },
+    "task_score": 73.2,
+    "verdict": "The design package is detailed and repository-shaped, but the undefined HINT_ID_BYTES makes the submitted implementation’s core back-channel path unusable.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T15:51:08.467393Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 448377,
+        "cached_input_tokens": 360325,
+        "cache_write_input_tokens": 70829,
+        "output_tokens": 10491,
+        "reasoning_output_tokens": 8667
+      },
+      "duration_ms": 260341
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 16,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 80,
+      "notes": "The issue provides unusually concrete markers, stopping behavior, source precedence, acceptance criteria, and non-goals. The submitted baseline context supports the presence-only `python3 --version` check, while the documented macOS prerequisite is Python 3.14+. Its largest weakness is that the claimed Phase 5 `uv sync` failure is not reproduced or tied to repository configuration disabling uv's automatic Python provisioning, and no independent task statement was supplied. It also leaves an unresolved interaction between an unavailable requirement and a missing interpreter: `PYTHON_FAIL` wins, but requirement-derived installation guidance then has no version."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 16,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 83,
+      "notes": "The LLD is strongly grounded in `.claude/skills/macos-setup/SKILL.md`, `INSTALL_DIR`, Phase 2, Phase 5, marker tokens, and the step log, with implementation-ready shell logic. Passing the version through `sys.argv`, bounding `curl`, validating numeric components, and capping tuple comparison at three components are sound decisions. The largest defects are that `docker-compose.yml` alone does not prove the directory is this repository and that `PYTHON_MIN` can be empty in both the missing-interpreter remediation and the later runbook command. Exact line-number, sibling-skill convention, and all-subproject metadata claims could not be independently confirmed because local repository command execution failed before reading the checkout."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 84,
+      "notes": "The review identifies concrete failure mechanisms, including malformed tuples, unsafe code interpolation, transport handling, source trust, default-mode halting, and PATH remediation, then records actionable resolutions. Its strongest evidence is reflected directly in the revised comparator using `sys.argv[1]`, a numeric allowlist, and a three-component slice. It misses the empty-`PYTHON_MIN` remediation path and accepts `docker-compose.yml` as repository identity even though the testing plan demonstrates that any unrelated directory can satisfy that gate; it also incorrectly describes ordinary TLS verification as certificate pinning. The quoted pre-revision interpolation defect cannot be checked against the submitted LLD because only the revised LLD is present."
+    },
+    "testing": {
+      "completeness": 23,
+      "correctness": 11,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 77,
+      "notes": "The plan covers all four markers, local and remote sources, malformed metadata, injection, compatibility, UX, and full-workflow stopping behavior with concrete output oracles. However, `sed -n '/^echo \"=== Python ===\"$/,/^fi$/p'` stops at the resolver's first `fi`, so the extracted script omits `PYTHON_MIN`, comparison logic, and every marker; most functional tests therefore cannot exercise the shipped behavior. The purportedly reliable no-Python test also sets `PATH` to a directory without `bash`, preventing the command from launching, while the injection test permits `PYTHON_OK` for malformed metadata. The scenarios are valuable, but the plan states they were not executed and its central harness requires correction."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The patch implements the revised design across the probe, marker documentation, remediation table, blocking instruction, step log, and error reference, and its hunk contexts align with the submitted baseline excerpts. The comparison itself is appropriately argv-based, bounded, and numeric for the repository's stated `>=3.14` value. The largest defect is that an unavailable requirement plus missing Python emits `PYTHON_FAIL` while rendering `brew install python@${PYTHON_MIN}` with an empty value; the runbook also relies on that transient variable outside the probe. Additionally, `docker-compose.yml` is an inadequate repository identity check and the extraction accepts a valid numeric prefix from otherwise malformed requirement text, so the summary overstates strict validation and trusted-local detection; the claimed `git apply --check` result could not be independently rerun."
+    }
+  },
+  "task_score": 80.2,
+  "verdict": "The submission is highly specific and thoughtfully reviewed, but its implementation has unresolved requirement/remediation edge cases and its testing harness does not actually extract or execute the complete probe.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T15:58:51.074620Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 275325,
+      "cached_input_tokens": 159872,
+      "cache_write_input_tokens": 42372,
+      "output_tokens": 11909,
+      "reasoning_output_tokens": 10025
+    },
+    "duration_ms": 462591
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "setup",
+    "skill",
+    "developer-experience",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 79.3,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4515,
+    "output_tokens": 68815,
+    "cache_read_tokens": 3103835,
+    "cache_write_tokens": 125607,
+    "total_tokens": 3302772,
+    "total_cost_usd": 4.07991125,
+    "latency_seconds": 867.3,
+    "num_turns": 27,
+    "generation_tokens_per_sec": 79.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4515,
+  "output_tokens": 68815,
+  "latency_seconds": 867.3,
+  "num_turns": 27,
+  "total_cost_usd": 4.07991125,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3103835,
+  "cache_creation_tokens": 125607,
+  "run_started_at": "2026-08-31T12:34:03.108195Z",
+  "run_ended_at": "2026-08-31T12:48:30.466039Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4515,
+    "output_tokens": 68815,
+    "cache_read_tokens": 3103835,
+    "cache_write_tokens": 125607,
+    "total_tokens": 3302772,
+    "total_cost_usd": 4.07991125,
+    "latency_seconds": 867.3,
+    "num_turns": 27,
+    "generation_tokens_per_sec": 79.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "macos-setup-python-version-precheck",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 16,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 80,
+        "notes": "The issue provides unusually concrete markers, stopping behavior, source precedence, acceptance criteria, and non-goals. The submitted baseline context supports the presence-only `python3 --version` check, while the documented macOS prerequisite is Python 3.14+. Its largest weakness is that the claimed Phase 5 `uv sync` failure is not reproduced or tied to repository configuration disabling uv's automatic Python provisioning, and no independent task statement was supplied. It also leaves an unresolved interaction between an unavailable requirement and a missing interpreter: `PYTHON_FAIL` wins, but requirement-derived installation guidance then has no version."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 16,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 83,
+        "notes": "The LLD is strongly grounded in `.claude/skills/macos-setup/SKILL.md`, `INSTALL_DIR`, Phase 2, Phase 5, marker tokens, and the step log, with implementation-ready shell logic. Passing the version through `sys.argv`, bounding `curl`, validating numeric components, and capping tuple comparison at three components are sound decisions. The largest defects are that `docker-compose.yml` alone does not prove the directory is this repository and that `PYTHON_MIN` can be empty in both the missing-interpreter remediation and the later runbook command. Exact line-number, sibling-skill convention, and all-subproject metadata claims could not be independently confirmed because local repository command execution failed before reading the checkout."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 84,
+        "notes": "The review identifies concrete failure mechanisms, including malformed tuples, unsafe code interpolation, transport handling, source trust, default-mode halting, and PATH remediation, then records actionable resolutions. Its strongest evidence is reflected directly in the revised comparator using `sys.argv[1]`, a numeric allowlist, and a three-component slice. It misses the empty-`PYTHON_MIN` remediation path and accepts `docker-compose.yml` as repository identity even though the testing plan demonstrates that any unrelated directory can satisfy that gate; it also incorrectly describes ordinary TLS verification as certificate pinning. The quoted pre-revision interpolation defect cannot be checked against the submitted LLD because only the revised LLD is present."
+      },
+      "testing": {
+        "completeness": 23,
+        "correctness": 11,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 77,
+        "notes": "The plan covers all four markers, local and remote sources, malformed metadata, injection, compatibility, UX, and full-workflow stopping behavior with concrete output oracles. However, `sed -n '/^echo \"=== Python ===\"$/,/^fi$/p'` stops at the resolver's first `fi`, so the extracted script omits `PYTHON_MIN`, comparison logic, and every marker; most functional tests therefore cannot exercise the shipped behavior. The purportedly reliable no-Python test also sets `PATH` to a directory without `bash`, preventing the command from launching, while the injection test permits `PYTHON_OK` for malformed metadata. The scenarios are valuable, but the plan states they were not executed and its central harness requires correction."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The patch implements the revised design across the probe, marker documentation, remediation table, blocking instruction, step log, and error reference, and its hunk contexts align with the submitted baseline excerpts. The comparison itself is appropriately argv-based, bounded, and numeric for the repository's stated `>=3.14` value. The largest defect is that an unavailable requirement plus missing Python emits `PYTHON_FAIL` while rendering `brew install python@${PYTHON_MIN}` with an empty value; the runbook also relies on that transient variable outside the probe. Additionally, `docker-compose.yml` is an inadequate repository identity check and the extraction accepts a valid numeric prefix from otherwise malformed requirement text, so the summary overstates strict validation and trusted-local detection; the claimed `git apply --check` result could not be independently rerun."
+      }
+    },
+    "task_score": 80.2,
+    "verdict": "The submission is highly specific and thoughtfully reviewed, but its implementation has unresolved requirement/remediation edge cases and its testing harness does not actually extract or execute the complete probe.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T15:58:51.074620Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 275325,
+        "cached_input_tokens": 159872,
+        "cache_write_input_tokens": 42372,
+        "output_tokens": 11909,
+        "reasoning_output_tokens": 10025
+      },
+      "duration_ms": 462591
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 17,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 84,
+      "notes": "The issue provides unusually concrete behavior, compatibility requirements, exclusions, and testable acceptance criteria, including bare-path POST preservation and reserved-route handling. It correctly identifies the generated location in registry/core/nginx_service.py and the auth_request consequence. Its largest correctness defect is claiming /a hijacks /api/servers even though the LLD itself says the longer static /api/ location wins nginx prefix selection. No independent task statement or upstream issue contents were supplied, so issue numbers and the exact reported production behavior remain unverifiable."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 17,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 84,
+      "notes": "The LLD names concrete integration points such as _create_location_block, _generate_transport_location_blocks, build_per_server_resource_url, the nginx templates, and the validation/reload path. Its internal-rewrite design and duplicate-location guard address the central routing and POST-compatibility risks in implementation-ready detail. The major gap is its claim that unsafe legacy paths retain prior behavior: the proposed code still changes every prefix to a normalized trailing-slash form while withholding the exact helper, potentially breaking bare requests, and it never proves that the helper regex covers every currently accepted path. The live-config grep for ROOT_PATH is also inconsistent with the documented placeholder replacement, while scheduler timing and related issue claims could not be independently verified."
+    },
+    "review": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 86,
+      "notes": "The review performs real adversarial analysis and produces actionable changes, notably the sanitized comment stub, rewrite interpolation guard, preflight check, and reserved-set drift test. Findings cite concrete symbols and consequences rather than merely assigning approving personas. It nevertheless misses the unsafe-legacy bare-path regression, the mismatch between the rewrite allowlist and documented registration validation, and the contradiction concerning /api/servers precedence. Its final assertion that every blocker is resolved therefore overstates the revised design's readiness."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 20,
+      "total": 77,
+      "notes": "The plan covers unit, compatibility, browser, deployment, rollback, and end-to-end cases with concrete requests and expected states. Several oracles are defective: the primary curl discards the body while requiring result.tools, the generated-location simulator ignores competing static locations, and the SSE expectation permits an unspecified upstream status. The grep intended to exclude ^~ locations does not exclude the caret, and the drift test exercises only the HTTPS template despite claiming coverage of both shipped configurations. The plan is extensive but unexecuted, and several registration endpoint shapes and deployment commands remain unverified."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 71,
+      "notes": "The supplied diff targets the cited generator symbols and implements the core trailing-slash prefix, exact internal rewrite, reserved-segment guard, inert stub, and focused unit tests consistently with the revised LLD. Its largest defect is that _NGINX_LOCATION_PATH_SAFE suppresses the exact helper for unsafe or otherwise non-allowlisted paths while _nginx_location_prefix still changes their location, contradicting the promise that legacy behavior is unchanged and potentially converting a working bare POST into a redirect. The reserved drift test reads only docker/nginx_rev_proxy_http_and_https.conf, and the tests explicitly accept omission of the helper without asserting backward-compatible bare-path behavior. The summary admits the project tests and nginx validation were not executed; local shell startup was unavailable, so git-apply applicability and surrounding source compatibility could not be independently confirmed and are treated as an evidence gap rather than an additional defect."
+    }
+  },
+  "task_score": 80.4,
+  "verdict": "The submission is highly specific and catches the central nginx routing hazard, but the implementation needs revision for legacy and non-allowlisted bare-path compatibility and for several inaccurate test oracles.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T16:03:57.328982Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 485017,
+      "cached_input_tokens": 395067,
+      "cache_write_input_tokens": 69136,
+      "output_tokens": 12358,
+      "reasoning_output_tokens": 10376
+    },
+    "duration_ms": 306238
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "medium",
+  "tags": [
+    "bug",
+    "security",
+    "nginx",
+    "routing",
+    "auth",
+    "python",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 75.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 11631,
+    "output_tokens": 103608,
+    "cache_read_tokens": 10321309,
+    "cache_write_tokens": 225170,
+    "total_tokens": 10661718,
+    "total_cost_usd": 9.216322,
+    "latency_seconds": 1366.2,
+    "num_turns": 57,
+    "generation_tokens_per_sec": 75.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 11631,
+  "output_tokens": 103608,
+  "latency_seconds": 1366.2,
+  "num_turns": 57,
+  "total_cost_usd": 9.216322,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 10321309,
+  "cache_creation_tokens": 225170,
+  "run_started_at": "2026-08-31T08:54:08.871251Z",
+  "run_ended_at": "2026-08-31T09:16:55.061181Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 11631,
+    "output_tokens": 103608,
+    "cache_read_tokens": 10321309,
+    "cache_write_tokens": 225170,
+    "total_tokens": 10661718,
+    "total_cost_usd": 9.216322,
+    "latency_seconds": 1366.2,
+    "num_turns": 57,
+    "generation_tokens_per_sec": 75.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "nginx-location-trailing-slash-route-hijack",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 17,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 84,
+        "notes": "The issue provides unusually concrete behavior, compatibility requirements, exclusions, and testable acceptance criteria, including bare-path POST preservation and reserved-route handling. It correctly identifies the generated location in registry/core/nginx_service.py and the auth_request consequence. Its largest correctness defect is claiming /a hijacks /api/servers even though the LLD itself says the longer static /api/ location wins nginx prefix selection. No independent task statement or upstream issue contents were supplied, so issue numbers and the exact reported production behavior remain unverifiable."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 17,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 84,
+        "notes": "The LLD names concrete integration points such as _create_location_block, _generate_transport_location_blocks, build_per_server_resource_url, the nginx templates, and the validation/reload path. Its internal-rewrite design and duplicate-location guard address the central routing and POST-compatibility risks in implementation-ready detail. The major gap is its claim that unsafe legacy paths retain prior behavior: the proposed code still changes every prefix to a normalized trailing-slash form while withholding the exact helper, potentially breaking bare requests, and it never proves that the helper regex covers every currently accepted path. The live-config grep for ROOT_PATH is also inconsistent with the documented placeholder replacement, while scheduler timing and related issue claims could not be independently verified."
+      },
+      "review": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 86,
+        "notes": "The review performs real adversarial analysis and produces actionable changes, notably the sanitized comment stub, rewrite interpolation guard, preflight check, and reserved-set drift test. Findings cite concrete symbols and consequences rather than merely assigning approving personas. It nevertheless misses the unsafe-legacy bare-path regression, the mismatch between the rewrite allowlist and documented registration validation, and the contradiction concerning /api/servers precedence. Its final assertion that every blocker is resolved therefore overstates the revised design's readiness."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 20,
+        "total": 77,
+        "notes": "The plan covers unit, compatibility, browser, deployment, rollback, and end-to-end cases with concrete requests and expected states. Several oracles are defective: the primary curl discards the body while requiring result.tools, the generated-location simulator ignores competing static locations, and the SSE expectation permits an unspecified upstream status. The grep intended to exclude ^~ locations does not exclude the caret, and the drift test exercises only the HTTPS template despite claiming coverage of both shipped configurations. The plan is extensive but unexecuted, and several registration endpoint shapes and deployment commands remain unverified."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 71,
+        "notes": "The supplied diff targets the cited generator symbols and implements the core trailing-slash prefix, exact internal rewrite, reserved-segment guard, inert stub, and focused unit tests consistently with the revised LLD. Its largest defect is that _NGINX_LOCATION_PATH_SAFE suppresses the exact helper for unsafe or otherwise non-allowlisted paths while _nginx_location_prefix still changes their location, contradicting the promise that legacy behavior is unchanged and potentially converting a working bare POST into a redirect. The reserved drift test reads only docker/nginx_rev_proxy_http_and_https.conf, and the tests explicitly accept omission of the helper without asserting backward-compatible bare-path behavior. The summary admits the project tests and nginx validation were not executed; local shell startup was unavailable, so git-apply applicability and surrounding source compatibility could not be independently confirmed and are treated as an evidence gap rather than an additional defect."
+      }
+    },
+    "task_score": 80.4,
+    "verdict": "The submission is highly specific and catches the central nginx routing hazard, but the implementation needs revision for legacy and non-allowlisted bare-path compatibility and for several inaccurate test oracles.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T16:03:57.328982Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 485017,
+        "cached_input_tokens": 395067,
+        "cache_write_input_tokens": 69136,
+        "output_tokens": 12358,
+        "reasoning_output_tokens": 10376
+      },
+      "duration_ms": 306238
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 90,
+      "notes": "The issue clearly identifies the affected compose files, exact environment entries, default-deny behavior, scope, and testable acceptance criteria. Its central premise that Compose service environment must explicitly pass these values is technically sound.  The largest evidence limitation is that no independent task statement exists and the exact cited repository lines and runtime 405 chain could not be locally rechecked because the sandbox failed before command execution. Some live-container criteria depend on an available internal upstream, but the core requested behavior remains precise."
+    },
+    "lld": {
+      "completeness": 24,
+      "correctness": 19,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 90,
+      "notes": "The LLD is unusually concrete about target files, insertion points, data flow, existing test conventions, deployment surfaces, rollback, and deferred duplication risk. It commits to exact passthrough syntax and a non-vacuous filesystem-discovered regression test rather than leaving major implementation decisions open. Its largest defect is the claim that `docker compose restart` is enough after changing `.env`; restart does not apply updated Compose configuration, while recreation does, contradicting the document's later guidance.  Exact paths, line numbers, and the claimed baseline commit remained locally unverifiable because repository commands could not start."
+    },
+    "review": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 24,
+      "total": 90,
+      "notes": "The review surfaces concrete defects rather than merely approving the design, especially hardcoded discovery, recursive glob scope, literal allowlist values, duplicated environment blocks, and the separate A2A configuration gap. Findings B1-B4 have specific consequences and actionable resolutions reflected in the proposed test. The largest weakness is that it declares the revised design resolved while overlooking the LLD's still-incorrect `docker compose restart` statement, despite discussing that exact operational question. Its detailed repository assertions could not be independently rechecked locally because the shell sandbox failed."
+    },
+    "testing": {
+      "completeness": 23,
+      "correctness": 17,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 85,
+      "notes": "The plan covers static invariants, rendered configuration, process environment, backward compatibility, fail-closed behavior, deployment surfaces, rollback, and end-to-end host and CIDR paths with concrete oracles. Its strongest tests are the pre-fix red check and the hardcoded-literal negative case. Several runnable details are wrong or fragile: `REGISTRY_URL` remains port 80 while Podman is documented as port 8080, the CIDR workflow passes a container ID to `docker network inspect` and suppresses failure, and the token prerequisite is labeled section-five-only despite earlier use. These defects can prevent the advertised E2E checks from testing the intended stack, although the security and compatibility cases themselves are well chosen."
+    },
+    "implementation": {
+      "completeness": 24,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 93,
+      "notes": "The submitted diff implements the narrow task end to end by adding both `${VAR:-}` entries at the stated registry environment anchors and preserving the empty default. The new test checks discovery is non-vacuous, both keys exist, values are exact passthroughs rather than literals, and documentation remains present. The main evidence gap is that patch applicability, baseline context, and test execution could not be independently verified because the local command sandbox failed; logically, the supplied Python and YAML are internally consistent. The summary accurately discloses unexecuted tests and deferred environment-block drift, with only a minor misdescription of the number of parametrized assertions."
+    }
+  },
+  "task_score": 89.6,
+  "verdict": "This is a strong, narrowly scoped submission with a coherent patch and unusually concrete design work, limited mainly by testing-command defects and a contradictory restart claim in the LLD.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T16:10:46.036006Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 417044,
+      "cached_input_tokens": 337273,
+      "cache_write_input_tokens": 51673,
+      "output_tokens": 13156,
+      "reasoning_output_tokens": 11042
+    },
+    "duration_ms": 408691
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "docker",
+    "compose",
+    "configuration",
+    "ssrf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 75.1,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 7186,
+    "output_tokens": 67207,
+    "cache_read_tokens": 7317615,
+    "cache_write_tokens": 156418,
+    "total_tokens": 7548426,
+    "total_cost_usd": 6.352525000000001,
+    "latency_seconds": 895.2,
+    "num_turns": 51,
+    "generation_tokens_per_sec": 75.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 7186,
+  "output_tokens": 67207,
+  "latency_seconds": 895.2,
+  "num_turns": 51,
+  "total_cost_usd": 6.352525000000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 7317615,
+  "cache_creation_tokens": 156418,
+  "run_started_at": "2026-08-31T12:19:04.056218Z",
+  "run_ended_at": "2026-08-31T12:33:59.221043Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 7186,
+    "output_tokens": 67207,
+    "cache_read_tokens": 7317615,
+    "cache_write_tokens": 156418,
+    "total_tokens": 7548426,
+    "total_cost_usd": 6.352525000000001,
+    "latency_seconds": 895.2,
+    "num_turns": 51,
+    "generation_tokens_per_sec": 75.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "pass-ssrf-allowlist-env-to-registry-container",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 90,
+        "notes": "The issue clearly identifies the affected compose files, exact environment entries, default-deny behavior, scope, and testable acceptance criteria. Its central premise that Compose service environment must explicitly pass these values is technically sound.  The largest evidence limitation is that no independent task statement exists and the exact cited repository lines and runtime 405 chain could not be locally rechecked because the sandbox failed before command execution. Some live-container criteria depend on an available internal upstream, but the core requested behavior remains precise."
+      },
+      "lld": {
+        "completeness": 24,
+        "correctness": 19,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 90,
+        "notes": "The LLD is unusually concrete about target files, insertion points, data flow, existing test conventions, deployment surfaces, rollback, and deferred duplication risk. It commits to exact passthrough syntax and a non-vacuous filesystem-discovered regression test rather than leaving major implementation decisions open. Its largest defect is the claim that `docker compose restart` is enough after changing `.env`; restart does not apply updated Compose configuration, while recreation does, contradicting the document's later guidance.  Exact paths, line numbers, and the claimed baseline commit remained locally unverifiable because repository commands could not start."
+      },
+      "review": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 24,
+        "total": 90,
+        "notes": "The review surfaces concrete defects rather than merely approving the design, especially hardcoded discovery, recursive glob scope, literal allowlist values, duplicated environment blocks, and the separate A2A configuration gap. Findings B1-B4 have specific consequences and actionable resolutions reflected in the proposed test. The largest weakness is that it declares the revised design resolved while overlooking the LLD's still-incorrect `docker compose restart` statement, despite discussing that exact operational question. Its detailed repository assertions could not be independently rechecked locally because the shell sandbox failed."
+      },
+      "testing": {
+        "completeness": 23,
+        "correctness": 17,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 85,
+        "notes": "The plan covers static invariants, rendered configuration, process environment, backward compatibility, fail-closed behavior, deployment surfaces, rollback, and end-to-end host and CIDR paths with concrete oracles. Its strongest tests are the pre-fix red check and the hardcoded-literal negative case. Several runnable details are wrong or fragile: `REGISTRY_URL` remains port 80 while Podman is documented as port 8080, the CIDR workflow passes a container ID to `docker network inspect` and suppresses failure, and the token prerequisite is labeled section-five-only despite earlier use. These defects can prevent the advertised E2E checks from testing the intended stack, although the security and compatibility cases themselves are well chosen."
+      },
+      "implementation": {
+        "completeness": 24,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 93,
+        "notes": "The submitted diff implements the narrow task end to end by adding both `${VAR:-}` entries at the stated registry environment anchors and preserving the empty default. The new test checks discovery is non-vacuous, both keys exist, values are exact passthroughs rather than literals, and documentation remains present. The main evidence gap is that patch applicability, baseline context, and test execution could not be independently verified because the local command sandbox failed; logically, the supplied Python and YAML are internally consistent. The summary accurately discloses unexecuted tests and deferred environment-block drift, with only a minor misdescription of the number of parametrized assertions."
+      }
+    },
+    "task_score": 89.6,
+    "verdict": "This is a strong, narrowly scoped submission with a coherent patch and unusually concrete design work, limited mainly by testing-command defects and a contradictory restart claim in the LLD.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T16:10:46.036006Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 417044,
+        "cached_input_tokens": 337273,
+        "cache_write_input_tokens": 51673,
+        "output_tokens": 13156,
+        "reasoning_output_tokens": 11042
+      },
+      "duration_ms": 408691
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 92,
+      "notes": "The issue's strongest aspect is its unusually testable acceptance criteria covering models, counters, quarantine semantics, APIs, CLI, UI, compatibility, and exclusions. Named integration points such as `RateLimiter.check()`, `_enforce_rate_limit`, and the three existing collections agree with the submitted source contexts. Its main deficiency is tension between describing quarantine as immediate and accepting propagation through an unspecified short-TTL cache, while also making it inert when the master switch is off. No independent task statement was supplied, so the intended breadth beyond the task identifier cannot be verified."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 17,
+      "specificity": 24,
+      "risk_awareness": 19,
+      "total": 83,
+      "notes": "The LLD is exceptionally concrete about real files, data flow, compatibility, API shapes, failure handling, observability, and rollout. Its largest correctness flaw is the unescaped `<identity>|<target>` counter subject: neither side is proven unable to contain `|`, and the proposed validation does not prevent collisions between distinct pairs. It also claims TTL-bounded store load, but the designed cold-start fail-open result is not cached, so every request during an outage can repeat the read timeout. Finally, sorting gates only by window cannot guarantee the stated same-window deny-does-not-consume behavior, a contradiction exposed by the implementation's own caller-versus-pair test."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 81,
+      "notes": "The review's strongest aspect is that it identifies concrete repository-specific defects, including unbounded quarantine lists, missing read timeouts, silent allow behavior, duplicated ID formats, and edit-time ID mutation. Recommendations are prioritized and accompanied by explicit LLD resolutions rather than generic reviewer approval. It nevertheless misses the composite-key collision, repeated cold-start timeout load, non-atomic member-cap race, and same-window gate-ordering contradiction. Its claim that all blocking findings were resolved is therefore overstated by the submitted implementation."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 82,
+      "notes": "The plan provides strong oracles for pair isolation, marker-free 403 responses, admin non-bypass, stale snapshots, compatibility, authorization, and zero fake-backend increments. The core manual isolation scenario does not place the agent in the `tenants` group, so its successful request cannot prove a distinct `(agent, atlassian)` counter. The plan also omits collision tests for the composite subject, repeated cold-start outage reads, and concurrent additions at the 500-member boundary. Several end-to-end steps depend on uncleared fixed-window state or placeholders such as `<documentdb-volume>`, and the submitted summary confirms none of the tests were executed."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 11,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 67,
+      "notes": "The patch is broad and internally traceable across models, repositories, enforcement, routes, CLI, UI, documentation, and focused tests. A submitted test is inconsistent with the code: gates are assembled caller-first and sorted only by window, so a same-window pair denial occurs after the wider caller counter increments, contradicting `test_tighter_pair_gate_denies_before_wider_caller_gate`. The raw `identity|target` key permits counter aliasing, cold-start store failures retry on every request because the empty fallback is not cached, and the read-then-`$addToSet` member-cap check races under concurrent additions. Independent `git apply --check` and test execution could not be performed because the provided read-only shell failed during sandbox initialization, so applicability beyond the full submitted diff context remains unverified."
+    }
+  },
+  "task_score": 81.0,
+  "verdict": "The design package is detailed and strongly repository-shaped, but the implementation is not merge-ready because its gate ordering contradicts its own test and its quarantine keying and outage behavior retain material correctness and security risks.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T16:15:06.095912Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 640301,
+      "cached_input_tokens": 525046,
+      "cache_write_input_tokens": 97085,
+      "output_tokens": 11182,
+      "reasoning_output_tokens": 9168
+    },
+    "duration_ms": 260039
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "high",
+  "tags": [
+    "rate-limiting",
+    "security",
+    "auth-server",
+    "api",
+    "operations",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 0.2,
+  "token_accounting_warning": "[task=per-caller-per-target-rate-limits-and-quarantine] TOKEN ACCOUNTING SUSPECT: 462 output tokens over 169 turns = 2.7/turn, below the 20 floor. An agent making edits emits hundreds per turn, so the omp usage is likely being read from one scope instead of summed across all of them (see the pi per-message usage bug, issue #99). Scores, turns, and latency are unaffected and still valid -- but DO NOT publish the token or cost columns from this run without re-checking the extractor.",
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6,
+    "output_tokens": 462,
+    "cache_read_tokens": 1263591,
+    "cache_write_tokens": 2306,
+    "total_tokens": 1266365,
+    "total_cost_usd": 0.657788,
+    "latency_seconds": 2207.6,
+    "num_turns": 169,
+    "generation_tokens_per_sec": 0.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 6,
+  "output_tokens": 462,
+  "latency_seconds": 2207.6,
+  "num_turns": 169,
+  "total_cost_usd": 0.657788,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 1263591,
+  "cache_creation_tokens": 2306,
+  "run_started_at": "2026-08-31T10:48:40.751921Z",
+  "run_ended_at": "2026-08-31T11:25:28.427048Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6,
+    "output_tokens": 462,
+    "cache_read_tokens": 1263591,
+    "cache_write_tokens": 2306,
+    "total_tokens": 1266365,
+    "total_cost_usd": 0.657788,
+    "latency_seconds": 2207.6,
+    "num_turns": 169,
+    "generation_tokens_per_sec": 0.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "per-caller-per-target-rate-limits-and-quarantine",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 92,
+        "notes": "The issue's strongest aspect is its unusually testable acceptance criteria covering models, counters, quarantine semantics, APIs, CLI, UI, compatibility, and exclusions. Named integration points such as `RateLimiter.check()`, `_enforce_rate_limit`, and the three existing collections agree with the submitted source contexts. Its main deficiency is tension between describing quarantine as immediate and accepting propagation through an unspecified short-TTL cache, while also making it inert when the master switch is off. No independent task statement was supplied, so the intended breadth beyond the task identifier cannot be verified."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 17,
+        "specificity": 24,
+        "risk_awareness": 19,
+        "total": 83,
+        "notes": "The LLD is exceptionally concrete about real files, data flow, compatibility, API shapes, failure handling, observability, and rollout. Its largest correctness flaw is the unescaped `<identity>|<target>` counter subject: neither side is proven unable to contain `|`, and the proposed validation does not prevent collisions between distinct pairs. It also claims TTL-bounded store load, but the designed cold-start fail-open result is not cached, so every request during an outage can repeat the read timeout. Finally, sorting gates only by window cannot guarantee the stated same-window deny-does-not-consume behavior, a contradiction exposed by the implementation's own caller-versus-pair test."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 81,
+        "notes": "The review's strongest aspect is that it identifies concrete repository-specific defects, including unbounded quarantine lists, missing read timeouts, silent allow behavior, duplicated ID formats, and edit-time ID mutation. Recommendations are prioritized and accompanied by explicit LLD resolutions rather than generic reviewer approval. It nevertheless misses the composite-key collision, repeated cold-start timeout load, non-atomic member-cap race, and same-window gate-ordering contradiction. Its claim that all blocking findings were resolved is therefore overstated by the submitted implementation."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 82,
+        "notes": "The plan provides strong oracles for pair isolation, marker-free 403 responses, admin non-bypass, stale snapshots, compatibility, authorization, and zero fake-backend increments. The core manual isolation scenario does not place the agent in the `tenants` group, so its successful request cannot prove a distinct `(agent, atlassian)` counter. The plan also omits collision tests for the composite subject, repeated cold-start outage reads, and concurrent additions at the 500-member boundary. Several end-to-end steps depend on uncleared fixed-window state or placeholders such as `<documentdb-volume>`, and the submitted summary confirms none of the tests were executed."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 11,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 67,
+        "notes": "The patch is broad and internally traceable across models, repositories, enforcement, routes, CLI, UI, documentation, and focused tests. A submitted test is inconsistent with the code: gates are assembled caller-first and sorted only by window, so a same-window pair denial occurs after the wider caller counter increments, contradicting `test_tighter_pair_gate_denies_before_wider_caller_gate`. The raw `identity|target` key permits counter aliasing, cold-start store failures retry on every request because the empty fallback is not cached, and the read-then-`$addToSet` member-cap check races under concurrent additions. Independent `git apply --check` and test execution could not be performed because the provided read-only shell failed during sandbox initialization, so applicability beyond the full submitted diff context remains unverified."
+      }
+    },
+    "task_score": 81.0,
+    "verdict": "The design package is detailed and strongly repository-shaped, but the implementation is not merge-ready because its gate ordering contradicts its own test and its quarantine keying and outage behavior retain material correctness and security risks.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T16:15:06.095912Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 640301,
+        "cached_input_tokens": 525046,
+        "cache_write_input_tokens": 97085,
+        "output_tokens": 11182,
+        "reasoning_output_tokens": 9168
+      },
+      "duration_ms": 260039
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 15,
+      "specificity": 23,
+      "risk_awareness": 16,
+      "total": 76,
+      "notes": "The issue precisely identifies the repeated sed-and-append sites, supplies reproducible acceptance checks, and defines unusually clear non-goals. Its largest weakness is unsupported impact analysis: shell sourcing uses the last assignment, so a surviving first empty assignment alone does not establish the asserted auth-server crash or Compose rejection. It also claims recurring METRICS_KEY_PEPPER rotation although the LLD later confirms its template entry is commented, so its guard stops firing after the first append. No independent task statement was supplied, leaving the proposed expansion into Keycloak cleanup and documentation only internally justified."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 16,
+      "specificity": 24,
+      "risk_awareness": 18,
+      "total": 81,
+      "notes": "The LLD is highly concrete about build_and_run.sh, clean-keycloak.sh, the helper interface, stdin handling, validation, atomic replacement, and tests. Its largest design defect is the documented migration behavior: unchanged guards generate a fresh value, while _upsert discards previously appended valid values, potentially invalidating sessions or an initialized MongoDB volume. The claim that fresh-Linux behavior is byte-for-byte identical is also false because the old code deleted then appended, while the new helper replaces the placeholder in place. It discusses the resulting rotation but treats a warning and operator preparation as sufficient rather than designing backward-compatible value preservation."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 76,
+      "notes": "The review surfaces concrete concerns around preflight checks, fsync, temporary-file naming, duplicate warnings, and commented placeholders, with actionable resolutions tied to symbols in the LLD. Its largest omission is failure to challenge the one-time replacement of the effective existing secret; it instead approves that potentially service-breaking migration as strictly better. It also repeats the unproven first-assignment consumer model underlying the crash-loop and Compose-failure claims. The role-based presentation is verbose, but most findings are specific rather than generic approval theater."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 15,
+      "specificity": 23,
+      "risk_awareness": 14,
+      "total": 74,
+      "notes": "The helper tests have concrete fixtures and strong oracles for replacement, duplicate collapse, formatting, permissions, input rejection, idempotence, and value non-disclosure. The plan nevertheless codifies the unsafe migration as expected behavior rather than testing preservation of the last effective credential. Several procedures are fragile or destructive, including unguarded git stash/pop, moving the helper, changing repository-directory permissions, and a rollback fallback using git reset --hard; multiple installer runs also hide failures with || true. The proposed /login and /api/servers workflow and some health endpoints were not established by the supplied task context."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 72,
+      "notes": "The patch consistently replaces the six build-script write sites and the Keycloak scrub operations, and the helper provides stdin-based values, validation, duplicate removal, same-directory replacement, and focused unit tests. Its largest defect is backward compatibility: the unchanged empty-placeholder guard generates a fresh secret, and _upsert then deletes the valid appended value currently used by last-wins consumers, which can break persistent credentials. The rewrite also changes symlink, ownership, ACL, extended-attribute, and newline-format behavior while claiming broad preservation, and the summary incorrectly includes METRICS_KEY_PEPPER among secrets rotating every BSD rerun. The candidate explicitly did not execute tests, and its claimed git apply verification could not be confirmed from the submitted diff alone."
+    }
+  },
+  "task_score": 75.8,
+  "verdict": "The submission is unusually specific and largely implements a portable upsert, but its knowingly destructive migration of already-effective secrets is the largest material limitation.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T16:19:45.926420Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 393845,
+      "cached_input_tokens": 296857,
+      "cache_write_input_tokens": 64303,
+      "output_tokens": 9886,
+      "reasoning_output_tokens": 8472
+    },
+    "duration_ms": 279814
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "portability",
+    "macos",
+    "secrets",
+    "setup",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1797,
+    "output_tokens": 131841,
+    "cache_read_tokens": 13524309,
+    "cache_write_tokens": 232515,
+    "total_tokens": 13890462,
+    "total_cost_usd": 11.520383250000002,
+    "latency_seconds": 1706.9,
+    "num_turns": 70,
+    "generation_tokens_per_sec": 77.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1797,
+  "output_tokens": 131841,
+  "latency_seconds": 1706.9,
+  "num_turns": 70,
+  "total_cost_usd": 11.520383250000002,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 13524309,
+  "cache_creation_tokens": 232515,
+  "run_started_at": "2026-08-31T12:48:34.500589Z",
+  "run_ended_at": "2026-08-31T13:17:01.425784Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1797,
+    "output_tokens": 131841,
+    "cache_read_tokens": 13524309,
+    "cache_write_tokens": 232515,
+    "total_tokens": 13890462,
+    "total_cost_usd": 11.520383250000002,
+    "latency_seconds": 1706.9,
+    "num_turns": 70,
+    "generation_tokens_per_sec": 77.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "portable-env-secret-generation-in-build-script",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 15,
+        "specificity": 23,
+        "risk_awareness": 16,
+        "total": 76,
+        "notes": "The issue precisely identifies the repeated sed-and-append sites, supplies reproducible acceptance checks, and defines unusually clear non-goals. Its largest weakness is unsupported impact analysis: shell sourcing uses the last assignment, so a surviving first empty assignment alone does not establish the asserted auth-server crash or Compose rejection. It also claims recurring METRICS_KEY_PEPPER rotation although the LLD later confirms its template entry is commented, so its guard stops firing after the first append. No independent task statement was supplied, leaving the proposed expansion into Keycloak cleanup and documentation only internally justified."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 16,
+        "specificity": 24,
+        "risk_awareness": 18,
+        "total": 81,
+        "notes": "The LLD is highly concrete about build_and_run.sh, clean-keycloak.sh, the helper interface, stdin handling, validation, atomic replacement, and tests. Its largest design defect is the documented migration behavior: unchanged guards generate a fresh value, while _upsert discards previously appended valid values, potentially invalidating sessions or an initialized MongoDB volume. The claim that fresh-Linux behavior is byte-for-byte identical is also false because the old code deleted then appended, while the new helper replaces the placeholder in place. It discusses the resulting rotation but treats a warning and operator preparation as sufficient rather than designing backward-compatible value preservation."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 76,
+        "notes": "The review surfaces concrete concerns around preflight checks, fsync, temporary-file naming, duplicate warnings, and commented placeholders, with actionable resolutions tied to symbols in the LLD. Its largest omission is failure to challenge the one-time replacement of the effective existing secret; it instead approves that potentially service-breaking migration as strictly better. It also repeats the unproven first-assignment consumer model underlying the crash-loop and Compose-failure claims. The role-based presentation is verbose, but most findings are specific rather than generic approval theater."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 15,
+        "specificity": 23,
+        "risk_awareness": 14,
+        "total": 74,
+        "notes": "The helper tests have concrete fixtures and strong oracles for replacement, duplicate collapse, formatting, permissions, input rejection, idempotence, and value non-disclosure. The plan nevertheless codifies the unsafe migration as expected behavior rather than testing preservation of the last effective credential. Several procedures are fragile or destructive, including unguarded git stash/pop, moving the helper, changing repository-directory permissions, and a rollback fallback using git reset --hard; multiple installer runs also hide failures with || true. The proposed /login and /api/servers workflow and some health endpoints were not established by the supplied task context."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 72,
+        "notes": "The patch consistently replaces the six build-script write sites and the Keycloak scrub operations, and the helper provides stdin-based values, validation, duplicate removal, same-directory replacement, and focused unit tests. Its largest defect is backward compatibility: the unchanged empty-placeholder guard generates a fresh secret, and _upsert then deletes the valid appended value currently used by last-wins consumers, which can break persistent credentials. The rewrite also changes symlink, ownership, ACL, extended-attribute, and newline-format behavior while claiming broad preservation, and the summary incorrectly includes METRICS_KEY_PEPPER among secrets rotating every BSD rerun. The candidate explicitly did not execute tests, and its claimed git apply verification could not be confirmed from the submitted diff alone."
+      }
+    },
+    "task_score": 75.8,
+    "verdict": "The submission is unusually specific and largely implements a portable upsert, but its knowingly destructive migration of already-effective secrets is the largest material limitation.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T16:19:45.926420Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 393845,
+        "cached_input_tokens": 296857,
+        "cache_write_input_tokens": 64303,
+        "output_tokens": 9886,
+        "reasoning_output_tokens": 8472
+      },
+      "duration_ms": 279814
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "registration-admission-control-gate",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 90,
+      "notes": "The issue provides unusually testable behavior, seven explicit route boundaries, configuration defaults, security requirements, and disciplined non-goals. The submitted diff contains corresponding handler and persistence anchors in the agent, server, and skill route modules. Its largest defect is inconsistency: it says malformed responses fail closed while later artifacts allow an empty or unparseable 200, and its claim that existing agent and skill scanners use a pre-persist window is contradicted by the review. No independent task statement exists, and local repository access failed before execution, so baseline and route claims could not all be independently verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 84,
+      "notes": "The LLD names concrete files, handlers, persistence calls, deployment surfaces, response contracts, lifecycle handling, and rollback behavior. Its largest flaw is a load-bearing placement contradiction: it promises effective payloads after local validation, but places the skill-create gate before `service.register_skill(... validate_url=True)` and agent gates before route-level transformation and model construction. Security treatment is otherwise strong, particularly recursive redaction, fixed non-leaking 503 responses, shared-client shutdown, and explicit residual risks. Claims about exact source line counts, audit middleware behavior, and repository-wide conventions could not be fully verified because the local shell sandbox failed."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 22,
+      "total": 84,
+      "notes": "The review identifies concrete defects with consequences, especially credential exfiltration, per-call clients, ECS wiring asymmetry, response leakage, and configuration fail-open behavior. The patch visibly implements several resulting recommendations through `_redact`, a reused `AsyncClient`, fixed caller-facing errors, and two ECS environment blocks. Its largest deficiency is declaring every blocker resolved while missing the pre-validation/raw-payload placement and the conflicting malformed-200 contract. The unrevised LLD draft was not submitted, so claims about what the review originally discovered versus what was already present are unverifiable."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 78,
+      "notes": "The plan has strong state-based oracles for all seven routes, denial, outages, redaction, authorization ordering, deployment wiring, rollback, and backward compatibility. It contradicts itself by saying malformed bodies block while specifying that an empty 200 allows, and its skill allow-path uses an example URL not established as valid despite `validate_url=True`. The submitted route tests also realize less than the plan claims: unavailable coverage is not parametrized across all seven paths, and no allow-ordering or disabled-route matrix is implemented. Test commands and referenced pre-existing test paths could not be executed or fully verified because repository shell access was unavailable."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 73,
+      "notes": "The patch implements the central service, typed envelope, five settings, seven route calls, recursive redaction, shutdown, documentation, deployment wiring, and substantial tests. Its largest correctness defect is that agent and skill calls occur before important local validation and normalization, so the gate can see raw or partial data and can replace an established validation response with a gate 403 or 503. It also treats malformed or empty 200 bodies as allow despite the issue's fail-closed wording, provides incomplete route-test coverage, and adds Helm existing-secret settings without visible workload wiring to consume that external secret. The claimed baseline commit and clean `git apply --check` could not be independently verified because the read-only shell sandbox failed before running commands."
+    }
+  },
+  "task_score": 81.8,
+  "verdict": "Strong, highly specific work with broad end-to-end coverage, materially limited by incorrect gate placement before local validation and unresolved contract and verification inconsistencies.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T16:24:34.294574Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 519622,
+      "cached_input_tokens": 405903,
+      "cache_write_input_tokens": 79932,
+      "output_tokens": 12998,
+      "reasoning_output_tokens": 10685
+    },
+    "duration_ms": 282350
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "registration-admission-control-gate",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "architecture",
+    "api",
+    "fastapi",
+    "webhooks",
+    "admission-control",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 1.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8,
+    "output_tokens": 1804,
+    "cache_read_tokens": 1173787,
+    "cache_write_tokens": 3255,
+    "total_tokens": 1178854,
+    "total_cost_usd": 0.6523772499999999,
+    "latency_seconds": 1484.1,
+    "num_turns": 82,
+    "generation_tokens_per_sec": 1.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 8,
+  "output_tokens": 1804,
+  "latency_seconds": 1484.1,
+  "num_turns": 82,
+  "total_cost_usd": 0.6523772499999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 1173787,
+  "cache_creation_tokens": 3255,
+  "run_started_at": "2026-08-31T09:16:59.182379Z",
+  "run_ended_at": "2026-08-31T09:41:43.322372Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8,
+    "output_tokens": 1804,
+    "cache_read_tokens": 1173787,
+    "cache_write_tokens": 3255,
+    "total_tokens": 1178854,
+    "total_cost_usd": 0.6523772499999999,
+    "latency_seconds": 1484.1,
+    "num_turns": 82,
+    "generation_tokens_per_sec": 1.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "registration-admission-control-gate",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 90,
+        "notes": "The issue provides unusually testable behavior, seven explicit route boundaries, configuration defaults, security requirements, and disciplined non-goals. The submitted diff contains corresponding handler and persistence anchors in the agent, server, and skill route modules. Its largest defect is inconsistency: it says malformed responses fail closed while later artifacts allow an empty or unparseable 200, and its claim that existing agent and skill scanners use a pre-persist window is contradicted by the review. No independent task statement exists, and local repository access failed before execution, so baseline and route claims could not all be independently verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 84,
+        "notes": "The LLD names concrete files, handlers, persistence calls, deployment surfaces, response contracts, lifecycle handling, and rollback behavior. Its largest flaw is a load-bearing placement contradiction: it promises effective payloads after local validation, but places the skill-create gate before `service.register_skill(... validate_url=True)` and agent gates before route-level transformation and model construction. Security treatment is otherwise strong, particularly recursive redaction, fixed non-leaking 503 responses, shared-client shutdown, and explicit residual risks. Claims about exact source line counts, audit middleware behavior, and repository-wide conventions could not be fully verified because the local shell sandbox failed."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 22,
+        "total": 84,
+        "notes": "The review identifies concrete defects with consequences, especially credential exfiltration, per-call clients, ECS wiring asymmetry, response leakage, and configuration fail-open behavior. The patch visibly implements several resulting recommendations through `_redact`, a reused `AsyncClient`, fixed caller-facing errors, and two ECS environment blocks. Its largest deficiency is declaring every blocker resolved while missing the pre-validation/raw-payload placement and the conflicting malformed-200 contract. The unrevised LLD draft was not submitted, so claims about what the review originally discovered versus what was already present are unverifiable."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 78,
+        "notes": "The plan has strong state-based oracles for all seven routes, denial, outages, redaction, authorization ordering, deployment wiring, rollback, and backward compatibility. It contradicts itself by saying malformed bodies block while specifying that an empty 200 allows, and its skill allow-path uses an example URL not established as valid despite `validate_url=True`. The submitted route tests also realize less than the plan claims: unavailable coverage is not parametrized across all seven paths, and no allow-ordering or disabled-route matrix is implemented. Test commands and referenced pre-existing test paths could not be executed or fully verified because repository shell access was unavailable."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 73,
+        "notes": "The patch implements the central service, typed envelope, five settings, seven route calls, recursive redaction, shutdown, documentation, deployment wiring, and substantial tests. Its largest correctness defect is that agent and skill calls occur before important local validation and normalization, so the gate can see raw or partial data and can replace an established validation response with a gate 403 or 503. It also treats malformed or empty 200 bodies as allow despite the issue's fail-closed wording, provides incomplete route-test coverage, and adds Helm existing-secret settings without visible workload wiring to consume that external secret. The claimed baseline commit and clean `git apply --check` could not be independently verified because the read-only shell sandbox failed before running commands."
+      }
+    },
+    "task_score": 81.8,
+    "verdict": "Strong, highly specific work with broad end-to-end coverage, materially limited by incorrect gate placement before local validation and unresolved contract and verification inconsistencies.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T16:24:34.294574Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 519622,
+        "cached_input_tokens": 405903,
+        "cache_write_input_tokens": 79932,
+        "output_tokens": 12998,
+        "reasoning_output_tokens": 10685
+      },
+      "duration_ms": 282350
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/run-summary.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/run-summary.json
@@ -1,0 +1,1438 @@
+{
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry-v2",
+  "provider": "bedrock",
+  "ref": null,
+  "refs": [
+    "1.23.0",
+    "1.24.3",
+    "1.24.7",
+    "1.25.0",
+    "1.27.1",
+    "1.28.0",
+    "v1.0.18",
+    "v1.0.19",
+    "v1.0.20",
+    "v1.0.21"
+  ],
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T13:44:40.580582Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 1039324,
+      "cached_input_tokens": 831145,
+      "cache_write_input_tokens": 149492,
+      "output_tokens": 12505,
+      "reasoning_output_tokens": 10539
+    },
+    "duration_ms": 321725
+  },
+  "num_tasks": 21,
+  "num_scored": 21,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 82.83,
+  "mean_cost_usd_excl_failed": 7.63,
+  "tasks": [
+    {
+      "task": "cli-custom-egress-oauth-provider-flags",
+      "complexity": "low",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 15131,
+      "output_tokens": 101277,
+      "total_tokens": 9707272,
+      "latency_seconds": 1241.4,
+      "total_cost_usd": 8.570658750000002,
+      "result_subtype": "success",
+      "task_score": 91.2,
+      "cache_read_tokens": 9387795,
+      "cache_write_tokens": 203069,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 81.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 24,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 91,
+          "notes": "The issue provides unusually concrete acceptance criteria, including exact flags, exit codes, omission semantics, compatibility cases, and explicit non-goals. Its largest factual weakness is the claim that curl is the only existing configuration path, which conflicts with its own evidence that Dashboard.tsx sends the two mandatory custom-provider URLs. The cited cmd_egress_configure, configure_egress_auth, EgressConfigRequest, and TokenEndpointAuthStyle integration points align consistently across the submitted artifacts. No independent task statement was supplied, so scope coverage can only be judged from the task identifier, repository context, and internally consistent evidence."
+        },
+        "lld": {
+          "completeness": 24,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 24,
+          "total": 94,
+          "notes": "The LLD commits to exact signature ordering, request-body gates, parser choices, validation ownership, file changes, compatibility behavior, and documentation updates. It correctly identifies the load-bearing full-declaration behavior of the route and preserves target_audience's positional slot by appending the five parameters. A limited inconsistency remains because it says the flags apply only to oauth_user plus custom while the proposed command silently forwards them for provider custom in other modes, and its environment-variable secret examples still expose the expanded secret through process argv. The design explicitly covers SSRF authority, enum drift, UI overwrite risk, response visibility, rollback, and the missing custom_resource model field."
+        },
+        "review": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 24,
+          "total": 93,
+          "notes": "The review finds concrete defects rather than merely approving the design, especially the original positional-parameter misbinding, normalization constraint, and duplicated-enum drift risk. Each major finding states a consequence and a specific resolution subsequently reflected in the revised LLD and patch. Its largest omission is that it does not directly challenge the issue's false curl-only claim despite noting that the server-edit modal already sends both required URLs. The claimed pre-revision LLD cannot be independently compared with the submitted revised version, but the resolved decisions are concrete and technically coherent."
+        },
+        "testing": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 89,
+          "notes": "The plan covers parser behavior, client body shape, positional compatibility, all modes, negative validation, documentation, live operation, and an actual OAuth flow with specific commands and expected states. Its principal correctness flaw is section 1.3.3 suggesting that a consent redirect can confirm basic_header persistence, although token-endpoint authentication style is exercised during token exchange, not authorization redirect construction. The implemented warning test also fails to assert that a warning occurred, and the bad-choice test does not directly prove that client construction was skipped. The plan recognizes SSRF, secret logging, rollback, read-back limitations, and compatibility risks, although expanding an environment variable still leaves the secret visible in process argv."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 89,
+          "notes": "The diff implements the designed path end to end: five parser flags, five appended client parameters, omission-preserving body construction, pre-client URL checks, documentation, and focused tests. The signature keeps target_audience in its existing positional slot, and the body uses is not None so an empty custom_scope_separator is transmitted. The main implementation defect is that the non-custom warning uses truthiness, so an explicitly supplied empty separator is forwarded without the warning promised by the design; one test docstring also incorrectly implies omitted custom fields cannot be cleared despite the documented full-rebuild behavior. The repository shell failed before commands executed, so patch applicability and source-context matching could not be independently confirmed; this is an evidence gap rather than a demonstrated patch failure."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "default-create-in-idp-checkbox-unchecked",
+      "complexity": "low",
+      "ref": "v1.0.21",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 39,
+      "input_tokens": 7713,
+      "output_tokens": 62118,
+      "total_tokens": 5718384,
+      "latency_seconds": 823.6,
+      "total_cost_usd": 5.52784725,
+      "result_subtype": "success",
+      "task_score": 90.6,
+      "cache_read_tokens": 5455152,
+      "cache_write_tokens": 193401,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 75.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 91,
+          "notes": "The issue identifies four concrete default sources in IAMGroups.tsx and management_routes.py, then supplies testable UI, payload, reset, JSON, and backend acceptance criteria. Its strongest feature is the explicit boundary around server_routes.py and existing groups, including the compatibility reason for excluding them. The main limitation is that changing the management endpoint's omitted-field behavior remains an API behavior change despite the otherwise narrow UI framing. No independent task statement was supplied, so the issue linkage and requirements beyond the task identifier and internally consistent artifacts could not be independently established."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 24,
+          "total": 91,
+          "notes": "The LLD traces createInIdp through _buildScopeJson, useIAM.createGroup, management_create_group, iam.create_group, and scope_service.import_group, with concrete file changes and test updates. It handles reset behavior, JSON round-tripping, mixed-version deployment, error translation, documentation, rollback, and the deliberately divergent server_routes.py defaults. Its largest defect is the alternatives matrix claiming the chosen approach is backward-compatible for CLI/curl while the design itself documents changed behavior for management-endpoint callers that omit the flag. Exact dependency versions, line references, and repository-wide consumer claims could not be independently rechecked because the read-only shell failed before commands ran."
+        },
+        "review": {
+          "completeness": 24,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 24,
+          "total": 93,
+          "notes": "The review finds concrete flaws rather than merely approving the design: resetForm, EXAMPLE_SCOPE_JSON, inaccessible labeling, seven backend tests, stale documentation, duplicate behavior, release communication, and divergent API defaults. It prioritizes each finding, explains consequences, and maps resolutions back to specific revised LLD steps. The main limitation is that claims such as the management endpoint having no consumer beyond the UI rely on repository grep and cannot establish external callers, while the aggregate verdict understates that several findings were initially mandatory. The cited symbols and patch changes are internally consistent, but the repository-wide grep claims could not be independently rerun."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 88,
+          "notes": "The plan has strong automated oracles for initial unchecked state, false and true payloads, reset-after-cancel, omitted backend flags, IdP error translation, authorization, and MongoDB import. It also covers mixed-version behavior, least-privilege deployment, rollback, accessibility, and both retained legacy defaults. Its largest weakness is that example download/upload behavior remains manual, the registry-list verification is hedged without a concrete MongoDB fallback command, and some grep checks are too broad to be reliable assertions. The commands were explicitly not executed, and their exact compatibility with the checkout could not be independently verified because shell execution was unavailable."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 90,
+          "notes": "The patch implements the design end to end: one frontend default constant, reset and example updates, accessible helper text, backend fallback and docstring changes, focused frontend tests, updated backend tests, and operator documentation. The hunks consistently target IAMGroups.tsx, management_create_group, and the named test cases, while the summary accurately discloses the unchanged server_routes.py defaults and lack of test execution. The largest remaining weakness is incomplete automated coverage for example JSON parsing/download behavior, plus documentation wording that treats omission as unconditionally local-only even though parsing an omitted key preserves the form's current state. A local git apply --check could not be rerun because the read-only shell failed before execution, so applicability is supported by coherent hunk context rather than an independent apply result."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "pass-ssrf-allowlist-env-to-registry-container",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 51,
+      "input_tokens": 7186,
+      "output_tokens": 67207,
+      "total_tokens": 7548426,
+      "latency_seconds": 895.2,
+      "total_cost_usd": 6.352525000000001,
+      "result_subtype": "success",
+      "task_score": 89.6,
+      "cache_read_tokens": 7317615,
+      "cache_write_tokens": 156418,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 75.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 90,
+          "notes": "The issue clearly identifies the affected compose files, exact environment entries, default-deny behavior, scope, and testable acceptance criteria. Its central premise that Compose service environment must explicitly pass these values is technically sound.  The largest evidence limitation is that no independent task statement exists and the exact cited repository lines and runtime 405 chain could not be locally rechecked because the sandbox failed before command execution. Some live-container criteria depend on an available internal upstream, but the core requested behavior remains precise."
+        },
+        "lld": {
+          "completeness": 24,
+          "correctness": 19,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 90,
+          "notes": "The LLD is unusually concrete about target files, insertion points, data flow, existing test conventions, deployment surfaces, rollback, and deferred duplication risk. It commits to exact passthrough syntax and a non-vacuous filesystem-discovered regression test rather than leaving major implementation decisions open. Its largest defect is the claim that `docker compose restart` is enough after changing `.env`; restart does not apply updated Compose configuration, while recreation does, contradicting the document's later guidance.  Exact paths, line numbers, and the claimed baseline commit remained locally unverifiable because repository commands could not start."
+        },
+        "review": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 24,
+          "total": 90,
+          "notes": "The review surfaces concrete defects rather than merely approving the design, especially hardcoded discovery, recursive glob scope, literal allowlist values, duplicated environment blocks, and the separate A2A configuration gap. Findings B1-B4 have specific consequences and actionable resolutions reflected in the proposed test. The largest weakness is that it declares the revised design resolved while overlooking the LLD's still-incorrect `docker compose restart` statement, despite discussing that exact operational question. Its detailed repository assertions could not be independently rechecked locally because the shell sandbox failed."
+        },
+        "testing": {
+          "completeness": 23,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 85,
+          "notes": "The plan covers static invariants, rendered configuration, process environment, backward compatibility, fail-closed behavior, deployment surfaces, rollback, and end-to-end host and CIDR paths with concrete oracles. Its strongest tests are the pre-fix red check and the hardcoded-literal negative case. Several runnable details are wrong or fragile: `REGISTRY_URL` remains port 80 while Podman is documented as port 8080, the CIDR workflow passes a container ID to `docker network inspect` and suppresses failure, and the token prerequisite is labeled section-five-only despite earlier use. These defects can prevent the advertised E2E checks from testing the intended stack, although the security and compatibility cases themselves are well chosen."
+        },
+        "implementation": {
+          "completeness": 24,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 93,
+          "notes": "The submitted diff implements the narrow task end to end by adding both `${VAR:-}` entries at the stated registry environment anchors and preserving the empty default. The new test checks discovery is non-vacuous, both keys exist, values are exact passthroughs rather than literals, and documentation remains present. The main evidence gap is that patch applicability, baseline context, and test execution could not be independently verified because the local command sandbox failed; logically, the supplied Python and YAML are internally consistent. The summary accurately discloses unexecuted tests and deferred environment-block drift, with only a minor misdescription of the number of parametrized assertions."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "honor-cloud-provider-override-in-ui",
+      "complexity": "low",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 33,
+      "input_tokens": 12465,
+      "output_tokens": 64334,
+      "total_tokens": 4587436,
+      "latency_seconds": 800.2,
+      "total_cost_usd": 4.814305250000001,
+      "result_subtype": "success",
+      "task_score": 88.4,
+      "cache_read_tokens": 4356148,
+      "cache_write_tokens": 154489,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 80.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 24,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 92,
+          "notes": "The issue provides unusually concrete scope, testable acceptance criteria, compatibility requirements, and explicit non-goals. It identifies the relevant endpoint, resolver, configuration field, UI consumer, authentication behavior, and documentation surfaces. Its largest flaw is that the proposed log suppression does not cover a cold-cache fallback through `_detect_cloud_provider_with_method()`, which can still log and increment the counter despite the absolute acceptance criterion. No independent task statement was supplied, and sandbox failure prevented independent confirmation of every cited repository line."
+        },
+        "lld": {
+          "completeness": 24,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 90,
+          "notes": "The LLD is implementation-ready, with committed interface changes, precedence, caching, failure handling, documentation, rollout, rollback, and file-level edits. The submitted diff corroborates its central symbols and integration shape: `_resolve_cloud`, `get_telemetry_detection_info`, and the unchanged response keys. Its material error is claiming the display path cannot log, increment metrics, or trigger IMDS when the uncached cascade branch remains unguarded and may execute on the endpoint's first call. Exact baseline paths and line references could not be independently checked because the repository shell sandbox failed before executing read-only commands."
+        },
+        "review": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 90,
+          "notes": "The review finds concrete defects rather than merely approving the design, especially per-request observability noise, documentation drift, hint-read I/O, validation, and missing resolver coverage. Its recommendations are prioritized and tied to specific symbols such as `_log_detection_result`, `_get_operator_cloud_hint`, and `CLOUD_DETECTION_TOTAL`. It nevertheless misses the revised design's cold-cache contradiction and incorrectly accepts blanket claims that the endpoint cannot emit a detection result or trigger an IMDS probe. Repository-level verification of its grep and line-number claims was unavailable due the execution sandbox failure."
+        },
+        "testing": {
+          "completeness": 23,
+          "correctness": 19,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 87,
+          "notes": "The plan supplies exact inputs, response bodies, status codes, compatibility checks, deployment surfaces, UX expectations, and unit-test oracles across override, hint, invalid-value, and unauthenticated cases. The proposed automated tests target the real changed functions and assert exact JSON rather than merely checking successful execution. The largest gap is that no test exercises `log_result=False` with an uncached cascade, so the plan would miss the implementation's remaining log, metric, and possible IMDS side effect; the named short-circuit test also never asserts that the cascade was not called. Token-file paths, service commands, and several operational assumptions could not be independently verified against the checkout."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 83,
+          "notes": "The diff implements the primary behavior end to end: the endpoint awaits `_resolve_cloud(log_result=False)`, preserves the response contract, documents the widened values, and adds focused resolver and endpoint tests. The changes are internally consistent with the LLD and retain `log_result=True` for existing callers by default. The largest defect is that the fallback still calls the logging, cached cascade, so a cold-cache endpoint request can increment `CLOUD_DETECTION_TOTAL`, emit the INFO line, and potentially probe IMDS despite the acceptance criteria and new documentation. The claimed baseline hash and `git apply --check` result could not be independently confirmed because all local shell commands failed before execution; the summary also truthfully states that tests were not run."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "fix-reserved-groups-var-in-service-account-script",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 35,
+      "input_tokens": 12059,
+      "output_tokens": 70559,
+      "total_tokens": 5252174,
+      "latency_seconds": 911.5,
+      "total_cost_usd": 5.348718750000001,
+      "result_subtype": "success",
+      "task_score": 87.6,
+      "cache_read_tokens": 5006135,
+      "cache_write_tokens": 163421,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 89,
+          "notes": "The issue precisely identifies the reserved GROUPS assignment, affected functions, expected behavior, exclusions, and testable acceptance criteria. The submitted patch context corroborates the cited GROUPS assignments and loose grep checks in all four named files. Its largest weakness is a minor step-count inconsistency with the LLD, which later describes verify_setup and token generation as steps 9 and 10 rather than 7 and 8. The claimed 91-file sweep, documentation references, and caller behavior could not be independently verified because repository commands failed during sandbox initialization."
+        },
+        "lld": {
+          "completeness": 24,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 24,
+          "total": 94,
+          "notes": "The LLD is unusually implementation-ready: it commits to exact files, functions, variable names, scoping, matching semantics, compatibility constraints, rollout, and rollback behavior. Its split local declaration and assignment correctly avoids masking command-substitution status, while grep -qxF aligns assign_to_group and verify_setup. The main technical weakness is that local scoping itself does not prevent a future collision with another special variable, and failures earlier in curl pipelines remain maskable without pipefail, although that residual risk is disclosed. Repository-wide counts, workflow claims, and exact integration paths could not be independently verified through the unavailable command sandbox."
+        },
+        "review": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 23,
+          "total": 90,
+          "notes": "The review surfaces concrete design defects rather than merely approving it, notably the global-scoping boundary, empty-pattern behavior, absent regression guard, scope expansion, and operational implications. Each material finding has a specific consequence and a documented resolution incorporated into the revised LLD. Its largest deficiency is that several frontend and security assertions about TypeScript command routing and authorization use are presented as verified without evidence available in the submitted diff. The concerns tied directly to CURRENT_GROUPS, ACCOUNT_GROUPS, grep -qxF, and the four patch targets are well supported."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 76,
+          "notes": "The plan broadly covers syntax, shellcheck, reproduction, live Keycloak behavior, idempotency, compatibility, CLI output, and independent server-state checks with concrete expected values. Its largest defect is that the purported negative membership test reruns the full script, which repairs membership and exits 0, then substitutes an isolated grep command instead of exercising verify_setup's red failure branch. The unreachable-Keycloak test fails during token acquisition and therefore cannot catch a combined local assignment inside verify_setup, while the deployment command includes terraform/ despite expecting no diff even though the patch intentionally changes a Terraform script. Several commands also depend on unverified local Keycloak, Terraform/SSM, and macOS environments, and no test was executed."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 89,
+          "notes": "The unified diff implements the stated design end to end across both setup scripts and both list_groups implementations, using function-local replacement variables and exact fixed-string membership checks. The hunk contexts and symbols are internally consistent, preserve the Terraform copy's defensive jq behavior, and introduce no unrelated interface or configuration changes. The largest remaining risk is the absence of an executable regression test or lint gate; additionally, grep lacks -- or -e before the operator-supplied pattern, so a group name beginning with a hyphen can still be misinterpreted as an option. Patch applicability and the claimed pristine-baseline checks could not be independently rerun because the read-only command runner failed before executing git apply --check."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "index-demo-videos-in-one-page",
+      "complexity": "trivial",
+      "ref": "1.24.3",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 48,
+      "input_tokens": 4,
+      "output_tokens": 1131,
+      "total_tokens": 417472,
+      "latency_seconds": 1011.0,
+      "total_cost_usd": 0.24824524999999997,
+      "result_subtype": "success",
+      "task_score": 87.0,
+      "cache_read_tokens": 414288,
+      "cache_write_tokens": 2049,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 1.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 88,
+          "notes": "The issue provides unusually testable scope, including 13 exact URLs, required entry points, preservation requirements, and explicit non-goals. Its inventory arithmetic is internally consistent with the cited 24 references, and the patch confirms the claimed broken `docs/index.md` anchor. The largest defect is the contradictory discoverability claim: it calls the virtual-server and ANS recordings effectively single-page discoveries while its own inventory shows additional README links. No independent task statement exists, so requirements beyond the task identifier and artifact consensus remain unverifiable."
+        },
+        "lld": {
+          "completeness": 24,
+          "correctness": 19,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 89,
+          "notes": "The LLD is implementation-ready, naming the four files, exact navigation placement, row assignments, relative-link rules, maintenance workflow, rollback, and external-hosting risks. Its target documents are credible repository components; public source confirms that `docs/mcp-registry-cli.md` and `docs/auth.md` cover the subjects assigned to them. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/mcp-registry-cli.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/auth.md)) The main correctness gaps are that its set-difference scan includes the index itself and excludes Loom, Vimeo, and direct media URLs from URL extraction despite claiming broader coverage. It also incorrectly implies ordinary table links play inline on GitHub and that iframe code executes in the project's own origin."
+        },
+        "review": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 23,
+          "total": 88,
+          "notes": "The review identifies concrete defects involving stale numeric labels, ambiguous partial listings, nav prominence, external hosting, public recordings, and executable completeness checks, then maps each recommendation to a design revision. Its strongest contribution is forcing canonicity and the ordered maintenance workflow rather than merely approving polished prose. It misses the flawed scan semantics and repeats the inaccurate claim that embedded third-party JavaScript would execute in the documentation site's origin. Several findings are disproportionate for a four-file documentation change, but they remain actionable rather than generic role-play."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 85,
+          "notes": "The plan covers URL-set equality, target existence, rendering, navigation, preservation of historical links, deployment, rollback, negative cases, and concrete reader tasks with explicit oracles. Its largest defect is test 2.1: replacing README line 14 necessarily creates a removed diff line containing every original video URL, so the command cannot produce the promised empty output on the submitted patch. The repository-wide URL set also includes `docs/demo-videos.md`, making the claimed page-only typo guard logically misleading, while the extraction regex omits several formats named by the scan regex. Redundant count, set, and line-specific checks still provide substantial coverage of the actual 13-video change."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 85,
+          "notes": "The patch implements the requested flow end to end: 13 distinct videos are grouped on a new page, existing links remain in the shown diff, the broken resource link is corrected, and MkDocs navigation is updated. The largest code-content defect is the new page's claim that ordinary Markdown links play inline on GitHub and open third-party players in a new tab, neither of which is guaranteed by the link markup used. The summary also says no configuration file changed while explicitly modifying `mkdocs.yml`, and external playback and content descriptions remain manually unverified. The local command runner failed before execution, so the claimed exact-tag `git apply --check` result could not be independently reproduced; public source only corroborates some link targets, not the complete `1.24.3` tree. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/mcp-registry-cli.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/auth.md))"
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "consistent-csrf-across-toggle-endpoints",
+      "complexity": "medium",
+      "ref": "v1.0.20",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 75,
+      "input_tokens": 7641,
+      "output_tokens": 95550,
+      "total_tokens": 14493408,
+      "latency_seconds": 1263.9,
+      "total_cost_usd": 10.937606,
+      "result_subtype": "success",
+      "task_score": 86.4,
+      "cache_read_tokens": 14161427,
+      "cache_write_tokens": 228790,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 75.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 85,
+          "notes": "The issue provides unusually concrete route inventory, testable rejection cases, non-goals, and downgrade-resistance requirements. Its largest defect is claiming the six routes share equivalent authentication and that bearer requests can succeed on all toggles, while its own table and exclusions identify cookie-only enhanced_auth and header-only validate_internal_auth. The named routes and existing verify_csrf_token_flexible behavior align with the submitted source contexts, but no independent task statement establishes that all six routes were required scope. Security boundaries, mismatched-session tokens, proxy signaling, and backward compatibility are otherwise handled strongly."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 90,
+          "notes": "The LLD is implementation-ready, naming concrete files, dependencies, handler symbols, test-fixture identity overrides, data flow, rollout, rollback, and operator effects. It correctly chooses cookie presence as the relaxing boundary and uses X-Auth-Method only to fail closed. Its main weakness is continuing to describe successful browser and bearer behavior uniformly across six endpoints even though it acknowledges that the form route is cookie-only and the internal route requires an internal JWT; those claims should be framed as CSRF-layer behavior. The submitted diff matches most named integration points, though exact baseline applicability and several line-number claims could not be independently re-executed in the available repository shell."
+        },
+        "review": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 23,
+          "total": 87,
+          "notes": "The review identifies concrete concerns including dependency-override identity, stale-token UX, proxy failure behavior, authorization preservation, and route-set regression coverage. Its most questionable judgment is treating constant-time comparison after successful HMAC verification as a blocking security defect while missing the more direct contradiction about heterogeneous endpoint authentication. It also says the revised design is implemented exactly, but the patch contains no real unauthorized-bearer route test or internal-toggle JWT test promised by the review. The findings are nevertheless prioritized, actionable, and tied to specific files and symbols rather than generic reviewer role-play."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 84,
+          "notes": "The plan supplies concrete requests, expected statuses and bodies, negative cases, dependency semantics, route introspection, rollback checks, and browser workflows. Its largest correctness problem is the checklist assertion that the bearer path returns 200 on all six endpoints, which conflicts with enhanced_auth on POST /api/toggle/{service_path:path} and the internal-JWT requirement on /api/internal/toggle. The patch implements extensive dependency tests and agent-route tests, but not the promised real-route unauthorized-bearer or internal-toggle no-op tests, and the valid-token curl loop exercises only two routes. Commands and paths appear consistent with the submitted repository evidence, but they were not independently executable in the available shell."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 86,
+          "notes": "The patch implements the central design end to end: one conditional dependency, fail-closed proxy signaling, six route declarations, fixture updates, route-set guards, focused tests, and operator documentation. Static inspection shows coherent imports and matching handler contexts for toggle_service_route, internal_toggle_service, toggle_service_api, toggle_agent, toggle_skill, and toggle_virtual_server. The largest deficiency is that it omits the explicitly promised authorization-preservation and actual internal-JWT route tests while the summary overstates exact conformance; only the agent toggle receives real-route CSRF coverage. No obvious production-code bypass or caller break is visible, although the submitted git-apply and execution claims could not be independently rerun in the constrained repository shell."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "hide-register-button-on-virtual-and-skills-tabs",
+      "complexity": "trivial",
+      "ref": "v1.0.18",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 31,
+      "input_tokens": 10671,
+      "output_tokens": 47752,
+      "total_tokens": 4094991,
+      "latency_seconds": 642.2,
+      "total_cost_usd": 3.9776857500000014,
+      "result_subtype": "success",
+      "task_score": 86.4,
+      "cache_read_tokens": 3912699,
+      "cache_write_tokens": 123869,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 74.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 87,
+          "notes": "The issue gives crisp scope, non-goals, and testable behavior for all six tabs. The submitted patch context supports its central Dashboard.tsx state and button claims. Its assertion that registration is appropriate on External Registries is a reasonable but unestablished product inference given the missing independent task statement. Local repository commands failed before execution with a sandbox loopback error, so cited line numbers and related-file claims could not be independently reverified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 89,
+          "notes": "The LLD commits to an exact data flow, condition, JSX integration point, compatibility boundary, and rollback approach. The supplied diff implements its named showRegisterButton allowlist and preserves the existing handler and button markup. Minor defects include incorrectly claiming a module-level tab array would allocate each render and inconsistently describing the automated tests as a complete six-tab matrix. Repository-only claims about hooks, feature flags, CI, and surrounding symbols could not be independently checked because the read-only shell sandbox failed."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 85,
+          "notes": "The review surfaces concrete concerns including ambiguous Register selectors, future-tab behavior, layout, permissions, caching, and absent CI enforcement. Its strongest finding correctly separates tab relevance from authorization and requires exact accessible-name matching. It is repetitive and misses that the proposed automated suite never covers the External Registries branch despite emphasizing preservation of that behavior. Claims such as the number of state hooks and exact workflow coverage remained unverifiable because repository inspection was unavailable."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 86,
+          "notes": "The plan provides a concrete six-tab manual matrix, navigation oracles, negative cases, compatibility checks, layout checks, and accessibility coverage. Its exact Register selector and expected /servers/register URL align with the submitted implementation. The automated suite omits External Registries, the populated-data prerequisite conflicts with the later empty-skills scenario, and page-wide claims about exactly one plus-icon button are broader than necessary. Package scripts, proxy settings, helper behavior, and CI commands could not be independently verified due to the shell failure."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 85,
+          "notes": "The code change directly implements the requested behavior with a closed allowlist and preserves the existing registration handler, route, and unrelated header controls. The diff is internally coherent: it adds showRegisterButton beside viewFilter, gates only the header button, and tests both affected tabs plus positive server and agent cases. Its largest gap is the absent External Registries automated assertion while the summary overstates the spec as a complete per-tab matrix; the tests and build were also explicitly not executed. The claimed git apply --check and exact compatibility with the real baseline could not be independently confirmed because every local read-only command failed before execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "build-docker-images-from-uv-lock",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 79,
+      "input_tokens": 3513,
+      "output_tokens": 102397,
+      "total_tokens": 16063407,
+      "latency_seconds": 1421.8,
+      "total_cost_usd": 11.99655025,
+      "result_subtype": "success",
+      "task_score": 83.2,
+      "cache_read_tokens": 15707008,
+      "cache_write_tokens": 250489,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 72.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 86,
+          "notes": "The strongest aspect is the concrete problem statement, naming the affected Dockerfiles, missing lockfiles, CPU PyTorch handling, CI gate, and explicit exclusions. Acceptance criteria include actionable commands such as the docker grep and uv lock checks, plus runtime and security oracles. The largest deficiency is that the promised reproducibility remains incomplete for MCP images with out-of-lock PyTorch, while dropping torchvision conflicts with the stated unchanged image behavior. No independent task statement was supplied, so the candidate-defined exclusions cannot be fully validated against external requirements."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 86,
+          "notes": "The LLD makes unusually concrete decisions around uv sync --locked, --no-dev, --inexact, the explicit PyTorch index, and --no-deps for the editable registry install. It identifies real integration points including pyproject.toml, uv.lock, five Dockerfiles, build contexts, CI, and regression tests. Its largest weakness is knowingly retaining an unpinned PyTorch installation in two MCP images while claiming locked, reproducible image dependencies; it also changes local development to CPU PyTorch and removes torchvision. Exact timing, package-delta, and build-context claims could not all be independently verified because the submitted patch was truncated and local shell execution was unavailable."
+        },
+        "review": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 23,
+          "total": 89,
+          "notes": "The review surfaces concrete defects with consequences, especially the unconstrained editable install, unsafe shell discovery loop, CUDA-size risk, missing rollback unit, and insufficient embeddings coverage. Its proposed regression test does not actually enforce the claimed future invariant because it checks a fixed list of five Dockerfiles rather than scanning every Dockerfile under docker/. The review also accepts the out-of-lock MCP PyTorch installation after merely documenting it, making the final approval more generous than the reproducibility goal warrants. Claims such as byte-identical frontend assets and measured lock-check timings were not independently verifiable from the available repository access."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 79,
+          "notes": "The plan has strong behavioral oracles for stale locks, CPU-only torch, absence of CUDA and development packages, embeddings operation, health endpoints, rollback, and repeated-build dependency equality. Several commands are unreliable: uv sync --extra dev does not select a dependency group, python -m pip may be unavailable in an unseeded uv-created environment, and git diff HEAD~1 does not isolate an uncommitted applied patch. Package-inspection docker run commands also omit an entrypoint override despite the documented image entrypoints, and some deployment checks assert unchanged output without constructing a baseline comparison. The breadth is excellent, but these executable errors materially reduce confidence that the plan can be followed successfully."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 20,
+          "total": 76,
+          "notes": "The visible patch and summary implement the central path: new lockfiles, locked synchronization in five Dockerfiles, an explicit CPU PyTorch source, a stale-lock workflow, and a targeted regression test. The largest defect is that Dockerfile.mcp-server and Dockerfile.mcp-server-cpu deliberately retain an unpinned, hash-free PyTorch install through --inexact, while the registry image also drops torchvision despite the unchanged-content objective. The regression test's hardcoded Dockerfile list will not catch the sixth-Dockerfile scenario it claims to prevent, and repository-controlled paths remain unescaped when emitted into workflow annotations and Markdown. The complete diff could not be apply-checked because the submission truncates it, and repository release notes later document that clean locked builds required pinning uv, confirming the acknowledged unpinned-tool risk. "
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-ui-title",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 75,
+      "input_tokens": 8,
+      "output_tokens": 2264,
+      "total_tokens": 1013359,
+      "latency_seconds": 1123.8,
+      "total_cost_usd": 0.6218915,
+      "result_subtype": "success",
+      "task_score": 83.2,
+      "cache_read_tokens": 1000703,
+      "cache_write_tokens": 10384,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 2.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 80,
+          "notes": "The issue is unusually concrete, covering backend resolution, four UI occurrences, three deployment surfaces, documentation, tests, and explicit non-goals. Its largest defect is a direct contradiction: registry-only deployments without UI_TITLE intentionally change to \"AI Registry\", while another user story and acceptance criterion promise that deployments without UI_TITLE change nothing. The submitted diff confirms the named Layout.tsx, Login.tsx, Logout.tsx, config routes, and deployment files are the intended change points. No independent task statement establishes the deployment-mode-derived default, so that requirement remains candidate-defined rather than externally verified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 87,
+          "notes": "The LLD is implementation-ready across Settings, both API paths, React consumers, exports, Docker, Terraform, Helm, documentation, rollout, and rollback. Its main weakness is preserving the issue's incompatible no-change claim; removing UI_TITLE does not restore pre-change registry-only text, and the blank raw System Config field does not directly show the effective value requested by a user story. Concrete decisions such as the conditional Helm environment entry, reserved-name guard, empty-string export semantics, public auth-config payload, and React text-only rendering are reflected in the patch. Exact tag, line-number, and cache-behavior claims could not be independently confirmed because the provided repository shell failed during sandbox initialization."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 86,
+          "notes": "The review finds several consequential design defects, including exporting None, whitespace-only titles, Helm positional-test breakage, duplicate environment names, unbounded public values, and unauthenticated disclosure. Its largest omission is failing to challenge the central backward-compatibility contradiction or the mismatch between showing a raw blank field and promising visibility of the effective title. Findings are prioritized and actionable, and the implementation visibly incorporates B1 through B6 in config.py, deployment.yaml, _helpers.tpl, and auth/routes.py. The reviewed Rev 1 artifact was not supplied, so claims about its exact contents and the asserted exhaustive repository test search are not independently verifiable."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 80,
+          "notes": "The plan covers resolution precedence, malformed input, both APIs, compatibility skew, UI behavior, every deployment surface, rollback, and end-to-end runtime configuration. Its largest weakness is executable reliability: it repeatedly appends to .env without cleanup, calls a Terraform task-definition change a no-op, and describes config/full fields inconsistently as top-level raw data in section 1.1.7 but nested value.display data in section 5.1. Several curl and jq examples display results without asserting status or the promised field values, and no automated React test verifies the header, login, logout, or fallback behavior. The unit-test and Helm regression commands otherwise align closely with the submitted patch and target the highest-risk backend and chart behaviors."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 83,
+          "notes": "The patch implements the feature end to end: Settings normalization and derivation, authenticated and public API exposure, all four UI strings, CONFIG_GROUPS, Docker, Terraform, Helm, documentation, and backend tests. Its largest deficiency is verification coverage and summary accuracy: the added file contains 16 test functions rather than the claimed 18, with no automated frontend, config/full, export-round-trip, warning-log, or Helm test additions. The submitted hunks are internally consistent around Settings.effective_ui_title, get_config, get_auth_config, useRegistryConfig, the conditional Helm entry, and Terraform pass-through, and the implementation honestly excludes static generated bundles. The claimed git apply checks and exact baseline compatibility could not be independently rerun because all repository shell commands failed at sandbox initialization."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "registration-admission-control-gate",
+      "complexity": "high",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 82,
+      "input_tokens": 8,
+      "output_tokens": 1804,
+      "total_tokens": 1178854,
+      "latency_seconds": 1484.1,
+      "total_cost_usd": 0.6523772499999999,
+      "result_subtype": "success",
+      "task_score": 81.8,
+      "cache_read_tokens": 1173787,
+      "cache_write_tokens": 3255,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 1.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 90,
+          "notes": "The issue provides unusually testable behavior, seven explicit route boundaries, configuration defaults, security requirements, and disciplined non-goals. The submitted diff contains corresponding handler and persistence anchors in the agent, server, and skill route modules. Its largest defect is inconsistency: it says malformed responses fail closed while later artifacts allow an empty or unparseable 200, and its claim that existing agent and skill scanners use a pre-persist window is contradicted by the review. No independent task statement exists, and local repository access failed before execution, so baseline and route claims could not all be independently verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 84,
+          "notes": "The LLD names concrete files, handlers, persistence calls, deployment surfaces, response contracts, lifecycle handling, and rollback behavior. Its largest flaw is a load-bearing placement contradiction: it promises effective payloads after local validation, but places the skill-create gate before `service.register_skill(... validate_url=True)` and agent gates before route-level transformation and model construction. Security treatment is otherwise strong, particularly recursive redaction, fixed non-leaking 503 responses, shared-client shutdown, and explicit residual risks. Claims about exact source line counts, audit middleware behavior, and repository-wide conventions could not be fully verified because the local shell sandbox failed."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 22,
+          "total": 84,
+          "notes": "The review identifies concrete defects with consequences, especially credential exfiltration, per-call clients, ECS wiring asymmetry, response leakage, and configuration fail-open behavior. The patch visibly implements several resulting recommendations through `_redact`, a reused `AsyncClient`, fixed caller-facing errors, and two ECS environment blocks. Its largest deficiency is declaring every blocker resolved while missing the pre-validation/raw-payload placement and the conflicting malformed-200 contract. The unrevised LLD draft was not submitted, so claims about what the review originally discovered versus what was already present are unverifiable."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 78,
+          "notes": "The plan has strong state-based oracles for all seven routes, denial, outages, redaction, authorization ordering, deployment wiring, rollback, and backward compatibility. It contradicts itself by saying malformed bodies block while specifying that an empty 200 allows, and its skill allow-path uses an example URL not established as valid despite `validate_url=True`. The submitted route tests also realize less than the plan claims: unavailable coverage is not parametrized across all seven paths, and no allow-ordering or disabled-route matrix is implemented. Test commands and referenced pre-existing test paths could not be executed or fully verified because repository shell access was unavailable."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 73,
+          "notes": "The patch implements the central service, typed envelope, five settings, seven route calls, recursive redaction, shutdown, documentation, deployment wiring, and substantial tests. Its largest correctness defect is that agent and skill calls occur before important local validation and normalization, so the gate can see raw or partial data and can replace an established validation response with a gate 403 or 503. It also treats malformed or empty 200 bodies as allow despite the issue's fail-closed wording, provides incomplete route-test coverage, and adds Helm existing-secret settings without visible workload wiring to consume that external secret. The claimed baseline commit and clean `git apply --check` could not be independently verified because the read-only shell sandbox failed before running commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "server-side-oauth-token-storage",
+      "complexity": "high",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 152,
+      "input_tokens": 10714,
+      "output_tokens": 136725,
+      "total_tokens": 38165619,
+      "latency_seconds": 1811.9,
+      "total_cost_usd": 24.323936,
+      "result_subtype": "success",
+      "task_score": 81.2,
+      "cache_read_tokens": 37697632,
+      "cache_write_tokens": 320548,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 75.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 88,
+          "notes": "The issue provides unusually concrete acceptance criteria covering encrypted storage, owner-scoped retrieval, expiry, revocation, compatibility, deployment surfaces, and the database-free authentication path. Its strongest evidence is the direct mapping to `oauth2_callback`, `validate_session_cookie`, `get_user_session_data`, and `POST /api/tokens/generate`, all of which are reflected in the submitted patch contexts. The largest weakness is the absent independent task statement, so requirements such as restoring the sidebar's provider-token display cannot be externally confirmed. It also says \"three new configuration parameters\" while defining four, a minor but testable scope inconsistency."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The LLD is strongly grounded in named repository files and commits precise decisions for models, repository interfaces, endpoint behavior, encryption, expiry, deployment, and rollback. Its strongest technical work is the user-scoped hashed reference plus read-time expiry gate and naive-BSON datetime normalization. The major flaw is its concurrency claim: `delete_many({username})` followed by insertion under a fresh hashed `_id` is non-atomic, so concurrent logins can both insert and violate the promised one-record-per-user invariant. It also claims token-store failures cannot break login or logout without specifying bounded database timeouts, leaving those request paths vulnerable to long infrastructure stalls."
+        },
+        "review": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 83,
+          "notes": "The review surfaces concrete, consequential defects including timezone comparison failure, eventual TTL deletion, missing retrieval auditing, cacheability, logout revocation, and cross-service key agreement. Its dispositions are specific and visibly propagated into the LLD and patch, rather than merely recording reviewer personas or generic approval. The largest miss is that Byte endorses delete-before-insert and Sage accepts the scaling story without noticing that concurrent logins can leave multiple documents because the operations and differing `_id` values are not atomic. It also does not challenge the unbounded latency introduced by awaiting the token database during login and logout."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The plan supplies concrete setup, actions, status codes, response fields, database state checks, deployment checks, compatibility cases, and lifecycle oracles across unit, HTTP, UX, and end-to-end levels. It directly tests important negative behavior such as cross-user lookup, stale TTL records, key rotation, revocation, 503 handling, and plaintext absence. Its largest gap is concurrency: sequential re-login coverage cannot detect the non-atomic delete-and-insert race in the repository design. The stated cookie regression is also unreliable as implemented because itsdangerous conditionally compresses highly repetitive payloads, while the patch uses thousands of repeated characters and may therefore fail its expected oversized assertion. "
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 71,
+          "notes": "The patch implements the central flow across `auth_server/server.py`, a new encrypted DocumentDB repository, `/api/auth/oauth-tokens`, logout revocation, frontend retrieval, configuration surfaces, and focused tests. The largest correctness defect is the non-atomic `delete_many` then `replace_one` sequence, which permits concurrent logins to retain multiple live records despite the summary's one-record-per-user guarantee. The submitted cookie tests use compressible repeated-character token bodies, and the route tests cover the registry dependency but not the promised auth-server `validate_session_cookie` database-access invariant; the settings test also references `settings.session_max_age_seconds` without adding that field in this patch. Exact forward applicability could not be independently confirmed because the provided local shell sandbox failed before `git apply --check`, although the unified-diff contexts are internally coherent."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "per-caller-per-target-rate-limits-and-quarantine",
+      "complexity": "high",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 169,
+      "input_tokens": 6,
+      "output_tokens": 462,
+      "total_tokens": 1266365,
+      "latency_seconds": 2207.6,
+      "total_cost_usd": 0.657788,
+      "result_subtype": "success",
+      "task_score": 81.0,
+      "cache_read_tokens": 1263591,
+      "cache_write_tokens": 2306,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 0.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 92,
+          "notes": "The issue's strongest aspect is its unusually testable acceptance criteria covering models, counters, quarantine semantics, APIs, CLI, UI, compatibility, and exclusions. Named integration points such as `RateLimiter.check()`, `_enforce_rate_limit`, and the three existing collections agree with the submitted source contexts. Its main deficiency is tension between describing quarantine as immediate and accepting propagation through an unspecified short-TTL cache, while also making it inert when the master switch is off. No independent task statement was supplied, so the intended breadth beyond the task identifier cannot be verified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 17,
+          "specificity": 24,
+          "risk_awareness": 19,
+          "total": 83,
+          "notes": "The LLD is exceptionally concrete about real files, data flow, compatibility, API shapes, failure handling, observability, and rollout. Its largest correctness flaw is the unescaped `<identity>|<target>` counter subject: neither side is proven unable to contain `|`, and the proposed validation does not prevent collisions between distinct pairs. It also claims TTL-bounded store load, but the designed cold-start fail-open result is not cached, so every request during an outage can repeat the read timeout. Finally, sorting gates only by window cannot guarantee the stated same-window deny-does-not-consume behavior, a contradiction exposed by the implementation's own caller-versus-pair test."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 81,
+          "notes": "The review's strongest aspect is that it identifies concrete repository-specific defects, including unbounded quarantine lists, missing read timeouts, silent allow behavior, duplicated ID formats, and edit-time ID mutation. Recommendations are prioritized and accompanied by explicit LLD resolutions rather than generic reviewer approval. It nevertheless misses the composite-key collision, repeated cold-start timeout load, non-atomic member-cap race, and same-window gate-ordering contradiction. Its claim that all blocking findings were resolved is therefore overstated by the submitted implementation."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The plan provides strong oracles for pair isolation, marker-free 403 responses, admin non-bypass, stale snapshots, compatibility, authorization, and zero fake-backend increments. The core manual isolation scenario does not place the agent in the `tenants` group, so its successful request cannot prove a distinct `(agent, atlassian)` counter. The plan also omits collision tests for the composite subject, repeated cold-start outage reads, and concurrent additions at the 500-member boundary. Several end-to-end steps depend on uncleared fixed-window state or placeholders such as `<documentdb-volume>`, and the submitted summary confirms none of the tests were executed."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 11,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 67,
+          "notes": "The patch is broad and internally traceable across models, repositories, enforcement, routes, CLI, UI, documentation, and focused tests. A submitted test is inconsistent with the code: gates are assembled caller-first and sorted only by window, so a same-window pair denial occurs after the wider caller counter increments, contradicting `test_tighter_pair_gate_denies_before_wider_caller_gate`. The raw `identity|target` key permits counter aliasing, cold-start store failures retry on every request because the empty fallback is not cached, and the read-then-`$addToSet` member-cap check races under concurrent additions. Independent `git apply --check` and test execution could not be performed because the provided read-only shell failed during sandbox initialization, so applicability beyond the full submitted diff context remains unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "nginx-location-trailing-slash-route-hijack",
+      "complexity": "medium",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 57,
+      "input_tokens": 11631,
+      "output_tokens": 103608,
+      "total_tokens": 10661718,
+      "latency_seconds": 1366.2,
+      "total_cost_usd": 9.216322,
+      "result_subtype": "success",
+      "task_score": 80.4,
+      "cache_read_tokens": 10321309,
+      "cache_write_tokens": 225170,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 75.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 84,
+          "notes": "The issue provides unusually concrete behavior, compatibility requirements, exclusions, and testable acceptance criteria, including bare-path POST preservation and reserved-route handling. It correctly identifies the generated location in registry/core/nginx_service.py and the auth_request consequence. Its largest correctness defect is claiming /a hijacks /api/servers even though the LLD itself says the longer static /api/ location wins nginx prefix selection. No independent task statement or upstream issue contents were supplied, so issue numbers and the exact reported production behavior remain unverifiable."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 84,
+          "notes": "The LLD names concrete integration points such as _create_location_block, _generate_transport_location_blocks, build_per_server_resource_url, the nginx templates, and the validation/reload path. Its internal-rewrite design and duplicate-location guard address the central routing and POST-compatibility risks in implementation-ready detail. The major gap is its claim that unsafe legacy paths retain prior behavior: the proposed code still changes every prefix to a normalized trailing-slash form while withholding the exact helper, potentially breaking bare requests, and it never proves that the helper regex covers every currently accepted path. The live-config grep for ROOT_PATH is also inconsistent with the documented placeholder replacement, while scheduler timing and related issue claims could not be independently verified."
+        },
+        "review": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 86,
+          "notes": "The review performs real adversarial analysis and produces actionable changes, notably the sanitized comment stub, rewrite interpolation guard, preflight check, and reserved-set drift test. Findings cite concrete symbols and consequences rather than merely assigning approving personas. It nevertheless misses the unsafe-legacy bare-path regression, the mismatch between the rewrite allowlist and documented registration validation, and the contradiction concerning /api/servers precedence. Its final assertion that every blocker is resolved therefore overstates the revised design's readiness."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 20,
+          "total": 77,
+          "notes": "The plan covers unit, compatibility, browser, deployment, rollback, and end-to-end cases with concrete requests and expected states. Several oracles are defective: the primary curl discards the body while requiring result.tools, the generated-location simulator ignores competing static locations, and the SSE expectation permits an unspecified upstream status. The grep intended to exclude ^~ locations does not exclude the caret, and the drift test exercises only the HTTPS template despite claiming coverage of both shipped configurations. The plan is extensive but unexecuted, and several registration endpoint shapes and deployment commands remain unverified."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 71,
+          "notes": "The supplied diff targets the cited generator symbols and implements the core trailing-slash prefix, exact internal rewrite, reserved-segment guard, inert stub, and focused unit tests consistently with the revised LLD. Its largest defect is that _NGINX_LOCATION_PATH_SAFE suppresses the exact helper for unsafe or otherwise non-allowlisted paths while _nginx_location_prefix still changes their location, contradicting the promise that legacy behavior is unchanged and potentially converting a working bare POST into a redirect. The reserved drift test reads only docker/nginx_rev_proxy_http_and_https.conf, and the tests explicitly accept omission of the helper without asserting backward-compatible bare-path behavior. The summary admits the project tests and nginx validation were not executed; local shell startup was unavailable, so git-apply applicability and surrounding source compatibility could not be independently confirmed and are treated as an evidence gap rather than an additional defect."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "macos-setup-python-version-precheck",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 27,
+      "input_tokens": 4515,
+      "output_tokens": 68815,
+      "total_tokens": 3302772,
+      "latency_seconds": 867.3,
+      "total_cost_usd": 4.07991125,
+      "result_subtype": "success",
+      "task_score": 80.2,
+      "cache_read_tokens": 3103835,
+      "cache_write_tokens": 125607,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 79.3,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 80,
+          "notes": "The issue provides unusually concrete markers, stopping behavior, source precedence, acceptance criteria, and non-goals. The submitted baseline context supports the presence-only `python3 --version` check, while the documented macOS prerequisite is Python 3.14+. Its largest weakness is that the claimed Phase 5 `uv sync` failure is not reproduced or tied to repository configuration disabling uv's automatic Python provisioning, and no independent task statement was supplied. It also leaves an unresolved interaction between an unavailable requirement and a missing interpreter: `PYTHON_FAIL` wins, but requirement-derived installation guidance then has no version."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 83,
+          "notes": "The LLD is strongly grounded in `.claude/skills/macos-setup/SKILL.md`, `INSTALL_DIR`, Phase 2, Phase 5, marker tokens, and the step log, with implementation-ready shell logic. Passing the version through `sys.argv`, bounding `curl`, validating numeric components, and capping tuple comparison at three components are sound decisions. The largest defects are that `docker-compose.yml` alone does not prove the directory is this repository and that `PYTHON_MIN` can be empty in both the missing-interpreter remediation and the later runbook command. Exact line-number, sibling-skill convention, and all-subproject metadata claims could not be independently confirmed because local repository command execution failed before reading the checkout."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 84,
+          "notes": "The review identifies concrete failure mechanisms, including malformed tuples, unsafe code interpolation, transport handling, source trust, default-mode halting, and PATH remediation, then records actionable resolutions. Its strongest evidence is reflected directly in the revised comparator using `sys.argv[1]`, a numeric allowlist, and a three-component slice. It misses the empty-`PYTHON_MIN` remediation path and accepts `docker-compose.yml` as repository identity even though the testing plan demonstrates that any unrelated directory can satisfy that gate; it also incorrectly describes ordinary TLS verification as certificate pinning. The quoted pre-revision interpolation defect cannot be checked against the submitted LLD because only the revised LLD is present."
+        },
+        "testing": {
+          "completeness": 23,
+          "correctness": 11,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 77,
+          "notes": "The plan covers all four markers, local and remote sources, malformed metadata, injection, compatibility, UX, and full-workflow stopping behavior with concrete output oracles. However, `sed -n '/^echo \"=== Python ===\"$/,/^fi$/p'` stops at the resolver's first `fi`, so the extracted script omits `PYTHON_MIN`, comparison logic, and every marker; most functional tests therefore cannot exercise the shipped behavior. The purportedly reliable no-Python test also sets `PATH` to a directory without `bash`, preventing the command from launching, while the injection test permits `PYTHON_OK` for malformed metadata. The scenarios are valuable, but the plan states they were not executed and its central harness requires correction."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The patch implements the revised design across the probe, marker documentation, remediation table, blocking instruction, step log, and error reference, and its hunk contexts align with the submitted baseline excerpts. The comparison itself is appropriately argv-based, bounded, and numeric for the repository's stated `>=3.14` value. The largest defect is that an unavailable requirement plus missing Python emits `PYTHON_FAIL` while rendering `brew install python@${PYTHON_MIN}` with an empty value; the runbook also relies on that transient variable outside the probe. Additionally, `docker-compose.yml` is an inadequate repository identity check and the extraction accepts a valid numeric prefix from otherwise malformed requirement text, so the summary overstates strict validation and trusted-local detection; the claimed `git apply --check` result could not be independently rerun."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-mcp-proxy-upstream-timeout",
+      "complexity": "medium",
+      "ref": "1.25.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 73,
+      "input_tokens": 20606,
+      "output_tokens": 89994,
+      "total_tokens": 13167510,
+      "latency_seconds": 1161.9,
+      "total_cost_usd": 10.118717749999998,
+      "result_subtype": "success",
+      "task_score": 79.2,
+      "cache_read_tokens": 12841713,
+      "cache_write_tokens": 215197,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 86,
+          "notes": "The issue precisely identifies the hardcoded AsyncClient timeout, affected proxy path, deployment surfaces, compatibility target, and testable acceptance criteria. The submitted baseline hunk corroborates auth_server/server.py using timeout=30.0 and preserving the existing 504 detail. Its largest weakness is describing the scalar httpx timeout as a strict total-duration ceiling and claiming byte-for-byte default behavior despite adding nginx timeout directives that can alter edge-case timing. No independent task statement was supplied, and issue-number history could not be independently verified."
+        },
+        "lld": {
+          "completeness": 24,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The LLD is unusually concrete about real files, symbols, configuration surfaces, rollout, observability, and nginx interaction. Its proposed changes align closely with the submitted source hunks for Settings, mcp_proxy, NginxConfigService, Helm, Compose, and Terraform. However, the settings-first helper makes its environment fallback largely unreachable once BaseSettings owns a defaulted field, so malformed deployment environment values can fail model construction before the promised warning and fallback; it also inserts nginx limits into common_settings rather than proving they apply only to the auth-server proxy branch. The design additionally treats httpx and nginx inactivity timeouts as total deadlines, weakening its guarantees about resource bounds and which component always returns the 504."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 78,
+          "notes": "The review finds substantive defects rather than merely approving the design, notably the missing upper bound, nginx's separate timeout, registry-side configuration propagation, and load-balancer limits. Its resolutions are prioritized and map to concrete fields, helpers, tests, and deployment files. It misses the BaseSettings precedence contradiction, the unconditional common_settings scope, and the fact that timeout activity can continue beyond the nominal scalar budget, while incorrectly presenting the ceiling as a complete slow-resource bound. Repository issue-history claims and the assertion that direct-to-8888 is unsupported were not independently verifiable."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 76,
+          "notes": "The plan spans focused unit tests, real route-level httpx assertions, nginx generation, compatibility, deployment rendering, rollback, and end-to-end long-call behavior with concrete expected values. The proposed unit tests meaningfully assert 30.0, 120.0, 35s, 305s, and the unchanged 504 body rather than merely checking execution. Its largest defect is accepting either clamping or startup ValidationError for an out-of-range environment value, which does not pin the issue's promised behavior, while the fallback tests artificially remove the Settings attribute instead of exercising normal configuration loading. It also omits a regression oracle for direct-transport locations and uses inconsistent authentication examples for /api/config between the LLD and testing plan."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 74,
+          "notes": "The patch implements the designed field, resolver, AsyncClient wiring, logging, admin exposure, nginx generation, deployment surfaces, documentation, and targeted tests rather than stopping at the call-site replacement. The auth_server/server.py hunk concretely removes timeout=30.0, passes the resolved value, and preserves the existing JSON 504 detail. The main defects are that malformed environment values can be rejected during Settings construction before the advertised fallback, and that timeout directives are added unconditionally to nginx common_settings, potentially changing direct-transport behavior without a regression test; inactivity semantics also invalidate the claim that the auth-server always times out first. The local sandbox failed before command execution, so git apply --check and independent source inspection were unavailable; applicability is therefore not independently verified, although the submitted paths and hunk contexts are internally consistent."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "derive-repo-url-from-skill-md",
+      "complexity": "medium",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 85,
+      "input_tokens": 6570,
+      "output_tokens": 81511,
+      "total_tokens": 16020128,
+      "latency_seconds": 1118.7,
+      "total_cost_usd": 11.2936675,
+      "result_subtype": "success",
+      "task_score": 78.2,
+      "cache_read_tokens": 15713435,
+      "cache_write_tokens": 218612,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 72.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 90,
+          "notes": "The issue provides unusually testable acceptance criteria, explicit non-goals, derivation examples, compatibility behavior, and both UI integration paths. The supplied baseline diff contexts corroborate key claims such as SkillInfo and the frontend Skill type lacking repository_url and both modals using View on GitHub. Its largest weakness is the unsupported assertion that most users omit the field, while no independent task statement establishes the full enterprise and semantic-search scope. Exact repository line references could not be independently re-read because shell execution failed at sandbox startup."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 15,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The LLD maps the data flow and named integration points in implementation-ready detail, including both SkillInfo construction sites, search metadata, form state, and modal rendering. Its central design error is that _extract_owner_repo validates only the first two segments and path length, so arbitrary GitHub paths such as /org/repo/issues are accepted despite the stated recognized-shapes-only contract. It also claims non-HTTP schemes cannot reach output and that logging is credential-safe, although ftp://github.com/org/repo/blob/main/SKILL.md derives successfully and debug messages interpolate the original credential-bearing URL. Leaving the file search backend unchanged also makes the semantic-search guarantee backend-dependent, and that claim could not be independently resolved through repository execution."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 76,
+          "notes": "The review identifies concrete defects\u2014especially positive owner/repository validation, credential removal from the rendered URL, index staleness, and search-plumbing scope\u2014and records actionable resolutions. Its largest miss is the load-bearing URL-shape flaw: every reviewer endorses taking the first two path segments without checking blob, raw, or SKILL.md structure. The security review also declares logging clean even though derive_repository_url logs the original input URL, which may contain userinfo. The findings are otherwise specific and prioritized, but exact source assertions could not be independently rerun in the unavailable shell."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The plan supplies concrete unit, API, compatibility, UX, build, and end-to-end oracles, with particularly strong credential, port, null-field, and stale-index coverage. It omits the cases that expose the implementation's main defect, such as GitHub /tree or /issues paths and a well-formed ftp://github.com URL; its javascript test has no parsed hostname and therefore proves little about scheme enforcement. The implementation also contains no automated API or component tests, and the E2E instructions delete the skill before the subsequent UI check. The proposed commands and endpoint payloads could not be independently executed because repository command execution was unavailable."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 72,
+          "notes": "The patch implements the design broadly across parsing, listing, search metadata, frontend types, form state, both modals, documentation, and 25 helper tests, with coherent baseline contexts in the submitted diff. The core helper does not actually recognize only supported SKILL.md shapes: any GitHub-like host with three path segments can derive a repository, and a well-formed non-HTTP URL such as ftp://github.com/org/repo/blob/main/SKILL.md also produces an HTTPS result. Debug logging includes the original URL and can expose embedded credentials, while the unchanged file search backend may omit repository_url; neither risk is covered by the added tests. The summary also omits SemanticSearchResults.tsx from its file table and oversells rejection behavior, and git apply --check could not be independently run because the read-only shell failed before command execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "lifecycle-workflow-webhooks",
+      "complexity": "high",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 173,
+      "input_tokens": 8,
+      "output_tokens": 1362,
+      "total_tokens": 1653970,
+      "latency_seconds": 2195.4,
+      "total_cost_usd": 0.8805955,
+      "result_subtype": "success",
+      "task_score": 77.8,
+      "cache_read_tokens": 1649086,
+      "cache_write_tokens": 3514,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 0.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 87,
+          "notes": "The issue's strongest aspect is its unusually concrete acceptance contract across webhook payloads, list filtering, registration policy, permissions, observability, documentation, and deployment surfaces. It names real baseline symbols such as `LifecycleStatus`, `webhook_service.py`, the three scan hooks, and the server and agent PUT/PATCH endpoints represented in the patch. Its largest gap is the existing agent batch register/patch/replace surface evidenced by `agent_batch_service` and the batch tests, which is omitted despite claiming the controls cover every agent registration and lifecycle update. The absence of an independent task statement limits external requirement verification, and the claim that leaking only the receiver URL defeats an already-verified bearer token overstates HMAC's incremental protection."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 17,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 80,
+          "notes": "The LLD is highly repository-specific and commits to important decisions including raw `content=` transmission, `model_fields_set` for omitted statuses, filtered-path `total_count`, and gates on PUT as well as PATCH. Its largest correctness defect is `status_change_requested`, which treats an explicitly supplied null or blank status as no change even though `ServerUpdateRequest.status` permits null and the design itself states server PUT previously persisted null, leaving a lifecycle-permission bypass. It also omits the agent batch register, patch, and replace processors, so both the initial-status mandate and lifecycle gate are incomplete for an established API surface. The Terraform design injects the HMAC secret through the ECS plaintext `environment` list while recommending a Secrets Manager reference, which ECS will not resolve without a `secrets.valueFrom` mapping."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 82,
+          "notes": "The review finds several genuine load-bearing defects, especially signing different bytes than those transmitted, PUT bypasses, omitted-status corruption, implicit admin bypass, and inaccurate filtered counts. Findings such as Byte-1, Byte-2, Cipher-2, and Circuit-1 include concrete consequences and actionable resolutions rather than generic role approval. Its largest deficiency is approving the lifecycle gate without noticing the explicit-null bypass or the existing agent batch mutation paths shown by the repository's batch imports and tests. The SRE review also recommends a Secrets Manager reference while overlooking that the proposed ECS task definition places the value in ordinary environment variables."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 72,
+          "notes": "The plan covers unit, compatibility, deployment, functional, and end-to-end levels with strong oracles for exact signed bytes, invalid filters, mandate mismatches, permission denials, and PUT status preservation. Several status-filter checks can pass vacuously without deterministic draft, beta, and active fixtures, while the permission scenarios depend on an undefined `lob-owned` asset and `$CSRF` setup. The receiver is bound to `127.0.0.1` while the container targets `host.docker.internal`, and using an unreachable proxy URL is not a reliable way to force the scanner itself to raise. No tests cover explicit null status updates or agent batch register, patch, and replace, which are the most consequential untested bypasses."
+        },
+        "implementation": {
+          "completeness": 16,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 68,
+          "notes": "The patch substantially implements the design through a centralized `_post_event`, exact-byte HMAC signing, scan summaries, lifecycle helpers, route wiring, scope configuration, metrics, documentation, and deployment parameters. The visible contexts target plausible baseline symbols including `_perform_security_scan_on_registration`, `update_server_endpoint`, `patch_agent`, `update_skill`, and `send_registration_webhook`, but the submission's `git apply --check` claim could not be independently confirmed from the available evidence. The largest defect is incomplete authorization coverage: agent batch register, patch, and replace paths are untouched, and explicit null or blank server status values evade `change_lifecycle_status` because `status_change_requested` returns false. The signing secret is also placed directly in the ECS environment and Terraform state, while the summary overstates backward compatibility despite immediately restricting existing non-admin status changes and requiring manual DocumentDB scope updates."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "idp-authenticated-embedding-endpoint",
+      "complexity": "high",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 113,
+      "input_tokens": 25453,
+      "output_tokens": 118214,
+      "total_tokens": 26755385,
+      "latency_seconds": 1547.6,
+      "total_cost_usd": 18.097903,
+      "result_subtype": "success",
+      "task_score": 77.0,
+      "cache_read_tokens": 26314426,
+      "cache_write_tokens": 297292,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 76.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 85,
+          "notes": "The issue is unusually concrete: it defines opt-in behavior, concurrency, retry bounds, validation, deployment surfaces, non-goals, and testable acceptance criteria. Its repository claims align with the supplied contexts for LiteLLMClient, FederationAuthManager, and search_repository._get_embedding_model. The largest deficiency is that it requires the secret to never appear in an export while later artifacts preserve the existing explicitly confirmed sensitive-export path, and it overlooks permanent _embedding_unavailable latching after a transient token-endpoint failure. No independent task statement was supplied, so the candidate-defined scope cannot be verified beyond the task identifier and repository evidence."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 16,
+          "total": 77,
+          "notes": "The LLD is highly repository-specific, naming real integration points such as registry/embeddings/client.py, Settings.__init__, config_routes.CONFIG_GROUPS, and the ECS secret and IAM blocks. It makes clear decisions about token caching, TLS validation, bounded retries, compatibility, deployment, and rollback. Its largest design flaw is that clear_token() and get_token() are separate operations after a 401, so concurrent rejected calls can each clear a newly refreshed token and stampede the IdP; it also explicitly allows token failures to reach _embed_texts() and latch _embedding_unavailable without a recovery strategy. The asserted LiteLLM api_key-to-bearer behavior is not validated end-to-end, and the security analysis misses the entrypoint's unredacted token-URL logging and Terraform secret-state lifecycle."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 78,
+          "notes": "The review identifies many concrete repository-level defects, including the missing ECS IAM grant, the misleading entrypoint warning, TLS enforcement, expires_in coercion, and None-on-token-failure semantics. Recommendations are prioritized and tied to specific design changes rather than generic reviewer approval. Its claim that all blocking issues are resolved is too strong because it misses the concurrent 401 refresh race, permanent embedding-disable latch after transient IdP failure, Terraform's not-configured secret bypass, and unredacted entrypoint URL. It also accepts the privileged sensitive-export behavior without reconciling it with the issue's absolute no-export acceptance criterion."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 74,
+          "notes": "The unit plan has strong, concrete oracles for caching, buffered refresh, failure propagation, secret logging, per-call injection, bounded retry, startup validation, and compatibility. The supplied tests exercise the principal classes and retain the existing embeddings suite unchanged. The E2E harness is not executable as described: ACCEPT and STATE live inside separate stub processes with no control or inspection endpoint, so the plan cannot force revocation, count token requests, or prove the initial Authorization header. It also omits concurrent-401 coverage, expects a no-change Terraform plan despite unconditional new task-definition environment entries, and does not establish that the named search endpoints and config raw_value oracle match the repository."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 71,
+          "notes": "The patch implements the nominal flow end to end across Settings, LiteLLMClient, search_repository, tests, documentation, Compose, Terraform, Helm, and config masking, and its hunks use the expected repository symbols and conventions. The largest code defect is the non-atomic 401 path: concurrent callers can repeatedly clear and remint tokens, violating the promised single-flight behavior; transient token acquisition errors can also trigger the existing permanent _embedding_unavailable latch. Terraform substitutes not-configured when IdP mode is enabled without a client secret, bypassing application fail-fast validation, while the entrypoint logs EMBEDDINGS_IDP_TOKEN_URL without redact_url and the summary overstates unchanged/default behavior. The local sandbox could not execute git apply --check, so forward applicability and test execution remain independently unverified despite coherent submitted hunk context."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "portable-env-secret-generation-in-build-script",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 70,
+      "input_tokens": 1797,
+      "output_tokens": 131841,
+      "total_tokens": 13890462,
+      "latency_seconds": 1706.9,
+      "total_cost_usd": 11.520383250000002,
+      "result_subtype": "success",
+      "task_score": 75.8,
+      "cache_read_tokens": 13524309,
+      "cache_write_tokens": 232515,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 15,
+          "specificity": 23,
+          "risk_awareness": 16,
+          "total": 76,
+          "notes": "The issue precisely identifies the repeated sed-and-append sites, supplies reproducible acceptance checks, and defines unusually clear non-goals. Its largest weakness is unsupported impact analysis: shell sourcing uses the last assignment, so a surviving first empty assignment alone does not establish the asserted auth-server crash or Compose rejection. It also claims recurring METRICS_KEY_PEPPER rotation although the LLD later confirms its template entry is commented, so its guard stops firing after the first append. No independent task statement was supplied, leaving the proposed expansion into Keycloak cleanup and documentation only internally justified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 16,
+          "specificity": 24,
+          "risk_awareness": 18,
+          "total": 81,
+          "notes": "The LLD is highly concrete about build_and_run.sh, clean-keycloak.sh, the helper interface, stdin handling, validation, atomic replacement, and tests. Its largest design defect is the documented migration behavior: unchanged guards generate a fresh value, while _upsert discards previously appended valid values, potentially invalidating sessions or an initialized MongoDB volume. The claim that fresh-Linux behavior is byte-for-byte identical is also false because the old code deleted then appended, while the new helper replaces the placeholder in place. It discusses the resulting rotation but treats a warning and operator preparation as sufficient rather than designing backward-compatible value preservation."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 76,
+          "notes": "The review surfaces concrete concerns around preflight checks, fsync, temporary-file naming, duplicate warnings, and commented placeholders, with actionable resolutions tied to symbols in the LLD. Its largest omission is failure to challenge the one-time replacement of the effective existing secret; it instead approves that potentially service-breaking migration as strictly better. It also repeats the unproven first-assignment consumer model underlying the crash-loop and Compose-failure claims. The role-based presentation is verbose, but most findings are specific rather than generic approval theater."
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 15,
+          "specificity": 23,
+          "risk_awareness": 14,
+          "total": 74,
+          "notes": "The helper tests have concrete fixtures and strong oracles for replacement, duplicate collapse, formatting, permissions, input rejection, idempotence, and value non-disclosure. The plan nevertheless codifies the unsafe migration as expected behavior rather than testing preservation of the last effective credential. Several procedures are fragile or destructive, including unguarded git stash/pop, moving the helper, changing repository-directory permissions, and a rollback fallback using git reset --hard; multiple installer runs also hide failures with || true. The proposed /login and /api/servers workflow and some health endpoints were not established by the supplied task context."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 72,
+          "notes": "The patch consistently replaces the six build-script write sites and the Keycloak scrub operations, and the helper provides stdin-based values, validation, duplicate removal, same-directory replacement, and focused unit tests. Its largest defect is backward compatibility: the unchanged empty-placeholder guard generates a fresh secret, and _upsert then deletes the valid appended value currently used by last-wins consumers, which can break persistent credentials. The rewrite also changes symlink, ownership, ACL, extended-attribute, and newline-format behavior while claiming broad preservation, and the summary incorrectly includes METRICS_KEY_PEPPER among secrets rotating every BSD rerun. The candidate explicitly did not execute tests, and its claimed git apply verification could not be confirmed from the submitted diff alone."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "logout-id-token-hint-out-of-browser-url",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 80,
+      "input_tokens": 4326,
+      "output_tokens": 101281,
+      "total_tokens": 14524116,
+      "latency_seconds": 1332.9,
+      "total_cost_usd": 10.97185275,
+      "result_subtype": "success",
+      "task_score": 73.2,
+      "cache_read_tokens": 14208258,
+      "cache_write_tokens": 210251,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 76.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 80,
+          "notes": "The issue provides unusually concrete scope, compatibility cases, exclusions, and testable acceptance criteria. Its cited logout flow aligns with the submitted diff context around registry/auth/routes.py and auth_server/server.py. The largest flaw is an unresolved contradiction: logout_hint_id remains in an edge-visible browser query string while the criteria require that it never be logged, and the final IdP redirect still carries the ID token through the browser. No independent task statement exists, and the exact baseline line references could not be independently rechecked."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 83,
+          "notes": "The LLD commits to concrete interfaces, storage semantics, mixed-version behavior, metrics, rollout, and named repository integration points. Its design correctly calls for HINT_ID_BYTES = 32, atomic find_one_and_delete, read-time expiry enforcement, and validation at both trust boundaries. Its largest gap is that index-creation failure is treated as recoverable without addressing indefinite retention when the TTL index is absent; it also promises log hygiene without specifying edge query-string redaction. Claims about nginx exposure, Helm reserved names, and pristine baseline applicability could not be independently verified."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 78,
+          "notes": "The review finds several real, actionable defects, especially TTL-sweep lag, unbounded request bodies, read-after-write behavior, and database-query/header validation. Those findings map directly to concrete proposed symbols such as consume_logout_hint, LogoutHintRequest, and _create_logout_hint. Its largest weakness is declaring security finding C3 resolved even though the design deliberately places the bearer handle in an edge-visible URL and introduces no access-log redaction; it also misses the TTL-index initialization failure mode. Assertions that every blocker is resolved and that /internal/* is unreachable were not independently verifiable."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 74,
+          "notes": "The plan has strong behavior-level oracles for URL shape, compatibility, expiry, concurrency, encryption, metrics, WAF regression, and IdP-session termination. Several tests cannot work in the written sequence: section 1.2.1 consumes HINT_ID before 1.2.2 expects its first use to succeed, and section 1.3.1 deletes the session before 1.3.2 reuses the same cookie. Stopping the shared MongoDB in section 2.5 also prevents registry session resolution rather than isolating a hint-store outage, while the rollback exec command does not persist the environment change. The listed commands and endpoints could not be executed independently, so their repository compatibility remains unverified."
+        },
+        "implementation": {
+          "completeness": 16,
+          "correctness": 3,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 51,
+          "notes": "The patch broadly covers the designed code, configuration, metrics, documentation, and unit-test surfaces, but the core feature is nonfunctional. In auth_server/logout_hint_store.py, generate_hint_id() calls secrets.token_hex(HINT_ID_BYTES), yet HINT_ID_BYTES is never defined, causing every creation attempt and its new tests to fail; the endpoint therefore returns 500 and the registry always falls back to the legacy token URL. Additionally, a failed index creation caches _collection while leaving _indexes_created false, so indexes are never retried and encrypted hints may persist indefinitely without the TTL index. The summary honestly states tests were not run, but its claimed git apply --check result could not be independently reproduced."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-31"
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 88,
+      "notes": "The issue provides unusually concrete acceptance criteria covering encrypted storage, owner-scoped retrieval, expiry, revocation, compatibility, deployment surfaces, and the database-free authentication path. Its strongest evidence is the direct mapping to `oauth2_callback`, `validate_session_cookie`, `get_user_session_data`, and `POST /api/tokens/generate`, all of which are reflected in the submitted patch contexts. The largest weakness is the absent independent task statement, so requirements such as restoring the sidebar's provider-token display cannot be externally confirmed. It also says \"three new configuration parameters\" while defining four, a minor but testable scope inconsistency."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 82,
+      "notes": "The LLD is strongly grounded in named repository files and commits precise decisions for models, repository interfaces, endpoint behavior, encryption, expiry, deployment, and rollback. Its strongest technical work is the user-scoped hashed reference plus read-time expiry gate and naive-BSON datetime normalization. The major flaw is its concurrency claim: `delete_many({username})` followed by insertion under a fresh hashed `_id` is non-atomic, so concurrent logins can both insert and violate the promised one-record-per-user invariant. It also claims token-store failures cannot break login or logout without specifying bounded database timeouts, leaving those request paths vulnerable to long infrastructure stalls."
+    },
+    "review": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 83,
+      "notes": "The review surfaces concrete, consequential defects including timezone comparison failure, eventual TTL deletion, missing retrieval auditing, cacheability, logout revocation, and cross-service key agreement. Its dispositions are specific and visibly propagated into the LLD and patch, rather than merely recording reviewer personas or generic approval. The largest miss is that Byte endorses delete-before-insert and Sage accepts the scaling story without noticing that concurrent logins can leave multiple documents because the operations and differing `_id` values are not atomic. It also does not challenge the unbounded latency introduced by awaiting the token database during login and logout."
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 82,
+      "notes": "The plan supplies concrete setup, actions, status codes, response fields, database state checks, deployment checks, compatibility cases, and lifecycle oracles across unit, HTTP, UX, and end-to-end levels. It directly tests important negative behavior such as cross-user lookup, stale TTL records, key rotation, revocation, 503 handling, and plaintext absence. Its largest gap is concurrency: sequential re-login coverage cannot detect the non-atomic delete-and-insert race in the repository design. The stated cookie regression is also unreliable as implemented because itsdangerous conditionally compresses highly repetitive payloads, while the patch uses thousands of repeated characters and may therefore fail its expected oversized assertion. "
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 71,
+      "notes": "The patch implements the central flow across `auth_server/server.py`, a new encrypted DocumentDB repository, `/api/auth/oauth-tokens`, logout revocation, frontend retrieval, configuration surfaces, and focused tests. The largest correctness defect is the non-atomic `delete_many` then `replace_one` sequence, which permits concurrent logins to retain multiple live records despite the summary's one-record-per-user guarantee. The submitted cookie tests use compressible repeated-character token bodies, and the route tests cover the registry dependency but not the promised auth-server `validate_session_cookie` database-access invariant; the settings test also references `settings.session_max_age_seconds` without adding that field in this patch. Exact forward applicability could not be independently confirmed because the provided local shell sandbox failed before `git apply --check`, although the unified-diff contexts are internally coherent."
+    }
+  },
+  "task_score": 81.2,
+  "verdict": "The submission is detailed and largely implementation-ready, but its claimed single-record concurrency guarantee is incorrect and the implementation includes unreliable or incomplete regression tests.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T16:28:27.108105Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 539854,
+      "cached_input_tokens": 439287,
+      "cache_write_input_tokens": 82012,
+      "output_tokens": 11051,
+      "reasoning_output_tokens": 8662
+    },
+    "duration_ms": 226734
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "high",
+  "tags": [
+    "authentication",
+    "oauth",
+    "session",
+    "mongodb",
+    "encryption",
+    "auth-server",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-5[1m]",
+  "model_slug": "claude-opus-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 75.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 10714,
+    "output_tokens": 136725,
+    "cache_read_tokens": 37697632,
+    "cache_write_tokens": 320548,
+    "total_tokens": 38165619,
+    "total_cost_usd": 24.323936,
+    "latency_seconds": 1811.9,
+    "num_turns": 152,
+    "generation_tokens_per_sec": 75.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 10714,
+  "output_tokens": 136725,
+  "latency_seconds": 1811.9,
+  "num_turns": 152,
+  "total_cost_usd": 24.323936,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 37697632,
+  "cache_creation_tokens": 320548,
+  "run_started_at": "2026-08-31T09:41:46.857813Z",
+  "run_ended_at": "2026-08-31T10:11:58.853995Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 10714,
+    "output_tokens": 136725,
+    "cache_read_tokens": 37697632,
+    "cache_write_tokens": 320548,
+    "total_tokens": 38165619,
+    "total_cost_usd": 24.323936,
+    "latency_seconds": 1811.9,
+    "num_turns": 152,
+    "generation_tokens_per_sec": 75.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "server-side-oauth-token-storage",
+    "model": "us.anthropic.claude-opus-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 88,
+        "notes": "The issue provides unusually concrete acceptance criteria covering encrypted storage, owner-scoped retrieval, expiry, revocation, compatibility, deployment surfaces, and the database-free authentication path. Its strongest evidence is the direct mapping to `oauth2_callback`, `validate_session_cookie`, `get_user_session_data`, and `POST /api/tokens/generate`, all of which are reflected in the submitted patch contexts. The largest weakness is the absent independent task statement, so requirements such as restoring the sidebar's provider-token display cannot be externally confirmed. It also says \"three new configuration parameters\" while defining four, a minor but testable scope inconsistency."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 82,
+        "notes": "The LLD is strongly grounded in named repository files and commits precise decisions for models, repository interfaces, endpoint behavior, encryption, expiry, deployment, and rollback. Its strongest technical work is the user-scoped hashed reference plus read-time expiry gate and naive-BSON datetime normalization. The major flaw is its concurrency claim: `delete_many({username})` followed by insertion under a fresh hashed `_id` is non-atomic, so concurrent logins can both insert and violate the promised one-record-per-user invariant. It also claims token-store failures cannot break login or logout without specifying bounded database timeouts, leaving those request paths vulnerable to long infrastructure stalls."
+      },
+      "review": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 83,
+        "notes": "The review surfaces concrete, consequential defects including timezone comparison failure, eventual TTL deletion, missing retrieval auditing, cacheability, logout revocation, and cross-service key agreement. Its dispositions are specific and visibly propagated into the LLD and patch, rather than merely recording reviewer personas or generic approval. The largest miss is that Byte endorses delete-before-insert and Sage accepts the scaling story without noticing that concurrent logins can leave multiple documents because the operations and differing `_id` values are not atomic. It also does not challenge the unbounded latency introduced by awaiting the token database during login and logout."
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 82,
+        "notes": "The plan supplies concrete setup, actions, status codes, response fields, database state checks, deployment checks, compatibility cases, and lifecycle oracles across unit, HTTP, UX, and end-to-end levels. It directly tests important negative behavior such as cross-user lookup, stale TTL records, key rotation, revocation, 503 handling, and plaintext absence. Its largest gap is concurrency: sequential re-login coverage cannot detect the non-atomic delete-and-insert race in the repository design. The stated cookie regression is also unreliable as implemented because itsdangerous conditionally compresses highly repetitive payloads, while the patch uses thousands of repeated characters and may therefore fail its expected oversized assertion. "
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 71,
+        "notes": "The patch implements the central flow across `auth_server/server.py`, a new encrypted DocumentDB repository, `/api/auth/oauth-tokens`, logout revocation, frontend retrieval, configuration surfaces, and focused tests. The largest correctness defect is the non-atomic `delete_many` then `replace_one` sequence, which permits concurrent logins to retain multiple live records despite the summary's one-record-per-user guarantee. The submitted cookie tests use compressible repeated-character token bodies, and the route tests cover the registry dependency but not the promised auth-server `validate_session_cookie` database-access invariant; the settings test also references `settings.session_max_age_seconds` without adding that field in this patch. Exact forward applicability could not be independently confirmed because the provided local shell sandbox failed before `git apply --check`, although the unified-diff contexts are internally coherent."
+      }
+    },
+    "task_score": 81.2,
+    "verdict": "The submission is detailed and largely implementation-ready, but its claimed single-record concurrency guarantee is incorrect and the implementation includes unreliable or incomplete regression tests.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T16:28:27.108105Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 539854,
+        "cached_input_tokens": 439287,
+        "cache_write_input_tokens": 82012,
+        "output_tokens": 11051,
+        "reasoning_output_tokens": 8662
+      },
+      "duration_ms": 226734
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 81,
+      "notes": "The issue clearly identifies affected Dockerfiles, missing lockfiles, CPU-only PyTorch concerns, CI enforcement, and explicit non-goals. Its largest defect is claiming that `uv sync --frozen` makes a Docker build fail on a stale lockfile, when frozen mode deliberately uses the lock without checking it against `pyproject.toml`. Official uv documentation assigns that validation behavior to `--locked` or `uv lock --check`, not `--frozen`. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) No independent task statement was supplied, and repository command execution failed, so active-build-path and file-content claims could not all be independently verified."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 13,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 76,
+      "notes": "The LLD is unusually concrete about files, copy stages, virtual projects, dependency groups, CPU indexes, venv placement, CI matrix entries, and per-Dockerfile flags. Its central choice is nevertheless unsound: `--frozen` cannot provide the promised stale-manifest build failure, and the comparison matrix incorrectly says that it does. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The two MCP Dockerfiles also retain freshly resolved torch-related packages through `--inexact`, which uv documents as preserving packages outside the lock and therefore leaves a material reproducibility gap. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The submitted patch was truncated before the Dockerfile hunks and local source inspection was unavailable, so claims such as every project using `package = false` remain partly unverifiable."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 68,
+      "notes": "The review surfaces two concrete issues: drift in the hardcoded CI matrix and the unlocked torch/sentence-transformers installation protected by `--inexact`. Its largest deficiency is treating the latter as documentation-only and approving the design despite its conflict with the task's core reproducibility objective. It also misses the more fundamental distinction between `--frozen` and `--locked`, even though uv explicitly states that frozen mode skips lock freshness validation. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The matrix-completeness recommendation is actionable, but several approving reviewer sections add little scrutiny and repository-specific assertions could not be independently checked."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 68,
+      "notes": "The plan provides concrete commands and useful oracles for lock drift, CUDA packages, development-dependency leakage, runtime directives, and smoke tests. It does not build every edited image or server context, notably omitting `Dockerfile.mcp-server-cpu`, and it never proves that a Docker build itself rejects a stale lock under `--frozen`. The claimed dependency-version compatibility check merely confirms that manifests were not edited, while `version: latest` is described inaccurately as a pinned uv version. The proposed health paths, ports, and exact command compatibility could not be independently verified against the repository."
+    },
+    "implementation": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 17,
+      "risk_awareness": 13,
+      "total": 55,
+      "notes": "The visible patch concretely adds the nine-root CI workflow and a generated `auth_server/uv.lock`, while the summary consistently enumerates the intended Dockerfile, lockfile, and CPU-index changes. The implementation does not meet the promised build-time stale-lock behavior because it uses `uv sync --frozen`; official uv behavior requires `--locked` for that assertion. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) It also knowingly preserves unlocked packages with `--inexact` and changes torch from 2.9.1 to 2.13.0+cpu while claiming dependency bumps are out of scope, creating reproducibility and compatibility risk. The diff is truncated before most core hunks, and local `git apply --check` and source inspection could not run, so the claimed applicability and exact repository fit remain unverified."
+    }
+  },
+  "task_score": 69.6,
+  "verdict": "The submission is highly specific and operationally thoughtful, but its use of `--frozen` and retention of unlocked MCP dependencies undermine the central reproducibility guarantee.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:26:01.402674Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 810664,
+      "cached_input_tokens": 633966,
+      "cache_write_input_tokens": 131197,
+      "output_tokens": 9941,
+      "reasoning_output_tokens": 8528
+    },
+    "duration_ms": 291057
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "docker",
+    "build",
+    "uv",
+    "dependencies",
+    "reproducibility",
+    "ci",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 84.1,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1958,
+    "output_tokens": 97960,
+    "cache_read_tokens": 12890489,
+    "cache_write_tokens": 204365,
+    "total_tokens": 13194772,
+    "total_cost_usd": 4.0725263,
+    "latency_seconds": 1164.7,
+    "num_turns": 79,
+    "generation_tokens_per_sec": 84.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1958,
+  "output_tokens": 97960,
+  "latency_seconds": 1164.7,
+  "num_turns": 79,
+  "total_cost_usd": 4.0725263,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 12890489,
+  "cache_creation_tokens": 204365,
+  "run_started_at": "2026-08-30T22:40:39.136065Z",
+  "run_ended_at": "2026-08-30T23:00:03.872766Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1958,
+    "output_tokens": 97960,
+    "cache_read_tokens": 12890489,
+    "cache_write_tokens": 204365,
+    "total_tokens": 13194772,
+    "total_cost_usd": 4.0725263,
+    "latency_seconds": 1164.7,
+    "num_turns": 79,
+    "generation_tokens_per_sec": 84.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "build-docker-images-from-uv-lock",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 81,
+        "notes": "The issue clearly identifies affected Dockerfiles, missing lockfiles, CPU-only PyTorch concerns, CI enforcement, and explicit non-goals. Its largest defect is claiming that `uv sync --frozen` makes a Docker build fail on a stale lockfile, when frozen mode deliberately uses the lock without checking it against `pyproject.toml`. Official uv documentation assigns that validation behavior to `--locked` or `uv lock --check`, not `--frozen`. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) No independent task statement was supplied, and repository command execution failed, so active-build-path and file-content claims could not all be independently verified."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 13,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 76,
+        "notes": "The LLD is unusually concrete about files, copy stages, virtual projects, dependency groups, CPU indexes, venv placement, CI matrix entries, and per-Dockerfile flags. Its central choice is nevertheless unsound: `--frozen` cannot provide the promised stale-manifest build failure, and the comparison matrix incorrectly says that it does. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The two MCP Dockerfiles also retain freshly resolved torch-related packages through `--inexact`, which uv documents as preserving packages outside the lock and therefore leaves a material reproducibility gap. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The submitted patch was truncated before the Dockerfile hunks and local source inspection was unavailable, so claims such as every project using `package = false` remain partly unverifiable."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 68,
+        "notes": "The review surfaces two concrete issues: drift in the hardcoded CI matrix and the unlocked torch/sentence-transformers installation protected by `--inexact`. Its largest deficiency is treating the latter as documentation-only and approving the design despite its conflict with the task's core reproducibility objective. It also misses the more fundamental distinction between `--frozen` and `--locked`, even though uv explicitly states that frozen mode skips lock freshness validation. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The matrix-completeness recommendation is actionable, but several approving reviewer sections add little scrutiny and repository-specific assertions could not be independently checked."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 68,
+        "notes": "The plan provides concrete commands and useful oracles for lock drift, CUDA packages, development-dependency leakage, runtime directives, and smoke tests. It does not build every edited image or server context, notably omitting `Dockerfile.mcp-server-cpu`, and it never proves that a Docker build itself rejects a stale lock under `--frozen`. The claimed dependency-version compatibility check merely confirms that manifests were not edited, while `version: latest` is described inaccurately as a pinned uv version. The proposed health paths, ports, and exact command compatibility could not be independently verified against the repository."
+      },
+      "implementation": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 17,
+        "risk_awareness": 13,
+        "total": 55,
+        "notes": "The visible patch concretely adds the nine-root CI workflow and a generated `auth_server/uv.lock`, while the summary consistently enumerates the intended Dockerfile, lockfile, and CPU-index changes. The implementation does not meet the promised build-time stale-lock behavior because it uses `uv sync --frozen`; official uv behavior requires `--locked` for that assertion. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) It also knowingly preserves unlocked packages with `--inexact` and changes torch from 2.9.1 to 2.13.0+cpu while claiming dependency bumps are out of scope, creating reproducibility and compatibility risk. The diff is truncated before most core hunks, and local `git apply --check` and source inspection could not run, so the claimed applicability and exact repository fit remain unverified."
+      }
+    },
+    "task_score": 69.6,
+    "verdict": "The submission is highly specific and operationally thoughtful, but its use of `--frozen` and retention of unlocked MCP dependencies undermine the central reproducibility guarantee.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T04:26:01.402674Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 810664,
+        "cached_input_tokens": 633966,
+        "cache_write_input_tokens": 131197,
+        "output_tokens": 9941,
+        "reasoning_output_tokens": 8528
+      },
+      "duration_ms": 291057
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 87,
+      "notes": "The issue provides testable acceptance criteria, explicit exclusions, and exact CLI-to-API field mappings. Its largest flaw is claiming curl is the only alternative while also stating that the React modal already submits the required custom URLs. The named configure_egress_auth, EgressConfigRequest, and resolve_provider interfaces are consistent with the submitted patch contexts. Exact repository and issue references could not be independently shell-verified because the read-only execution wrapper failed before running commands."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 19,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 88,
+      "notes": "The LLD commits to concrete signatures, body construction, argparse choices, integration points, rollout, and security-validation ownership. Its largest defect is saying omitted required URLs may be persisted as None even though it also says resolve_provider validates before persistence; such a request should be rejected rather than silently overwrite those fields. The proposed appended parameters and five guarded body assignments precisely match the implementation diff. Exact line references and the claimed unhandled enum exception path remained independently unverifiable due the repository shell failure."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 81,
+      "notes": "The review gives prioritized recommendations on documentation, positional compatibility, parser validation, and deferred server behavior. Its principal weakness is elevating the questionable required-URL preservation claim into a blocker and presenting the enum-to-500 path without decisive evidence. The recommendation to append parameters and the identified documentation gap are concrete, but the claimed grep verification of callers is not demonstrated. Repository-side confirmation of those claims was unavailable because commands could not execute."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 79,
+      "notes": "The plan covers request inclusion and omission, command forwarding, valid enum values, built-in-provider compatibility, and help behavior with concrete oracles. The invalid-value test asserts only SystemExit(2), so it also passes on the pre-change unrecognized-argument failure, contradicting the checklist claim that every new test fails before the fix. The body assertions are strong, but no exact pytest command or automated server-success test proves the headline CLI workflow. Test harness compatibility with the checkout could not be independently executed in the available environment."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 89,
+      "notes": "The patch implements the full CLI-to-client path by appending five optional parameters, conditionally adding their JSON keys, adding five parser flags, and forwarding all values. The largest weakness is the non-discriminating invalid-choice test, although the actual choices declaration is correct and the remaining tests would catch an absent feature. The diff contexts consistently target RegistryClient.configure_egress_auth, cmd_egress_configure, and the existing egress-configure parser without changing server code or existing positional parameters. The claimed git apply check and test compatibility could not be independently rerun because the repository command wrapper failed before execution."
+    }
+  },
+  "task_score": 84.8,
+  "verdict": "Strong, narrowly scoped work with a sound implementation, limited mainly by mischaracterized edit semantics, an under-specified argparse failure oracle, and unavailable independent worktree verification.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:29:10.660107Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 275059,
+      "cached_input_tokens": 219964,
+      "cache_write_input_tokens": 47495,
+      "output_tokens": 9230,
+      "reasoning_output_tokens": 7393
+    },
+    "duration_ms": 189245
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "cli",
+    "python",
+    "egress-auth",
+    "oauth",
+    "api-parity",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 86.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2363,
+    "output_tokens": 55884,
+    "cache_read_tokens": 6774122,
+    "cache_write_tokens": 142798,
+    "total_tokens": 6975167,
+    "total_cost_usd": 2.2753854000000002,
+    "latency_seconds": 647.1,
+    "num_turns": 53,
+    "generation_tokens_per_sec": 86.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2363,
+  "output_tokens": 55884,
+  "latency_seconds": 647.1,
+  "num_turns": 53,
+  "total_cost_usd": 2.2753854000000002,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 6774122,
+  "cache_creation_tokens": 142798,
+  "run_started_at": "2026-08-30T23:18:18.707570Z",
+  "run_ended_at": "2026-08-30T23:29:05.816291Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2363,
+    "output_tokens": 55884,
+    "cache_read_tokens": 6774122,
+    "cache_write_tokens": 142798,
+    "total_tokens": 6975167,
+    "total_cost_usd": 2.2753854000000002,
+    "latency_seconds": 647.1,
+    "num_turns": 53,
+    "generation_tokens_per_sec": 86.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "cli-custom-egress-oauth-provider-flags",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 87,
+        "notes": "The issue provides testable acceptance criteria, explicit exclusions, and exact CLI-to-API field mappings. Its largest flaw is claiming curl is the only alternative while also stating that the React modal already submits the required custom URLs. The named configure_egress_auth, EgressConfigRequest, and resolve_provider interfaces are consistent with the submitted patch contexts. Exact repository and issue references could not be independently shell-verified because the read-only execution wrapper failed before running commands."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 19,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 88,
+        "notes": "The LLD commits to concrete signatures, body construction, argparse choices, integration points, rollout, and security-validation ownership. Its largest defect is saying omitted required URLs may be persisted as None even though it also says resolve_provider validates before persistence; such a request should be rejected rather than silently overwrite those fields. The proposed appended parameters and five guarded body assignments precisely match the implementation diff. Exact line references and the claimed unhandled enum exception path remained independently unverifiable due the repository shell failure."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 81,
+        "notes": "The review gives prioritized recommendations on documentation, positional compatibility, parser validation, and deferred server behavior. Its principal weakness is elevating the questionable required-URL preservation claim into a blocker and presenting the enum-to-500 path without decisive evidence. The recommendation to append parameters and the identified documentation gap are concrete, but the claimed grep verification of callers is not demonstrated. Repository-side confirmation of those claims was unavailable because commands could not execute."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 79,
+        "notes": "The plan covers request inclusion and omission, command forwarding, valid enum values, built-in-provider compatibility, and help behavior with concrete oracles. The invalid-value test asserts only SystemExit(2), so it also passes on the pre-change unrecognized-argument failure, contradicting the checklist claim that every new test fails before the fix. The body assertions are strong, but no exact pytest command or automated server-success test proves the headline CLI workflow. Test harness compatibility with the checkout could not be independently executed in the available environment."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 89,
+        "notes": "The patch implements the full CLI-to-client path by appending five optional parameters, conditionally adding their JSON keys, adding five parser flags, and forwarding all values. The largest weakness is the non-discriminating invalid-choice test, although the actual choices declaration is correct and the remaining tests would catch an absent feature. The diff contexts consistently target RegistryClient.configure_egress_auth, cmd_egress_configure, and the existing egress-configure parser without changing server code or existing positional parameters. The claimed git apply check and test compatibility could not be independently rerun because the repository command wrapper failed before execution."
+      }
+    },
+    "task_score": 84.8,
+    "verdict": "Strong, narrowly scoped work with a sound implementation, limited mainly by mischaracterized edit semantics, an under-specified argparse failure oracle, and unavailable independent worktree verification.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T04:29:10.660107Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 275059,
+        "cached_input_tokens": 219964,
+        "cache_write_input_tokens": 47495,
+        "output_tokens": 9230,
+        "reasoning_output_tokens": 7393
+      },
+      "duration_ms": 189245
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 85,
+      "notes": "The issue provides a crisp problem, explicit non-goals, deployment scope, and acceptance criteria with concrete defaults and testable outcomes. The submitted diff corroborates the central `auth_server/server.py` hardcoded `timeout=30.0` claim and the named configuration surfaces. Its largest weakness is prescribing an arbitrary five-second floor and a broad solution before repository or task evidence establishes that values below five are unusable. No independent task statement was supplied, and the cited Issue #1026/#1320 history could not be independently verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 84,
+      "notes": "The LLD is highly implementation-ready, naming exact fields, helper behavior, route data flow, Terraform propagation, Helm rendering, validation semantics, and rollback behavior. Its proposed contexts match the submitted preimages for `_read_mcp_proxy_max_body_bytes`, `mcp_proxy`, `Settings`, and `CONFIG_GROUPS`. The largest design gap is treating `settings` as effectively shared across services: the admin export runs from registry settings while ECS and Helm inject the new value only into auth-server, so it may display the default rather than the deployed effective value. The five-second floor remains weakly justified, and claims about exact line locations and the complete deployment footprint could not be independently checked."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 19,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 79,
+      "notes": "The review surfaces concrete, actionable concerns about zero-value denial of service, ingress timeout interaction, and the distinction between startup rejection and defensive runtime clamping. Each finding has a consequence and a documented resolution in the revised LLD rather than generic persona approval. Its largest omission is failing to challenge the cross-process admin-config value problem or the absence of a direct environment-to-`Settings` integration test. Claims about generic UI rendering and the completeness of every deployment surface remain asserted rather than demonstrated."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 76,
+      "notes": "The plan supplies meaningful oracles for defaults, overrides, both clamp paths, Pydantic rejection, route-to-`AsyncClient` wiring, admin exposure, and deployment rendering. The most concrete correctness defect is recommending `uv run python -m unittest discover -s tests` for tests written as pytest classes using `monkeypatch` and pytest marks, so that command would not reliably execute the proposed coverage. It also never tests that `MCP_PROXY_UPSTREAM_TIMEOUT_SECONDS` is actually bound by a fresh `Settings()` instance; setting the singleton attribute to `None` only exercises the defensive fallback. Several Terraform, Helm, and Compose checks are manual or toolchain-dependent, and their repository-specific invocations could not be independently validated."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 82,
+      "notes": "The patch implements the core change end to end: a validated settings field, a sibling reader helper, route wiring into `httpx.AsyncClient`, deployment propagation, documentation, and focused unit tests. Its hunks are internally consistent with the supplied source contexts and preserve the existing timeout-to-504 path while retaining the 30-second default. The largest limitation is that registry-side config export can report a different value from the auth-server-only ECS/Helm environment, and no test proves real environment binding across that boundary; the summary also says 18 files although its table and diff contain 19. Local shell sandbox failure prevented independently rerunning `git apply --check` or the repository test suite, so the candidate's applicability claim remains unverified rather than contradicted."
+    }
+  },
+  "task_score": 81.2,
+  "verdict": "A strong and detailed core implementation, limited primarily by cross-process config-surface accuracy and incomplete verification of actual environment binding and test execution.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:32:53.345222Z",
+    "repo_ref": "1.25.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 314768,
+      "cached_input_tokens": 240504,
+      "cache_write_input_tokens": 43246,
+      "output_tokens": 13498,
+      "reasoning_output_tokens": 11090
+    },
+    "duration_ms": 222673
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.25.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "config",
+    "auth-server",
+    "httpx",
+    "proxy",
+    "timeouts",
+    "fixed-in-1.26.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 86.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4779,
+    "output_tokens": 66908,
+    "cache_read_tokens": 9414789,
+    "cache_write_tokens": 280706,
+    "total_tokens": 9767182,
+    "total_cost_usd": 3.263360799999999,
+    "latency_seconds": 769.6,
+    "num_turns": 67,
+    "generation_tokens_per_sec": 86.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4779,
+  "output_tokens": 66908,
+  "latency_seconds": 769.6,
+  "num_turns": 67,
+  "total_cost_usd": 3.263360799999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 9414789,
+  "cache_creation_tokens": 280706,
+  "run_started_at": "2026-08-31T00:18:40.247264Z",
+  "run_ended_at": "2026-08-31T00:31:29.834713Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4779,
+    "output_tokens": 66908,
+    "cache_read_tokens": 9414789,
+    "cache_write_tokens": 280706,
+    "total_tokens": 9767182,
+    "total_cost_usd": 3.263360799999999,
+    "latency_seconds": 769.6,
+    "num_turns": 67,
+    "generation_tokens_per_sec": 86.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-mcp-proxy-upstream-timeout",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 85,
+        "notes": "The issue provides a crisp problem, explicit non-goals, deployment scope, and acceptance criteria with concrete defaults and testable outcomes. The submitted diff corroborates the central `auth_server/server.py` hardcoded `timeout=30.0` claim and the named configuration surfaces. Its largest weakness is prescribing an arbitrary five-second floor and a broad solution before repository or task evidence establishes that values below five are unusable. No independent task statement was supplied, and the cited Issue #1026/#1320 history could not be independently verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 84,
+        "notes": "The LLD is highly implementation-ready, naming exact fields, helper behavior, route data flow, Terraform propagation, Helm rendering, validation semantics, and rollback behavior. Its proposed contexts match the submitted preimages for `_read_mcp_proxy_max_body_bytes`, `mcp_proxy`, `Settings`, and `CONFIG_GROUPS`. The largest design gap is treating `settings` as effectively shared across services: the admin export runs from registry settings while ECS and Helm inject the new value only into auth-server, so it may display the default rather than the deployed effective value. The five-second floor remains weakly justified, and claims about exact line locations and the complete deployment footprint could not be independently checked."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 19,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 79,
+        "notes": "The review surfaces concrete, actionable concerns about zero-value denial of service, ingress timeout interaction, and the distinction between startup rejection and defensive runtime clamping. Each finding has a consequence and a documented resolution in the revised LLD rather than generic persona approval. Its largest omission is failing to challenge the cross-process admin-config value problem or the absence of a direct environment-to-`Settings` integration test. Claims about generic UI rendering and the completeness of every deployment surface remain asserted rather than demonstrated."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 76,
+        "notes": "The plan supplies meaningful oracles for defaults, overrides, both clamp paths, Pydantic rejection, route-to-`AsyncClient` wiring, admin exposure, and deployment rendering. The most concrete correctness defect is recommending `uv run python -m unittest discover -s tests` for tests written as pytest classes using `monkeypatch` and pytest marks, so that command would not reliably execute the proposed coverage. It also never tests that `MCP_PROXY_UPSTREAM_TIMEOUT_SECONDS` is actually bound by a fresh `Settings()` instance; setting the singleton attribute to `None` only exercises the defensive fallback. Several Terraform, Helm, and Compose checks are manual or toolchain-dependent, and their repository-specific invocations could not be independently validated."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 82,
+        "notes": "The patch implements the core change end to end: a validated settings field, a sibling reader helper, route wiring into `httpx.AsyncClient`, deployment propagation, documentation, and focused unit tests. Its hunks are internally consistent with the supplied source contexts and preserve the existing timeout-to-504 path while retaining the 30-second default. The largest limitation is that registry-side config export can report a different value from the auth-server-only ECS/Helm environment, and no test proves real environment binding across that boundary; the summary also says 18 files although its table and diff contain 19. Local shell sandbox failure prevented independently rerunning `git apply --check` or the repository test suite, so the candidate's applicability claim remains unverified rather than contradicted."
+      }
+    },
+    "task_score": 81.2,
+    "verdict": "A strong and detailed core implementation, limited primarily by cross-process config-surface accuracy and incomplete verification of actual environment binding and test execution.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T04:32:53.345222Z",
+      "repo_ref": "1.25.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 314768,
+        "cached_input_tokens": 240504,
+        "cache_write_input_tokens": 43246,
+        "output_tokens": 13498,
+        "reasoning_output_tokens": 11090
+      },
+      "duration_ms": 222673
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-ui-title",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 19,
+      "total": 85,
+      "notes": "The issue precisely identifies the affected UI locations, API fields, deployment surfaces, defaults, and explicit non-goals. Its largest defect is the claim that unset UI_TITLE causes no behavioral change, which contradicts the required registry-only title change from the current hardcoded value. The submitted patch contains matching paths for Layout.tsx, Login.tsx, Logout.tsx, both config endpoints, and all named infrastructure surfaces. No independent task statement exists, and exact baseline-source verification was unavailable because repository shell commands failed before execution."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 86,
+      "notes": "The LLD is unusually concrete about Settings.effective_ui_title, CONFIG_GROUPS, useRegistryConfig, infrastructure wiring, fallbacks, and rejected alternatives. Its largest deficiency is internal inconsistency: it repeatedly calls the rollout behavior-preserving although registry-only deployments intentionally change, and its file table still reports zero tests despite later requiring TestEffectiveUiTitle. The submitted diff contexts support the named symbols and integration shape, including the generic computed-property field and Helm reserved-name guard. Exact line references, caching details, and applicability to commit 0038b687 could not be independently verified because repository reads were unavailable."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 84,
+      "notes": "The review surfaces concrete frontend, backend, infrastructure, and security concerns and produces an actionable unit-test addition based on TestNginxUpdatesEnabled. Its weakest decision is dismissing frontend regression tests and central parameter documentation primarily because they were absent from acceptance criteria, while also missing the design's contradictory compatibility claim. The patch confirms that the recommended TestEffectiveUiTitle and UI_TITLE reserved-name protection were implemented. Claims about repository-wide document.title searches and exact existing coverage patterns could not be independently verified due the repository-tool failure."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 77,
+      "notes": "The plan covers derivation, APIs, mixed-version compatibility, three UI locations, rollback, and each deployment surface with specific expected values. Its primary unit command is wrong: python -m unittest will not collect the submitted plain pytest class, and the Terraform target contradicts the patch's nested module ecs_service_registry structure. Several startup commands remain placeholders, and the stack-chart test omits the dependency-build step that may be required. Despite those execution defects, the behavioral oracles for empty, overridden, registry-only, escaping, reserved-name, and rollback cases are strong."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 86,
+      "notes": "The patch implements the described flow end to end: backend derivation and APIs, all three React consumers, Docker, Terraform/ECS, Helm, and five focused property tests. The code shown is internally coherent, preserves the with-gateway fallback, safely uses JSX text interpolation, and conditionally renders the Helm variable while reserving its name. Its largest limitation is that automated coverage stops at the computed property, leaving the API response, frontend consumers, and deployment templates dependent on unexecuted manual checks; the central parameter reference is also deferred. The claimed clean git application and correspondence with the actual baseline could not be independently confirmed because every repository shell invocation failed before running."
+    }
+  },
+  "task_score": 83.6,
+  "verdict": "This is strong, repository-specific work with a coherent implementation, but its verification plan contains nonfunctional commands and the exact patch applicability could not be independently confirmed.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:36:17.165647Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 210019,
+      "cached_input_tokens": 150483,
+      "cache_write_input_tokens": 39787,
+      "output_tokens": 9712,
+      "reasoning_output_tokens": 8205
+    },
+    "duration_ms": 203808
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "configurable-ui-title",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "ui",
+    "react",
+    "config",
+    "branding",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 78.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 10609,
+    "output_tokens": 75510,
+    "cache_read_tokens": 16338912,
+    "cache_write_tokens": 203808,
+    "total_tokens": 16628839,
+    "total_cost_usd": 4.553620400000001,
+    "latency_seconds": 958.3,
+    "num_turns": 96,
+    "generation_tokens_per_sec": 78.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 10609,
+  "output_tokens": 75510,
+  "latency_seconds": 958.3,
+  "num_turns": 96,
+  "total_cost_usd": 4.553620400000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 16338912,
+  "cache_creation_tokens": 203808,
+  "run_started_at": "2026-08-31T00:02:38.969986Z",
+  "run_ended_at": "2026-08-31T00:18:37.299780Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 10609,
+    "output_tokens": 75510,
+    "cache_read_tokens": 16338912,
+    "cache_write_tokens": 203808,
+    "total_tokens": 16628839,
+    "total_cost_usd": 4.553620400000001,
+    "latency_seconds": 958.3,
+    "num_turns": 96,
+    "generation_tokens_per_sec": 78.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-ui-title",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 19,
+        "total": 85,
+        "notes": "The issue precisely identifies the affected UI locations, API fields, deployment surfaces, defaults, and explicit non-goals. Its largest defect is the claim that unset UI_TITLE causes no behavioral change, which contradicts the required registry-only title change from the current hardcoded value. The submitted patch contains matching paths for Layout.tsx, Login.tsx, Logout.tsx, both config endpoints, and all named infrastructure surfaces. No independent task statement exists, and exact baseline-source verification was unavailable because repository shell commands failed before execution."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 86,
+        "notes": "The LLD is unusually concrete about Settings.effective_ui_title, CONFIG_GROUPS, useRegistryConfig, infrastructure wiring, fallbacks, and rejected alternatives. Its largest deficiency is internal inconsistency: it repeatedly calls the rollout behavior-preserving although registry-only deployments intentionally change, and its file table still reports zero tests despite later requiring TestEffectiveUiTitle. The submitted diff contexts support the named symbols and integration shape, including the generic computed-property field and Helm reserved-name guard. Exact line references, caching details, and applicability to commit 0038b687 could not be independently verified because repository reads were unavailable."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 84,
+        "notes": "The review surfaces concrete frontend, backend, infrastructure, and security concerns and produces an actionable unit-test addition based on TestNginxUpdatesEnabled. Its weakest decision is dismissing frontend regression tests and central parameter documentation primarily because they were absent from acceptance criteria, while also missing the design's contradictory compatibility claim. The patch confirms that the recommended TestEffectiveUiTitle and UI_TITLE reserved-name protection were implemented. Claims about repository-wide document.title searches and exact existing coverage patterns could not be independently verified due the repository-tool failure."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 77,
+        "notes": "The plan covers derivation, APIs, mixed-version compatibility, three UI locations, rollback, and each deployment surface with specific expected values. Its primary unit command is wrong: python -m unittest will not collect the submitted plain pytest class, and the Terraform target contradicts the patch's nested module ecs_service_registry structure. Several startup commands remain placeholders, and the stack-chart test omits the dependency-build step that may be required. Despite those execution defects, the behavioral oracles for empty, overridden, registry-only, escaping, reserved-name, and rollback cases are strong."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 86,
+        "notes": "The patch implements the described flow end to end: backend derivation and APIs, all three React consumers, Docker, Terraform/ECS, Helm, and five focused property tests. The code shown is internally coherent, preserves the with-gateway fallback, safely uses JSX text interpolation, and conditionally renders the Helm variable while reserving its name. Its largest limitation is that automated coverage stops at the computed property, leaving the API response, frontend consumers, and deployment templates dependent on unexecuted manual checks; the central parameter reference is also deferred. The claimed clean git application and correspondence with the actual baseline could not be independently confirmed because every repository shell invocation failed before running."
+      }
+    },
+    "task_score": 83.6,
+    "verdict": "This is strong, repository-specific work with a coherent implementation, but its verification plan contains nonfunctional commands and the exact patch applicability could not be independently confirmed.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T04:36:17.165647Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 210019,
+        "cached_input_tokens": 150483,
+        "cache_write_input_tokens": 39787,
+        "output_tokens": 9712,
+        "reasoning_output_tokens": 8205
+      },
+      "duration_ms": 203808
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 79,
+      "notes": "The issue clearly identifies the bearer-client failure, browser-session exposure, affected routes, non-goals, and observable 200/403 outcomes. Its largest defect is contradictory acceptance language: it requires bearer-only success on all five user-facing endpoints even though `/api/toggle/{service_path}` uses session-only `enhanced_auth`, and it initially says all six receive consistent dependencies while explicitly exempting `/api/internal/toggle`. The submitted route contexts support the distinction between `nginx_proxied_auth`, `enhanced_auth`, and `validate_internal_auth`, while the repository release record confirms this CSRF/bearer compatibility problem was fixed in v1.0.21. No independent task statement was supplied, so broader requirement coverage and the claim that every M2M registration pipeline was affected cannot be fully verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 86,
+      "notes": "The LLD commits to a concrete request-level rule, names the actual functions and files, explains form versus JSON token transport, and provides implementable route signatures and failure behavior. Its main gap is that changing the shared `verify_csrf_token_flexible` dependency alters non-toggle callers such as logout, edit forms, and ANS routes without a complete caller audit or regression coverage, while it also fails to reconcile the issue's impossible bearer-success criterion for the session-only UI route. The patch confirms the named integration points exist: `registry/auth/csrf.py`, `toggle_service_api`, `toggle_virtual_server`, and the already-dependent agent and skill routes. Claims about every endpoint's audit logging and all frontend call paths could not be independently verified from the local repository because command execution failed before file access."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 22,
+      "total": 84,
+      "notes": "The review surfaces three concrete improvements with consequences and resolutions: accurate route documentation, a cookie-plus-Authorization invariant test, and documentation of the internal endpoint's intentional exclusion. It does not challenge the issue/LLD contradiction concerning bearer access to the session-only UI route, and Pixel's discussion inconsistently says the newly protected virtual-server endpoint is not called directly while grouping its UI flow with already-protected routes. The implementation diff shows all three recommended changes were actually carried forward into comments, docstrings, and tests. Assertions about `AuthContext.tsx`, template call sites, proxy header stripping, and the absence of external callers were not independently verifiable."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 79,
+      "notes": "The plan has strong dependency-level matrices, exact status/detail oracles, negative cases, token/session mismatch coverage, and the important cookie-plus-bearer-header invariant. Its principal weakness is claiming browser compatibility is covered by existing tests that override the CSRF dependency to a no-op; those tests cannot prove a valid cookie and token traverse the real route dependency successfully, and the plan does not add that case consistently across agent, server, and virtual-server routes. The supplied patch implements the proposed direct tests and bearer/cookie route tests, but only the skill route includes a real valid-cookie-plus-valid-token success test. The suggested `python -m unittest discover` command is unreliable for these pytest-style tests, although the alternative `uv run pytest` command is appropriate."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 82,
+      "notes": "The production patch implements the central design end to end by moving the cookie decision into `verify_csrf_token_flexible` and adding the dependency to the server and virtual-server toggle routes, while honestly documenting the test-location deviation. The strongest evidence is the coherent diff across eight files, including direct validation tests and route tests for both newly protected endpoints plus the already-protected agent and skill endpoints. The largest remaining weakness is uneven route-level success coverage for valid cookie-bound CSRF tokens; additionally, `if not session_id` technically exempts an explicitly present empty cookie despite the stated invariant being based on cookie presence. Local `git apply --check` and fixture compatibility could not be independently rerun because the repository command sandbox failed before execution, so the summary's applicability and test-compatibility claims remain partially unverified."
+    }
+  },
+  "task_score": 82.0,
+  "verdict": "This is a strong, repository-specific security change with coherent implementation, limited chiefly by contradictory endpoint acceptance language, uneven real-dependency compatibility tests, and incomplete independent applicability verification.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:42:54.033182Z",
+    "repo_ref": "v1.0.20",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 436514,
+      "cached_input_tokens": 320559,
+      "cache_write_input_tokens": 48102,
+      "output_tokens": 12520,
+      "reasoning_output_tokens": 10019
+    },
+    "duration_ms": 396856
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.20",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "csrf",
+    "authentication",
+    "api",
+    "fastapi",
+    "m2m",
+    "fixed-in-1.0.21"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 80.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 13431,
+    "output_tokens": 91121,
+    "cache_read_tokens": 17983026,
+    "cache_write_tokens": 473468,
+    "total_tokens": 18561046,
+    "total_cost_usd": 5.718347199999999,
+    "latency_seconds": 1132.8,
+    "num_turns": 94,
+    "generation_tokens_per_sec": 80.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 13431,
+  "output_tokens": 91121,
+  "latency_seconds": 1132.8,
+  "num_turns": 94,
+  "total_cost_usd": 5.718347199999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 17983026,
+  "cache_creation_tokens": 473468,
+  "run_started_at": "2026-08-30T23:43:43.373576Z",
+  "run_ended_at": "2026-08-31T00:02:36.194844Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 13431,
+    "output_tokens": 91121,
+    "cache_read_tokens": 17983026,
+    "cache_write_tokens": 473468,
+    "total_tokens": 18561046,
+    "total_cost_usd": 5.718347199999999,
+    "latency_seconds": 1132.8,
+    "num_turns": 94,
+    "generation_tokens_per_sec": 80.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "consistent-csrf-across-toggle-endpoints",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 79,
+        "notes": "The issue clearly identifies the bearer-client failure, browser-session exposure, affected routes, non-goals, and observable 200/403 outcomes. Its largest defect is contradictory acceptance language: it requires bearer-only success on all five user-facing endpoints even though `/api/toggle/{service_path}` uses session-only `enhanced_auth`, and it initially says all six receive consistent dependencies while explicitly exempting `/api/internal/toggle`. The submitted route contexts support the distinction between `nginx_proxied_auth`, `enhanced_auth`, and `validate_internal_auth`, while the repository release record confirms this CSRF/bearer compatibility problem was fixed in v1.0.21. No independent task statement was supplied, so broader requirement coverage and the claim that every M2M registration pipeline was affected cannot be fully verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 86,
+        "notes": "The LLD commits to a concrete request-level rule, names the actual functions and files, explains form versus JSON token transport, and provides implementable route signatures and failure behavior. Its main gap is that changing the shared `verify_csrf_token_flexible` dependency alters non-toggle callers such as logout, edit forms, and ANS routes without a complete caller audit or regression coverage, while it also fails to reconcile the issue's impossible bearer-success criterion for the session-only UI route. The patch confirms the named integration points exist: `registry/auth/csrf.py`, `toggle_service_api`, `toggle_virtual_server`, and the already-dependent agent and skill routes. Claims about every endpoint's audit logging and all frontend call paths could not be independently verified from the local repository because command execution failed before file access."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 22,
+        "total": 84,
+        "notes": "The review surfaces three concrete improvements with consequences and resolutions: accurate route documentation, a cookie-plus-Authorization invariant test, and documentation of the internal endpoint's intentional exclusion. It does not challenge the issue/LLD contradiction concerning bearer access to the session-only UI route, and Pixel's discussion inconsistently says the newly protected virtual-server endpoint is not called directly while grouping its UI flow with already-protected routes. The implementation diff shows all three recommended changes were actually carried forward into comments, docstrings, and tests. Assertions about `AuthContext.tsx`, template call sites, proxy header stripping, and the absence of external callers were not independently verifiable."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 79,
+        "notes": "The plan has strong dependency-level matrices, exact status/detail oracles, negative cases, token/session mismatch coverage, and the important cookie-plus-bearer-header invariant. Its principal weakness is claiming browser compatibility is covered by existing tests that override the CSRF dependency to a no-op; those tests cannot prove a valid cookie and token traverse the real route dependency successfully, and the plan does not add that case consistently across agent, server, and virtual-server routes. The supplied patch implements the proposed direct tests and bearer/cookie route tests, but only the skill route includes a real valid-cookie-plus-valid-token success test. The suggested `python -m unittest discover` command is unreliable for these pytest-style tests, although the alternative `uv run pytest` command is appropriate."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 82,
+        "notes": "The production patch implements the central design end to end by moving the cookie decision into `verify_csrf_token_flexible` and adding the dependency to the server and virtual-server toggle routes, while honestly documenting the test-location deviation. The strongest evidence is the coherent diff across eight files, including direct validation tests and route tests for both newly protected endpoints plus the already-protected agent and skill endpoints. The largest remaining weakness is uneven route-level success coverage for valid cookie-bound CSRF tokens; additionally, `if not session_id` technically exempts an explicitly present empty cookie despite the stated invariant being based on cookie presence. Local `git apply --check` and fixture compatibility could not be independently rerun because the repository command sandbox failed before execution, so the summary's applicability and test-compatibility claims remain partially unverified."
+      }
+    },
+    "task_score": 82.0,
+    "verdict": "This is a strong, repository-specific security change with coherent implementation, limited chiefly by contradictory endpoint acceptance language, uneven real-dependency compatibility tests, and incomplete independent applicability verification.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T04:42:54.033182Z",
+      "repo_ref": "v1.0.20",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 436514,
+        "cached_input_tokens": 320559,
+        "cache_write_input_tokens": 48102,
+        "output_tokens": 12520,
+        "reasoning_output_tokens": 10019
+      },
+      "duration_ms": 396856
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 87,
+      "notes": "The issue clearly defines the unwanted default, explicit opt-in behavior, testable acceptance criteria, and narrow exclusions. The submitted diff corroborates the cited `createInIdp` initializer and `management_create_group` fallback. Its largest weakness is expanding a UI-named task into a behavior-changing API default without an independent task statement confirming that scope. Claims about every CLI and bulk-import caller could not be independently verified."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 81,
+      "notes": "The LLD gives concrete files, symbols, data flow, implementation steps, and explicit true/false behavior. Its claim that only three tests target the endpoint is contradicted by the implementation, which modifies six additional tests that implicitly relied on the old default. It recognizes the endpoint compatibility change, but the rollout plan primarily discusses UI users rather than direct API consumers. The patch context supports the named frontend and backend integration points, although working-tree applicability could not be independently confirmed."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 81,
+      "notes": "The review surfaces concrete concerns including direct-API compatibility, hook mocking, release communication, and boolean-property assertions. Its largest defect is declaring the endpoint-test audit resolved with only three matching tests, directly contradicted by six additional affected tests documented and patched later. The backend compatibility concern is appropriately prioritized and actionable. The security claim that a debug value log preserves audit visibility is overstated because the cited log does not establish actor attribution or durable audit logging."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 76,
+      "notes": "The plan provides concrete backend setup, commands, and strong oracles for omitted, explicit-false, and explicit-true behavior. The frontend tests assert the actual `checked` property and mock the identified hooks. However, toggling the checkbox does not verify the payload passed to `createGroup`, and no test covers the promised reset behavior after cancellation or successful creation. Thus the suite could pass while the submit path sends the wrong value, and the listed commands were not independently executable in the available repository sandbox."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 19,
+      "total": 82,
+      "notes": "The patch implements the design across the initial state, reset path, backend fallback, documentation, backend tests, and an accessible frontend checkbox test. Its test updates correctly make six IdP-path cases explicit and invert the omitted-key contract, exposing an omission in the earlier analysis. The largest remaining gap is that the frontend test proves only visual state and toggling, not the submitted request payload; the endpoint default change also remains behaviorally breaking for omitted-key callers. The unified-diff contexts are internally consistent, but clean application and compilation against the working tree could not be independently confirmed because repository command execution failed before running."
+    }
+  },
+  "task_score": 81.4,
+  "verdict": "Strong, concrete work that implements the intended safer default, limited chiefly by a contradictory test audit and incomplete frontend submission-path coverage.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:49:20.753889Z",
+    "repo_ref": "v1.0.21",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 323203,
+      "cached_input_tokens": 250928,
+      "cache_write_input_tokens": 37259,
+      "output_tokens": 9915,
+      "reasoning_output_tokens": 8245
+    },
+    "duration_ms": 386709
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.21",
+  "complexity": "low",
+  "tags": [
+    "ui",
+    "react",
+    "iam",
+    "groups",
+    "ux",
+    "fixed-in-1.0.22"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 9.3,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 40,
+    "output_tokens": 9405,
+    "cache_read_tokens": 3004211,
+    "cache_write_tokens": 169640,
+    "total_tokens": 3183296,
+    "total_cost_usd": 1.1190722,
+    "latency_seconds": 1009.3,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 9.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 40,
+  "output_tokens": 9405,
+  "latency_seconds": 1009.3,
+  "num_turns": 80,
+  "total_cost_usd": 1.1190722,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3004211,
+  "cache_creation_tokens": 169640,
+  "run_started_at": "2026-08-30T22:23:47.074023Z",
+  "run_ended_at": "2026-08-30T22:40:36.365486Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 40,
+    "output_tokens": 9405,
+    "cache_read_tokens": 3004211,
+    "cache_write_tokens": 169640,
+    "total_tokens": 3183296,
+    "total_cost_usd": 1.1190722,
+    "latency_seconds": 1009.3,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 9.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "default-create-in-idp-checkbox-unchecked",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 87,
+        "notes": "The issue clearly defines the unwanted default, explicit opt-in behavior, testable acceptance criteria, and narrow exclusions. The submitted diff corroborates the cited `createInIdp` initializer and `management_create_group` fallback. Its largest weakness is expanding a UI-named task into a behavior-changing API default without an independent task statement confirming that scope. Claims about every CLI and bulk-import caller could not be independently verified."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 81,
+        "notes": "The LLD gives concrete files, symbols, data flow, implementation steps, and explicit true/false behavior. Its claim that only three tests target the endpoint is contradicted by the implementation, which modifies six additional tests that implicitly relied on the old default. It recognizes the endpoint compatibility change, but the rollout plan primarily discusses UI users rather than direct API consumers. The patch context supports the named frontend and backend integration points, although working-tree applicability could not be independently confirmed."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 81,
+        "notes": "The review surfaces concrete concerns including direct-API compatibility, hook mocking, release communication, and boolean-property assertions. Its largest defect is declaring the endpoint-test audit resolved with only three matching tests, directly contradicted by six additional affected tests documented and patched later. The backend compatibility concern is appropriately prioritized and actionable. The security claim that a debug value log preserves audit visibility is overstated because the cited log does not establish actor attribution or durable audit logging."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 76,
+        "notes": "The plan provides concrete backend setup, commands, and strong oracles for omitted, explicit-false, and explicit-true behavior. The frontend tests assert the actual `checked` property and mock the identified hooks. However, toggling the checkbox does not verify the payload passed to `createGroup`, and no test covers the promised reset behavior after cancellation or successful creation. Thus the suite could pass while the submit path sends the wrong value, and the listed commands were not independently executable in the available repository sandbox."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 19,
+        "total": 82,
+        "notes": "The patch implements the design across the initial state, reset path, backend fallback, documentation, backend tests, and an accessible frontend checkbox test. Its test updates correctly make six IdP-path cases explicit and invert the omitted-key contract, exposing an omission in the earlier analysis. The largest remaining gap is that the frontend test proves only visual state and toggling, not the submitted request payload; the endpoint default change also remains behaviorally breaking for omitted-key callers. The unified-diff contexts are internally consistent, but clean application and compilation against the working tree could not be independently confirmed because repository command execution failed before running."
+      }
+    },
+    "task_score": 81.4,
+    "verdict": "Strong, concrete work that implements the intended safer default, limited chiefly by a contradictory test audit and incomplete frontend submission-path coverage.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T04:49:20.753889Z",
+      "repo_ref": "v1.0.21",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 323203,
+        "cached_input_tokens": 250928,
+        "cache_write_input_tokens": 37259,
+        "output_tokens": 9915,
+        "reasoning_output_tokens": 8245
+      },
+      "duration_ms": 386709
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 91,
+      "notes": "The issue clearly defines the registration and read-path problems, with concrete, testable acceptance criteria for blob, raw, enterprise, negative, persistence, and UI cases. The submitted diff context corroborates its named integration points: SkillInfo, SkillSearchResult, Dashboard.tsx, SkillCard.tsx, and SemanticSearchResults.tsx all require the described additions. Its main limitation is that no independent task statement establishes whether the expanded semantic-search and modal scope is required, although it is internally consistent with the task identifier and repository tags. Exact baseline-source claims could not be independently re-read because every local read-only shell invocation failed before execution with a bwrap loopback error."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 14,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 75,
+      "notes": "The LLD is unusually concrete about files, symbols, response models, data flow, null behavior, compatibility, and DocumentDB indexing, and its proposed backend plumbing matches the submitted patch structure. Its central frontend decision is wrong: repository_url: data.repository_url || prev.repository_url selects the newly parsed value whenever present, so it overwrites an existing user edit rather than preserving it. This directly violates an acceptance criterion and invalidates repeated claims that the merge is non-clobbering, while the design otherwise handles optional fields, old records, and non-GitHub URLs sensibly. Line-level and production-backend assertions could not be independently verified against the local checkout because repository commands were blocked before startup."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 12,
+      "specificity": 19,
+      "risk_awareness": 16,
+      "total": 64,
+      "notes": "The review identifies concrete architectural risks, notably duplicated SkillInfo construction, repeated DocumentDB result builders, loose GitHub-host classification, and old index entries lacking new metadata. Its largest failure is explicitly approving data.repository_url || prev.repository_url as edit-preserving, despite JavaScript evaluation making it overwrite a nonempty previous value. It also claims the construction-site regression concern is resolved, but the testing plan queries a nonexistent tag without asserting a returned skill and then performs an unfiltered request, so the fallback path is not actually verified. Several statements labeled confirmed against repository internals could not be independently checked because local read-only execution was unavailable."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 13,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 71,
+      "notes": "The plan covers helper behavior, API responses, compatibility, both modals, registration state, negative cases, and an end-to-end registration-to-search flow with specific expected values. Its advertised fallback regression check is ineffective: the registered skill has no test tag, the nonexistent-tag request cannot return it, and the subsequent unfiltered request does not demonstrate the second SkillInfo construction path. The live octocat URLs are acknowledged placeholders rather than demonstrated SKILL.md resources, and the proposed branch-name test accepts either outcome instead of enforcing one oracle. The manual edit-and-reparse scenario is valuable because it would expose the implementation's overwrite bug, but the stated repository commands and test paths could not be independently executed."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 68,
+      "notes": "The patch is focused and appears to implement the backend derivation, list and semantic-search plumbing, frontend types, conditional links, and helper unit tests across the expected files. The material defect is Dashboard.tsx using data.repository_url || prev.repository_url, which overwrites a user-edited value whenever parsing returns a repository URL and therefore fails an explicit acceptance criterion. No test covers that state transition or the two SkillInfo construction paths, and implementation.md incorrectly claims the patch avoids clobbering and implements the design without deviation. The diff contexts and symbols are internally coherent, but the claimed baseline commit and git apply --check result could not be independently verified because all local shell commands failed before execution."
+    }
+  },
+  "task_score": 73.8,
+  "verdict": "The submission is detailed and largely implements the end-to-end plumbing, but a reversed frontend merge expression breaks the required edit-preservation behavior and was missed by both the design review and implemented tests.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:53:10.721886Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 249372,
+      "cached_input_tokens": 188158,
+      "cache_write_input_tokens": 43881,
+      "output_tokens": 10503,
+      "reasoning_output_tokens": 8617
+    },
+    "duration_ms": 229956
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "skills",
+    "ui",
+    "react",
+    "api",
+    "ux",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 82.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 11732,
+    "output_tokens": 72111,
+    "cache_read_tokens": 11856237,
+    "cache_write_tokens": 183310,
+    "total_tokens": 12123390,
+    "total_cost_usd": 3.5740964000000006,
+    "latency_seconds": 872.0,
+    "num_turns": 77,
+    "generation_tokens_per_sec": 82.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 11732,
+  "output_tokens": 72111,
+  "latency_seconds": 872.0,
+  "num_turns": 77,
+  "total_cost_usd": 3.5740964000000006,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 11856237,
+  "cache_creation_tokens": 183310,
+  "run_started_at": "2026-08-30T23:29:08.558560Z",
+  "run_ended_at": "2026-08-30T23:43:40.578988Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 11732,
+    "output_tokens": 72111,
+    "cache_read_tokens": 11856237,
+    "cache_write_tokens": 183310,
+    "total_tokens": 12123390,
+    "total_cost_usd": 3.5740964000000006,
+    "latency_seconds": 872.0,
+    "num_turns": 77,
+    "generation_tokens_per_sec": 82.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "derive-repo-url-from-skill-md",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 91,
+        "notes": "The issue clearly defines the registration and read-path problems, with concrete, testable acceptance criteria for blob, raw, enterprise, negative, persistence, and UI cases. The submitted diff context corroborates its named integration points: SkillInfo, SkillSearchResult, Dashboard.tsx, SkillCard.tsx, and SemanticSearchResults.tsx all require the described additions. Its main limitation is that no independent task statement establishes whether the expanded semantic-search and modal scope is required, although it is internally consistent with the task identifier and repository tags. Exact baseline-source claims could not be independently re-read because every local read-only shell invocation failed before execution with a bwrap loopback error."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 14,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 75,
+        "notes": "The LLD is unusually concrete about files, symbols, response models, data flow, null behavior, compatibility, and DocumentDB indexing, and its proposed backend plumbing matches the submitted patch structure. Its central frontend decision is wrong: repository_url: data.repository_url || prev.repository_url selects the newly parsed value whenever present, so it overwrites an existing user edit rather than preserving it. This directly violates an acceptance criterion and invalidates repeated claims that the merge is non-clobbering, while the design otherwise handles optional fields, old records, and non-GitHub URLs sensibly. Line-level and production-backend assertions could not be independently verified against the local checkout because repository commands were blocked before startup."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 12,
+        "specificity": 19,
+        "risk_awareness": 16,
+        "total": 64,
+        "notes": "The review identifies concrete architectural risks, notably duplicated SkillInfo construction, repeated DocumentDB result builders, loose GitHub-host classification, and old index entries lacking new metadata. Its largest failure is explicitly approving data.repository_url || prev.repository_url as edit-preserving, despite JavaScript evaluation making it overwrite a nonempty previous value. It also claims the construction-site regression concern is resolved, but the testing plan queries a nonexistent tag without asserting a returned skill and then performs an unfiltered request, so the fallback path is not actually verified. Several statements labeled confirmed against repository internals could not be independently checked because local read-only execution was unavailable."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 13,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 71,
+        "notes": "The plan covers helper behavior, API responses, compatibility, both modals, registration state, negative cases, and an end-to-end registration-to-search flow with specific expected values. Its advertised fallback regression check is ineffective: the registered skill has no test tag, the nonexistent-tag request cannot return it, and the subsequent unfiltered request does not demonstrate the second SkillInfo construction path. The live octocat URLs are acknowledged placeholders rather than demonstrated SKILL.md resources, and the proposed branch-name test accepts either outcome instead of enforcing one oracle. The manual edit-and-reparse scenario is valuable because it would expose the implementation's overwrite bug, but the stated repository commands and test paths could not be independently executed."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 68,
+        "notes": "The patch is focused and appears to implement the backend derivation, list and semantic-search plumbing, frontend types, conditional links, and helper unit tests across the expected files. The material defect is Dashboard.tsx using data.repository_url || prev.repository_url, which overwrites a user-edited value whenever parsing returns a repository URL and therefore fails an explicit acceptance criterion. No test covers that state transition or the two SkillInfo construction paths, and implementation.md incorrectly claims the patch avoids clobbering and implements the design without deviation. The diff contexts and symbols are internally coherent, but the claimed baseline commit and git apply --check result could not be independently verified because all local shell commands failed before execution."
+      }
+    },
+    "task_score": 73.8,
+    "verdict": "The submission is detailed and largely implements the end-to-end plumbing, but a reversed frontend merge expression breaks the required edit-preservation behavior and was missed by both the design review and implemented tests.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T04:53:10.721886Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 249372,
+        "cached_input_tokens": 188158,
+        "cache_write_input_tokens": 43881,
+        "output_tokens": 10503,
+        "reasoning_output_tokens": 8617
+      },
+      "duration_ms": 229956
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 86,
+      "notes": "The issue clearly identifies the GROUPS assignment in verify_setup(), its interaction with set -e, both affected script paths, and testable success, failure, compatibility, and scope boundaries. The submitted patch context corroborates the named functions and the two GROUPS-based membership checks. Its largest technical overstatement is that separating local declaration from assignment makes failed curl and jq commands surface independently; without pipefail, a curl failure can still be masked by jq. No independent task statement was supplied, and the claims about issue #1570 and the macos-setup consumer could not be independently verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 86,
+      "notes": "The LLD is implementation-ready, naming both verify_setup() functions, the exact replacement, unchanged interfaces, Bash-version constraint, error behavior, and rollout boundary. It correctly recognizes that local must be separate from command substitution to preserve the pipeline's final status and explicitly records the pre-existing lack of pipefail. Its main weakness is imprecise portability and failure language: local is Bash-compatible but not POSIX, and a failed curl still does not necessarily propagate. The asserted repository-wide reserved-variable sweep, exact line numbers, and macos-setup behavior were not independently verifiable in the unavailable repository execution environment."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 18,
+      "specificity": 20,
+      "risk_awareness": 20,
+      "total": 76,
+      "notes": "The backend and security sections identify concrete risks, including the curl-versus-pipefail diagnostic gap, newline-delimited group assumptions, and the distinction between verification output and actual authorization. The review also assesses the precise grep semantics and Bash 3.2 tradeoff rather than offering only generic approval. However, much of the persona structure is non-contributory approval theater, and the backend section incorrectly attributes the SC2128 fix to grep -Fxq when renaming away from the special array fixes that warning. It does not challenge the unsupported macos-setup operational claims or require correction of the LLD's curl-status wording."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 67,
+      "notes": "The plan provides concrete commands and expected exit codes for the GROUPS reproduction, positive and negative membership paths, syntax checks, idempotent provisioning, output compatibility, and optional live-Keycloak coverage. Its largest defect is Section 2.4: mcp-servers-restricted is not a substring of mcp-servers-unrestricted, so the old grep -q implementation passes the same oracle and the test cannot detect omission of -Fx. Most core tests execute a copied verify_setup_sim function rather than the patched scripts, allowing implementation drift or a bad hunk to escape unless the optional end-to-end test is run. Bash 3.2 is listed as a prerequisite but no version-selecting command or recorded 3.2 execution is provided."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 86,
+      "notes": "The patch implements the design end to end in both submitted target contexts: it replaces GROUPS with a function-local sa_groups, preserves command-substitution status by separating declaration, updates both reads, and uses an exact fixed-string line match. The changes are minimal, internally consistent, Bash 3.2-compatible, and preserve the existing verification messages and genuine not-a-member failure branch. The largest remaining risk is validation depth: no repository test was added, live Keycloak and Bash 3.2 runs were not performed, and the summary's apply-check and sweep results are self-reported. Direct source inspection and an independent git apply --check were unavailable because repository command execution failed at sandbox startup, so the baseline commit, blob contexts, and applyability could not be independently confirmed."
+    }
+  },
+  "task_score": 80.2,
+  "verdict": "This is a strong, narrowly scoped fix with unusually specific design artifacts, but the testing plan fails to exercise its key exact-match regression and repository-level verification remained unavailable.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:56:34.751719Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 220393,
+      "cached_input_tokens": 141999,
+      "cache_write_input_tokens": 30042,
+      "output_tokens": 11810,
+      "reasoning_output_tokens": 10473
+    },
+    "duration_ms": 204018
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "bash",
+    "keycloak",
+    "setup-scripts",
+    "shellcheck",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 85.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2308,
+    "output_tokens": 36513,
+    "cache_read_tokens": 2501018,
+    "cache_write_tokens": 84849,
+    "total_tokens": 2624688,
+    "total_cost_usd": 1.0820721,
+    "latency_seconds": 428.5,
+    "num_turns": 28,
+    "generation_tokens_per_sec": 85.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2308,
+  "output_tokens": 36513,
+  "latency_seconds": 428.5,
+  "num_turns": 28,
+  "total_cost_usd": 1.0820721,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2501018,
+  "cache_creation_tokens": 84849,
+  "run_started_at": "2026-08-30T23:11:06.904884Z",
+  "run_ended_at": "2026-08-30T23:18:15.420345Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2308,
+    "output_tokens": 36513,
+    "cache_read_tokens": 2501018,
+    "cache_write_tokens": 84849,
+    "total_tokens": 2624688,
+    "total_cost_usd": 1.0820721,
+    "latency_seconds": 428.5,
+    "num_turns": 28,
+    "generation_tokens_per_sec": 85.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "fix-reserved-groups-var-in-service-account-script",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 86,
+        "notes": "The issue clearly identifies the GROUPS assignment in verify_setup(), its interaction with set -e, both affected script paths, and testable success, failure, compatibility, and scope boundaries. The submitted patch context corroborates the named functions and the two GROUPS-based membership checks. Its largest technical overstatement is that separating local declaration from assignment makes failed curl and jq commands surface independently; without pipefail, a curl failure can still be masked by jq. No independent task statement was supplied, and the claims about issue #1570 and the macos-setup consumer could not be independently verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 86,
+        "notes": "The LLD is implementation-ready, naming both verify_setup() functions, the exact replacement, unchanged interfaces, Bash-version constraint, error behavior, and rollout boundary. It correctly recognizes that local must be separate from command substitution to preserve the pipeline's final status and explicitly records the pre-existing lack of pipefail. Its main weakness is imprecise portability and failure language: local is Bash-compatible but not POSIX, and a failed curl still does not necessarily propagate. The asserted repository-wide reserved-variable sweep, exact line numbers, and macos-setup behavior were not independently verifiable in the unavailable repository execution environment."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 18,
+        "specificity": 20,
+        "risk_awareness": 20,
+        "total": 76,
+        "notes": "The backend and security sections identify concrete risks, including the curl-versus-pipefail diagnostic gap, newline-delimited group assumptions, and the distinction between verification output and actual authorization. The review also assesses the precise grep semantics and Bash 3.2 tradeoff rather than offering only generic approval. However, much of the persona structure is non-contributory approval theater, and the backend section incorrectly attributes the SC2128 fix to grep -Fxq when renaming away from the special array fixes that warning. It does not challenge the unsupported macos-setup operational claims or require correction of the LLD's curl-status wording."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 67,
+        "notes": "The plan provides concrete commands and expected exit codes for the GROUPS reproduction, positive and negative membership paths, syntax checks, idempotent provisioning, output compatibility, and optional live-Keycloak coverage. Its largest defect is Section 2.4: mcp-servers-restricted is not a substring of mcp-servers-unrestricted, so the old grep -q implementation passes the same oracle and the test cannot detect omission of -Fx. Most core tests execute a copied verify_setup_sim function rather than the patched scripts, allowing implementation drift or a bad hunk to escape unless the optional end-to-end test is run. Bash 3.2 is listed as a prerequisite but no version-selecting command or recorded 3.2 execution is provided."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 86,
+        "notes": "The patch implements the design end to end in both submitted target contexts: it replaces GROUPS with a function-local sa_groups, preserves command-substitution status by separating declaration, updates both reads, and uses an exact fixed-string line match. The changes are minimal, internally consistent, Bash 3.2-compatible, and preserve the existing verification messages and genuine not-a-member failure branch. The largest remaining risk is validation depth: no repository test was added, live Keycloak and Bash 3.2 runs were not performed, and the summary's apply-check and sweep results are self-reported. Direct source inspection and an independent git apply --check were unavailable because repository command execution failed at sandbox startup, so the baseline commit, blob contexts, and applyability could not be independently confirmed."
+      }
+    },
+    "task_score": 80.2,
+    "verdict": "This is a strong, narrowly scoped fix with unusually specific design artifacts, but the testing plan fails to exercise its key exact-match regression and repository-level verification remained unavailable.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T04:56:34.751719Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 220393,
+        "cached_input_tokens": 141999,
+        "cache_write_input_tokens": 30042,
+        "output_tokens": 11810,
+        "reasoning_output_tokens": 10473
+      },
+      "duration_ms": 204018
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 90,
+      "notes": "The issue provides a precise visibility matrix, testable acceptance criteria, and unusually clear non-goals for this small UI fix. It concretely identifies Dashboard.tsx, handleRegisterServer, /servers/register, and the scoped Add Virtual Server and Add Skill actions. The largest limitation is the absent independent task statement, which prevents external confirmation that every asserted behavior and related issue is authoritative. Repository shell access failed before reads could execute, so the named symbols and routing claims could not be independently verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 87,
+      "notes": "The LLD commits to a minimal single-node JSX guard and clearly preserves the surrounding search and Refresh Health controls through a six-state decision table. Its proposed condition is internally consistent with the submitted patch and the stated viewFilter union. The weakest decision is treating default visibility on future tabs as safer; a future tab with its own scoped action could recreate this defect, and the design does not require an explicit applicability decision. Exact line numbers, symbols, and repository conventions could not be independently confirmed because local read commands failed before execution."
+    },
+    "review": {
+      "completeness": 19,
+      "correctness": 20,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 76,
+      "notes": "The review concretely checks that the guard surrounds only the Register button and calls out layout reflow, shared-handler regression checks, authorization boundaries, and JSX brace placement. Its largest weakness is that every reviewer approves and the only concerns are execution reminders, so it does not seriously challenge the exclusion-list semantics or the absence of an implemented automated regression test. The summary accurately reflects its own findings: visual inspection and brace balancing are the sole raised concerns. Repository-dependent claims about permissions, handlers, and routes remained unverifiable due unavailable local shell execution."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 80,
+      "notes": "The plan covers all six tab states with concrete visibility oracles and adds compatibility checks for navigation, unaffected controls, layout, rapid tab switching, and production compilation. Its main defect is locator robustness: button.btn-primary:has-text(\"Register\") is broad enough to match longer Register-labelled CTAs, while the Agents locator relies on DOM ordering through first(). The checklist promises destination and unaffected-control checks that are only described as follow-up extensions rather than included in the proposed executable spec. The claimed Playwright configuration, loginAsAdmin helper, file convention, and npm commands could not be verified against repository files because command execution failed."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 90,
+      "notes": "The patch fully implements the described behavior by wrapping only the header Register button with exclusions for virtual and skills while leaving the Refresh Health sibling untouched. The submitted diff is syntactically balanced and, under the existing outer non-Discover condition described by the artifacts, produces the required six-tab visibility matrix. The largest limitation is the lack of an accompanying regression test, while the summary states that no follow-up remains despite the testing plan proposing a new Playwright spec. The asserted baseline commit, target-file context, and git apply --check result could not be independently confirmed because the repository shell failed before executing read-only commands."
+    }
+  },
+  "task_score": 84.6,
+  "verdict": "This is a strong, narrowly scoped solution with an apparently correct patch, limited chiefly by a largely non-adversarial review, fragile proposed browser selectors, and unavailable independent repository verification.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:01:15.663086Z",
+    "repo_ref": "v1.0.18",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 321118,
+      "cached_input_tokens": 228150,
+      "cache_write_input_tokens": 31341,
+      "output_tokens": 10589,
+      "reasoning_output_tokens": 8819
+    },
+    "duration_ms": 280900
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.18",
+  "complexity": "trivial",
+  "tags": [
+    "ui",
+    "react",
+    "dashboard",
+    "ux",
+    "fixed-in-v1.0.19"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 71.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 72,
+    "output_tokens": 28009,
+    "cache_read_tokens": 3207542,
+    "cache_write_tokens": 77522,
+    "total_tokens": 3313145,
+    "total_cost_usd": 1.1155474,
+    "latency_seconds": 391.4,
+    "num_turns": 36,
+    "generation_tokens_per_sec": 71.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 72,
+  "output_tokens": 28009,
+  "latency_seconds": 391.4,
+  "num_turns": 36,
+  "total_cost_usd": 1.1155474,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3207542,
+  "cache_creation_tokens": 77522,
+  "run_started_at": "2026-08-31T03:27:51.513242Z",
+  "run_ended_at": "2026-08-31T03:34:22.896302Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 72,
+    "output_tokens": 28009,
+    "cache_read_tokens": 3207542,
+    "cache_write_tokens": 77522,
+    "total_tokens": 3313145,
+    "total_cost_usd": 1.1155474,
+    "latency_seconds": 391.4,
+    "num_turns": 36,
+    "generation_tokens_per_sec": 71.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "hide-register-button-on-virtual-and-skills-tabs",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 90,
+        "notes": "The issue provides a precise visibility matrix, testable acceptance criteria, and unusually clear non-goals for this small UI fix. It concretely identifies Dashboard.tsx, handleRegisterServer, /servers/register, and the scoped Add Virtual Server and Add Skill actions. The largest limitation is the absent independent task statement, which prevents external confirmation that every asserted behavior and related issue is authoritative. Repository shell access failed before reads could execute, so the named symbols and routing claims could not be independently verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 87,
+        "notes": "The LLD commits to a minimal single-node JSX guard and clearly preserves the surrounding search and Refresh Health controls through a six-state decision table. Its proposed condition is internally consistent with the submitted patch and the stated viewFilter union. The weakest decision is treating default visibility on future tabs as safer; a future tab with its own scoped action could recreate this defect, and the design does not require an explicit applicability decision. Exact line numbers, symbols, and repository conventions could not be independently confirmed because local read commands failed before execution."
+      },
+      "review": {
+        "completeness": 19,
+        "correctness": 20,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 76,
+        "notes": "The review concretely checks that the guard surrounds only the Register button and calls out layout reflow, shared-handler regression checks, authorization boundaries, and JSX brace placement. Its largest weakness is that every reviewer approves and the only concerns are execution reminders, so it does not seriously challenge the exclusion-list semantics or the absence of an implemented automated regression test. The summary accurately reflects its own findings: visual inspection and brace balancing are the sole raised concerns. Repository-dependent claims about permissions, handlers, and routes remained unverifiable due unavailable local shell execution."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 80,
+        "notes": "The plan covers all six tab states with concrete visibility oracles and adds compatibility checks for navigation, unaffected controls, layout, rapid tab switching, and production compilation. Its main defect is locator robustness: button.btn-primary:has-text(\"Register\") is broad enough to match longer Register-labelled CTAs, while the Agents locator relies on DOM ordering through first(). The checklist promises destination and unaffected-control checks that are only described as follow-up extensions rather than included in the proposed executable spec. The claimed Playwright configuration, loginAsAdmin helper, file convention, and npm commands could not be verified against repository files because command execution failed."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 90,
+        "notes": "The patch fully implements the described behavior by wrapping only the header Register button with exclusions for virtual and skills while leaving the Refresh Health sibling untouched. The submitted diff is syntactically balanced and, under the existing outer non-Discover condition described by the artifacts, produces the required six-tab visibility matrix. The largest limitation is the lack of an accompanying regression test, while the summary states that no follow-up remains despite the testing plan proposing a new Playwright spec. The asserted baseline commit, target-file context, and git apply --check result could not be independently confirmed because the repository shell failed before executing read-only commands."
+      }
+    },
+    "task_score": 84.6,
+    "verdict": "This is a strong, narrowly scoped solution with an apparently correct patch, limited chiefly by a largely non-adversarial review, fragile proposed browser selectors, and unavailable independent repository verification.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:01:15.663086Z",
+      "repo_ref": "v1.0.18",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 321118,
+        "cached_input_tokens": 228150,
+        "cache_write_input_tokens": 31341,
+        "output_tokens": 10589,
+        "reasoning_output_tokens": 8819
+      },
+      "duration_ms": 280900
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 80,
+      "notes": "The issue clearly identifies the affected endpoint, resolver, frontend consumer, desired precedence, response contract, tests, and non-goals. The submitted diff's preimage corroborates its central claim that get_telemetry_detection_info directly called _detect_cloud_provider_with_method. Its largest defect is claiming override-unset behavior remains exactly unchanged even though using _resolve_cloud introduces operator-declared and operator-declined outcomes previously bypassed by this endpoint. Exact source locations and the claimed .env.example defaults could not be independently verified because every local read command failed during sandbox initialization."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 79,
+      "notes": "The LLD is unusually concrete about the route, async call flow, resolver precedence, response shape, tests, and exact files to modify. Its proposed await _resolve_cloud() change is internally consistent with the supplied preimage and implementation patch. The principal flaw is repeatedly describing override-unset behavior as backward-compatible while deliberately adding registry-card hint and declined outcomes, with no migration or compatibility analysis for existing endpoint consumers; it also treats additional metric increments as purely beneficial. Repository line numbers, cache implementation, and exception-handling claims remained independently unverifiable due the unavailable local shell."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The review surfaces actionable issues, notably missing direct _resolve_cloud coverage, cold-cache duplicate reads, auth preservation, and the user-facing explicit label. It then records concrete resolutions that appear in the revised LLD and patch. Its largest miss is failing to challenge the false backward-compatibility claim for operator hints and instead endorsing the new behavior as unconditionally preferable; it also does not examine repeated UI-driven logging and counter inflation. Assertions described as grep-confirmed or code-confirmed could not be independently reproduced because repository commands could not execute."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 77,
+      "notes": "The plan provides concrete resolver-level and endpoint-level tests with exact JSON and tuple oracles, plus retained 401 coverage and targeted pytest commands. The two layers would catch both loss of explicit precedence and regression to the route's old raw-cascade wiring. It omits tests for the newly reachable operator_declared and operator_declined branches, does not fully isolate ambient cloud environment variables, and inconsistently describes whether the forced-startup response contains an event field. The manual log comparison is only a proxy for the transmitted telemetry payload, and the cited commands and existing test names could not be independently executed."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 21,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 82,
+      "notes": "The patch implements the central fix end to end by replacing the local raw-detector import and synchronous call with await _resolve_cloud(), while preserving the endpoint response keys and adding focused resolver and route tests. Its diff context is internally coherent with the artifacts, and the endpoint mock works with the route's function-local import. The largest weakness is that the summary overstates override-unset compatibility and the tests omit the operator-hint behavior that this implementation newly exposes through the endpoint. The claimed clean git apply and runtime compatibility could not be independently confirmed because all local shell commands failed before execution, although no obvious syntax or control-flow defect is visible in the submitted diff."
+    }
+  },
+  "task_score": 79.0,
+  "verdict": "This is a strong, implementation-ready submission whose main limitation is an unacknowledged and untested behavior change for registry-card hints when the explicit override is unset.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:04:52.302681Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 179190,
+      "cached_input_tokens": 116255,
+      "cache_write_input_tokens": 33455,
+      "output_tokens": 9079,
+      "reasoning_output_tokens": 7768
+    },
+    "duration_ms": 216628
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "telemetry",
+    "api",
+    "ui",
+    "deployment",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 76.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1430,
+    "output_tokens": 50480,
+    "cache_read_tokens": 8813702,
+    "cache_write_tokens": 143529,
+    "total_tokens": 9009141,
+    "total_cost_usd": 2.629222900000001,
+    "latency_seconds": 656.8,
+    "num_turns": 69,
+    "generation_tokens_per_sec": 76.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1430,
+  "output_tokens": 50480,
+  "latency_seconds": 656.8,
+  "num_turns": 69,
+  "total_cost_usd": 2.629222900000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 8813702,
+  "cache_creation_tokens": 143529,
+  "run_started_at": "2026-08-30T23:00:07.049367Z",
+  "run_ended_at": "2026-08-30T23:11:03.907039Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1430,
+    "output_tokens": 50480,
+    "cache_read_tokens": 8813702,
+    "cache_write_tokens": 143529,
+    "total_tokens": 9009141,
+    "total_cost_usd": 2.629222900000001,
+    "latency_seconds": 656.8,
+    "num_turns": 69,
+    "generation_tokens_per_sec": 76.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "honor-cloud-provider-override-in-ui",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 80,
+        "notes": "The issue clearly identifies the affected endpoint, resolver, frontend consumer, desired precedence, response contract, tests, and non-goals. The submitted diff's preimage corroborates its central claim that get_telemetry_detection_info directly called _detect_cloud_provider_with_method. Its largest defect is claiming override-unset behavior remains exactly unchanged even though using _resolve_cloud introduces operator-declared and operator-declined outcomes previously bypassed by this endpoint. Exact source locations and the claimed .env.example defaults could not be independently verified because every local read command failed during sandbox initialization."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 79,
+        "notes": "The LLD is unusually concrete about the route, async call flow, resolver precedence, response shape, tests, and exact files to modify. Its proposed await _resolve_cloud() change is internally consistent with the supplied preimage and implementation patch. The principal flaw is repeatedly describing override-unset behavior as backward-compatible while deliberately adding registry-card hint and declined outcomes, with no migration or compatibility analysis for existing endpoint consumers; it also treats additional metric increments as purely beneficial. Repository line numbers, cache implementation, and exception-handling claims remained independently unverifiable due the unavailable local shell."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The review surfaces actionable issues, notably missing direct _resolve_cloud coverage, cold-cache duplicate reads, auth preservation, and the user-facing explicit label. It then records concrete resolutions that appear in the revised LLD and patch. Its largest miss is failing to challenge the false backward-compatibility claim for operator hints and instead endorsing the new behavior as unconditionally preferable; it also does not examine repeated UI-driven logging and counter inflation. Assertions described as grep-confirmed or code-confirmed could not be independently reproduced because repository commands could not execute."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 77,
+        "notes": "The plan provides concrete resolver-level and endpoint-level tests with exact JSON and tuple oracles, plus retained 401 coverage and targeted pytest commands. The two layers would catch both loss of explicit precedence and regression to the route's old raw-cascade wiring. It omits tests for the newly reachable operator_declared and operator_declined branches, does not fully isolate ambient cloud environment variables, and inconsistently describes whether the forced-startup response contains an event field. The manual log comparison is only a proxy for the transmitted telemetry payload, and the cited commands and existing test names could not be independently executed."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 21,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 82,
+        "notes": "The patch implements the central fix end to end by replacing the local raw-detector import and synchronous call with await _resolve_cloud(), while preserving the endpoint response keys and adding focused resolver and route tests. Its diff context is internally coherent with the artifacts, and the endpoint mock works with the route's function-local import. The largest weakness is that the summary overstates override-unset compatibility and the tests omit the operator-hint behavior that this implementation newly exposes through the endpoint. The claimed clean git apply and runtime compatibility could not be independently confirmed because all local shell commands failed before execution, although no obvious syntax or control-flow defect is visible in the submitted diff."
+      }
+    },
+    "task_score": 79.0,
+    "verdict": "This is a strong, implementation-ready submission whose main limitation is an unacknowledged and untested behavior change for registry-card hints when the explicit override is unset.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:04:52.302681Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 179190,
+        "cached_input_tokens": 116255,
+        "cache_write_input_tokens": 33455,
+        "output_tokens": 9079,
+        "reasoning_output_tokens": 7768
+      },
+      "duration_ms": 216628
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 88,
+      "notes": "The issue defines concrete OAuth behavior, configuration, deployment surfaces, security expectations, non-goals, and testable failure cases. Its cited paths and symbols align with the submitted baseline contexts for LiteLLMClient, FederationAuthManager, config routing, Terraform, and Helm. The largest flaw is the absolute backward-compatibility criterion: the implementation necessarily adds Settings fields and unconditionally rendered deployment variables, so behavior cannot literally remain byte-for-byte identical with no new variable read. No independent task statement exists, and local repository inspection was unavailable because the shell sandbox failed before execution, so the external issue and exact baseline could not be independently verified."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 19,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 86,
+      "notes": "The LLD is unusually concrete about files, signatures, token flow, validation, masking, deployment wiring, compatibility, and rejected alternatives. It correctly commits to per-call api_key injection, locked token refresh, and a provider compatibility check in Settings. Its largest omission is Terraform's empty-secret lifecycle: it never ensures a missing client secret remains detectably missing, and the resulting \"not-configured\" ECS secret defeats the promised fail-fast validation when the other required fields are set. Claims about the installed LiteLLM signature, exact single-call-site topology, and line-specific repository findings could not be independently verified locally."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 80,
+      "notes": "The review identifies a real misconfiguration defect—IdP enabled with sentence-transformers—and turns it into a specific startup validation change. It also gives actionable findings for Helm reserved names, secret recovery configuration, credential precedence documentation, and benchmark-only comments. Its largest miss is the Terraform placeholder secret, which can bypass missing-secret validation; it also calls backward compatibility \"airtight\" despite unconditional new Helm and ECS environment entries. The claimed independent greps, installed-package inspection, and frontend behavior could not be reproduced because local command execution was unavailable."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 13,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 72,
+      "notes": "The plan spans token caching, bearer injection, failures, compatibility, configuration masking, Docker, Terraform, Helm, rollback, and mock-server lifecycle testing with generally concrete oracles. Several commands are unreliable: unittest discovery will not exercise the submitted plain pytest tests, the Helm decode pipeline ends with \"|| true\" and can pass on failure, and the unchanged-default Helm assertion contradicts the unconditional EMBEDDINGS_IDP_ENABLED Secret entry. It also omits a concurrent-refresh test and the critical ECS case where IdP is enabled while the client-secret variable is empty but becomes \"not-configured\". None of the commands were executed, and their repository-specific flags and response shapes could not be independently verified locally."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 78,
+      "notes": "The patch implements the main design end to end across Settings, LiteLLMClient, the token provider, repository wiring, config masking, three deployment systems, documentation, and focused unit tests. The largest defect is in secrets.tf: an empty Terraform client-secret variable becomes \"not-configured\" and is always injected into ECS, so startup validation can accept an absent credential and defer failure to the first token request. The provider also does not normalize malformed JSON or invalid expires_in values into its documented RuntimeError contract, while tests omit concurrency and deployment-validation coverage. The unified diff has internally consistent symbols and contexts, but git apply --check and the candidate's claimed pinned commit could not be independently verified because the local shell sandbox failed before executing commands."
+    }
+  },
+  "task_score": 80.8,
+  "verdict": "Strong, implementation-ready work overall, limited most materially by Terraform secret handling that can violate the required startup fail-fast behavior and by unreliable verification commands.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:09:11.354526Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 498529,
+      "cached_input_tokens": 402799,
+      "cache_write_input_tokens": 65405,
+      "output_tokens": 10560,
+      "reasoning_output_tokens": 8614
+    },
+    "duration_ms": 259039
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "high",
+  "tags": [
+    "semantic-search",
+    "embeddings",
+    "oauth",
+    "authentication",
+    "litellm",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 0.2,
+  "token_accounting_warning": "[task=idp-authenticated-embedding-endpoint] TOKEN ACCOUNTING SUSPECT: 323 output tokens over 187 turns = 1.7/turn, below the 20 floor. An agent making edits emits hundreds per turn, so the omp usage is likely being read from one scope instead of summed across all of them (see the pi per-message usage bug, issue #99). Scores, turns, and latency are unaffected and still valid -- but DO NOT publish the token or cost columns from this run without re-checking the extractor.",
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4,
+    "output_tokens": 323,
+    "cache_read_tokens": 714753,
+    "cache_write_tokens": 1618,
+    "total_tokens": 716698,
+    "total_cost_usd": 0.15023360000000002,
+    "latency_seconds": 1853.3,
+    "num_turns": 187,
+    "generation_tokens_per_sec": 0.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4,
+  "output_tokens": 323,
+  "latency_seconds": 1853.3,
+  "num_turns": 187,
+  "total_cost_usd": 0.15023360000000002,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 714753,
+  "cache_creation_tokens": 1618,
+  "run_started_at": "2026-08-31T02:49:00.487588Z",
+  "run_ended_at": "2026-08-31T03:19:53.783511Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4,
+    "output_tokens": 323,
+    "cache_read_tokens": 714753,
+    "cache_write_tokens": 1618,
+    "total_tokens": 716698,
+    "total_cost_usd": 0.15023360000000002,
+    "latency_seconds": 1853.3,
+    "num_turns": 187,
+    "generation_tokens_per_sec": 0.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "idp-authenticated-embedding-endpoint",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 88,
+        "notes": "The issue defines concrete OAuth behavior, configuration, deployment surfaces, security expectations, non-goals, and testable failure cases. Its cited paths and symbols align with the submitted baseline contexts for LiteLLMClient, FederationAuthManager, config routing, Terraform, and Helm. The largest flaw is the absolute backward-compatibility criterion: the implementation necessarily adds Settings fields and unconditionally rendered deployment variables, so behavior cannot literally remain byte-for-byte identical with no new variable read. No independent task statement exists, and local repository inspection was unavailable because the shell sandbox failed before execution, so the external issue and exact baseline could not be independently verified."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 19,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 86,
+        "notes": "The LLD is unusually concrete about files, signatures, token flow, validation, masking, deployment wiring, compatibility, and rejected alternatives. It correctly commits to per-call api_key injection, locked token refresh, and a provider compatibility check in Settings. Its largest omission is Terraform's empty-secret lifecycle: it never ensures a missing client secret remains detectably missing, and the resulting \"not-configured\" ECS secret defeats the promised fail-fast validation when the other required fields are set. Claims about the installed LiteLLM signature, exact single-call-site topology, and line-specific repository findings could not be independently verified locally."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 80,
+        "notes": "The review identifies a real misconfiguration defect—IdP enabled with sentence-transformers—and turns it into a specific startup validation change. It also gives actionable findings for Helm reserved names, secret recovery configuration, credential precedence documentation, and benchmark-only comments. Its largest miss is the Terraform placeholder secret, which can bypass missing-secret validation; it also calls backward compatibility \"airtight\" despite unconditional new Helm and ECS environment entries. The claimed independent greps, installed-package inspection, and frontend behavior could not be reproduced because local command execution was unavailable."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 13,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 72,
+        "notes": "The plan spans token caching, bearer injection, failures, compatibility, configuration masking, Docker, Terraform, Helm, rollback, and mock-server lifecycle testing with generally concrete oracles. Several commands are unreliable: unittest discovery will not exercise the submitted plain pytest tests, the Helm decode pipeline ends with \"|| true\" and can pass on failure, and the unchanged-default Helm assertion contradicts the unconditional EMBEDDINGS_IDP_ENABLED Secret entry. It also omits a concurrent-refresh test and the critical ECS case where IdP is enabled while the client-secret variable is empty but becomes \"not-configured\". None of the commands were executed, and their repository-specific flags and response shapes could not be independently verified locally."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 78,
+        "notes": "The patch implements the main design end to end across Settings, LiteLLMClient, the token provider, repository wiring, config masking, three deployment systems, documentation, and focused unit tests. The largest defect is in secrets.tf: an empty Terraform client-secret variable becomes \"not-configured\" and is always injected into ECS, so startup validation can accept an absent credential and defer failure to the first token request. The provider also does not normalize malformed JSON or invalid expires_in values into its documented RuntimeError contract, while tests omit concurrency and deployment-validation coverage. The unified diff has internally consistent symbols and contexts, but git apply --check and the candidate's claimed pinned commit could not be independently verified because the local shell sandbox failed before executing commands."
+      }
+    },
+    "task_score": 80.8,
+    "verdict": "Strong, implementation-ready work overall, limited most materially by Terraform secret handling that can violate the required startup fail-fast behavior and by unreliable verification commands.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:09:11.354526Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 498529,
+        "cached_input_tokens": 402799,
+        "cache_write_input_tokens": 65405,
+        "output_tokens": 10560,
+        "reasoning_output_tokens": 8614
+      },
+      "duration_ms": 259039
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 88,
+      "notes": "The issue clearly defines an additive documentation index, eight feature groups, URL-based deduplication, source-page attribution, and preservation of existing links. Its named paths and video types are consistent with the submitted README and documentation evidence, while the absent independent task statement prevents confirming that every proposed requirement was externally mandated. The strongest aspect is its directly testable acceptance criteria and explicit GIF and code-change exclusions. Its main limitation is limited treatment of ongoing index maintenance and external-link decay."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 19,
+      "total": 77,
+      "notes": "The LLD is unusually concrete for a documentation change, identifying README.md, docs/index.md, individual source documents, duplicate URLs, grouping, and relative-link behavior. Its largest defect is contradicting the issue's requirement that every entry name its source pages: it limits attribution to selected duplicate groups even though Agent Skills appears in both README.md and docs/agent-skills-operational-guide.md and singleton videos also have source pages. It also says only three groups need attribution, while the implementation gives Authentication & Security such a column, exposing an internal inconsistency. The maintenance scan, GIF exclusion, additive rollout, and duplicate-name warning show useful risk awareness, although exact line and baseline claims could not all be independently verified."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 18,
+      "total": 69,
+      "notes": "The review raises concrete UX, maintenance, third-party hosting, and security considerations and converts several findings into actionable changes. Its largest failure is endorsing omission of source attribution from most groups, thereby preserving a direct acceptance-criteria violation instead of catching it. The claim that only Platform Overview, Dynamic Tool Discovery, and Virtual MCP Servers have cross-page duplicates is contradicted by Agent Skills appearing in both the submitted README context and its operational guide; the review also says there are four Vidcast demos while naming and implementing only three. The safe-scan and Vidcast link-rot discussions are specific, but some asserted task history and permanence guarantees are not verifiable from the supplied task context."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 12,
+      "specificity": 20,
+      "risk_awareness": 14,
+      "total": 61,
+      "notes": "The completeness check has a meaningful oracle: comm -23 reports repository video identifiers absent from the index, and the plan also checks unchanged source files and README navigation. The central deduplication test is ineffective because index-video-ids.txt is created with sort -u before uniq -d, so it always reports no duplicates. No test verifies the issue's requirement that each row identify every source page, which would have caught the implementation's largest omission. The commands are concrete, but the recursive grep is not limited to tracked files, youtu.be is omitted from the index-side extraction, and external-link validation is only optional."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 17,
+      "total": 73,
+      "notes": "The patch provides the core deliverable: 13 distinct video links arranged in eight feature groups and an additive README.md entry point while retaining existing links. Its largest defect is incomplete source attribution: CLI, Agent Skills, Security Scanning, both federation entries, and ANS omit their source documents, while rows such as OAuth, Dynamic Tool Discovery, Full End-to-End, and Virtual MCP Servers omit README.md as a source. The patch also deviates from the claimed design by including an attribution column for Authentication & Security despite stating that only three groups would have one. Relative links and the maintenance note appear coherent, but the pinned commit and git apply --check claim could not be independently executed because the provided repository shell failed before running commands."
+    }
+  },
+  "task_score": 73.6,
+  "verdict": "The submission delivers a useful and likely complete video index, but repeatedly misses its own requirement to identify every video's source pages and includes a deduplication test that cannot detect duplicates.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:15:16.296370Z",
+    "repo_ref": "1.24.3",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 232542,
+      "cached_input_tokens": 157894,
+      "cache_write_input_tokens": 37340,
+      "output_tokens": 10782,
+      "reasoning_output_tokens": 9152
+    },
+    "duration_ms": 364930
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.3",
+  "complexity": "trivial",
+  "tags": [
+    "docs",
+    "markdown",
+    "readme",
+    "discoverability",
+    "fixed-in-1.24.4"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 73.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 739,
+    "output_tokens": 34723,
+    "cache_read_tokens": 3930830,
+    "cache_write_tokens": 104961,
+    "total_tokens": 4071253,
+    "total_cost_usd": 1.3972765000000003,
+    "latency_seconds": 470.7,
+    "num_turns": 37,
+    "generation_tokens_per_sec": 73.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 739,
+  "output_tokens": 34723,
+  "latency_seconds": 470.7,
+  "num_turns": 37,
+  "total_cost_usd": 1.3972765000000003,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3930830,
+  "cache_creation_tokens": 104961,
+  "run_started_at": "2026-08-31T03:19:57.385259Z",
+  "run_ended_at": "2026-08-31T03:27:48.120370Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 739,
+    "output_tokens": 34723,
+    "cache_read_tokens": 3930830,
+    "cache_write_tokens": 104961,
+    "total_tokens": 4071253,
+    "total_cost_usd": 1.3972765000000003,
+    "latency_seconds": 470.7,
+    "num_turns": 37,
+    "generation_tokens_per_sec": 73.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "index-demo-videos-in-one-page",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 88,
+        "notes": "The issue clearly defines an additive documentation index, eight feature groups, URL-based deduplication, source-page attribution, and preservation of existing links. Its named paths and video types are consistent with the submitted README and documentation evidence, while the absent independent task statement prevents confirming that every proposed requirement was externally mandated. The strongest aspect is its directly testable acceptance criteria and explicit GIF and code-change exclusions. Its main limitation is limited treatment of ongoing index maintenance and external-link decay."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 19,
+        "total": 77,
+        "notes": "The LLD is unusually concrete for a documentation change, identifying README.md, docs/index.md, individual source documents, duplicate URLs, grouping, and relative-link behavior. Its largest defect is contradicting the issue's requirement that every entry name its source pages: it limits attribution to selected duplicate groups even though Agent Skills appears in both README.md and docs/agent-skills-operational-guide.md and singleton videos also have source pages. It also says only three groups need attribution, while the implementation gives Authentication & Security such a column, exposing an internal inconsistency. The maintenance scan, GIF exclusion, additive rollout, and duplicate-name warning show useful risk awareness, although exact line and baseline claims could not all be independently verified."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 18,
+        "total": 69,
+        "notes": "The review raises concrete UX, maintenance, third-party hosting, and security considerations and converts several findings into actionable changes. Its largest failure is endorsing omission of source attribution from most groups, thereby preserving a direct acceptance-criteria violation instead of catching it. The claim that only Platform Overview, Dynamic Tool Discovery, and Virtual MCP Servers have cross-page duplicates is contradicted by Agent Skills appearing in both the submitted README context and its operational guide; the review also says there are four Vidcast demos while naming and implementing only three. The safe-scan and Vidcast link-rot discussions are specific, but some asserted task history and permanence guarantees are not verifiable from the supplied task context."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 12,
+        "specificity": 20,
+        "risk_awareness": 14,
+        "total": 61,
+        "notes": "The completeness check has a meaningful oracle: comm -23 reports repository video identifiers absent from the index, and the plan also checks unchanged source files and README navigation. The central deduplication test is ineffective because index-video-ids.txt is created with sort -u before uniq -d, so it always reports no duplicates. No test verifies the issue's requirement that each row identify every source page, which would have caught the implementation's largest omission. The commands are concrete, but the recursive grep is not limited to tracked files, youtu.be is omitted from the index-side extraction, and external-link validation is only optional."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 17,
+        "total": 73,
+        "notes": "The patch provides the core deliverable: 13 distinct video links arranged in eight feature groups and an additive README.md entry point while retaining existing links. Its largest defect is incomplete source attribution: CLI, Agent Skills, Security Scanning, both federation entries, and ANS omit their source documents, while rows such as OAuth, Dynamic Tool Discovery, Full End-to-End, and Virtual MCP Servers omit README.md as a source. The patch also deviates from the claimed design by including an attribution column for Authentication & Security despite stating that only three groups would have one. Relative links and the maintenance note appear coherent, but the pinned commit and git apply --check claim could not be independently executed because the provided repository shell failed before running commands."
+      }
+    },
+    "task_score": 73.6,
+    "verdict": "The submission delivers a useful and likely complete video index, but repeatedly misses its own requirement to identify every video's source pages and includes a deduplication test that cannot detect duplicates.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:15:16.296370Z",
+      "repo_ref": "1.24.3",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 232542,
+        "cached_input_tokens": 157894,
+        "cache_write_input_tokens": 37340,
+        "output_tokens": 10782,
+        "reasoning_output_tokens": 9152
+      },
+      "duration_ms": 364930
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 82,
+      "notes": "The issue provides unusually concrete, testable behavior for five deliverables across servers, agents, and skills, including exact webhook fields, defaults, metrics, indexes, and explicit exclusions. Its HMAC threat model and backward-compatibility requirements are particularly strong. The largest gap is that its authorization goal says registrants cannot promote assets, while the submission later acknowledges that the existing `edit_server_submit` route can still change status using only `modify_service`; it also says every registration is covered while the LLD excludes `internal_register_service`. No independent task statement was supplied, and the sandbox failure prevented independent baseline-source verification, so requirement provenance beyond the internally consistent artifacts remains unverified."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 69,
+      "notes": "The LLD is highly specific about real-looking integration points such as `webhook_service.py`, the three `_perform_*_security_scan_on_registration` functions, scope seeds, repository indexes, and exact-byte HMAC transmission. Its strongest risk decisions are guarded index creation, explicit rollout compatibility, and exact request-body signing. However, its agent/skill call-site design overwrites an omitted default status with `None` when enforcement is unset, and it lists `scan_failed`/`error_message` as result fields but never uses them to distinguish a returned scan failure from success; it also leaves the legacy server edit authorization bypass outside the design. Exact repository applicability and several asserted backend behaviors could not be independently checked because local read commands failed before execution."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 71,
+      "notes": "The review surfaces concrete, consequential defects, especially admin lockout without scope-seed changes, unguarded index creation, Helm deployment gaps, signature comparison, and key-rotation limitations. It provides actionable resolutions tied to named files and symbols rather than generic reviewer approval. Its largest weakness is missing the omitted-status regression and ignored `scan_failed` result fields, while Byte incorrectly treats a plain `str(e)` slice as sufficient sanitization and the group collectively accepts the acknowledged HTML lifecycle-permission bypass. The repository claims behind the review could not be independently re-read due the sandbox execution failure, though the review's internal references can be checked against the submitted diff."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 64,
+      "notes": "The plan covers success, failure, disabled scanning, signatures, all asset types, compatibility, deployment, rollback, and an end-to-end lifecycle with concrete expected values. Its strongest oracle is the explicit admin status-change regression test corresponding to the review's scope-seed finding. The permission fixture grants `register_service` but not the already-required `modify_service`, so tests 1.14 and 1.15 cannot isolate the new permission and the expected non-status PATCH success is impossible; the tamper test can also mutate no bytes if its exact replacement is absent, and fixed sleeps make webhook checks flaky. It additionally lacks targeted automated tests for returned `scan_failed` results, the legacy edit-form bypass, and agent default-status preservation, while some commands could not be verified against the checkout."
+    },
+    "implementation": {
+      "completeness": 14,
+      "correctness": 9,
+      "specificity": 20,
+      "risk_awareness": 12,
+      "total": 55,
+      "notes": "The patch concretely touches all five requested feature areas and correctly centralizes exact-byte signing, metric emission, filters, indexes, configuration, documentation, and default admin scope grants. It nevertheless contains central correctness defects: agent and skill registration assign `None` when status was omitted and enforcement is unset, normal scan results always emit `scan_error: null` despite the documented `scan_failed`/`error_message` fields, and `truncate_scan_error` can return 514 characters while performing no real sanitization. The agent PUT code also contradicts the summary's `model_fields_set` claim, and the summary acknowledges that `edit_server_submit` remains a lifecycle-permission bypass, undermining the primary authorization goal. The submitted hunk contexts and symbols are internally coherent, but `git apply --check` and direct surrounding-source inspection could not be completed because the read-only sandbox wrapper failed before every command."
+    }
+  },
+  "task_score": 68.2,
+  "verdict": "The submission is exceptionally specific and identifies several real operational risks, but central status-default, scan-failure, and authorization-bypass defects keep the implementation from reliably delivering its stated lifecycle security guarantees.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:19:08.205822Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 362827,
+      "cached_input_tokens": 279312,
+      "cache_write_input_tokens": 67747,
+      "output_tokens": 11150,
+      "reasoning_output_tokens": 9147
+    },
+    "duration_ms": 231897
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
@@ -1,0 +1,154 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "high",
+  "tags": [
+    "architecture",
+    "security",
+    "api",
+    "webhooks",
+    "hmac",
+    "lifecycle",
+    "permissions",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 70.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 20173,
+    "output_tokens": 140054,
+    "cache_read_tokens": 51352443,
+    "cache_write_tokens": 381679,
+    "total_tokens": 51894349,
+    "total_cost_usd": 12.6655721,
+    "latency_seconds": 1994.4,
+    "num_turns": 186,
+    "generation_tokens_per_sec": 70.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 20173,
+  "output_tokens": 140054,
+  "latency_seconds": 1994.4,
+  "num_turns": 186,
+  "total_cost_usd": 12.6655721,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 51352443,
+  "cache_creation_tokens": 381679,
+  "run_started_at": "2026-08-31T01:30:23.229593Z",
+  "run_ended_at": "2026-08-31T02:03:37.687636Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 20173,
+    "output_tokens": 140054,
+    "cache_read_tokens": 51352443,
+    "cache_write_tokens": 381679,
+    "total_tokens": 51894349,
+    "total_cost_usd": 12.6655721,
+    "latency_seconds": 1994.4,
+    "num_turns": 186,
+    "generation_tokens_per_sec": 70.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "lifecycle-workflow-webhooks",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 82,
+        "notes": "The issue provides unusually concrete, testable behavior for five deliverables across servers, agents, and skills, including exact webhook fields, defaults, metrics, indexes, and explicit exclusions. Its HMAC threat model and backward-compatibility requirements are particularly strong. The largest gap is that its authorization goal says registrants cannot promote assets, while the submission later acknowledges that the existing `edit_server_submit` route can still change status using only `modify_service`; it also says every registration is covered while the LLD excludes `internal_register_service`. No independent task statement was supplied, and the sandbox failure prevented independent baseline-source verification, so requirement provenance beyond the internally consistent artifacts remains unverified."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 69,
+        "notes": "The LLD is highly specific about real-looking integration points such as `webhook_service.py`, the three `_perform_*_security_scan_on_registration` functions, scope seeds, repository indexes, and exact-byte HMAC transmission. Its strongest risk decisions are guarded index creation, explicit rollout compatibility, and exact request-body signing. However, its agent/skill call-site design overwrites an omitted default status with `None` when enforcement is unset, and it lists `scan_failed`/`error_message` as result fields but never uses them to distinguish a returned scan failure from success; it also leaves the legacy server edit authorization bypass outside the design. Exact repository applicability and several asserted backend behaviors could not be independently checked because local read commands failed before execution."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 71,
+        "notes": "The review surfaces concrete, consequential defects, especially admin lockout without scope-seed changes, unguarded index creation, Helm deployment gaps, signature comparison, and key-rotation limitations. It provides actionable resolutions tied to named files and symbols rather than generic reviewer approval. Its largest weakness is missing the omitted-status regression and ignored `scan_failed` result fields, while Byte incorrectly treats a plain `str(e)` slice as sufficient sanitization and the group collectively accepts the acknowledged HTML lifecycle-permission bypass. The repository claims behind the review could not be independently re-read due the sandbox execution failure, though the review's internal references can be checked against the submitted diff."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 64,
+        "notes": "The plan covers success, failure, disabled scanning, signatures, all asset types, compatibility, deployment, rollback, and an end-to-end lifecycle with concrete expected values. Its strongest oracle is the explicit admin status-change regression test corresponding to the review's scope-seed finding. The permission fixture grants `register_service` but not the already-required `modify_service`, so tests 1.14 and 1.15 cannot isolate the new permission and the expected non-status PATCH success is impossible; the tamper test can also mutate no bytes if its exact replacement is absent, and fixed sleeps make webhook checks flaky. It additionally lacks targeted automated tests for returned `scan_failed` results, the legacy edit-form bypass, and agent default-status preservation, while some commands could not be verified against the checkout."
+      },
+      "implementation": {
+        "completeness": 14,
+        "correctness": 9,
+        "specificity": 20,
+        "risk_awareness": 12,
+        "total": 55,
+        "notes": "The patch concretely touches all five requested feature areas and correctly centralizes exact-byte signing, metric emission, filters, indexes, configuration, documentation, and default admin scope grants. It nevertheless contains central correctness defects: agent and skill registration assign `None` when status was omitted and enforcement is unset, normal scan results always emit `scan_error: null` despite the documented `scan_failed`/`error_message` fields, and `truncate_scan_error` can return 514 characters while performing no real sanitization. The agent PUT code also contradicts the summary's `model_fields_set` claim, and the summary acknowledges that `edit_server_submit` remains a lifecycle-permission bypass, undermining the primary authorization goal. The submitted hunk contexts and symbols are internally coherent, but `git apply --check` and direct surrounding-source inspection could not be completed because the read-only sandbox wrapper failed before every command."
+      }
+    },
+    "task_score": 68.2,
+    "verdict": "The submission is exceptionally specific and identifies several real operational risks, but central status-default, scan-failure, and authorization-bypass defects keep the implementation from reliably delivering its stated lifecycle security guarantees.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:19:08.205822Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 362827,
+        "cached_input_tokens": 279312,
+        "cache_write_input_tokens": 67747,
+        "output_tokens": 11150,
+        "reasoning_output_tokens": 9147
+      },
+      "duration_ms": 231897
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 86,
+      "notes": "The issue clearly defines the exposed redirect, mixed-version behavior, graceful degradation, security properties, and explicit non-goals. The submitted diff confirms the named logout_handler and oauth2_logout integration points and the existing id_token_hint behavior. Its largest correctness weakness is overstating id_token_hint as required by the OIDC specification and describing the ID token as being revoked, which logout does not necessarily do. No independent task statement was supplied, and the asserted production WAF topology could not be independently verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 17,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 81,
+      "notes": "The LLD is unusually concrete about files, functions, collection schema, compatibility, atomic redemption, expiry, and degradation behavior. Its embedded create_logout_ticket code calls encrypt_id_token outside the exception boundary, while failed index creation is cached through _collection and never retried, contradicting its broad failure and self-cleaning guarantees. Its observability claim is also incorrect because the registry increments the present counter before auth-server redemption, so that counter cannot reveal redemption failures. Residual ticket exposure is addressed well, but index failure, encryption failure, and auth-side delivery observability remain material gaps."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 22,
+      "total": 81,
+      "notes": "The review’s strongest work is the security analysis of ticket capture, TTL exposure, legacy-path visibility, and database documentation, followed by explicit resolutions. It identifies concrete changes rather than merely approving the design and correctly preserves atomic single-use redemption. However, it states that the logout contract is a 303 to /login despite the described OAuth path redirecting to the auth server, and it overstates TTL cleanup timing. It also misses the LLD’s encryption exception boundary and permanent index-retry suppression."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 18,
+      "total": 71,
+      "notes": "The plan supplies meaningful oracles for encrypted storage, expiry, replay prevention, backward compatibility, graceful store failure, and the complete redirect chain. Its curl command captures the literal Location header prefix and then passes that entire string to curl, so the documented second hop is not executable as written. The URL-length test constructs a standalone short string instead of invoking production code and would pass even if logout_handler still leaked the token. Coverage also omits both-parameter precedence, invalid redirect_uri consuming a ticket, encryption failure, and index-creation failure."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 14,
+      "total": 66,
+      "notes": "The patch implements the normal end-to-end ticket flow in the named handlers, preserves legacy id_token_hint handling, uses atomic find_one_and_delete, and documents the new collection. Its largest defect is redeeming and deleting the one-time ticket before the existing redirect_uri safety validation, contrary to the LLD, allowing an invalid request to consume the ticket and prevent legitimate IdP logout. Additional weaknesses are encryption occurring outside create_logout_ticket’s try block, silently falling back to an unnamespaced collection on import failure, never retrying failed index creation, and committing no regression tests. The command sandbox failed before process launch, so git apply --check could not be independently run; applicability was assessed from the matching unified-diff preimages without scoring that tooling gap as a candidate defect."
+    }
+  },
+  "task_score": 77.0,
+  "verdict": "The submission offers strong, repository-shaped design work, but the implementation’s pre-validation ticket redemption and untested failure paths leave material reliability and security gaps.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:25:26.220573Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 372848,
+      "cached_input_tokens": 289341,
+      "cache_write_input_tokens": 50787,
+      "output_tokens": 14022,
+      "reasoning_output_tokens": 12077
+    },
+    "duration_ms": 378002
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "auth",
+    "oidc",
+    "logout",
+    "security",
+    "waf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 84.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 3067,
+    "output_tokens": 78001,
+    "cache_read_tokens": 8574847,
+    "cache_write_tokens": 185406,
+    "total_tokens": 8841321,
+    "total_cost_usd": 2.964628400000001,
+    "latency_seconds": 928.6,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 84.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 3067,
+  "output_tokens": 78001,
+  "latency_seconds": 928.6,
+  "num_turns": 56,
+  "total_cost_usd": 2.964628400000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 8574847,
+  "cache_creation_tokens": 185406,
+  "run_started_at": "2026-08-31T04:06:06.223385Z",
+  "run_ended_at": "2026-08-31T04:21:09.806327Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 3067,
+    "output_tokens": 78001,
+    "cache_read_tokens": 8574847,
+    "cache_write_tokens": 185406,
+    "total_tokens": 8841321,
+    "total_cost_usd": 2.964628400000001,
+    "latency_seconds": 928.6,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 84.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "agent_invocations": 2,
+  "evaluation": {
+    "task": "logout-id-token-hint-out-of-browser-url",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 86,
+        "notes": "The issue clearly defines the exposed redirect, mixed-version behavior, graceful degradation, security properties, and explicit non-goals. The submitted diff confirms the named logout_handler and oauth2_logout integration points and the existing id_token_hint behavior. Its largest correctness weakness is overstating id_token_hint as required by the OIDC specification and describing the ID token as being revoked, which logout does not necessarily do. No independent task statement was supplied, and the asserted production WAF topology could not be independently verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 17,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 81,
+        "notes": "The LLD is unusually concrete about files, functions, collection schema, compatibility, atomic redemption, expiry, and degradation behavior. Its embedded create_logout_ticket code calls encrypt_id_token outside the exception boundary, while failed index creation is cached through _collection and never retried, contradicting its broad failure and self-cleaning guarantees. Its observability claim is also incorrect because the registry increments the present counter before auth-server redemption, so that counter cannot reveal redemption failures. Residual ticket exposure is addressed well, but index failure, encryption failure, and auth-side delivery observability remain material gaps."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 22,
+        "total": 81,
+        "notes": "The review’s strongest work is the security analysis of ticket capture, TTL exposure, legacy-path visibility, and database documentation, followed by explicit resolutions. It identifies concrete changes rather than merely approving the design and correctly preserves atomic single-use redemption. However, it states that the logout contract is a 303 to /login despite the described OAuth path redirecting to the auth server, and it overstates TTL cleanup timing. It also misses the LLD’s encryption exception boundary and permanent index-retry suppression."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 18,
+        "total": 71,
+        "notes": "The plan supplies meaningful oracles for encrypted storage, expiry, replay prevention, backward compatibility, graceful store failure, and the complete redirect chain. Its curl command captures the literal Location header prefix and then passes that entire string to curl, so the documented second hop is not executable as written. The URL-length test constructs a standalone short string instead of invoking production code and would pass even if logout_handler still leaked the token. Coverage also omits both-parameter precedence, invalid redirect_uri consuming a ticket, encryption failure, and index-creation failure."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 14,
+        "total": 66,
+        "notes": "The patch implements the normal end-to-end ticket flow in the named handlers, preserves legacy id_token_hint handling, uses atomic find_one_and_delete, and documents the new collection. Its largest defect is redeeming and deleting the one-time ticket before the existing redirect_uri safety validation, contrary to the LLD, allowing an invalid request to consume the ticket and prevent legitimate IdP logout. Additional weaknesses are encryption occurring outside create_logout_ticket’s try block, silently falling back to an unnamespaced collection on import failure, never retrying failed index creation, and committing no regression tests. The command sandbox failed before process launch, so git apply --check could not be independently run; applicability was assessed from the matching unified-diff preimages without scoring that tooling gap as a candidate defect."
+      }
+    },
+    "task_score": 77.0,
+    "verdict": "The submission offers strong, repository-shaped design work, but the implementation’s pre-validation ticket redemption and untested failure paths leave material reliability and security gaps.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:25:26.220573Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 372848,
+        "cached_input_tokens": 289341,
+        "cache_write_input_tokens": 50787,
+        "output_tokens": 14022,
+        "reasoning_output_tokens": 12077
+      },
+      "duration_ms": 378002
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 84,
+      "notes": "The issue clearly defines the failure timing, desired sentinel behavior, portability constraint, scope, and testable outcomes. Its cited Phase 1 snippet and Python 3.14 requirement agree with the submitted patch context and public setup guide.  The largest gap is that it requires remote metadata before cloning but does not define behavior when retrieval or parsing fails. Because no independent task statement was supplied, the claimed later uv failure and full user journey could not be independently established."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 23,
+      "risk_awareness": 16,
+      "total": 75,
+      "notes": "The LLD is unusually concrete about the target block, sentinel contract, data flow, comparison algorithm, timeout, and unchanged phases. Its largest defect is the hard-coded 3.14 fallback, which contradicts the issue's source-of-truth requirement and can falsely pass after the project minimum increases. It also incorrectly says curl and grep are checked by Phase 1, while its own inventory lists only Docker, Python, uv, Node.js, git, jq, and gettext checks. The narrow grep parser is acknowledged, but warning about fallback does not mitigate stale-version correctness."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 67,
+      "notes": "The review identifies concrete concerns around silent fallback, mutable-branch metadata, TOML extraction, and BSD portability, with consequences and resolutions. Its main failure is approving the stale hard-coded fallback as safe without recognizing that it can violate the central acceptance criterion and produce a false success. It also claims the LLD's Alternatives Considered section documents the main-branch trust equivalence, but the submitted section contains no such discussion. The role-based structure adds little beyond these findings and does not challenge the unverified failure premise or testing portability."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 12,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 68,
+      "notes": "The plan supplies concrete expected output for old, boundary, sufficient, local, remote, and offline cases and honestly marks full end-to-end runs unexecuted. The claimed missing-python execution is invalid as written because PATH is replaced with an empty directory before invoking bash, so bash itself cannot be found. The compatibility command also contains an unresolved repository placeholder and BASE_SHA while using --staged against an external patch, and the local-source test does not actually prove curl was not invoked. No test runs on macOS/BSD userland or covers malformed metadata and a stale fallback after a minimum-version increase."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 72,
+      "notes": "The diff implements the normal local and remote metadata paths, numeric comparison, informative output, unchanged sentinels, bounded network access, and remediation-row update described by the LLD. Its largest defect is the literal 3.14 fallback, which can false-pass when metadata is unavailable after requires-python changes and therefore does not fully implement the issue's source-of-truth requirement. The hunks and surrounding symbols are internally consistent with the submitted baseline excerpts, and the summary accurately describes the patch, but the repository command sandbox failed before execution so git apply --check could not be independently repeated. The hard-coded brew example and major.minor-only extraction also preserve future drift and mishandle patch-level or prerelease requirements."
+    }
+  },
+  "task_score": 73.2,
+  "verdict": "The submission is specific and mostly implementation-ready, but its hard-coded offline fallback undermines the central metadata-driven guarantee, and several claimed test executions are not reproducible as written.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:31:35.959681Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 207752,
+      "cached_input_tokens": 143080,
+      "cache_write_input_tokens": 36228,
+      "output_tokens": 9251,
+      "reasoning_output_tokens": 7363
+    },
+    "duration_ms": 369727
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "setup",
+    "skill",
+    "developer-experience",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 70.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 168,
+    "output_tokens": 54411,
+    "cache_read_tokens": 4443835,
+    "cache_write_tokens": 105033,
+    "total_tokens": 4603447,
+    "total_cost_usd": 1.6957954999999998,
+    "latency_seconds": 770.1,
+    "num_turns": 43,
+    "generation_tokens_per_sec": 70.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 168,
+  "output_tokens": 54411,
+  "latency_seconds": 770.1,
+  "num_turns": 43,
+  "total_cost_usd": 1.6957954999999998,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 4443835,
+  "cache_creation_tokens": 105033,
+  "run_started_at": "2026-08-31T03:42:27.383547Z",
+  "run_ended_at": "2026-08-31T03:55:17.534836Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 168,
+    "output_tokens": 54411,
+    "cache_read_tokens": 4443835,
+    "cache_write_tokens": 105033,
+    "total_tokens": 4603447,
+    "total_cost_usd": 1.6957954999999998,
+    "latency_seconds": 770.1,
+    "num_turns": 43,
+    "generation_tokens_per_sec": 70.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "macos-setup-python-version-precheck",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 84,
+        "notes": "The issue clearly defines the failure timing, desired sentinel behavior, portability constraint, scope, and testable outcomes. Its cited Phase 1 snippet and Python 3.14 requirement agree with the submitted patch context and public setup guide.  The largest gap is that it requires remote metadata before cloning but does not define behavior when retrieval or parsing fails. Because no independent task statement was supplied, the claimed later uv failure and full user journey could not be independently established."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 23,
+        "risk_awareness": 16,
+        "total": 75,
+        "notes": "The LLD is unusually concrete about the target block, sentinel contract, data flow, comparison algorithm, timeout, and unchanged phases. Its largest defect is the hard-coded 3.14 fallback, which contradicts the issue's source-of-truth requirement and can falsely pass after the project minimum increases. It also incorrectly says curl and grep are checked by Phase 1, while its own inventory lists only Docker, Python, uv, Node.js, git, jq, and gettext checks. The narrow grep parser is acknowledged, but warning about fallback does not mitigate stale-version correctness."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 67,
+        "notes": "The review identifies concrete concerns around silent fallback, mutable-branch metadata, TOML extraction, and BSD portability, with consequences and resolutions. Its main failure is approving the stale hard-coded fallback as safe without recognizing that it can violate the central acceptance criterion and produce a false success. It also claims the LLD's Alternatives Considered section documents the main-branch trust equivalence, but the submitted section contains no such discussion. The role-based structure adds little beyond these findings and does not challenge the unverified failure premise or testing portability."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 12,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 68,
+        "notes": "The plan supplies concrete expected output for old, boundary, sufficient, local, remote, and offline cases and honestly marks full end-to-end runs unexecuted. The claimed missing-python execution is invalid as written because PATH is replaced with an empty directory before invoking bash, so bash itself cannot be found. The compatibility command also contains an unresolved repository placeholder and BASE_SHA while using --staged against an external patch, and the local-source test does not actually prove curl was not invoked. No test runs on macOS/BSD userland or covers malformed metadata and a stale fallback after a minimum-version increase."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 72,
+        "notes": "The diff implements the normal local and remote metadata paths, numeric comparison, informative output, unchanged sentinels, bounded network access, and remediation-row update described by the LLD. Its largest defect is the literal 3.14 fallback, which can false-pass when metadata is unavailable after requires-python changes and therefore does not fully implement the issue's source-of-truth requirement. The hunks and surrounding symbols are internally consistent with the submitted baseline excerpts, and the summary accurately describes the patch, but the repository command sandbox failed before execution so git apply --check could not be independently repeated. The hard-coded brew example and major.minor-only extraction also preserve future drift and mishandle patch-level or prerelease requirements."
+      }
+    },
+    "task_score": 73.2,
+    "verdict": "The submission is specific and mostly implementation-ready, but its hard-coded offline fallback undermines the central metadata-driven guarantee, and several claimed test executions are not reproducible as written.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:31:35.959681Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 207752,
+        "cached_input_tokens": 143080,
+        "cache_write_input_tokens": 36228,
+        "output_tokens": 9251,
+        "reasoning_output_tokens": 7363
+      },
+      "duration_ms": 369727
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 85,
+      "notes": "The issue clearly defines the prefix-hijack problem, affected routes, desired redirect behavior, compatibility expectations, and explicit non-goals. Its strongest evidence is the identified `NginxConfigService._create_location_block` integration point and testable `/a` versus `/api` acceptance example. It does not acknowledge reserved-location duplication or the behavior change for non-GET requests to the bare path, and its statement about longer static guards is imprecise because nginx selects the longest matching prefix. No independent task statement was supplied, and exact baseline source verification was unavailable when the local execution sandbox failed."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 16,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 79,
+      "notes": "The LLD is unusually concrete about `_create_location_block`, its caller, root-path handling, regeneration, duplicate static locations, and the exact rendered directives. Its largest technical gap is repeatedly claiming proxy behavior is unchanged: with a URI-bearing `proxy_pass`, changing the matched location from `/test` to `/test/` changes nginx's request-URI replacement boundary and therefore warrants explicit compatibility testing.  It also treats leading-slash normalization as meaningful nginx-injection protection without establishing restrictions on whitespace, braces, or newlines. The exact cited baseline files and line contexts could not be independently read because repository command execution failed before process launch."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 80,
+      "notes": "The review performs real design stress-testing and catches two concrete issues: root-path `//` generation and duplicate `/api/` locations that can stall configuration updates. The recommendations are prioritized, actionable, and reflected in the revised LLD rather than merely approving the proposal. Its largest omission is accepting the assertion that `_normalize_server_path` prevents nginx directive injection despite only describing leading-slash normalization, and it also misses the `proxy_pass` URI-substitution change. Claims about the exact reserved-location inventory and rollback implementation could not be independently verified against the local baseline."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 8,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 62,
+      "notes": "The plan provides concrete setup, actions, expected directive strings, sibling-route cases, compatibility checks, and deployment-oriented manual scenarios. However, `test_create_location_block_root_path_has_no_double_slash` is guaranteed to fail because the rendered block contains URLs such as `http://auth-server...`, which satisfy the blanket `assert \"//\" not in block`. The prescribed `python -m unittest discover` command will not collect the shown pytest fixture functions, while the Prometheus check searches for the Python identifier `NGINX_CONFIG_WRITES` instead of the documented exported metric `mcpgw_registry_nginx_config_writes_total`.  It also lacks an automated nginx syntax/runtime test capable of detecting duplicate locations, redirect behavior, or changed upstream URI rewriting."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 15,
+      "total": 68,
+      "notes": "The production-code hunk implements the revised design end to end: normal paths receive an exact redirect plus trailing-slash prefix, while the literal root retains its prior single block. The largest definite defect is the added root-path test's blanket `assert \"//\" not in block`, which also matches every `http://` proxy URL and makes the submitted test suite fail. The patch also changes nginx's URI replacement boundary for the existing URI-bearing `proxy_pass` but adds no test for the resulting upstream request path, so the summary overstates unchanged proxy behavior. Exact `git apply --check` and baseline-context validation could not be independently rerun because the mandatory local sandbox failed before launching commands."
+    }
+  },
+  "task_score": 74.8,
+  "verdict": "The submission presents a strong, repository-specific design and plausible fix, but its implementation includes a deterministically failing test and leaves a material nginx upstream-URI behavior change unverified.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:37:36.714121Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 306022,
+      "cached_input_tokens": 207790,
+      "cache_write_input_tokens": 46410,
+      "output_tokens": 13053,
+      "reasoning_output_tokens": 10532
+    },
+    "duration_ms": 360743
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "medium",
+  "tags": [
+    "bug",
+    "security",
+    "nginx",
+    "routing",
+    "auth",
+    "python",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2821,
+    "output_tokens": 69787,
+    "cache_read_tokens": 10023875,
+    "cache_write_tokens": 187556,
+    "total_tokens": 10284039,
+    "total_cost_usd": 3.177177,
+    "latency_seconds": 897.7,
+    "num_turns": 67,
+    "generation_tokens_per_sec": 77.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2821,
+  "output_tokens": 69787,
+  "latency_seconds": 897.7,
+  "num_turns": 67,
+  "total_cost_usd": 3.177177,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 10023875,
+  "cache_creation_tokens": 187556,
+  "run_started_at": "2026-08-31T00:31:32.857590Z",
+  "run_ended_at": "2026-08-31T00:46:30.580033Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2821,
+    "output_tokens": 69787,
+    "cache_read_tokens": 10023875,
+    "cache_write_tokens": 187556,
+    "total_tokens": 10284039,
+    "total_cost_usd": 3.177177,
+    "latency_seconds": 897.7,
+    "num_turns": 67,
+    "generation_tokens_per_sec": 77.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "nginx-location-trailing-slash-route-hijack",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 85,
+        "notes": "The issue clearly defines the prefix-hijack problem, affected routes, desired redirect behavior, compatibility expectations, and explicit non-goals. Its strongest evidence is the identified `NginxConfigService._create_location_block` integration point and testable `/a` versus `/api` acceptance example. It does not acknowledge reserved-location duplication or the behavior change for non-GET requests to the bare path, and its statement about longer static guards is imprecise because nginx selects the longest matching prefix. No independent task statement was supplied, and exact baseline source verification was unavailable when the local execution sandbox failed."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 16,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 79,
+        "notes": "The LLD is unusually concrete about `_create_location_block`, its caller, root-path handling, regeneration, duplicate static locations, and the exact rendered directives. Its largest technical gap is repeatedly claiming proxy behavior is unchanged: with a URI-bearing `proxy_pass`, changing the matched location from `/test` to `/test/` changes nginx's request-URI replacement boundary and therefore warrants explicit compatibility testing.  It also treats leading-slash normalization as meaningful nginx-injection protection without establishing restrictions on whitespace, braces, or newlines. The exact cited baseline files and line contexts could not be independently read because repository command execution failed before process launch."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 80,
+        "notes": "The review performs real design stress-testing and catches two concrete issues: root-path `//` generation and duplicate `/api/` locations that can stall configuration updates. The recommendations are prioritized, actionable, and reflected in the revised LLD rather than merely approving the proposal. Its largest omission is accepting the assertion that `_normalize_server_path` prevents nginx directive injection despite only describing leading-slash normalization, and it also misses the `proxy_pass` URI-substitution change. Claims about the exact reserved-location inventory and rollback implementation could not be independently verified against the local baseline."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 8,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 62,
+        "notes": "The plan provides concrete setup, actions, expected directive strings, sibling-route cases, compatibility checks, and deployment-oriented manual scenarios. However, `test_create_location_block_root_path_has_no_double_slash` is guaranteed to fail because the rendered block contains URLs such as `http://auth-server...`, which satisfy the blanket `assert \"//\" not in block`. The prescribed `python -m unittest discover` command will not collect the shown pytest fixture functions, while the Prometheus check searches for the Python identifier `NGINX_CONFIG_WRITES` instead of the documented exported metric `mcpgw_registry_nginx_config_writes_total`.  It also lacks an automated nginx syntax/runtime test capable of detecting duplicate locations, redirect behavior, or changed upstream URI rewriting."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 15,
+        "total": 68,
+        "notes": "The production-code hunk implements the revised design end to end: normal paths receive an exact redirect plus trailing-slash prefix, while the literal root retains its prior single block. The largest definite defect is the added root-path test's blanket `assert \"//\" not in block`, which also matches every `http://` proxy URL and makes the submitted test suite fail. The patch also changes nginx's URI replacement boundary for the existing URI-bearing `proxy_pass` but adds no test for the resulting upstream request path, so the summary overstates unchanged proxy behavior. Exact `git apply --check` and baseline-context validation could not be independently rerun because the mandatory local sandbox failed before launching commands."
+      }
+    },
+    "task_score": 74.8,
+    "verdict": "The submission presents a strong, repository-specific design and plausible fix, but its implementation includes a deterministically failing test and leaves a material nginx upstream-URI behavior change unverified.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:37:36.714121Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 306022,
+        "cached_input_tokens": 207790,
+        "cache_write_input_tokens": 46410,
+        "output_tokens": 13053,
+        "reasoning_output_tokens": 10532
+      },
+      "duration_ms": 360743
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 23,
+      "total": 92,
+      "notes": "The issue precisely identifies the two affected Compose files, required environment entries, unchanged empty defaults, and explicit exclusions. Its acceptance criteria are directly testable against the registry service environment and container process environment. The patch context corroborates the named REGISTRY_CONTACT_URL and SECRET_KEY insertion area, while the absent independent task statement limits verification of issue #1513 and the asserted downstream health-routing behavior. Security and upgrade risks are handled proportionately through fail-closed defaults and narrow scope."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 90,
+      "notes": "The LLD commits to exact files, values, placement, defaults, data flow, exclusions, and alternatives, making the small change implementation-ready. Its strongest evidence is the exact SSRF settings-to-URL-guard path and replication of the existing docker-compose.yml syntax. Minor correctness weaknesses include saying an unset ${VAR} generally causes a Compose error and several broad repository claims that could not be independently verified, such as the absence of all relevant automated Compose tests. It treats the principal security risk correctly but originally omits the operational requirement to recreate rather than merely restart the container."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 20,
+      "total": 79,
+      "notes": "The review surfaces a concrete rollout defect—changed environment configuration requires container recreation—and requests useful rendered-config and exact-syntax checks. It also prioritizes the empty default as the primary security invariant and records resolution of its recommendations. Its largest factual defect is the claim that list-form Compose environment values replace the whole list; Compose treats environment as a key-based mapping during merges regardless of YAML presentation. Several reviewer sections mostly repeat the LLD, and claims such as zero deployment risk and the fresh DHI grep were not independently verifiable."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 18,
+      "risk_awareness": 17,
+      "total": 71,
+      "notes": "The core tests have meaningful oracles for set and unset interpolation, YAML validity, actual container environment, file scope, and both target Compose variants. The main deficiency is that the E2E scenario is not executable as written: it leaves internal-server registration, hostname, authentication, API schema, and health-check timing as placeholders while assuming /api/servers and a five-second cycle. The rollback procedure uses broad git stash operations and the grep-based rendered-config checks are not explicitly scoped to the registry service, creating avoidable false-positive and workspace risks. The asserted absence of an automated Compose test suite and the runtime commands could not be independently verified."
+    },
+    "implementation": {
+      "completeness": 24,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 92,
+      "notes": "The patch implements the requested change end to end by adding both exact empty-default passthroughs to both named registry environment blocks and touching nothing else. Its diff contexts consistently anchor the additions between REGISTRY_CONTACT_URL or the BUILD_VERSION explanation and SECRET_KEY, and the YAML indentation and substitution syntax are appropriate. The summary honestly distinguishes rendered-config checks from the unexecuted container and E2E verification, although no automated regression protection is added. Local git apply --check and the claimed baseline commit could not be independently confirmed because repository command execution failed at the sandbox boundary, but no contradiction is visible in the submitted source contexts."
+    }
+  },
+  "task_score": 84.8,
+  "verdict": "This is a strong, implementation-ready configuration fix whose largest material limitation is an E2E testing procedure that depends on ungrounded placeholders and unspecified API setup.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:45:03.114315Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 287759,
+      "cached_input_tokens": 198088,
+      "cache_write_input_tokens": 41060,
+      "output_tokens": 12038,
+      "reasoning_output_tokens": 9931
+    },
+    "duration_ms": 446388
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "docker",
+    "compose",
+    "configuration",
+    "ssrf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 79.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 76,
+    "output_tokens": 37974,
+    "cache_read_tokens": 3614564,
+    "cache_write_tokens": 96244,
+    "total_tokens": 3748858,
+    "total_cost_usd": 1.3434148,
+    "latency_seconds": 477.4,
+    "num_turns": 38,
+    "generation_tokens_per_sec": 79.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 76,
+  "output_tokens": 37974,
+  "latency_seconds": 477.4,
+  "num_turns": 38,
+  "total_cost_usd": 1.3434148,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3614564,
+  "cache_creation_tokens": 96244,
+  "run_started_at": "2026-08-31T03:34:26.973234Z",
+  "run_ended_at": "2026-08-31T03:42:24.405962Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 76,
+    "output_tokens": 37974,
+    "cache_read_tokens": 3614564,
+    "cache_write_tokens": 96244,
+    "total_tokens": 3748858,
+    "total_cost_usd": 1.3434148,
+    "latency_seconds": 477.4,
+    "num_turns": 38,
+    "generation_tokens_per_sec": 79.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "pass-ssrf-allowlist-env-to-registry-container",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 23,
+        "total": 92,
+        "notes": "The issue precisely identifies the two affected Compose files, required environment entries, unchanged empty defaults, and explicit exclusions. Its acceptance criteria are directly testable against the registry service environment and container process environment. The patch context corroborates the named REGISTRY_CONTACT_URL and SECRET_KEY insertion area, while the absent independent task statement limits verification of issue #1513 and the asserted downstream health-routing behavior. Security and upgrade risks are handled proportionately through fail-closed defaults and narrow scope."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 90,
+        "notes": "The LLD commits to exact files, values, placement, defaults, data flow, exclusions, and alternatives, making the small change implementation-ready. Its strongest evidence is the exact SSRF settings-to-URL-guard path and replication of the existing docker-compose.yml syntax. Minor correctness weaknesses include saying an unset ${VAR} generally causes a Compose error and several broad repository claims that could not be independently verified, such as the absence of all relevant automated Compose tests. It treats the principal security risk correctly but originally omits the operational requirement to recreate rather than merely restart the container."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 20,
+        "total": 79,
+        "notes": "The review surfaces a concrete rollout defect—changed environment configuration requires container recreation—and requests useful rendered-config and exact-syntax checks. It also prioritizes the empty default as the primary security invariant and records resolution of its recommendations. Its largest factual defect is the claim that list-form Compose environment values replace the whole list; Compose treats environment as a key-based mapping during merges regardless of YAML presentation. Several reviewer sections mostly repeat the LLD, and claims such as zero deployment risk and the fresh DHI grep were not independently verifiable."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 18,
+        "risk_awareness": 17,
+        "total": 71,
+        "notes": "The core tests have meaningful oracles for set and unset interpolation, YAML validity, actual container environment, file scope, and both target Compose variants. The main deficiency is that the E2E scenario is not executable as written: it leaves internal-server registration, hostname, authentication, API schema, and health-check timing as placeholders while assuming /api/servers and a five-second cycle. The rollback procedure uses broad git stash operations and the grep-based rendered-config checks are not explicitly scoped to the registry service, creating avoidable false-positive and workspace risks. The asserted absence of an automated Compose test suite and the runtime commands could not be independently verified."
+      },
+      "implementation": {
+        "completeness": 24,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 92,
+        "notes": "The patch implements the requested change end to end by adding both exact empty-default passthroughs to both named registry environment blocks and touching nothing else. Its diff contexts consistently anchor the additions between REGISTRY_CONTACT_URL or the BUILD_VERSION explanation and SECRET_KEY, and the YAML indentation and substitution syntax are appropriate. The summary honestly distinguishes rendered-config checks from the unexecuted container and E2E verification, although no automated regression protection is added. Local git apply --check and the claimed baseline commit could not be independently confirmed because repository command execution failed at the sandbox boundary, but no contradiction is visible in the submitted source contexts."
+      }
+    },
+    "task_score": 84.8,
+    "verdict": "This is a strong, implementation-ready configuration fix whose largest material limitation is an E2E testing procedure that depends on ungrounded placeholders and unspecified API setup.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:45:03.114315Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 287759,
+        "cached_input_tokens": 198088,
+        "cache_write_input_tokens": 41060,
+        "output_tokens": 12038,
+        "reasoning_output_tokens": 9931
+      },
+      "duration_ms": 446388
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 85,
+      "notes": "The issue provides unusually testable acceptance criteria covering counter scope, admin asymmetry, failure policy, response semantics, management surfaces, and explicit non-goals. Its references to `RateLimitDefinition`, `RateLimiter.check()`, `_validate_caller_floor`, and the `/validate` hook align with the source contexts represented in the patch. Its largest gap is calling quarantine immediate without defining an enforcement-propagation bound, despite the later design allowing per-process cache staleness, and it does not state clearly that quarantine is inactive when the master rate-limiting switch is off. No independent task statement was supplied, so claims about issues #295 and #1504 could not be used to establish additional requirements."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 16,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 79,
+      "notes": "The LLD is highly concrete about data flow, repository methods, API shapes, failure behavior, rollout, and exact integration points such as `RateLimiter.check()` and nginx's throttle marker. Its largest technical flaw is using unescaped colon-delimited `group_name`, target name, and caller identity values in definition IDs and counter subjects even though it explicitly recognizes that names may contain colons; distinct definitions or caller-target pairs can therefore alias. It also promises reuse of `RATE_LIMIT_BACKEND_TIMEOUT_MS` while specifying a hardcoded repository default, and its five-second process-local cache does not satisfy the issue's unqualified immediate-kill-switch language. The stated `cli/api/...` paths are contradicted by the repository's `api/registry_client.py` and `api/registry_management.py` paths, which the implementation summary later acknowledges."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 80,
+      "notes": "The review performs real design work by identifying the missing caller-target floor safeguard and the unsafe inherited fail-open policy, then tracing their resolutions to `_validate_caller_floor` and the quarantine repository design. It also gives actionable frontend, backend, operations, and security recommendations rather than generic approvals. Its largest omission is failing to catch the ambiguous composite IDs and counter keys, along with the UI's need to surface quarantine-list loading failures. Circuit's claim that a five-second TTL implies approximately ten seconds of normal propagation is unsupported; ordinary expiry is bounded by roughly one TTL plus read latency, while backend failure can preserve stale last-known-good state much longer."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 76,
+      "notes": "The plan has strong behavioral oracles, including exact quota counts, independent caller and target buckets, plain-403 header absence, admin-bypass asymmetry, seed idempotency, and a zero-counter-call assertion. A concrete execution defect is that its CLI commands invoke `registry_management.py` from the repository root even though the implementation confirms the real path is `api/registry_management.py`. Sleeping twelve seconds before checking quarantine proves eventual behavior but does not measure or enforce the promised propagation bound, and the plan omits delimiter-collision, concurrent mutation, degraded-read metric, and quarantine-fetch-error UI cases. The plan reports no executed results, which is acceptable, but its rollback and default-200 assumptions remain unverified."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 71,
+      "notes": "The patch covers the principal end-to-end surfaces: model validation, definition lookup, limiter gates, quarantine storage, startup seeding, admin routes, auth-server response handling, CLI, UI, and substantial unit and integration coverage. Its largest correctness defect is delimiter aliasing: `build_id()` concatenates two unrestricted fields and `_build_caller_target_gates()` concatenates identity and target name with colons, allowing distinct definitions or counters to share a key. Additional material gaps include a hardcoded 0.25-second quarantine timeout instead of `RATE_LIMIT_BACKEND_TIMEOUT_MS`, no promised `rate_limit_errors_total` update on degraded reads, non-atomic find-then-pull removal, and a UI that ignores quarantine loading errors and can display empty lists after a failed fetch. The diff's contexts are internally plausible, but `git apply --check` could not be independently executed because the provided shell sandbox failed before command execution; this evidence limitation was not scored as a candidate defect."
+    }
+  },
+  "task_score": 78.2,
+  "verdict": "The submission is comprehensive and thoughtfully reviewed, but ambiguous composite keys and several quarantine consistency and failure-reporting defects keep the implementation from being production-ready.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:49:32.424583Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 502547,
+      "cached_input_tokens": 397746,
+      "cache_write_input_tokens": 81949,
+      "output_tokens": 14959,
+      "reasoning_output_tokens": 13112
+    },
+    "duration_ms": 269297
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "high",
+  "tags": [
+    "rate-limiting",
+    "security",
+    "auth-server",
+    "api",
+    "operations",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 0.1,
+  "token_accounting_warning": "[task=per-caller-per-target-rate-limits-and-quarantine] TOKEN ACCOUNTING SUSPECT: 362 output tokens over 245 turns = 1.5/turn, below the 20 floor. An agent making edits emits hundreds per turn, so the omp usage is likely being read from one scope instead of summed across all of them (see the pi per-message usage bug, issue #99). Scores, turns, and latency are unaffected and still valid -- but DO NOT publish the token or cost columns from this run without re-checking the extractor.",
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4,
+    "output_tokens": 362,
+    "cache_read_tokens": 946102,
+    "cache_write_tokens": 1746,
+    "total_tokens": 948214,
+    "total_cost_usd": 0.19721340000000004,
+    "latency_seconds": 2716.7,
+    "num_turns": 245,
+    "generation_tokens_per_sec": 0.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4,
+  "output_tokens": 362,
+  "latency_seconds": 2716.7,
+  "num_turns": 245,
+  "total_cost_usd": 0.19721340000000004,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 946102,
+  "cache_creation_tokens": 1746,
+  "run_started_at": "2026-08-31T02:03:40.646265Z",
+  "run_ended_at": "2026-08-31T02:48:57.451368Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4,
+    "output_tokens": 362,
+    "cache_read_tokens": 946102,
+    "cache_write_tokens": 1746,
+    "total_tokens": 948214,
+    "total_cost_usd": 0.19721340000000004,
+    "latency_seconds": 2716.7,
+    "num_turns": 245,
+    "generation_tokens_per_sec": 0.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "per-caller-per-target-rate-limits-and-quarantine",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 85,
+        "notes": "The issue provides unusually testable acceptance criteria covering counter scope, admin asymmetry, failure policy, response semantics, management surfaces, and explicit non-goals. Its references to `RateLimitDefinition`, `RateLimiter.check()`, `_validate_caller_floor`, and the `/validate` hook align with the source contexts represented in the patch. Its largest gap is calling quarantine immediate without defining an enforcement-propagation bound, despite the later design allowing per-process cache staleness, and it does not state clearly that quarantine is inactive when the master rate-limiting switch is off. No independent task statement was supplied, so claims about issues #295 and #1504 could not be used to establish additional requirements."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 16,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 79,
+        "notes": "The LLD is highly concrete about data flow, repository methods, API shapes, failure behavior, rollout, and exact integration points such as `RateLimiter.check()` and nginx's throttle marker. Its largest technical flaw is using unescaped colon-delimited `group_name`, target name, and caller identity values in definition IDs and counter subjects even though it explicitly recognizes that names may contain colons; distinct definitions or caller-target pairs can therefore alias. It also promises reuse of `RATE_LIMIT_BACKEND_TIMEOUT_MS` while specifying a hardcoded repository default, and its five-second process-local cache does not satisfy the issue's unqualified immediate-kill-switch language. The stated `cli/api/...` paths are contradicted by the repository's `api/registry_client.py` and `api/registry_management.py` paths, which the implementation summary later acknowledges."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 80,
+        "notes": "The review performs real design work by identifying the missing caller-target floor safeguard and the unsafe inherited fail-open policy, then tracing their resolutions to `_validate_caller_floor` and the quarantine repository design. It also gives actionable frontend, backend, operations, and security recommendations rather than generic approvals. Its largest omission is failing to catch the ambiguous composite IDs and counter keys, along with the UI's need to surface quarantine-list loading failures. Circuit's claim that a five-second TTL implies approximately ten seconds of normal propagation is unsupported; ordinary expiry is bounded by roughly one TTL plus read latency, while backend failure can preserve stale last-known-good state much longer."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 76,
+        "notes": "The plan has strong behavioral oracles, including exact quota counts, independent caller and target buckets, plain-403 header absence, admin-bypass asymmetry, seed idempotency, and a zero-counter-call assertion. A concrete execution defect is that its CLI commands invoke `registry_management.py` from the repository root even though the implementation confirms the real path is `api/registry_management.py`. Sleeping twelve seconds before checking quarantine proves eventual behavior but does not measure or enforce the promised propagation bound, and the plan omits delimiter-collision, concurrent mutation, degraded-read metric, and quarantine-fetch-error UI cases. The plan reports no executed results, which is acceptable, but its rollback and default-200 assumptions remain unverified."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 71,
+        "notes": "The patch covers the principal end-to-end surfaces: model validation, definition lookup, limiter gates, quarantine storage, startup seeding, admin routes, auth-server response handling, CLI, UI, and substantial unit and integration coverage. Its largest correctness defect is delimiter aliasing: `build_id()` concatenates two unrestricted fields and `_build_caller_target_gates()` concatenates identity and target name with colons, allowing distinct definitions or counters to share a key. Additional material gaps include a hardcoded 0.25-second quarantine timeout instead of `RATE_LIMIT_BACKEND_TIMEOUT_MS`, no promised `rate_limit_errors_total` update on degraded reads, non-atomic find-then-pull removal, and a UI that ignores quarantine loading errors and can display empty lists after a failed fetch. The diff's contexts are internally plausible, but `git apply --check` could not be independently executed because the provided shell sandbox failed before command execution; this evidence limitation was not scored as a candidate defect."
+      }
+    },
+    "task_score": 78.2,
+    "verdict": "The submission is comprehensive and thoughtfully reviewed, but ambiguous composite keys and several quarantine consistency and failure-reporting defects keep the implementation from being production-ready.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:49:32.424583Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 502547,
+        "cached_input_tokens": 397746,
+        "cache_write_input_tokens": 81949,
+        "output_tokens": 14959,
+        "reasoning_output_tokens": 13112
+      },
+      "duration_ms": 269297
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 69,
+      "notes": "The issue clearly identifies the five static secret blocks and dynamic metrics-key loop shown in the submitted diff, with concrete acceptance criteria and exclusions. Its largest gap is recovery from the exact corrupted state it describes: removing only empty entries and appending a value leaves an existing nonempty duplicate intact. It also acknowledges that `source .env` uses the last assignment while grouping it with first-match consumers, and provides no repository paths for the asserted `grep -m1` or `awk` consumers. No independent task statement was supplied, so the claimed crash-loop impact and linked issue could not be independently established."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 71,
+      "notes": "The LLD is unusually concrete about the helper, six integration sites, `set -e` handling, temporary-file placement, and the resulting 0600 mode. It nevertheless omits migration of an already affected file containing both `KEY=` and `KEY=old`, which the proposed patterns transform into two nonempty assignments after appending the new value. Its explanation of `grep -vE` status 1 is incorrect: that status means no output lines were selected, not that the removal pattern matched nothing. The accepted permission change also conflicts with the stated zero Linux behavior change and ignores other replaced-file metadata such as ACLs or extended attributes."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 12,
+      "specificity": 18,
+      "risk_awareness": 16,
+      "total": 61,
+      "notes": "The review surfaces concrete concerns about 0600 permissions, interrupted-run temporary files, and unescaped regular-expression arguments. Its largest deficiency is approving the design without noticing that the documented macOS duplicate state is not normalized by the proposed empty-only patterns. It repeats unsupported claims about first-match consumers and same-user access without identifying corresponding repository paths or callers. The role-based structure adds breadth, but it misses the load-bearing compatibility defect while treating peripheral findings as the principal risks."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 12,
+      "specificity": 20,
+      "risk_awareness": 10,
+      "total": 55,
+      "notes": "The plan provides executable-looking commands and specific content/count oracles for empty placeholders, quoted empties, dynamic keys, malformed patterns, and shell syntax. Test 1.2.1 is not the exact reported regression state because it omits the previously appended nonempty value; consequently it would not catch the implementation leaving two nonempty assignments. Test 1.2.3 also does not exercise `grep -vE` status 1 because an unrelated line is selected and produces status 0. No test invokes the real secret-generation section, runs on BSD/macOS, checks mode changes, or induces the filesystem failures explicitly named by the acceptance criteria."
+    },
+    "implementation": {
+      "completeness": 17,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 13,
+      "total": 66,
+      "notes": "The diff consistently adds one Bash helper and replaces all six logical deletion sites, and its normal missing-or-single-empty-placeholder behavior is portable and internally coherent. The largest defect is that an affected file containing `KEY=` followed by `KEY=old` becomes `KEY=old` plus `KEY=new`, violating the claimed one-line invariant and leaving recovery semantics parser-dependent. Replacing the file also changes its mode and metadata, contradicting the summary's unchanged-behavior framing despite the LLD accepting the 0600 side effect. The submitted hunk contexts are coherent, but the claimed baseline commit and `git apply --check` result could not be independently verified because repository shell execution was blocked before commands ran."
+    }
+  },
+  "task_score": 64.4,
+  "verdict": "The submission offers a focused and mostly sound portability mechanism, but it misses recovery of the duplicate state caused by the original bug and its tests do not expose that central defect.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T05:55:35.997081Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 298086,
+      "cached_input_tokens": 213259,
+      "cache_write_input_tokens": 41443,
+      "output_tokens": 13376,
+      "reasoning_output_tokens": 11159
+    },
+    "duration_ms": 363560
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "portability",
+    "macos",
+    "secrets",
+    "setup",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 81.3,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 78,
+    "output_tokens": 49972,
+    "cache_read_tokens": 3890948,
+    "cache_write_tokens": 99099,
+    "total_tokens": 4040097,
+    "total_cost_usd": 1.5258131000000004,
+    "latency_seconds": 614.6,
+    "num_turns": 39,
+    "generation_tokens_per_sec": 81.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 78,
+  "output_tokens": 49972,
+  "latency_seconds": 614.6,
+  "num_turns": 39,
+  "total_cost_usd": 1.5258131000000004,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3890948,
+  "cache_creation_tokens": 99099,
+  "run_started_at": "2026-08-31T03:55:20.504203Z",
+  "run_ended_at": "2026-08-31T04:05:35.079934Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 78,
+    "output_tokens": 49972,
+    "cache_read_tokens": 3890948,
+    "cache_write_tokens": 99099,
+    "total_tokens": 4040097,
+    "total_cost_usd": 1.5258131000000004,
+    "latency_seconds": 614.6,
+    "num_turns": 39,
+    "generation_tokens_per_sec": 81.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "portable-env-secret-generation-in-build-script",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 69,
+        "notes": "The issue clearly identifies the five static secret blocks and dynamic metrics-key loop shown in the submitted diff, with concrete acceptance criteria and exclusions. Its largest gap is recovery from the exact corrupted state it describes: removing only empty entries and appending a value leaves an existing nonempty duplicate intact. It also acknowledges that `source .env` uses the last assignment while grouping it with first-match consumers, and provides no repository paths for the asserted `grep -m1` or `awk` consumers. No independent task statement was supplied, so the claimed crash-loop impact and linked issue could not be independently established."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 71,
+        "notes": "The LLD is unusually concrete about the helper, six integration sites, `set -e` handling, temporary-file placement, and the resulting 0600 mode. It nevertheless omits migration of an already affected file containing both `KEY=` and `KEY=old`, which the proposed patterns transform into two nonempty assignments after appending the new value. Its explanation of `grep -vE` status 1 is incorrect: that status means no output lines were selected, not that the removal pattern matched nothing. The accepted permission change also conflicts with the stated zero Linux behavior change and ignores other replaced-file metadata such as ACLs or extended attributes."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 12,
+        "specificity": 18,
+        "risk_awareness": 16,
+        "total": 61,
+        "notes": "The review surfaces concrete concerns about 0600 permissions, interrupted-run temporary files, and unescaped regular-expression arguments. Its largest deficiency is approving the design without noticing that the documented macOS duplicate state is not normalized by the proposed empty-only patterns. It repeats unsupported claims about first-match consumers and same-user access without identifying corresponding repository paths or callers. The role-based structure adds breadth, but it misses the load-bearing compatibility defect while treating peripheral findings as the principal risks."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 12,
+        "specificity": 20,
+        "risk_awareness": 10,
+        "total": 55,
+        "notes": "The plan provides executable-looking commands and specific content/count oracles for empty placeholders, quoted empties, dynamic keys, malformed patterns, and shell syntax. Test 1.2.1 is not the exact reported regression state because it omits the previously appended nonempty value; consequently it would not catch the implementation leaving two nonempty assignments. Test 1.2.3 also does not exercise `grep -vE` status 1 because an unrelated line is selected and produces status 0. No test invokes the real secret-generation section, runs on BSD/macOS, checks mode changes, or induces the filesystem failures explicitly named by the acceptance criteria."
+      },
+      "implementation": {
+        "completeness": 17,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 13,
+        "total": 66,
+        "notes": "The diff consistently adds one Bash helper and replaces all six logical deletion sites, and its normal missing-or-single-empty-placeholder behavior is portable and internally coherent. The largest defect is that an affected file containing `KEY=` followed by `KEY=old` becomes `KEY=old` plus `KEY=new`, violating the claimed one-line invariant and leaving recovery semantics parser-dependent. Replacing the file also changes its mode and metadata, contradicting the summary's unchanged-behavior framing despite the LLD accepting the 0600 side effect. The submitted hunk contexts are coherent, but the claimed baseline commit and `git apply --check` result could not be independently verified because repository shell execution was blocked before commands ran."
+      }
+    },
+    "task_score": 64.4,
+    "verdict": "The submission offers a focused and mostly sound portability mechanism, but it misses recovery of the duplicate state caused by the original bug and its tests do not expose that central defect.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T05:55:35.997081Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 298086,
+        "cached_input_tokens": 213259,
+        "cache_write_input_tokens": 41443,
+        "output_tokens": 13376,
+        "reasoning_output_tokens": 11159
+      },
+      "duration_ms": 363560
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "registration-admission-control-gate",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 24,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 92,
+      "notes": "The issue clearly defines fail-closed behavior, default-off compatibility, seven registration/update entry points, deployment surfaces, and testable status-code outcomes. Its named route categories and configuration agree with the submitted patch's agent, server, skill, and Settings changes. The largest gap is an underspecified 403 response-body contract, alongside limited discussion of transmitting sensitive registration metadata to an external service. No independent task statement was supplied, so requirement completeness beyond this internally defined contract cannot be verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 84,
+      "notes": "The LLD is unusually concrete, naming real route functions, persistence calls, configuration fields, stable endpoint identifiers, and failure translations that correspond to the patch. It makes useful decisions about call ordering, service identities, encrypted server credentials, and default-off rollout. Its largest design omission is that the Helm existing-secret option requires a deployment secretKeyRef change, yet deployment.yaml is absent from the LLD's file checklist and later appears in the implementation. It also leaves malformed URLs, invalid timeout values, potentially non-JSON-serializable server dictionaries, and Terraform's plaintext ECS environment handling of the token insufficiently addressed."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 21,
+      "risk_awareness": 22,
+      "total": 83,
+      "notes": "The review identifies concrete concerns including server register/update ambiguity, internal service identities, call-before-persistence testing, credential encryption ordering, HTTPS guidance, outage impact, and keyword-only arguments. Several recommendations are visibly reflected in the patch, notably the keyword-only signature, service-identity documentation, and route-ordering tests. Its largest weakness is accepting unsupported assertions about frontend error handling and encryption placement while missing the LLD's Helm deployment omission and the Terraform token's exposure through ECS environment variables. Exact claims about existing UI, metrics, and deployment conventions could not all be independently confirmed from the unavailable local baseline."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The plan provides concrete setups and oracles for disabled, allow, deny, timeout, connection, status, authentication-header, deployment, and rollback behavior, plus seven persistence-order checks. The largest gap is that route tests do not assert each gate call's exact endpoint, username, or payload and do not prove that an enabled 200 response permits persistence across all seven paths. The promised token-log coverage spans allow, deny, and timeout, but the patch tests only the allow path, and no test pins encrypted rather than plaintext server credentials. The plan's 13 service tests plus 7 route tests total 20, contradicting implementation.md's claim of 23, while exact command and marker compatibility could not be locally executed."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 19,
+      "risk_awareness": 17,
+      "total": 73,
+      "notes": "The patch implements the shared gate, all seven stated call sites, default-off configuration, fail-closed status handling, deployment wiring, and focused unit and ordering tests. Error handling catches HTTPX failures but not configuration or serialization failures such as an invalid timeout, malformed URL outside HTTPX's caught hierarchy, or a non-JSON-serializable server_entry, which can produce an unintended 500 while still blocking the write. Terraform places the bearer token directly in the ECS task environment, and disabled calls still eagerly evaluate model_dump arguments despite claims of a zero-cost no-op. The summary is demonstrably inaccurate: the displayed diff contains 19 files and 1,027 added lines rather than 17 files and 738 lines, and exact git applicability could not be independently checked because the read-only shell sandbox failed before command execution."
+    }
+  },
+  "task_score": 81.8,
+  "verdict": "This is a strong, repository-specific submission with an end-to-end implementation, but incomplete test oracles, configuration and secret-handling risks, and materially inaccurate implementation accounting prevent an excellent score.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T06:02:25.613576Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 435217,
+      "cached_input_tokens": 337579,
+      "cache_write_input_tokens": 60565,
+      "output_tokens": 16361,
+      "reasoning_output_tokens": 14410
+    },
+    "duration_ms": 409604
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "registration-admission-control-gate",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "architecture",
+    "api",
+    "fastapi",
+    "webhooks",
+    "admission-control",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 79.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8678,
+    "output_tokens": 104515,
+    "cache_read_tokens": 25860336,
+    "cache_write_tokens": 293112,
+    "total_tokens": 26266641,
+    "total_cost_usd": 6.9673532,
+    "latency_seconds": 1313.7,
+    "num_turns": 120,
+    "generation_tokens_per_sec": 79.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 8678,
+  "output_tokens": 104515,
+  "latency_seconds": 1313.7,
+  "num_turns": 120,
+  "total_cost_usd": 6.9673532,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 25860336,
+  "cache_creation_tokens": 293112,
+  "run_started_at": "2026-08-31T00:46:33.228863Z",
+  "run_ended_at": "2026-08-31T01:08:26.927976Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8678,
+    "output_tokens": 104515,
+    "cache_read_tokens": 25860336,
+    "cache_write_tokens": 293112,
+    "total_tokens": 26266641,
+    "total_cost_usd": 6.9673532,
+    "latency_seconds": 1313.7,
+    "num_turns": 120,
+    "generation_tokens_per_sec": 79.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "registration-admission-control-gate",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 24,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 92,
+        "notes": "The issue clearly defines fail-closed behavior, default-off compatibility, seven registration/update entry points, deployment surfaces, and testable status-code outcomes. Its named route categories and configuration agree with the submitted patch's agent, server, skill, and Settings changes. The largest gap is an underspecified 403 response-body contract, alongside limited discussion of transmitting sensitive registration metadata to an external service. No independent task statement was supplied, so requirement completeness beyond this internally defined contract cannot be verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 84,
+        "notes": "The LLD is unusually concrete, naming real route functions, persistence calls, configuration fields, stable endpoint identifiers, and failure translations that correspond to the patch. It makes useful decisions about call ordering, service identities, encrypted server credentials, and default-off rollout. Its largest design omission is that the Helm existing-secret option requires a deployment secretKeyRef change, yet deployment.yaml is absent from the LLD's file checklist and later appears in the implementation. It also leaves malformed URLs, invalid timeout values, potentially non-JSON-serializable server dictionaries, and Terraform's plaintext ECS environment handling of the token insufficiently addressed."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 21,
+        "risk_awareness": 22,
+        "total": 83,
+        "notes": "The review identifies concrete concerns including server register/update ambiguity, internal service identities, call-before-persistence testing, credential encryption ordering, HTTPS guidance, outage impact, and keyword-only arguments. Several recommendations are visibly reflected in the patch, notably the keyword-only signature, service-identity documentation, and route-ordering tests. Its largest weakness is accepting unsupported assertions about frontend error handling and encryption placement while missing the LLD's Helm deployment omission and the Terraform token's exposure through ECS environment variables. Exact claims about existing UI, metrics, and deployment conventions could not all be independently confirmed from the unavailable local baseline."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The plan provides concrete setups and oracles for disabled, allow, deny, timeout, connection, status, authentication-header, deployment, and rollback behavior, plus seven persistence-order checks. The largest gap is that route tests do not assert each gate call's exact endpoint, username, or payload and do not prove that an enabled 200 response permits persistence across all seven paths. The promised token-log coverage spans allow, deny, and timeout, but the patch tests only the allow path, and no test pins encrypted rather than plaintext server credentials. The plan's 13 service tests plus 7 route tests total 20, contradicting implementation.md's claim of 23, while exact command and marker compatibility could not be locally executed."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 19,
+        "risk_awareness": 17,
+        "total": 73,
+        "notes": "The patch implements the shared gate, all seven stated call sites, default-off configuration, fail-closed status handling, deployment wiring, and focused unit and ordering tests. Error handling catches HTTPX failures but not configuration or serialization failures such as an invalid timeout, malformed URL outside HTTPX's caught hierarchy, or a non-JSON-serializable server_entry, which can produce an unintended 500 while still blocking the write. Terraform places the bearer token directly in the ECS task environment, and disabled calls still eagerly evaluate model_dump arguments despite claims of a zero-cost no-op. The summary is demonstrably inaccurate: the displayed diff contains 19 files and 1,027 added lines rather than 17 files and 738 lines, and exact git applicability could not be independently checked because the read-only shell sandbox failed before command execution."
+      }
+    },
+    "task_score": 81.8,
+    "verdict": "This is a strong, repository-specific submission with an end-to-end implementation, but incomplete test oracles, configuration and secret-handling risks, and materially inaccurate implementation accounting prevent an excellent score.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T06:02:25.613576Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 435217,
+        "cached_input_tokens": 337579,
+        "cache_write_input_tokens": 60565,
+        "output_tokens": 16361,
+        "reasoning_output_tokens": 14410
+      },
+      "duration_ms": 409604
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/run-summary.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/run-summary.json
@@ -1,0 +1,1438 @@
+{
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry-v2",
+  "provider": "bedrock",
+  "ref": null,
+  "refs": [
+    "1.23.0",
+    "1.24.3",
+    "1.24.7",
+    "1.25.0",
+    "1.27.1",
+    "1.28.0",
+    "v1.0.18",
+    "v1.0.19",
+    "v1.0.20",
+    "v1.0.21"
+  ],
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T04:26:01.402674Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 810664,
+      "cached_input_tokens": 633966,
+      "cache_write_input_tokens": 131197,
+      "output_tokens": 9941,
+      "reasoning_output_tokens": 8528
+    },
+    "duration_ms": 291057
+  },
+  "num_tasks": 21,
+  "num_scored": 21,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 76.97,
+  "mean_cost_usd_excl_failed": 3.21,
+  "tasks": [
+    {
+      "task": "cli-custom-egress-oauth-provider-flags",
+      "complexity": "low",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 53,
+      "input_tokens": 2363,
+      "output_tokens": 55884,
+      "total_tokens": 6975167,
+      "latency_seconds": 647.1,
+      "total_cost_usd": 2.2753854000000002,
+      "result_subtype": "success",
+      "task_score": 84.8,
+      "cache_read_tokens": 6774122,
+      "cache_write_tokens": 142798,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 86.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 87,
+          "notes": "The issue provides testable acceptance criteria, explicit exclusions, and exact CLI-to-API field mappings. Its largest flaw is claiming curl is the only alternative while also stating that the React modal already submits the required custom URLs. The named configure_egress_auth, EgressConfigRequest, and resolve_provider interfaces are consistent with the submitted patch contexts. Exact repository and issue references could not be independently shell-verified because the read-only execution wrapper failed before running commands."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 19,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 88,
+          "notes": "The LLD commits to concrete signatures, body construction, argparse choices, integration points, rollout, and security-validation ownership. Its largest defect is saying omitted required URLs may be persisted as None even though it also says resolve_provider validates before persistence; such a request should be rejected rather than silently overwrite those fields. The proposed appended parameters and five guarded body assignments precisely match the implementation diff. Exact line references and the claimed unhandled enum exception path remained independently unverifiable due the repository shell failure."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 81,
+          "notes": "The review gives prioritized recommendations on documentation, positional compatibility, parser validation, and deferred server behavior. Its principal weakness is elevating the questionable required-URL preservation claim into a blocker and presenting the enum-to-500 path without decisive evidence. The recommendation to append parameters and the identified documentation gap are concrete, but the claimed grep verification of callers is not demonstrated. Repository-side confirmation of those claims was unavailable because commands could not execute."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 79,
+          "notes": "The plan covers request inclusion and omission, command forwarding, valid enum values, built-in-provider compatibility, and help behavior with concrete oracles. The invalid-value test asserts only SystemExit(2), so it also passes on the pre-change unrecognized-argument failure, contradicting the checklist claim that every new test fails before the fix. The body assertions are strong, but no exact pytest command or automated server-success test proves the headline CLI workflow. Test harness compatibility with the checkout could not be independently executed in the available environment."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 89,
+          "notes": "The patch implements the full CLI-to-client path by appending five optional parameters, conditionally adding their JSON keys, adding five parser flags, and forwarding all values. The largest weakness is the non-discriminating invalid-choice test, although the actual choices declaration is correct and the remaining tests would catch an absent feature. The diff contexts consistently target RegistryClient.configure_egress_auth, cmd_egress_configure, and the existing egress-configure parser without changing server code or existing positional parameters. The claimed git apply check and test compatibility could not be independently rerun because the repository command wrapper failed before execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "pass-ssrf-allowlist-env-to-registry-container",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 38,
+      "input_tokens": 76,
+      "output_tokens": 37974,
+      "total_tokens": 3748858,
+      "latency_seconds": 477.4,
+      "total_cost_usd": 1.3434148,
+      "result_subtype": "success",
+      "task_score": 84.8,
+      "cache_read_tokens": 3614564,
+      "cache_write_tokens": 96244,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 79.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 23,
+          "total": 92,
+          "notes": "The issue precisely identifies the two affected Compose files, required environment entries, unchanged empty defaults, and explicit exclusions. Its acceptance criteria are directly testable against the registry service environment and container process environment. The patch context corroborates the named REGISTRY_CONTACT_URL and SECRET_KEY insertion area, while the absent independent task statement limits verification of issue #1513 and the asserted downstream health-routing behavior. Security and upgrade risks are handled proportionately through fail-closed defaults and narrow scope."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 90,
+          "notes": "The LLD commits to exact files, values, placement, defaults, data flow, exclusions, and alternatives, making the small change implementation-ready. Its strongest evidence is the exact SSRF settings-to-URL-guard path and replication of the existing docker-compose.yml syntax. Minor correctness weaknesses include saying an unset ${VAR} generally causes a Compose error and several broad repository claims that could not be independently verified, such as the absence of all relevant automated Compose tests. It treats the principal security risk correctly but originally omits the operational requirement to recreate rather than merely restart the container."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 20,
+          "total": 79,
+          "notes": "The review surfaces a concrete rollout defect\u2014changed environment configuration requires container recreation\u2014and requests useful rendered-config and exact-syntax checks. It also prioritizes the empty default as the primary security invariant and records resolution of its recommendations. Its largest factual defect is the claim that list-form Compose environment values replace the whole list; Compose treats environment as a key-based mapping during merges regardless of YAML presentation. Several reviewer sections mostly repeat the LLD, and claims such as zero deployment risk and the fresh DHI grep were not independently verifiable."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 18,
+          "risk_awareness": 17,
+          "total": 71,
+          "notes": "The core tests have meaningful oracles for set and unset interpolation, YAML validity, actual container environment, file scope, and both target Compose variants. The main deficiency is that the E2E scenario is not executable as written: it leaves internal-server registration, hostname, authentication, API schema, and health-check timing as placeholders while assuming /api/servers and a five-second cycle. The rollback procedure uses broad git stash operations and the grep-based rendered-config checks are not explicitly scoped to the registry service, creating avoidable false-positive and workspace risks. The asserted absence of an automated Compose test suite and the runtime commands could not be independently verified."
+        },
+        "implementation": {
+          "completeness": 24,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 92,
+          "notes": "The patch implements the requested change end to end by adding both exact empty-default passthroughs to both named registry environment blocks and touching nothing else. Its diff contexts consistently anchor the additions between REGISTRY_CONTACT_URL or the BUILD_VERSION explanation and SECRET_KEY, and the YAML indentation and substitution syntax are appropriate. The summary honestly distinguishes rendered-config checks from the unexecuted container and E2E verification, although no automated regression protection is added. Local git apply --check and the claimed baseline commit could not be independently confirmed because repository command execution failed at the sandbox boundary, but no contradiction is visible in the submitted source contexts."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "hide-register-button-on-virtual-and-skills-tabs",
+      "complexity": "trivial",
+      "ref": "v1.0.18",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 36,
+      "input_tokens": 72,
+      "output_tokens": 28009,
+      "total_tokens": 3313145,
+      "latency_seconds": 391.4,
+      "total_cost_usd": 1.1155474,
+      "result_subtype": "success",
+      "task_score": 84.6,
+      "cache_read_tokens": 3207542,
+      "cache_write_tokens": 77522,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 71.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 90,
+          "notes": "The issue provides a precise visibility matrix, testable acceptance criteria, and unusually clear non-goals for this small UI fix. It concretely identifies Dashboard.tsx, handleRegisterServer, /servers/register, and the scoped Add Virtual Server and Add Skill actions. The largest limitation is the absent independent task statement, which prevents external confirmation that every asserted behavior and related issue is authoritative. Repository shell access failed before reads could execute, so the named symbols and routing claims could not be independently verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 87,
+          "notes": "The LLD commits to a minimal single-node JSX guard and clearly preserves the surrounding search and Refresh Health controls through a six-state decision table. Its proposed condition is internally consistent with the submitted patch and the stated viewFilter union. The weakest decision is treating default visibility on future tabs as safer; a future tab with its own scoped action could recreate this defect, and the design does not require an explicit applicability decision. Exact line numbers, symbols, and repository conventions could not be independently confirmed because local read commands failed before execution."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 20,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The review concretely checks that the guard surrounds only the Register button and calls out layout reflow, shared-handler regression checks, authorization boundaries, and JSX brace placement. Its largest weakness is that every reviewer approves and the only concerns are execution reminders, so it does not seriously challenge the exclusion-list semantics or the absence of an implemented automated regression test. The summary accurately reflects its own findings: visual inspection and brace balancing are the sole raised concerns. Repository-dependent claims about permissions, handlers, and routes remained unverifiable due unavailable local shell execution."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 80,
+          "notes": "The plan covers all six tab states with concrete visibility oracles and adds compatibility checks for navigation, unaffected controls, layout, rapid tab switching, and production compilation. Its main defect is locator robustness: button.btn-primary:has-text(\"Register\") is broad enough to match longer Register-labelled CTAs, while the Agents locator relies on DOM ordering through first(). The checklist promises destination and unaffected-control checks that are only described as follow-up extensions rather than included in the proposed executable spec. The claimed Playwright configuration, loginAsAdmin helper, file convention, and npm commands could not be verified against repository files because command execution failed."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 90,
+          "notes": "The patch fully implements the described behavior by wrapping only the header Register button with exclusions for virtual and skills while leaving the Refresh Health sibling untouched. The submitted diff is syntactically balanced and, under the existing outer non-Discover condition described by the artifacts, produces the required six-tab visibility matrix. The largest limitation is the lack of an accompanying regression test, while the summary states that no follow-up remains despite the testing plan proposing a new Playwright spec. The asserted baseline commit, target-file context, and git apply --check result could not be independently confirmed because the repository shell failed before executing read-only commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-ui-title",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 96,
+      "input_tokens": 10609,
+      "output_tokens": 75510,
+      "total_tokens": 16628839,
+      "latency_seconds": 958.3,
+      "total_cost_usd": 4.553620400000001,
+      "result_subtype": "success",
+      "task_score": 83.6,
+      "cache_read_tokens": 16338912,
+      "cache_write_tokens": 203808,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 78.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 19,
+          "total": 85,
+          "notes": "The issue precisely identifies the affected UI locations, API fields, deployment surfaces, defaults, and explicit non-goals. Its largest defect is the claim that unset UI_TITLE causes no behavioral change, which contradicts the required registry-only title change from the current hardcoded value. The submitted patch contains matching paths for Layout.tsx, Login.tsx, Logout.tsx, both config endpoints, and all named infrastructure surfaces. No independent task statement exists, and exact baseline-source verification was unavailable because repository shell commands failed before execution."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 86,
+          "notes": "The LLD is unusually concrete about Settings.effective_ui_title, CONFIG_GROUPS, useRegistryConfig, infrastructure wiring, fallbacks, and rejected alternatives. Its largest deficiency is internal inconsistency: it repeatedly calls the rollout behavior-preserving although registry-only deployments intentionally change, and its file table still reports zero tests despite later requiring TestEffectiveUiTitle. The submitted diff contexts support the named symbols and integration shape, including the generic computed-property field and Helm reserved-name guard. Exact line references, caching details, and applicability to commit 0038b687 could not be independently verified because repository reads were unavailable."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 84,
+          "notes": "The review surfaces concrete frontend, backend, infrastructure, and security concerns and produces an actionable unit-test addition based on TestNginxUpdatesEnabled. Its weakest decision is dismissing frontend regression tests and central parameter documentation primarily because they were absent from acceptance criteria, while also missing the design's contradictory compatibility claim. The patch confirms that the recommended TestEffectiveUiTitle and UI_TITLE reserved-name protection were implemented. Claims about repository-wide document.title searches and exact existing coverage patterns could not be independently verified due the repository-tool failure."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 77,
+          "notes": "The plan covers derivation, APIs, mixed-version compatibility, three UI locations, rollback, and each deployment surface with specific expected values. Its primary unit command is wrong: python -m unittest will not collect the submitted plain pytest class, and the Terraform target contradicts the patch's nested module ecs_service_registry structure. Several startup commands remain placeholders, and the stack-chart test omits the dependency-build step that may be required. Despite those execution defects, the behavioral oracles for empty, overridden, registry-only, escaping, reserved-name, and rollback cases are strong."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 86,
+          "notes": "The patch implements the described flow end to end: backend derivation and APIs, all three React consumers, Docker, Terraform/ECS, Helm, and five focused property tests. The code shown is internally coherent, preserves the with-gateway fallback, safely uses JSX text interpolation, and conditionally renders the Helm variable while reserving its name. Its largest limitation is that automated coverage stops at the computed property, leaving the API response, frontend consumers, and deployment templates dependent on unexecuted manual checks; the central parameter reference is also deferred. The claimed clean git application and correspondence with the actual baseline could not be independently confirmed because every repository shell invocation failed before running."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "consistent-csrf-across-toggle-endpoints",
+      "complexity": "medium",
+      "ref": "v1.0.20",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 94,
+      "input_tokens": 13431,
+      "output_tokens": 91121,
+      "total_tokens": 18561046,
+      "latency_seconds": 1132.8,
+      "total_cost_usd": 5.718347199999999,
+      "result_subtype": "success",
+      "task_score": 82.0,
+      "cache_read_tokens": 17983026,
+      "cache_write_tokens": 473468,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 80.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 79,
+          "notes": "The issue clearly identifies the bearer-client failure, browser-session exposure, affected routes, non-goals, and observable 200/403 outcomes. Its largest defect is contradictory acceptance language: it requires bearer-only success on all five user-facing endpoints even though `/api/toggle/{service_path}` uses session-only `enhanced_auth`, and it initially says all six receive consistent dependencies while explicitly exempting `/api/internal/toggle`. The submitted route contexts support the distinction between `nginx_proxied_auth`, `enhanced_auth`, and `validate_internal_auth`, while the repository release record confirms this CSRF/bearer compatibility problem was fixed in v1.0.21. No independent task statement was supplied, so broader requirement coverage and the claim that every M2M registration pipeline was affected cannot be fully verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 86,
+          "notes": "The LLD commits to a concrete request-level rule, names the actual functions and files, explains form versus JSON token transport, and provides implementable route signatures and failure behavior. Its main gap is that changing the shared `verify_csrf_token_flexible` dependency alters non-toggle callers such as logout, edit forms, and ANS routes without a complete caller audit or regression coverage, while it also fails to reconcile the issue's impossible bearer-success criterion for the session-only UI route. The patch confirms the named integration points exist: `registry/auth/csrf.py`, `toggle_service_api`, `toggle_virtual_server`, and the already-dependent agent and skill routes. Claims about every endpoint's audit logging and all frontend call paths could not be independently verified from the local repository because command execution failed before file access."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 22,
+          "total": 84,
+          "notes": "The review surfaces three concrete improvements with consequences and resolutions: accurate route documentation, a cookie-plus-Authorization invariant test, and documentation of the internal endpoint's intentional exclusion. It does not challenge the issue/LLD contradiction concerning bearer access to the session-only UI route, and Pixel's discussion inconsistently says the newly protected virtual-server endpoint is not called directly while grouping its UI flow with already-protected routes. The implementation diff shows all three recommended changes were actually carried forward into comments, docstrings, and tests. Assertions about `AuthContext.tsx`, template call sites, proxy header stripping, and the absence of external callers were not independently verifiable."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 79,
+          "notes": "The plan has strong dependency-level matrices, exact status/detail oracles, negative cases, token/session mismatch coverage, and the important cookie-plus-bearer-header invariant. Its principal weakness is claiming browser compatibility is covered by existing tests that override the CSRF dependency to a no-op; those tests cannot prove a valid cookie and token traverse the real route dependency successfully, and the plan does not add that case consistently across agent, server, and virtual-server routes. The supplied patch implements the proposed direct tests and bearer/cookie route tests, but only the skill route includes a real valid-cookie-plus-valid-token success test. The suggested `python -m unittest discover` command is unreliable for these pytest-style tests, although the alternative `uv run pytest` command is appropriate."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 82,
+          "notes": "The production patch implements the central design end to end by moving the cookie decision into `verify_csrf_token_flexible` and adding the dependency to the server and virtual-server toggle routes, while honestly documenting the test-location deviation. The strongest evidence is the coherent diff across eight files, including direct validation tests and route tests for both newly protected endpoints plus the already-protected agent and skill endpoints. The largest remaining weakness is uneven route-level success coverage for valid cookie-bound CSRF tokens; additionally, `if not session_id` technically exempts an explicitly present empty cookie despite the stated invariant being based on cookie presence. Local `git apply --check` and fixture compatibility could not be independently rerun because the repository command sandbox failed before execution, so the summary's applicability and test-compatibility claims remain partially unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "registration-admission-control-gate",
+      "complexity": "high",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 120,
+      "input_tokens": 8678,
+      "output_tokens": 104515,
+      "total_tokens": 26266641,
+      "latency_seconds": 1313.7,
+      "total_cost_usd": 6.9673532,
+      "result_subtype": "success",
+      "task_score": 81.8,
+      "cache_read_tokens": 25860336,
+      "cache_write_tokens": 293112,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 79.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 24,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 92,
+          "notes": "The issue clearly defines fail-closed behavior, default-off compatibility, seven registration/update entry points, deployment surfaces, and testable status-code outcomes. Its named route categories and configuration agree with the submitted patch's agent, server, skill, and Settings changes. The largest gap is an underspecified 403 response-body contract, alongside limited discussion of transmitting sensitive registration metadata to an external service. No independent task statement was supplied, so requirement completeness beyond this internally defined contract cannot be verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 84,
+          "notes": "The LLD is unusually concrete, naming real route functions, persistence calls, configuration fields, stable endpoint identifiers, and failure translations that correspond to the patch. It makes useful decisions about call ordering, service identities, encrypted server credentials, and default-off rollout. Its largest design omission is that the Helm existing-secret option requires a deployment secretKeyRef change, yet deployment.yaml is absent from the LLD's file checklist and later appears in the implementation. It also leaves malformed URLs, invalid timeout values, potentially non-JSON-serializable server dictionaries, and Terraform's plaintext ECS environment handling of the token insufficiently addressed."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 21,
+          "risk_awareness": 22,
+          "total": 83,
+          "notes": "The review identifies concrete concerns including server register/update ambiguity, internal service identities, call-before-persistence testing, credential encryption ordering, HTTPS guidance, outage impact, and keyword-only arguments. Several recommendations are visibly reflected in the patch, notably the keyword-only signature, service-identity documentation, and route-ordering tests. Its largest weakness is accepting unsupported assertions about frontend error handling and encryption placement while missing the LLD's Helm deployment omission and the Terraform token's exposure through ECS environment variables. Exact claims about existing UI, metrics, and deployment conventions could not all be independently confirmed from the unavailable local baseline."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The plan provides concrete setups and oracles for disabled, allow, deny, timeout, connection, status, authentication-header, deployment, and rollback behavior, plus seven persistence-order checks. The largest gap is that route tests do not assert each gate call's exact endpoint, username, or payload and do not prove that an enabled 200 response permits persistence across all seven paths. The promised token-log coverage spans allow, deny, and timeout, but the patch tests only the allow path, and no test pins encrypted rather than plaintext server credentials. The plan's 13 service tests plus 7 route tests total 20, contradicting implementation.md's claim of 23, while exact command and marker compatibility could not be locally executed."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 19,
+          "risk_awareness": 17,
+          "total": 73,
+          "notes": "The patch implements the shared gate, all seven stated call sites, default-off configuration, fail-closed status handling, deployment wiring, and focused unit and ordering tests. Error handling catches HTTPX failures but not configuration or serialization failures such as an invalid timeout, malformed URL outside HTTPX's caught hierarchy, or a non-JSON-serializable server_entry, which can produce an unintended 500 while still blocking the write. Terraform places the bearer token directly in the ECS task environment, and disabled calls still eagerly evaluate model_dump arguments despite claims of a zero-cost no-op. The summary is demonstrably inaccurate: the displayed diff contains 19 files and 1,027 added lines rather than 17 files and 738 lines, and exact git applicability could not be independently checked because the read-only shell sandbox failed before command execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "default-create-in-idp-checkbox-unchecked",
+      "complexity": "low",
+      "ref": "v1.0.21",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 80,
+      "input_tokens": 40,
+      "output_tokens": 9405,
+      "total_tokens": 3183296,
+      "latency_seconds": 1009.3,
+      "total_cost_usd": 1.1190722,
+      "result_subtype": "success",
+      "task_score": 81.4,
+      "cache_read_tokens": 3004211,
+      "cache_write_tokens": 169640,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 9.3,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 87,
+          "notes": "The issue clearly defines the unwanted default, explicit opt-in behavior, testable acceptance criteria, and narrow exclusions. The submitted diff corroborates the cited `createInIdp` initializer and `management_create_group` fallback. Its largest weakness is expanding a UI-named task into a behavior-changing API default without an independent task statement confirming that scope. Claims about every CLI and bulk-import caller could not be independently verified."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 81,
+          "notes": "The LLD gives concrete files, symbols, data flow, implementation steps, and explicit true/false behavior. Its claim that only three tests target the endpoint is contradicted by the implementation, which modifies six additional tests that implicitly relied on the old default. It recognizes the endpoint compatibility change, but the rollout plan primarily discusses UI users rather than direct API consumers. The patch context supports the named frontend and backend integration points, although working-tree applicability could not be independently confirmed."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 81,
+          "notes": "The review surfaces concrete concerns including direct-API compatibility, hook mocking, release communication, and boolean-property assertions. Its largest defect is declaring the endpoint-test audit resolved with only three matching tests, directly contradicted by six additional affected tests documented and patched later. The backend compatibility concern is appropriately prioritized and actionable. The security claim that a debug value log preserves audit visibility is overstated because the cited log does not establish actor attribution or durable audit logging."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The plan provides concrete backend setup, commands, and strong oracles for omitted, explicit-false, and explicit-true behavior. The frontend tests assert the actual `checked` property and mock the identified hooks. However, toggling the checkbox does not verify the payload passed to `createGroup`, and no test covers the promised reset behavior after cancellation or successful creation. Thus the suite could pass while the submit path sends the wrong value, and the listed commands were not independently executable in the available repository sandbox."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The patch implements the design across the initial state, reset path, backend fallback, documentation, backend tests, and an accessible frontend checkbox test. Its test updates correctly make six IdP-path cases explicit and invert the omitted-key contract, exposing an omission in the earlier analysis. The largest remaining gap is that the frontend test proves only visual state and toggling, not the submitted request payload; the endpoint default change also remains behaviorally breaking for omitted-key callers. The unified-diff contexts are internally consistent, but clean application and compilation against the working tree could not be independently confirmed because repository command execution failed before running."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-mcp-proxy-upstream-timeout",
+      "complexity": "medium",
+      "ref": "1.25.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 67,
+      "input_tokens": 4779,
+      "output_tokens": 66908,
+      "total_tokens": 9767182,
+      "latency_seconds": 769.6,
+      "total_cost_usd": 3.263360799999999,
+      "result_subtype": "success",
+      "task_score": 81.2,
+      "cache_read_tokens": 9414789,
+      "cache_write_tokens": 280706,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 86.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 85,
+          "notes": "The issue provides a crisp problem, explicit non-goals, deployment scope, and acceptance criteria with concrete defaults and testable outcomes. The submitted diff corroborates the central `auth_server/server.py` hardcoded `timeout=30.0` claim and the named configuration surfaces. Its largest weakness is prescribing an arbitrary five-second floor and a broad solution before repository or task evidence establishes that values below five are unusable. No independent task statement was supplied, and the cited Issue #1026/#1320 history could not be independently verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 84,
+          "notes": "The LLD is highly implementation-ready, naming exact fields, helper behavior, route data flow, Terraform propagation, Helm rendering, validation semantics, and rollback behavior. Its proposed contexts match the submitted preimages for `_read_mcp_proxy_max_body_bytes`, `mcp_proxy`, `Settings`, and `CONFIG_GROUPS`. The largest design gap is treating `settings` as effectively shared across services: the admin export runs from registry settings while ECS and Helm inject the new value only into auth-server, so it may display the default rather than the deployed effective value. The five-second floor remains weakly justified, and claims about exact line locations and the complete deployment footprint could not be independently checked."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 19,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 79,
+          "notes": "The review surfaces concrete, actionable concerns about zero-value denial of service, ingress timeout interaction, and the distinction between startup rejection and defensive runtime clamping. Each finding has a consequence and a documented resolution in the revised LLD rather than generic persona approval. Its largest omission is failing to challenge the cross-process admin-config value problem or the absence of a direct environment-to-`Settings` integration test. Claims about generic UI rendering and the completeness of every deployment surface remain asserted rather than demonstrated."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 76,
+          "notes": "The plan supplies meaningful oracles for defaults, overrides, both clamp paths, Pydantic rejection, route-to-`AsyncClient` wiring, admin exposure, and deployment rendering. The most concrete correctness defect is recommending `uv run python -m unittest discover -s tests` for tests written as pytest classes using `monkeypatch` and pytest marks, so that command would not reliably execute the proposed coverage. It also never tests that `MCP_PROXY_UPSTREAM_TIMEOUT_SECONDS` is actually bound by a fresh `Settings()` instance; setting the singleton attribute to `None` only exercises the defensive fallback. Several Terraform, Helm, and Compose checks are manual or toolchain-dependent, and their repository-specific invocations could not be independently validated."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 82,
+          "notes": "The patch implements the core change end to end: a validated settings field, a sibling reader helper, route wiring into `httpx.AsyncClient`, deployment propagation, documentation, and focused unit tests. Its hunks are internally consistent with the supplied source contexts and preserve the existing timeout-to-504 path while retaining the 30-second default. The largest limitation is that registry-side config export can report a different value from the auth-server-only ECS/Helm environment, and no test proves real environment binding across that boundary; the summary also says 18 files although its table and diff contain 19. Local shell sandbox failure prevented independently rerunning `git apply --check` or the repository test suite, so the candidate's applicability claim remains unverified rather than contradicted."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "idp-authenticated-embedding-endpoint",
+      "complexity": "high",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 187,
+      "input_tokens": 4,
+      "output_tokens": 323,
+      "total_tokens": 716698,
+      "latency_seconds": 1853.3,
+      "total_cost_usd": 0.15023360000000002,
+      "result_subtype": "success",
+      "task_score": 80.8,
+      "cache_read_tokens": 714753,
+      "cache_write_tokens": 1618,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 0.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 88,
+          "notes": "The issue defines concrete OAuth behavior, configuration, deployment surfaces, security expectations, non-goals, and testable failure cases. Its cited paths and symbols align with the submitted baseline contexts for LiteLLMClient, FederationAuthManager, config routing, Terraform, and Helm. The largest flaw is the absolute backward-compatibility criterion: the implementation necessarily adds Settings fields and unconditionally rendered deployment variables, so behavior cannot literally remain byte-for-byte identical with no new variable read. No independent task statement exists, and local repository inspection was unavailable because the shell sandbox failed before execution, so the external issue and exact baseline could not be independently verified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 19,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 86,
+          "notes": "The LLD is unusually concrete about files, signatures, token flow, validation, masking, deployment wiring, compatibility, and rejected alternatives. It correctly commits to per-call api_key injection, locked token refresh, and a provider compatibility check in Settings. Its largest omission is Terraform's empty-secret lifecycle: it never ensures a missing client secret remains detectably missing, and the resulting \"not-configured\" ECS secret defeats the promised fail-fast validation when the other required fields are set. Claims about the installed LiteLLM signature, exact single-call-site topology, and line-specific repository findings could not be independently verified locally."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 80,
+          "notes": "The review identifies a real misconfiguration defect\u2014IdP enabled with sentence-transformers\u2014and turns it into a specific startup validation change. It also gives actionable findings for Helm reserved names, secret recovery configuration, credential precedence documentation, and benchmark-only comments. Its largest miss is the Terraform placeholder secret, which can bypass missing-secret validation; it also calls backward compatibility \"airtight\" despite unconditional new Helm and ECS environment entries. The claimed independent greps, installed-package inspection, and frontend behavior could not be reproduced because local command execution was unavailable."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 13,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 72,
+          "notes": "The plan spans token caching, bearer injection, failures, compatibility, configuration masking, Docker, Terraform, Helm, rollback, and mock-server lifecycle testing with generally concrete oracles. Several commands are unreliable: unittest discovery will not exercise the submitted plain pytest tests, the Helm decode pipeline ends with \"|| true\" and can pass on failure, and the unchanged-default Helm assertion contradicts the unconditional EMBEDDINGS_IDP_ENABLED Secret entry. It also omits a concurrent-refresh test and the critical ECS case where IdP is enabled while the client-secret variable is empty but becomes \"not-configured\". None of the commands were executed, and their repository-specific flags and response shapes could not be independently verified locally."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 78,
+          "notes": "The patch implements the main design end to end across Settings, LiteLLMClient, the token provider, repository wiring, config masking, three deployment systems, documentation, and focused unit tests. The largest defect is in secrets.tf: an empty Terraform client-secret variable becomes \"not-configured\" and is always injected into ECS, so startup validation can accept an absent credential and defer failure to the first token request. The provider also does not normalize malformed JSON or invalid expires_in values into its documented RuntimeError contract, while tests omit concurrency and deployment-validation coverage. The unified diff has internally consistent symbols and contexts, but git apply --check and the candidate's claimed pinned commit could not be independently verified because the local shell sandbox failed before executing commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "fix-reserved-groups-var-in-service-account-script",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 28,
+      "input_tokens": 2308,
+      "output_tokens": 36513,
+      "total_tokens": 2624688,
+      "latency_seconds": 428.5,
+      "total_cost_usd": 1.0820721,
+      "result_subtype": "success",
+      "task_score": 80.2,
+      "cache_read_tokens": 2501018,
+      "cache_write_tokens": 84849,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 85.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 86,
+          "notes": "The issue clearly identifies the GROUPS assignment in verify_setup(), its interaction with set -e, both affected script paths, and testable success, failure, compatibility, and scope boundaries. The submitted patch context corroborates the named functions and the two GROUPS-based membership checks. Its largest technical overstatement is that separating local declaration from assignment makes failed curl and jq commands surface independently; without pipefail, a curl failure can still be masked by jq. No independent task statement was supplied, and the claims about issue #1570 and the macos-setup consumer could not be independently verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 86,
+          "notes": "The LLD is implementation-ready, naming both verify_setup() functions, the exact replacement, unchanged interfaces, Bash-version constraint, error behavior, and rollout boundary. It correctly recognizes that local must be separate from command substitution to preserve the pipeline's final status and explicitly records the pre-existing lack of pipefail. Its main weakness is imprecise portability and failure language: local is Bash-compatible but not POSIX, and a failed curl still does not necessarily propagate. The asserted repository-wide reserved-variable sweep, exact line numbers, and macos-setup behavior were not independently verifiable in the unavailable repository execution environment."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 20,
+          "total": 76,
+          "notes": "The backend and security sections identify concrete risks, including the curl-versus-pipefail diagnostic gap, newline-delimited group assumptions, and the distinction between verification output and actual authorization. The review also assesses the precise grep semantics and Bash 3.2 tradeoff rather than offering only generic approval. However, much of the persona structure is non-contributory approval theater, and the backend section incorrectly attributes the SC2128 fix to grep -Fxq when renaming away from the special array fixes that warning. It does not challenge the unsupported macos-setup operational claims or require correction of the LLD's curl-status wording."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 67,
+          "notes": "The plan provides concrete commands and expected exit codes for the GROUPS reproduction, positive and negative membership paths, syntax checks, idempotent provisioning, output compatibility, and optional live-Keycloak coverage. Its largest defect is Section 2.4: mcp-servers-restricted is not a substring of mcp-servers-unrestricted, so the old grep -q implementation passes the same oracle and the test cannot detect omission of -Fx. Most core tests execute a copied verify_setup_sim function rather than the patched scripts, allowing implementation drift or a bad hunk to escape unless the optional end-to-end test is run. Bash 3.2 is listed as a prerequisite but no version-selecting command or recorded 3.2 execution is provided."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 86,
+          "notes": "The patch implements the design end to end in both submitted target contexts: it replaces GROUPS with a function-local sa_groups, preserves command-substitution status by separating declaration, updates both reads, and uses an exact fixed-string line match. The changes are minimal, internally consistent, Bash 3.2-compatible, and preserve the existing verification messages and genuine not-a-member failure branch. The largest remaining risk is validation depth: no repository test was added, live Keycloak and Bash 3.2 runs were not performed, and the summary's apply-check and sweep results are self-reported. Direct source inspection and an independent git apply --check were unavailable because repository command execution failed at sandbox startup, so the baseline commit, blob contexts, and applyability could not be independently confirmed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "honor-cloud-provider-override-in-ui",
+      "complexity": "low",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 69,
+      "input_tokens": 1430,
+      "output_tokens": 50480,
+      "total_tokens": 9009141,
+      "latency_seconds": 656.8,
+      "total_cost_usd": 2.629222900000001,
+      "result_subtype": "success",
+      "task_score": 79.0,
+      "cache_read_tokens": 8813702,
+      "cache_write_tokens": 143529,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 76.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 80,
+          "notes": "The issue clearly identifies the affected endpoint, resolver, frontend consumer, desired precedence, response contract, tests, and non-goals. The submitted diff's preimage corroborates its central claim that get_telemetry_detection_info directly called _detect_cloud_provider_with_method. Its largest defect is claiming override-unset behavior remains exactly unchanged even though using _resolve_cloud introduces operator-declared and operator-declined outcomes previously bypassed by this endpoint. Exact source locations and the claimed .env.example defaults could not be independently verified because every local read command failed during sandbox initialization."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 79,
+          "notes": "The LLD is unusually concrete about the route, async call flow, resolver precedence, response shape, tests, and exact files to modify. Its proposed await _resolve_cloud() change is internally consistent with the supplied preimage and implementation patch. The principal flaw is repeatedly describing override-unset behavior as backward-compatible while deliberately adding registry-card hint and declined outcomes, with no migration or compatibility analysis for existing endpoint consumers; it also treats additional metric increments as purely beneficial. Repository line numbers, cache implementation, and exception-handling claims remained independently unverifiable due the unavailable local shell."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The review surfaces actionable issues, notably missing direct _resolve_cloud coverage, cold-cache duplicate reads, auth preservation, and the user-facing explicit label. It then records concrete resolutions that appear in the revised LLD and patch. Its largest miss is failing to challenge the false backward-compatibility claim for operator hints and instead endorsing the new behavior as unconditionally preferable; it also does not examine repeated UI-driven logging and counter inflation. Assertions described as grep-confirmed or code-confirmed could not be independently reproduced because repository commands could not execute."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 77,
+          "notes": "The plan provides concrete resolver-level and endpoint-level tests with exact JSON and tuple oracles, plus retained 401 coverage and targeted pytest commands. The two layers would catch both loss of explicit precedence and regression to the route's old raw-cascade wiring. It omits tests for the newly reachable operator_declared and operator_declined branches, does not fully isolate ambient cloud environment variables, and inconsistently describes whether the forced-startup response contains an event field. The manual log comparison is only a proxy for the transmitted telemetry payload, and the cited commands and existing test names could not be independently executed."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 21,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 82,
+          "notes": "The patch implements the central fix end to end by replacing the local raw-detector import and synchronous call with await _resolve_cloud(), while preserving the endpoint response keys and adding focused resolver and route tests. Its diff context is internally coherent with the artifacts, and the endpoint mock works with the route's function-local import. The largest weakness is that the summary overstates override-unset compatibility and the tests omit the operator-hint behavior that this implementation newly exposes through the endpoint. The claimed clean git apply and runtime compatibility could not be independently confirmed because all local shell commands failed before execution, although no obvious syntax or control-flow defect is visible in the submitted diff."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "per-caller-per-target-rate-limits-and-quarantine",
+      "complexity": "high",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 245,
+      "input_tokens": 4,
+      "output_tokens": 362,
+      "total_tokens": 948214,
+      "latency_seconds": 2716.7,
+      "total_cost_usd": 0.19721340000000004,
+      "result_subtype": "success",
+      "task_score": 78.2,
+      "cache_read_tokens": 946102,
+      "cache_write_tokens": 1746,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 0.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 85,
+          "notes": "The issue provides unusually testable acceptance criteria covering counter scope, admin asymmetry, failure policy, response semantics, management surfaces, and explicit non-goals. Its references to `RateLimitDefinition`, `RateLimiter.check()`, `_validate_caller_floor`, and the `/validate` hook align with the source contexts represented in the patch. Its largest gap is calling quarantine immediate without defining an enforcement-propagation bound, despite the later design allowing per-process cache staleness, and it does not state clearly that quarantine is inactive when the master rate-limiting switch is off. No independent task statement was supplied, so claims about issues #295 and #1504 could not be used to establish additional requirements."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 79,
+          "notes": "The LLD is highly concrete about data flow, repository methods, API shapes, failure behavior, rollout, and exact integration points such as `RateLimiter.check()` and nginx's throttle marker. Its largest technical flaw is using unescaped colon-delimited `group_name`, target name, and caller identity values in definition IDs and counter subjects even though it explicitly recognizes that names may contain colons; distinct definitions or caller-target pairs can therefore alias. It also promises reuse of `RATE_LIMIT_BACKEND_TIMEOUT_MS` while specifying a hardcoded repository default, and its five-second process-local cache does not satisfy the issue's unqualified immediate-kill-switch language. The stated `cli/api/...` paths are contradicted by the repository's `api/registry_client.py` and `api/registry_management.py` paths, which the implementation summary later acknowledges."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 80,
+          "notes": "The review performs real design work by identifying the missing caller-target floor safeguard and the unsafe inherited fail-open policy, then tracing their resolutions to `_validate_caller_floor` and the quarantine repository design. It also gives actionable frontend, backend, operations, and security recommendations rather than generic approvals. Its largest omission is failing to catch the ambiguous composite IDs and counter keys, along with the UI's need to surface quarantine-list loading failures. Circuit's claim that a five-second TTL implies approximately ten seconds of normal propagation is unsupported; ordinary expiry is bounded by roughly one TTL plus read latency, while backend failure can preserve stale last-known-good state much longer."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 76,
+          "notes": "The plan has strong behavioral oracles, including exact quota counts, independent caller and target buckets, plain-403 header absence, admin-bypass asymmetry, seed idempotency, and a zero-counter-call assertion. A concrete execution defect is that its CLI commands invoke `registry_management.py` from the repository root even though the implementation confirms the real path is `api/registry_management.py`. Sleeping twelve seconds before checking quarantine proves eventual behavior but does not measure or enforce the promised propagation bound, and the plan omits delimiter-collision, concurrent mutation, degraded-read metric, and quarantine-fetch-error UI cases. The plan reports no executed results, which is acceptable, but its rollback and default-200 assumptions remain unverified."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 71,
+          "notes": "The patch covers the principal end-to-end surfaces: model validation, definition lookup, limiter gates, quarantine storage, startup seeding, admin routes, auth-server response handling, CLI, UI, and substantial unit and integration coverage. Its largest correctness defect is delimiter aliasing: `build_id()` concatenates two unrestricted fields and `_build_caller_target_gates()` concatenates identity and target name with colons, allowing distinct definitions or counters to share a key. Additional material gaps include a hardcoded 0.25-second quarantine timeout instead of `RATE_LIMIT_BACKEND_TIMEOUT_MS`, no promised `rate_limit_errors_total` update on degraded reads, non-atomic find-then-pull removal, and a UI that ignores quarantine loading errors and can display empty lists after a failed fetch. The diff's contexts are internally plausible, but `git apply --check` could not be independently executed because the provided shell sandbox failed before command execution; this evidence limitation was not scored as a candidate defect."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "logout-id-token-hint-out-of-browser-url",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 3067,
+      "output_tokens": 78001,
+      "total_tokens": 8841321,
+      "latency_seconds": 928.6,
+      "total_cost_usd": 2.964628400000001,
+      "result_subtype": "success",
+      "task_score": 77.0,
+      "cache_read_tokens": 8574847,
+      "cache_write_tokens": 185406,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 84.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 86,
+          "notes": "The issue clearly defines the exposed redirect, mixed-version behavior, graceful degradation, security properties, and explicit non-goals. The submitted diff confirms the named logout_handler and oauth2_logout integration points and the existing id_token_hint behavior. Its largest correctness weakness is overstating id_token_hint as required by the OIDC specification and describing the ID token as being revoked, which logout does not necessarily do. No independent task statement was supplied, and the asserted production WAF topology could not be independently verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 81,
+          "notes": "The LLD is unusually concrete about files, functions, collection schema, compatibility, atomic redemption, expiry, and degradation behavior. Its embedded create_logout_ticket code calls encrypt_id_token outside the exception boundary, while failed index creation is cached through _collection and never retried, contradicting its broad failure and self-cleaning guarantees. Its observability claim is also incorrect because the registry increments the present counter before auth-server redemption, so that counter cannot reveal redemption failures. Residual ticket exposure is addressed well, but index failure, encryption failure, and auth-side delivery observability remain material gaps."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 22,
+          "total": 81,
+          "notes": "The review\u2019s strongest work is the security analysis of ticket capture, TTL exposure, legacy-path visibility, and database documentation, followed by explicit resolutions. It identifies concrete changes rather than merely approving the design and correctly preserves atomic single-use redemption. However, it states that the logout contract is a 303 to /login despite the described OAuth path redirecting to the auth server, and it overstates TTL cleanup timing. It also misses the LLD\u2019s encryption exception boundary and permanent index-retry suppression."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 18,
+          "total": 71,
+          "notes": "The plan supplies meaningful oracles for encrypted storage, expiry, replay prevention, backward compatibility, graceful store failure, and the complete redirect chain. Its curl command captures the literal Location header prefix and then passes that entire string to curl, so the documented second hop is not executable as written. The URL-length test constructs a standalone short string instead of invoking production code and would pass even if logout_handler still leaked the token. Coverage also omits both-parameter precedence, invalid redirect_uri consuming a ticket, encryption failure, and index-creation failure."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 66,
+          "notes": "The patch implements the normal end-to-end ticket flow in the named handlers, preserves legacy id_token_hint handling, uses atomic find_one_and_delete, and documents the new collection. Its largest defect is redeeming and deleting the one-time ticket before the existing redirect_uri safety validation, contrary to the LLD, allowing an invalid request to consume the ticket and prevent legitimate IdP logout. Additional weaknesses are encryption occurring outside create_logout_ticket\u2019s try block, silently falling back to an unnamespaced collection on import failure, never retrying failed index creation, and committing no regression tests. The command sandbox failed before process launch, so git apply --check could not be independently run; applicability was assessed from the matching unified-diff preimages without scoring that tooling gap as a candidate defect."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "nginx-location-trailing-slash-route-hijack",
+      "complexity": "medium",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 67,
+      "input_tokens": 2821,
+      "output_tokens": 69787,
+      "total_tokens": 10284039,
+      "latency_seconds": 897.7,
+      "total_cost_usd": 3.177177,
+      "result_subtype": "success",
+      "task_score": 74.8,
+      "cache_read_tokens": 10023875,
+      "cache_write_tokens": 187556,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 85,
+          "notes": "The issue clearly defines the prefix-hijack problem, affected routes, desired redirect behavior, compatibility expectations, and explicit non-goals. Its strongest evidence is the identified `NginxConfigService._create_location_block` integration point and testable `/a` versus `/api` acceptance example. It does not acknowledge reserved-location duplication or the behavior change for non-GET requests to the bare path, and its statement about longer static guards is imprecise because nginx selects the longest matching prefix. No independent task statement was supplied, and exact baseline source verification was unavailable when the local execution sandbox failed."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 79,
+          "notes": "The LLD is unusually concrete about `_create_location_block`, its caller, root-path handling, regeneration, duplicate static locations, and the exact rendered directives. Its largest technical gap is repeatedly claiming proxy behavior is unchanged: with a URI-bearing `proxy_pass`, changing the matched location from `/test` to `/test/` changes nginx's request-URI replacement boundary and therefore warrants explicit compatibility testing.  It also treats leading-slash normalization as meaningful nginx-injection protection without establishing restrictions on whitespace, braces, or newlines. The exact cited baseline files and line contexts could not be independently read because repository command execution failed before process launch."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 80,
+          "notes": "The review performs real design stress-testing and catches two concrete issues: root-path `//` generation and duplicate `/api/` locations that can stall configuration updates. The recommendations are prioritized, actionable, and reflected in the revised LLD rather than merely approving the proposal. Its largest omission is accepting the assertion that `_normalize_server_path` prevents nginx directive injection despite only describing leading-slash normalization, and it also misses the `proxy_pass` URI-substitution change. Claims about the exact reserved-location inventory and rollback implementation could not be independently verified against the local baseline."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 62,
+          "notes": "The plan provides concrete setup, actions, expected directive strings, sibling-route cases, compatibility checks, and deployment-oriented manual scenarios. However, `test_create_location_block_root_path_has_no_double_slash` is guaranteed to fail because the rendered block contains URLs such as `http://auth-server...`, which satisfy the blanket `assert \"//\" not in block`. The prescribed `python -m unittest discover` command will not collect the shown pytest fixture functions, while the Prometheus check searches for the Python identifier `NGINX_CONFIG_WRITES` instead of the documented exported metric `mcpgw_registry_nginx_config_writes_total`.  It also lacks an automated nginx syntax/runtime test capable of detecting duplicate locations, redirect behavior, or changed upstream URI rewriting."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 68,
+          "notes": "The production-code hunk implements the revised design end to end: normal paths receive an exact redirect plus trailing-slash prefix, while the literal root retains its prior single block. The largest definite defect is the added root-path test's blanket `assert \"//\" not in block`, which also matches every `http://` proxy URL and makes the submitted test suite fail. The patch also changes nginx's URI replacement boundary for the existing URI-bearing `proxy_pass` but adds no test for the resulting upstream request path, so the summary overstates unchanged proxy behavior. Exact `git apply --check` and baseline-context validation could not be independently rerun because the mandatory local sandbox failed before launching commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "derive-repo-url-from-skill-md",
+      "complexity": "medium",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 77,
+      "input_tokens": 11732,
+      "output_tokens": 72111,
+      "total_tokens": 12123390,
+      "latency_seconds": 872.0,
+      "total_cost_usd": 3.5740964000000006,
+      "result_subtype": "success",
+      "task_score": 73.8,
+      "cache_read_tokens": 11856237,
+      "cache_write_tokens": 183310,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 82.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 91,
+          "notes": "The issue clearly defines the registration and read-path problems, with concrete, testable acceptance criteria for blob, raw, enterprise, negative, persistence, and UI cases. The submitted diff context corroborates its named integration points: SkillInfo, SkillSearchResult, Dashboard.tsx, SkillCard.tsx, and SemanticSearchResults.tsx all require the described additions. Its main limitation is that no independent task statement establishes whether the expanded semantic-search and modal scope is required, although it is internally consistent with the task identifier and repository tags. Exact baseline-source claims could not be independently re-read because every local read-only shell invocation failed before execution with a bwrap loopback error."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 14,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 75,
+          "notes": "The LLD is unusually concrete about files, symbols, response models, data flow, null behavior, compatibility, and DocumentDB indexing, and its proposed backend plumbing matches the submitted patch structure. Its central frontend decision is wrong: repository_url: data.repository_url || prev.repository_url selects the newly parsed value whenever present, so it overwrites an existing user edit rather than preserving it. This directly violates an acceptance criterion and invalidates repeated claims that the merge is non-clobbering, while the design otherwise handles optional fields, old records, and non-GitHub URLs sensibly. Line-level and production-backend assertions could not be independently verified against the local checkout because repository commands were blocked before startup."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 19,
+          "risk_awareness": 16,
+          "total": 64,
+          "notes": "The review identifies concrete architectural risks, notably duplicated SkillInfo construction, repeated DocumentDB result builders, loose GitHub-host classification, and old index entries lacking new metadata. Its largest failure is explicitly approving data.repository_url || prev.repository_url as edit-preserving, despite JavaScript evaluation making it overwrite a nonempty previous value. It also claims the construction-site regression concern is resolved, but the testing plan queries a nonexistent tag without asserting a returned skill and then performs an unfiltered request, so the fallback path is not actually verified. Several statements labeled confirmed against repository internals could not be independently checked because local read-only execution was unavailable."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 13,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 71,
+          "notes": "The plan covers helper behavior, API responses, compatibility, both modals, registration state, negative cases, and an end-to-end registration-to-search flow with specific expected values. Its advertised fallback regression check is ineffective: the registered skill has no test tag, the nonexistent-tag request cannot return it, and the subsequent unfiltered request does not demonstrate the second SkillInfo construction path. The live octocat URLs are acknowledged placeholders rather than demonstrated SKILL.md resources, and the proposed branch-name test accepts either outcome instead of enforcing one oracle. The manual edit-and-reparse scenario is valuable because it would expose the implementation's overwrite bug, but the stated repository commands and test paths could not be independently executed."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 68,
+          "notes": "The patch is focused and appears to implement the backend derivation, list and semantic-search plumbing, frontend types, conditional links, and helper unit tests across the expected files. The material defect is Dashboard.tsx using data.repository_url || prev.repository_url, which overwrites a user-edited value whenever parsing returns a repository URL and therefore fails an explicit acceptance criterion. No test covers that state transition or the two SkillInfo construction paths, and implementation.md incorrectly claims the patch avoids clobbering and implements the design without deviation. The diff contexts and symbols are internally coherent, but the claimed baseline commit and git apply --check result could not be independently verified because all local shell commands failed before execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "index-demo-videos-in-one-page",
+      "complexity": "trivial",
+      "ref": "1.24.3",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 37,
+      "input_tokens": 739,
+      "output_tokens": 34723,
+      "total_tokens": 4071253,
+      "latency_seconds": 470.7,
+      "total_cost_usd": 1.3972765000000003,
+      "result_subtype": "success",
+      "task_score": 73.6,
+      "cache_read_tokens": 3930830,
+      "cache_write_tokens": 104961,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 73.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 88,
+          "notes": "The issue clearly defines an additive documentation index, eight feature groups, URL-based deduplication, source-page attribution, and preservation of existing links. Its named paths and video types are consistent with the submitted README and documentation evidence, while the absent independent task statement prevents confirming that every proposed requirement was externally mandated. The strongest aspect is its directly testable acceptance criteria and explicit GIF and code-change exclusions. Its main limitation is limited treatment of ongoing index maintenance and external-link decay."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 77,
+          "notes": "The LLD is unusually concrete for a documentation change, identifying README.md, docs/index.md, individual source documents, duplicate URLs, grouping, and relative-link behavior. Its largest defect is contradicting the issue's requirement that every entry name its source pages: it limits attribution to selected duplicate groups even though Agent Skills appears in both README.md and docs/agent-skills-operational-guide.md and singleton videos also have source pages. It also says only three groups need attribution, while the implementation gives Authentication & Security such a column, exposing an internal inconsistency. The maintenance scan, GIF exclusion, additive rollout, and duplicate-name warning show useful risk awareness, although exact line and baseline claims could not all be independently verified."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 18,
+          "total": 69,
+          "notes": "The review raises concrete UX, maintenance, third-party hosting, and security considerations and converts several findings into actionable changes. Its largest failure is endorsing omission of source attribution from most groups, thereby preserving a direct acceptance-criteria violation instead of catching it. The claim that only Platform Overview, Dynamic Tool Discovery, and Virtual MCP Servers have cross-page duplicates is contradicted by Agent Skills appearing in both the submitted README context and its operational guide; the review also says there are four Vidcast demos while naming and implementing only three. The safe-scan and Vidcast link-rot discussions are specific, but some asserted task history and permanence guarantees are not verifiable from the supplied task context."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 12,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 61,
+          "notes": "The completeness check has a meaningful oracle: comm -23 reports repository video identifiers absent from the index, and the plan also checks unchanged source files and README navigation. The central deduplication test is ineffective because index-video-ids.txt is created with sort -u before uniq -d, so it always reports no duplicates. No test verifies the issue's requirement that each row identify every source page, which would have caught the implementation's largest omission. The commands are concrete, but the recursive grep is not limited to tracked files, youtu.be is omitted from the index-side extraction, and external-link validation is only optional."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 73,
+          "notes": "The patch provides the core deliverable: 13 distinct video links arranged in eight feature groups and an additive README.md entry point while retaining existing links. Its largest defect is incomplete source attribution: CLI, Agent Skills, Security Scanning, both federation entries, and ANS omit their source documents, while rows such as OAuth, Dynamic Tool Discovery, Full End-to-End, and Virtual MCP Servers omit README.md as a source. The patch also deviates from the claimed design by including an attribution column for Authentication & Security despite stating that only three groups would have one. Relative links and the maintenance note appear coherent, but the pinned commit and git apply --check claim could not be independently executed because the provided repository shell failed before running commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "macos-setup-python-version-precheck",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 43,
+      "input_tokens": 168,
+      "output_tokens": 54411,
+      "total_tokens": 4603447,
+      "latency_seconds": 770.1,
+      "total_cost_usd": 1.6957954999999998,
+      "result_subtype": "success",
+      "task_score": 73.2,
+      "cache_read_tokens": 4443835,
+      "cache_write_tokens": 105033,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 70.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 84,
+          "notes": "The issue clearly defines the failure timing, desired sentinel behavior, portability constraint, scope, and testable outcomes. Its cited Phase 1 snippet and Python 3.14 requirement agree with the submitted patch context and public setup guide.  The largest gap is that it requires remote metadata before cloning but does not define behavior when retrieval or parsing fails. Because no independent task statement was supplied, the claimed later uv failure and full user journey could not be independently established."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 16,
+          "total": 75,
+          "notes": "The LLD is unusually concrete about the target block, sentinel contract, data flow, comparison algorithm, timeout, and unchanged phases. Its largest defect is the hard-coded 3.14 fallback, which contradicts the issue's source-of-truth requirement and can falsely pass after the project minimum increases. It also incorrectly says curl and grep are checked by Phase 1, while its own inventory lists only Docker, Python, uv, Node.js, git, jq, and gettext checks. The narrow grep parser is acknowledged, but warning about fallback does not mitigate stale-version correctness."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 67,
+          "notes": "The review identifies concrete concerns around silent fallback, mutable-branch metadata, TOML extraction, and BSD portability, with consequences and resolutions. Its main failure is approving the stale hard-coded fallback as safe without recognizing that it can violate the central acceptance criterion and produce a false success. It also claims the LLD's Alternatives Considered section documents the main-branch trust equivalence, but the submitted section contains no such discussion. The role-based structure adds little beyond these findings and does not challenge the unverified failure premise or testing portability."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 12,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 68,
+          "notes": "The plan supplies concrete expected output for old, boundary, sufficient, local, remote, and offline cases and honestly marks full end-to-end runs unexecuted. The claimed missing-python execution is invalid as written because PATH is replaced with an empty directory before invoking bash, so bash itself cannot be found. The compatibility command also contains an unresolved repository placeholder and BASE_SHA while using --staged against an external patch, and the local-source test does not actually prove curl was not invoked. No test runs on macOS/BSD userland or covers malformed metadata and a stale fallback after a minimum-version increase."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 72,
+          "notes": "The diff implements the normal local and remote metadata paths, numeric comparison, informative output, unchanged sentinels, bounded network access, and remediation-row update described by the LLD. Its largest defect is the literal 3.14 fallback, which can false-pass when metadata is unavailable after requires-python changes and therefore does not fully implement the issue's source-of-truth requirement. The hunks and surrounding symbols are internally consistent with the submitted baseline excerpts, and the summary accurately describes the patch, but the repository command sandbox failed before execution so git apply --check could not be independently repeated. The hard-coded brew example and major.minor-only extraction also preserve future drift and mishandle patch-level or prerelease requirements."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "build-docker-images-from-uv-lock",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 79,
+      "input_tokens": 1958,
+      "output_tokens": 97960,
+      "total_tokens": 13194772,
+      "latency_seconds": 1164.7,
+      "total_cost_usd": 4.0725263,
+      "result_subtype": "success",
+      "task_score": 69.6,
+      "cache_read_tokens": 12890489,
+      "cache_write_tokens": 204365,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 84.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 81,
+          "notes": "The issue clearly identifies affected Dockerfiles, missing lockfiles, CPU-only PyTorch concerns, CI enforcement, and explicit non-goals. Its largest defect is claiming that `uv sync --frozen` makes a Docker build fail on a stale lockfile, when frozen mode deliberately uses the lock without checking it against `pyproject.toml`. Official uv documentation assigns that validation behavior to `--locked` or `uv lock --check`, not `--frozen`. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) No independent task statement was supplied, and repository command execution failed, so active-build-path and file-content claims could not all be independently verified."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 13,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 76,
+          "notes": "The LLD is unusually concrete about files, copy stages, virtual projects, dependency groups, CPU indexes, venv placement, CI matrix entries, and per-Dockerfile flags. Its central choice is nevertheless unsound: `--frozen` cannot provide the promised stale-manifest build failure, and the comparison matrix incorrectly says that it does. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The two MCP Dockerfiles also retain freshly resolved torch-related packages through `--inexact`, which uv documents as preserving packages outside the lock and therefore leaves a material reproducibility gap. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The submitted patch was truncated before the Dockerfile hunks and local source inspection was unavailable, so claims such as every project using `package = false` remain partly unverifiable."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 68,
+          "notes": "The review surfaces two concrete issues: drift in the hardcoded CI matrix and the unlocked torch/sentence-transformers installation protected by `--inexact`. Its largest deficiency is treating the latter as documentation-only and approving the design despite its conflict with the task's core reproducibility objective. It also misses the more fundamental distinction between `--frozen` and `--locked`, even though uv explicitly states that frozen mode skips lock freshness validation. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) The matrix-completeness recommendation is actionable, but several approving reviewer sections add little scrutiny and repository-specific assertions could not be independently checked."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 68,
+          "notes": "The plan provides concrete commands and useful oracles for lock drift, CUDA packages, development-dependency leakage, runtime directives, and smoke tests. It does not build every edited image or server context, notably omitting `Dockerfile.mcp-server-cpu`, and it never proves that a Docker build itself rejects a stale lock under `--frozen`. The claimed dependency-version compatibility check merely confirms that manifests were not edited, while `version: latest` is described inaccurately as a pinned uv version. The proposed health paths, ports, and exact command compatibility could not be independently verified against the repository."
+        },
+        "implementation": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 17,
+          "risk_awareness": 13,
+          "total": 55,
+          "notes": "The visible patch concretely adds the nine-root CI workflow and a generated `auth_server/uv.lock`, while the summary consistently enumerates the intended Dockerfile, lockfile, and CPU-index changes. The implementation does not meet the promised build-time stale-lock behavior because it uses `uv sync --frozen`; official uv behavior requires `--locked` for that assertion. ([docs.astral.sh](https://docs.astral.sh/uv/concepts/projects/sync/)) It also knowingly preserves unlocked packages with `--inexact` and changes torch from 2.9.1 to 2.13.0+cpu while claiming dependency bumps are out of scope, creating reproducibility and compatibility risk. The diff is truncated before most core hunks, and local `git apply --check` and source inspection could not run, so the claimed applicability and exact repository fit remain unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "lifecycle-workflow-webhooks",
+      "complexity": "high",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 186,
+      "input_tokens": 20173,
+      "output_tokens": 140054,
+      "total_tokens": 51894349,
+      "latency_seconds": 1994.4,
+      "total_cost_usd": 12.6655721,
+      "result_subtype": "success",
+      "task_score": 68.2,
+      "cache_read_tokens": 51352443,
+      "cache_write_tokens": 381679,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 70.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 82,
+          "notes": "The issue provides unusually concrete, testable behavior for five deliverables across servers, agents, and skills, including exact webhook fields, defaults, metrics, indexes, and explicit exclusions. Its HMAC threat model and backward-compatibility requirements are particularly strong. The largest gap is that its authorization goal says registrants cannot promote assets, while the submission later acknowledges that the existing `edit_server_submit` route can still change status using only `modify_service`; it also says every registration is covered while the LLD excludes `internal_register_service`. No independent task statement was supplied, and the sandbox failure prevented independent baseline-source verification, so requirement provenance beyond the internally consistent artifacts remains unverified."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 69,
+          "notes": "The LLD is highly specific about real-looking integration points such as `webhook_service.py`, the three `_perform_*_security_scan_on_registration` functions, scope seeds, repository indexes, and exact-byte HMAC transmission. Its strongest risk decisions are guarded index creation, explicit rollout compatibility, and exact request-body signing. However, its agent/skill call-site design overwrites an omitted default status with `None` when enforcement is unset, and it lists `scan_failed`/`error_message` as result fields but never uses them to distinguish a returned scan failure from success; it also leaves the legacy server edit authorization bypass outside the design. Exact repository applicability and several asserted backend behaviors could not be independently checked because local read commands failed before execution."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 71,
+          "notes": "The review surfaces concrete, consequential defects, especially admin lockout without scope-seed changes, unguarded index creation, Helm deployment gaps, signature comparison, and key-rotation limitations. It provides actionable resolutions tied to named files and symbols rather than generic reviewer approval. Its largest weakness is missing the omitted-status regression and ignored `scan_failed` result fields, while Byte incorrectly treats a plain `str(e)` slice as sufficient sanitization and the group collectively accepts the acknowledged HTML lifecycle-permission bypass. The repository claims behind the review could not be independently re-read due the sandbox execution failure, though the review's internal references can be checked against the submitted diff."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 64,
+          "notes": "The plan covers success, failure, disabled scanning, signatures, all asset types, compatibility, deployment, rollback, and an end-to-end lifecycle with concrete expected values. Its strongest oracle is the explicit admin status-change regression test corresponding to the review's scope-seed finding. The permission fixture grants `register_service` but not the already-required `modify_service`, so tests 1.14 and 1.15 cannot isolate the new permission and the expected non-status PATCH success is impossible; the tamper test can also mutate no bytes if its exact replacement is absent, and fixed sleeps make webhook checks flaky. It additionally lacks targeted automated tests for returned `scan_failed` results, the legacy edit-form bypass, and agent default-status preservation, while some commands could not be verified against the checkout."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 55,
+          "notes": "The patch concretely touches all five requested feature areas and correctly centralizes exact-byte signing, metric emission, filters, indexes, configuration, documentation, and default admin scope grants. It nevertheless contains central correctness defects: agent and skill registration assign `None` when status was omitted and enforcement is unset, normal scan results always emit `scan_error: null` despite the documented `scan_failed`/`error_message` fields, and `truncate_scan_error` can return 514 characters while performing no real sanitization. The agent PUT code also contradicts the summary's `model_fields_set` claim, and the summary acknowledges that `edit_server_submit` remains a lifecycle-permission bypass, undermining the primary authorization goal. The submitted hunk contexts and symbols are internally coherent, but `git apply --check` and direct surrounding-source inspection could not be completed because the read-only sandbox wrapper failed before every command."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "portable-env-secret-generation-in-build-script",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 39,
+      "input_tokens": 78,
+      "output_tokens": 49972,
+      "total_tokens": 4040097,
+      "latency_seconds": 614.6,
+      "total_cost_usd": 1.5258131000000004,
+      "result_subtype": "success",
+      "task_score": 64.4,
+      "cache_read_tokens": 3890948,
+      "cache_write_tokens": 99099,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 81.3,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 69,
+          "notes": "The issue clearly identifies the five static secret blocks and dynamic metrics-key loop shown in the submitted diff, with concrete acceptance criteria and exclusions. Its largest gap is recovery from the exact corrupted state it describes: removing only empty entries and appending a value leaves an existing nonempty duplicate intact. It also acknowledges that `source .env` uses the last assignment while grouping it with first-match consumers, and provides no repository paths for the asserted `grep -m1` or `awk` consumers. No independent task statement was supplied, so the claimed crash-loop impact and linked issue could not be independently established."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 71,
+          "notes": "The LLD is unusually concrete about the helper, six integration sites, `set -e` handling, temporary-file placement, and the resulting 0600 mode. It nevertheless omits migration of an already affected file containing both `KEY=` and `KEY=old`, which the proposed patterns transform into two nonempty assignments after appending the new value. Its explanation of `grep -vE` status 1 is incorrect: that status means no output lines were selected, not that the removal pattern matched nothing. The accepted permission change also conflicts with the stated zero Linux behavior change and ignores other replaced-file metadata such as ACLs or extended attributes."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 12,
+          "specificity": 18,
+          "risk_awareness": 16,
+          "total": 61,
+          "notes": "The review surfaces concrete concerns about 0600 permissions, interrupted-run temporary files, and unescaped regular-expression arguments. Its largest deficiency is approving the design without noticing that the documented macOS duplicate state is not normalized by the proposed empty-only patterns. It repeats unsupported claims about first-match consumers and same-user access without identifying corresponding repository paths or callers. The role-based structure adds breadth, but it misses the load-bearing compatibility defect while treating peripheral findings as the principal risks."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 12,
+          "specificity": 20,
+          "risk_awareness": 10,
+          "total": 55,
+          "notes": "The plan provides executable-looking commands and specific content/count oracles for empty placeholders, quoted empties, dynamic keys, malformed patterns, and shell syntax. Test 1.2.1 is not the exact reported regression state because it omits the previously appended nonempty value; consequently it would not catch the implementation leaving two nonempty assignments. Test 1.2.3 also does not exercise `grep -vE` status 1 because an unrelated line is selected and produces status 0. No test invokes the real secret-generation section, runs on BSD/macOS, checks mode changes, or induces the filesystem failures explicitly named by the acceptance criteria."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 13,
+          "total": 66,
+          "notes": "The diff consistently adds one Bash helper and replaces all six logical deletion sites, and its normal missing-or-single-empty-placeholder behavior is portable and internally coherent. The largest defect is that an affected file containing `KEY=` followed by `KEY=old` becomes `KEY=old` plus `KEY=new`, violating the claimed one-line invariant and leaving recovery semantics parser-dependent. Replacing the file also changes its mode and metadata, contradicting the summary's unchanged-behavior framing despite the LLD accepting the 0600 side effect. The submitted hunk contexts are coherent, but the claimed baseline commit and `git apply --check` result could not be independently verified because repository shell execution was blocked before commands ran."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "server-side-oauth-token-storage",
+      "complexity": "high",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 99,
+      "input_tokens": 12228,
+      "output_tokens": 104977,
+      "total_tokens": 21565844,
+      "latency_seconds": 1310.5,
+      "total_cost_usd": 5.9693252999999995,
+      "result_subtype": "success",
+      "task_score": 59.4,
+      "cache_read_tokens": 21185434,
+      "cache_write_tokens": 263205,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 80.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 61,
+          "notes": "The issue provides unusually concrete scope, status codes, compatibility expectations, and negative cases. Its central diagnosis is defective: it admits the baseline already omits access_token and refresh_token, while the proposed change retains large id_token and groups fields and therefore does not resolve the current cookie overflow. The shipped repository approach moved the full session payload server-side and retained only a session identifier in the cookie. No independent task statement was supplied, limiting assessment beyond the identifier and repository history."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 63,
+          "notes": "The LLD is highly specific about files, interfaces, data fields, TTL behavior, ownership checks, fallback behavior, and rollout. Its load-bearing architecture cannot achieve its stated cookie-size goal because oauth2_callback still signs id_token, groups, and identity metadata; its claimed approximately 600-byte cookie is therefore unsupported. The proposed repository, Fernet helper, endpoint, factory wiring, and logout hook are otherwise internally coherent and closely follow the submitted source context. Claims about exact existing encryption and dependency conventions could not all be independently verified because local command execution failed before repository inspection began."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 13,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 64,
+          "notes": "The review surfaces concrete defects, especially unscoped revocation, missing datetime imports, serialization churn, frontend ambiguity, and live-TTL verification. Its largest failure is approving the design without noticing that the baseline already excludes access and refresh tokens and that the unchanged id_token and groups remain the likely large cookie contents. Cipher's recommended delete filter is actionable and was incorporated consistently into the design and patch. Several claims about existing response shapes and dependencies remained unverifiable through the unavailable local executor."
+        },
+        "testing": {
+          "completeness": 12,
+          "correctness": 10,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 58,
+          "notes": "The plan gives concrete test files, inputs, expected statuses, ownership checks, expiry queries, encryption oracles, and backend fallback cases. The callback tests do not invoke oauth2_callback: one directly calls the mock repository and catches its exception itself, while the TTL test merely recomputes max(), so both would pass if production wiring were absent or broken. There is no real logout-handler test, no assertion on final cookie size or retained id_token/groups, and no proof that normal authentication avoids repository reads. The proposed commands and tests were not executed, and the submitted patch contains none of the tests described here."
+        },
+        "implementation": {
+          "completeness": 11,
+          "correctness": 8,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 51,
+          "notes": "The patch coherently adds an encrypted repository, factory wiring, retrieval endpoint, username-scoped revocation, TTL filtering, configuration, and documentation. It does not solve the stated overflow: the issue itself says access and refresh tokens are already absent, and the patch inserts token storage after the existing session construction without removing id_token, groups, or other large fields, while adding token_ref. It also contains no tests, logs the raw username despite the LLD's redaction guidance, and returns 404 rather than the summary's claimed 503 on file-backend sessions lacking token_ref because that check occurs first. The local sandbox failed before commands ran, so the claimed git apply check and testability could not be independently verified, although the submitted diff context is structurally plausible."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-08-31"
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "scores": {
+    "github_issue": {
+      "completeness": 14,
+      "correctness": 9,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 61,
+      "notes": "The issue provides unusually concrete scope, status codes, compatibility expectations, and negative cases. Its central diagnosis is defective: it admits the baseline already omits access_token and refresh_token, while the proposed change retains large id_token and groups fields and therefore does not resolve the current cookie overflow. The shipped repository approach moved the full session payload server-side and retained only a session identifier in the cookie. No independent task statement was supplied, limiting assessment beyond the identifier and repository history."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 63,
+      "notes": "The LLD is highly specific about files, interfaces, data fields, TTL behavior, ownership checks, fallback behavior, and rollout. Its load-bearing architecture cannot achieve its stated cookie-size goal because oauth2_callback still signs id_token, groups, and identity metadata; its claimed approximately 600-byte cookie is therefore unsupported. The proposed repository, Fernet helper, endpoint, factory wiring, and logout hook are otherwise internally coherent and closely follow the submitted source context. Claims about exact existing encryption and dependency conventions could not all be independently verified because local command execution failed before repository inspection began."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 13,
+      "specificity": 21,
+      "risk_awareness": 17,
+      "total": 64,
+      "notes": "The review surfaces concrete defects, especially unscoped revocation, missing datetime imports, serialization churn, frontend ambiguity, and live-TTL verification. Its largest failure is approving the design without noticing that the baseline already excludes access and refresh tokens and that the unchanged id_token and groups remain the likely large cookie contents. Cipher's recommended delete filter is actionable and was incorporated consistently into the design and patch. Several claims about existing response shapes and dependencies remained unverifiable through the unavailable local executor."
+    },
+    "testing": {
+      "completeness": 12,
+      "correctness": 10,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 58,
+      "notes": "The plan gives concrete test files, inputs, expected statuses, ownership checks, expiry queries, encryption oracles, and backend fallback cases. The callback tests do not invoke oauth2_callback: one directly calls the mock repository and catches its exception itself, while the TTL test merely recomputes max(), so both would pass if production wiring were absent or broken. There is no real logout-handler test, no assertion on final cookie size or retained id_token/groups, and no proof that normal authentication avoids repository reads. The proposed commands and tests were not executed, and the submitted patch contains none of the tests described here."
+    },
+    "implementation": {
+      "completeness": 11,
+      "correctness": 8,
+      "specificity": 20,
+      "risk_awareness": 12,
+      "total": 51,
+      "notes": "The patch coherently adds an encrypted repository, factory wiring, retrieval endpoint, username-scoped revocation, TTL filtering, configuration, and documentation. It does not solve the stated overflow: the issue itself says access and refresh tokens are already absent, and the patch inserts token storage after the existing session construction without removing id_token, groups, or other large fields, while adding token_ref. It also contains no tests, logs the raw username despite the LLD's redaction guidance, and returns 404 rather than the summary's claimed 503 on file-backend sessions lacking token_ref because that check occurs first. The local sandbox failed before commands ran, so the claimed git apply check and testability could not be independently verified, although the submitted diff context is structurally plausible."
+    }
+  },
+  "task_score": 59.4,
+  "verdict": "The submission is detailed and internally organized, but it implements a secondary token-retrieval facility while leaving the actual oversized session payload in the cookie.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-08-31T06:08:54.493874Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 386307,
+      "cached_input_tokens": 280020,
+      "cache_write_input_tokens": 54840,
+      "output_tokens": 11012,
+      "reasoning_output_tokens": 9041
+    },
+    "duration_ms": 388868
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-sonnet-5/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "high",
+  "tags": [
+    "authentication",
+    "oauth",
+    "session",
+    "mongodb",
+    "encryption",
+    "auth-server",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-sonnet-5[1m]",
+  "model_slug": "claude-sonnet-5",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 80.1,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 12228,
+    "output_tokens": 104977,
+    "cache_read_tokens": 21185434,
+    "cache_write_tokens": 263205,
+    "total_tokens": 21565844,
+    "total_cost_usd": 5.9693252999999995,
+    "latency_seconds": 1310.5,
+    "num_turns": 99,
+    "generation_tokens_per_sec": 80.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 12228,
+  "output_tokens": 104977,
+  "latency_seconds": 1310.5,
+  "num_turns": 99,
+  "total_cost_usd": 5.9693252999999995,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 21185434,
+  "cache_creation_tokens": 263205,
+  "run_started_at": "2026-08-31T01:08:29.703802Z",
+  "run_ended_at": "2026-08-31T01:30:20.286820Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 12228,
+    "output_tokens": 104977,
+    "cache_read_tokens": 21185434,
+    "cache_write_tokens": 263205,
+    "total_tokens": 21565844,
+    "total_cost_usd": 5.9693252999999995,
+    "latency_seconds": 1310.5,
+    "num_turns": 99,
+    "generation_tokens_per_sec": 80.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "server-side-oauth-token-storage",
+    "model": "us.anthropic.claude-sonnet-5[1m]",
+    "scores": {
+      "github_issue": {
+        "completeness": 14,
+        "correctness": 9,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 61,
+        "notes": "The issue provides unusually concrete scope, status codes, compatibility expectations, and negative cases. Its central diagnosis is defective: it admits the baseline already omits access_token and refresh_token, while the proposed change retains large id_token and groups fields and therefore does not resolve the current cookie overflow. The shipped repository approach moved the full session payload server-side and retained only a session identifier in the cookie. No independent task statement was supplied, limiting assessment beyond the identifier and repository history."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 63,
+        "notes": "The LLD is highly specific about files, interfaces, data fields, TTL behavior, ownership checks, fallback behavior, and rollout. Its load-bearing architecture cannot achieve its stated cookie-size goal because oauth2_callback still signs id_token, groups, and identity metadata; its claimed approximately 600-byte cookie is therefore unsupported. The proposed repository, Fernet helper, endpoint, factory wiring, and logout hook are otherwise internally coherent and closely follow the submitted source context. Claims about exact existing encryption and dependency conventions could not all be independently verified because local command execution failed before repository inspection began."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 13,
+        "specificity": 21,
+        "risk_awareness": 17,
+        "total": 64,
+        "notes": "The review surfaces concrete defects, especially unscoped revocation, missing datetime imports, serialization churn, frontend ambiguity, and live-TTL verification. Its largest failure is approving the design without noticing that the baseline already excludes access and refresh tokens and that the unchanged id_token and groups remain the likely large cookie contents. Cipher's recommended delete filter is actionable and was incorporated consistently into the design and patch. Several claims about existing response shapes and dependencies remained unverifiable through the unavailable local executor."
+      },
+      "testing": {
+        "completeness": 12,
+        "correctness": 10,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 58,
+        "notes": "The plan gives concrete test files, inputs, expected statuses, ownership checks, expiry queries, encryption oracles, and backend fallback cases. The callback tests do not invoke oauth2_callback: one directly calls the mock repository and catches its exception itself, while the TTL test merely recomputes max(), so both would pass if production wiring were absent or broken. There is no real logout-handler test, no assertion on final cookie size or retained id_token/groups, and no proof that normal authentication avoids repository reads. The proposed commands and tests were not executed, and the submitted patch contains none of the tests described here."
+      },
+      "implementation": {
+        "completeness": 11,
+        "correctness": 8,
+        "specificity": 20,
+        "risk_awareness": 12,
+        "total": 51,
+        "notes": "The patch coherently adds an encrypted repository, factory wiring, retrieval endpoint, username-scoped revocation, TTL filtering, configuration, and documentation. It does not solve the stated overflow: the issue itself says access and refresh tokens are already absent, and the patch inserts token storage after the existing session construction without removing id_token, groups, or other large fields, while adding token_ref. It also contains no tests, logs the raw username despite the LLD's redaction guidance, and returns 404 rather than the summary's claimed 503 on file-backend sessions lacking token_ref because that check occurs first. The local sandbox failed before commands ran, so the claimed git apply check and testability could not be independently verified, although the submitted diff context is structurally plausible."
+      }
+    },
+    "task_score": 59.4,
+    "verdict": "The submission is detailed and internally organized, but it implements a secondary token-retrieval facility while leaving the actual oversized session payload in the cookie.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-08-31T06:08:54.493874Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 386307,
+        "cached_input_tokens": 280020,
+        "cache_write_input_tokens": 54840,
+        "output_tokens": 11012,
+        "reasoning_output_tokens": 9041
+      },
+      "duration_ms": 388868
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Lands the **omp** harness results for the three Anthropic models on **Amazon Bedrock** (Path 1), over the v2 dataset (`mcp-gateway-registry-v2`, 21 release-sourced tasks) under the single-agent `/swe3` skill. Data only: per-task `metrics.json` and `eval.json` plus each model's `run-summary.json`. No source, config, or script changes.

This is the **first omp-on-Bedrock run in this repo** -- every prior omp result was `provider: endpoint` against a self-hosted vLLM server. It completes the omp harness picture: four self-hosted models landed in #146, three API models here.

## Results

| Model | Mean score | Scored | Failed | Run cost | $/task |
|---|---:|---:|---:|---:|---:|
| claude-opus-5 | 82.83 | 21/21 | 0 | $160.21 | $7.63 |
| claude-sonnet-5 | 76.97 | 21/21 | 0 | $67.46 | $3.21 |
| claude-haiku-4-5 | 56.18 | 21/21 | 0 | $14.53 | $0.69 |

**Zero failed tasks across all 63.** Every task produced all six artifacts and was scored -- a cleaner record than the self-hosted omp runs in #146, where qwen3.8-27b lost one task to a 241-turn abort.

Total metered spend: **$242.20**.

## Cost basis

These are **metered Bedrock bills** read from each run's `total_cost_usd`, not the hardware-derived figures used for the self-hosted rows. The two bases are not directly comparable as raw dollars; see [cost-per-task-methodology.md](docs/cost-per-task-methodology.md), which the repo already applies when merging paths into a single chart.

Note the token-accounting shape differs from the self-hosted runs: on this path the judge logs `partition signature NOT detected`, i.e. cache reads are additive rather than a partition of `input_tokens` (a typical task reports ~256 fresh input tokens against ~2.7M cache-read). `summarize_run.py` handles both shapes; this is the Bedrock case described in issue #136.

## How it was run

The multi-model batch script could **not** be used here: it is vLLM-only (its registry holds HuggingFace repos and it hardcodes `--provider vllm`), and `claude-opus-5` is rejected with `Unknown model`. `--judge-mode async` is also counter-indicated on this path -- its benefit is reclaiming idle GPU time, and on Bedrock there is no GPU, while the agent and the judge would contend for the same Bedrock quota.

So each model ran through `run-e2e-benchmark.sh --provider bedrock --agent omp --skill swe3` in turn, which judges inline and writes its own run summary.

A 1-task smoke run on Haiku preceded the batch, since omp-on-Bedrock was unexercised. It surfaced one behavior worth recording: omp exited after 4 of 6 artifacts and the harness's top-up pass produced the remaining `patch.diff` and `implementation.md`. That did not recur systematically -- all 63 tasks completed.

**Opus's judging ran in two passes.** The batch process was killed during task 11 of its judging (a session teardown; the log stops mid-task with no error). Generation was already complete, so the judge was resumed with `--no-overwrite`, which skipped the 10 finished tasks and scored 11-21. Same judge model and prompt throughout, so the scores are consistent, but the run spans two dates.

## Testing

- All three models verified complete: 21 `eval.json`, 21 `metrics.json`, and both `run-summary.{json,md}` each.
- `run-summary.json` regenerated by `summarize_run.py` after judging; scored/failed counts and means agree with the per-task `eval.json` files.
- Security gate run over the pending diff before committing: no credentials, no local paths, no request bodies. Artifacts carry counts, latencies, model ids, `provider: bedrock` and the region name only.

## Follow-ups (not in this PR)

- The published tables and charts are not regenerated here; `docs/harness-omp-swe3.md` still shows only the self-hosted rows.
- If Bedrock batches become routine, `run-multi-model-benchmark.sh` would need a Bedrock path (API-model registry entries, skipping the serve/wait/metrics steps, forcing inline judging). That would also bring the `--judge-mode async` failure handling from #147 -- its wait-before-ALL-DONE and non-zero exit naming the failed stage -- to this path, which is exactly what would have made the killed judge loud instead of silent.
