### PR TITLE
benchmark: omp /swe3 results on mcp-gateway-registry-v2 for Opus 4.6 and Opus 4.8

### DIFF
--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 12,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 68,
+      "notes": "The issue is unusually concrete, identifying six Dockerfiles, missing lockfiles, CPU Torch handling, CI enforcement, explicit non-goals, and testable acceptance criteria. Its largest defect is the central claim that `uv sync --frozen` fails when the lockfile is stale; uv documents `--frozen` as using the lock without checking freshness, while `--locked` performs that check.  It also promises reproducible images although mutable base images, system packages, and the unpinned `uv` installation remain outside its controls. The asserted project inventory and claim that the root Dockerfile is unused could not be independently verified because local repository commands failed before execution."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 8,
+      "specificity": 21,
+      "risk_awareness": 11,
+      "total": 58,
+      "notes": "The LLD provides concrete file-level changes, installation flows, caching boundaries, index configuration, CI behavior, alternatives, and rollout steps. Its design rests on two incorrect assumptions: `--frozen` does not detect stale locks, and exact `uv sync` removes packages not declared by the project, so the MCP Dockerfiles can remove the separately installed Torch packages.  The lock-generation command `cd / && uv lock` targets the filesystem root, and the rollout orders merging Dockerfile changes before generating required lockfiles. Exact line-number and repository-pattern claims could not be locally confirmed because repository shell access failed."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 9,
+      "specificity": 19,
+      "risk_awareness": 16,
+      "total": 60,
+      "notes": "The review's strongest contribution is identifying omitted lockfiles as a merge-blocking defect, along with concrete CI-discovery, cache, fallback-security, documentation, and dependency-pin concerns. It nevertheless explicitly endorses the incorrect beliefs that `--frozen` catches stale locks and that syncing over the pre-existing MCP environment safely preserves undeclared Torch packages.  Its resolution accepts post-apply lock generation despite calling same-PR inclusion mandatory, and it says the LLD was revised for dynamic discovery although the submitted LLD still contains a hardcoded list. The cited repository-specific scanner pin and workflow conventions could not be independently checked due unavailable local command execution."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 6,
+      "specificity": 20,
+      "risk_awareness": 14,
+      "total": 57,
+      "notes": "The plan covers lock existence and freshness, image builds, runtime smoke checks, ports, entrypoints, user identity, CI wiring, rollback, and dependency-set comparison with concrete commands. Its stale-lock test appends an invalid bare dependency line at the end of TOML and merely greps generic error text, so it can pass on a syntax failure; moreover, `--frozen` would not reject a correctly formed stale manifest.  Image coverage omits an explicit `mcp-server-cpu` build, and `git diff HEAD` does not establish that existing workflows are unchanged from the baseline. Health endpoints, API response shapes, compose prerequisites, and entrypoint compatibility with the `pip freeze` command were not verified against local source."
+    },
+    "implementation": {
+      "completeness": 7,
+      "correctness": 4,
+      "specificity": 18,
+      "risk_awareness": 7,
+      "total": 36,
+      "notes": "The patch is focused and concrete, modifying the six named Dockerfiles, root manifest, and a dynamically discovering CI workflow, while the summary clearly discloses that verification was not run. It omits every required generated lockfile and the regenerated root lock, so `Dockerfile.auth` references a missing file and the existing root lock cannot contain the new CPU-index resolution. The MCP full and CPU images retain a separate Torch installation that exact `uv sync` can remove, while comments incorrectly claim `--frozen` rejects stale locks.  Patch applicability and surrounding repository conventions could not be independently confirmed because the local sandbox failed before `git apply --check` or source reads could execute."
+    }
+  },
+  "task_score": 55.8,
+  "verdict": "The submission is detailed and repository-shaped, but incorrect uv semantics and omitted mandatory lockfiles leave the implementation incomplete and potentially runtime-breaking.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:35:41.594936Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 246962,
+      "cached_input_tokens": 183277,
+      "cache_write_input_tokens": 39088,
+      "output_tokens": 10735,
+      "reasoning_output_tokens": 8427
+    },
+    "duration_ms": 153754
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "docker",
+    "build",
+    "uv",
+    "dependencies",
+    "reproducibility",
+    "ci",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 55.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 9398,
+    "output_tokens": 40742,
+    "cache_read_tokens": 5886306,
+    "cache_write_tokens": 107719,
+    "total_tokens": 6044165,
+    "total_cost_usd": 4.68193675,
+    "latency_seconds": 737.6,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 55.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 9398,
+  "output_tokens": 40742,
+  "latency_seconds": 737.6,
+  "num_turns": 56,
+  "total_cost_usd": 4.68193675,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 5886306,
+  "cache_creation_tokens": 107719,
+  "run_started_at": "2026-09-01T03:13:56.050813Z",
+  "run_ended_at": "2026-09-01T03:26:13.657249Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 9398,
+    "output_tokens": 40742,
+    "cache_read_tokens": 5886306,
+    "cache_write_tokens": 107719,
+    "total_tokens": 6044165,
+    "total_cost_usd": 4.68193675,
+    "latency_seconds": 737.6,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 55.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "build-docker-images-from-uv-lock",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 12,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 68,
+        "notes": "The issue is unusually concrete, identifying six Dockerfiles, missing lockfiles, CPU Torch handling, CI enforcement, explicit non-goals, and testable acceptance criteria. Its largest defect is the central claim that `uv sync --frozen` fails when the lockfile is stale; uv documents `--frozen` as using the lock without checking freshness, while `--locked` performs that check.  It also promises reproducible images although mutable base images, system packages, and the unpinned `uv` installation remain outside its controls. The asserted project inventory and claim that the root Dockerfile is unused could not be independently verified because local repository commands failed before execution."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 8,
+        "specificity": 21,
+        "risk_awareness": 11,
+        "total": 58,
+        "notes": "The LLD provides concrete file-level changes, installation flows, caching boundaries, index configuration, CI behavior, alternatives, and rollout steps. Its design rests on two incorrect assumptions: `--frozen` does not detect stale locks, and exact `uv sync` removes packages not declared by the project, so the MCP Dockerfiles can remove the separately installed Torch packages.  The lock-generation command `cd / && uv lock` targets the filesystem root, and the rollout orders merging Dockerfile changes before generating required lockfiles. Exact line-number and repository-pattern claims could not be locally confirmed because repository shell access failed."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 9,
+        "specificity": 19,
+        "risk_awareness": 16,
+        "total": 60,
+        "notes": "The review's strongest contribution is identifying omitted lockfiles as a merge-blocking defect, along with concrete CI-discovery, cache, fallback-security, documentation, and dependency-pin concerns. It nevertheless explicitly endorses the incorrect beliefs that `--frozen` catches stale locks and that syncing over the pre-existing MCP environment safely preserves undeclared Torch packages.  Its resolution accepts post-apply lock generation despite calling same-PR inclusion mandatory, and it says the LLD was revised for dynamic discovery although the submitted LLD still contains a hardcoded list. The cited repository-specific scanner pin and workflow conventions could not be independently checked due unavailable local command execution."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 6,
+        "specificity": 20,
+        "risk_awareness": 14,
+        "total": 57,
+        "notes": "The plan covers lock existence and freshness, image builds, runtime smoke checks, ports, entrypoints, user identity, CI wiring, rollback, and dependency-set comparison with concrete commands. Its stale-lock test appends an invalid bare dependency line at the end of TOML and merely greps generic error text, so it can pass on a syntax failure; moreover, `--frozen` would not reject a correctly formed stale manifest.  Image coverage omits an explicit `mcp-server-cpu` build, and `git diff HEAD` does not establish that existing workflows are unchanged from the baseline. Health endpoints, API response shapes, compose prerequisites, and entrypoint compatibility with the `pip freeze` command were not verified against local source."
+      },
+      "implementation": {
+        "completeness": 7,
+        "correctness": 4,
+        "specificity": 18,
+        "risk_awareness": 7,
+        "total": 36,
+        "notes": "The patch is focused and concrete, modifying the six named Dockerfiles, root manifest, and a dynamically discovering CI workflow, while the summary clearly discloses that verification was not run. It omits every required generated lockfile and the regenerated root lock, so `Dockerfile.auth` references a missing file and the existing root lock cannot contain the new CPU-index resolution. The MCP full and CPU images retain a separate Torch installation that exact `uv sync` can remove, while comments incorrectly claim `--frozen` rejects stale locks.  Patch applicability and surrounding repository conventions could not be independently confirmed because the local sandbox failed before `git apply --check` or source reads could execute."
+      }
+    },
+    "task_score": 55.8,
+    "verdict": "The submission is detailed and repository-shaped, but incorrect uv semantics and omitted mandatory lockfiles leave the implementation incomplete and potentially runtime-breaking.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:35:41.594936Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 246962,
+        "cached_input_tokens": 183277,
+        "cache_write_input_tokens": 39088,
+        "output_tokens": 10735,
+        "reasoning_output_tokens": 8427
+      },
+      "duration_ms": 153754
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 87,
+      "notes": "The issue clearly identifies the CLI-to-client gap, specifies all five fields, and provides testable acceptance criteria and explicit non-goals. Its named integration points align with the submitted patch's RegistryClient.configure_egress_auth and cmd_egress_configure changes. The statement that the server requires all five fields is imprecise because its own table identifies only the authorize and token URLs as required. No independent task statement was supplied, and repository-local execution was unavailable, so the UI, SSRF-validation, and persistence claims could not be independently verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 83,
+      "notes": "The LLD commits to exact files, method arguments, body keys, CLI flags, and conditional insertion behavior, making the core change implementation-ready. The submitted diff follows its named api/registry_management.py and api/registry_client.py integration points and the proposed non-None body construction. It inconsistently says registry/core/schemas.py stores four custom fields while listing five, and assertions about audit logging and detailed server URL validation are not substantiated within the available evidence. Compatibility and rollout are addressed proportionately, although the claim that no open questions remain is stronger than warranted without repository verification."
+    },
+    "review": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 19,
+      "risk_awareness": 16,
+      "total": 72,
+      "notes": "The review identifies actionable details, especially the missing client docstring update and the coupling created by hardcoded token-auth choices. It also considers secret exposure, server-side URL validation, migrations, dependencies, and rollback implications specific to this change. Its largest weakness is that it is predominantly approving role-play and does not challenge unconditional args.custom_* access, incomplete parser-level coverage, or the testing plan's questionable E2E hosts. Claims about SSRF checks, resource validation, and audit redaction could not be independently verified against the repository."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 76,
+      "notes": "The plan provides concrete setups, actions, and value-level oracles for handler forwarding, request-body omission, complete body construction, valid choices, and non-custom compatibility. Test 5 calls registry_management.build_parser(), while the implementation instead exercises registry_management.main(), so the documented API is not corroborated by the submitted patch. The E2E success case uses idp.example.com and mcp.example.com despite claiming DNS-aware SSRF validation, making the expected successful result questionable, and parser-level mapping is not directly asserted for every flag. Negative choice coverage is useful, but backward compatibility and server response-field assertions rely substantially on inference."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 85,
+      "notes": "The diff implements the full stated data path: five argparse flags, five handler kwargs, five optional client parameters, conditional POST-body insertion, docstrings, and focused tests. The changes are internally coherent around RegistryClient.configure_egress_auth and cmd_egress_configure and preserve positional compatibility by appending defaulted parameters. The invalid-choice test asserts only SystemExit code 2 and could pass for an unrelated parse error, while unconditional args.custom_* reads can affect direct handler callers using older handcrafted Namespaces, contradicting the summary's absolute claim that existing behavior cannot break. The sandbox failed before local commands could run, so git apply --check, surrounding-source compatibility, and the claimed baseline commit could not be independently verified."
+    }
+  },
+  "task_score": 80.6,
+  "verdict": "This is a strong and likely correct additive implementation, with the largest limitation being testing and review gaps compounded by unavailable repository-local applicability verification.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:37:52.326740Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 237927,
+      "cached_input_tokens": 199915,
+      "cache_write_input_tokens": 36132,
+      "output_tokens": 9283,
+      "reasoning_output_tokens": 6806
+    },
+    "duration_ms": 130720
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "cli",
+    "python",
+    "egress-auth",
+    "oauth",
+    "api-parity",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 57.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 214,
+    "output_tokens": 23492,
+    "cache_read_tokens": 2981228,
+    "cache_write_tokens": 81702,
+    "total_tokens": 3086636,
+    "total_cost_usd": 2.5896215,
+    "latency_seconds": 407.8,
+    "num_turns": 36,
+    "generation_tokens_per_sec": 57.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 214,
+  "output_tokens": 23492,
+  "latency_seconds": 407.8,
+  "num_turns": 36,
+  "total_cost_usd": 2.5896215,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2981228,
+  "cache_creation_tokens": 81702,
+  "run_started_at": "2026-09-01T03:39:57.602867Z",
+  "run_ended_at": "2026-09-01T03:46:45.390465Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 214,
+    "output_tokens": 23492,
+    "cache_read_tokens": 2981228,
+    "cache_write_tokens": 81702,
+    "total_tokens": 3086636,
+    "total_cost_usd": 2.5896215,
+    "latency_seconds": 407.8,
+    "num_turns": 36,
+    "generation_tokens_per_sec": 57.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "cli-custom-egress-oauth-provider-flags",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 87,
+        "notes": "The issue clearly identifies the CLI-to-client gap, specifies all five fields, and provides testable acceptance criteria and explicit non-goals. Its named integration points align with the submitted patch's RegistryClient.configure_egress_auth and cmd_egress_configure changes. The statement that the server requires all five fields is imprecise because its own table identifies only the authorize and token URLs as required. No independent task statement was supplied, and repository-local execution was unavailable, so the UI, SSRF-validation, and persistence claims could not be independently verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 83,
+        "notes": "The LLD commits to exact files, method arguments, body keys, CLI flags, and conditional insertion behavior, making the core change implementation-ready. The submitted diff follows its named api/registry_management.py and api/registry_client.py integration points and the proposed non-None body construction. It inconsistently says registry/core/schemas.py stores four custom fields while listing five, and assertions about audit logging and detailed server URL validation are not substantiated within the available evidence. Compatibility and rollout are addressed proportionately, although the claim that no open questions remain is stronger than warranted without repository verification."
+      },
+      "review": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 19,
+        "risk_awareness": 16,
+        "total": 72,
+        "notes": "The review identifies actionable details, especially the missing client docstring update and the coupling created by hardcoded token-auth choices. It also considers secret exposure, server-side URL validation, migrations, dependencies, and rollback implications specific to this change. Its largest weakness is that it is predominantly approving role-play and does not challenge unconditional args.custom_* access, incomplete parser-level coverage, or the testing plan's questionable E2E hosts. Claims about SSRF checks, resource validation, and audit redaction could not be independently verified against the repository."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 76,
+        "notes": "The plan provides concrete setups, actions, and value-level oracles for handler forwarding, request-body omission, complete body construction, valid choices, and non-custom compatibility. Test 5 calls registry_management.build_parser(), while the implementation instead exercises registry_management.main(), so the documented API is not corroborated by the submitted patch. The E2E success case uses idp.example.com and mcp.example.com despite claiming DNS-aware SSRF validation, making the expected successful result questionable, and parser-level mapping is not directly asserted for every flag. Negative choice coverage is useful, but backward compatibility and server response-field assertions rely substantially on inference."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 85,
+        "notes": "The diff implements the full stated data path: five argparse flags, five handler kwargs, five optional client parameters, conditional POST-body insertion, docstrings, and focused tests. The changes are internally coherent around RegistryClient.configure_egress_auth and cmd_egress_configure and preserve positional compatibility by appending defaulted parameters. The invalid-choice test asserts only SystemExit code 2 and could pass for an unrelated parse error, while unconditional args.custom_* reads can affect direct handler callers using older handcrafted Namespaces, contradicting the summary's absolute claim that existing behavior cannot break. The sandbox failed before local commands could run, so git apply --check, surrounding-source compatibility, and the claimed baseline commit could not be independently verified."
+      }
+    },
+    "task_score": 80.6,
+    "verdict": "This is a strong and likely correct additive implementation, with the largest limitation being testing and review gaps compounded by unavailable repository-local applicability verification.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:37:52.326740Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 237927,
+        "cached_input_tokens": 199915,
+        "cache_write_input_tokens": 36132,
+        "output_tokens": 9283,
+        "reasoning_output_tokens": 6806
+      },
+      "duration_ms": 130720
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 80,
+      "notes": "The issue clearly defines the hardcoded `httpx.AsyncClient(timeout=30.0)` problem, deployment scope, non-goals, and testable acceptance criteria. Its named files and `mcp_proxy_max_body_bytes` precedent align with the submitted baseline contexts. The largest flaw is requiring values below one to be clamped while also prescribing a Pydantic `int` field with `ge=1`, which can reject them during Settings construction before clamping occurs. No independent task statement was supplied, so the asserted production incidents and nginx sufficiency could not be independently established."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 15,
+      "specificity": 23,
+      "risk_awareness": 15,
+      "total": 74,
+      "notes": "The LLD is unusually concrete, identifying the handler, Settings field, admin configuration, and every Compose, Terraform, Helm, documentation, and test integration point. Its paths and surrounding symbols correspond to the patch contexts, and the valid-value flow into `httpx.AsyncClient` is feasible. Its major correctness defect is claiming that fractional, invalid, and below-floor environment values reach the reader, although the always-present Pydantic `int` field can validate or reject them first. It also understates resource growth from longer-lived requests and does not resolve the nginx timeout dependency raised elsewhere."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 15,
+      "specificity": 18,
+      "risk_awareness": 18,
+      "total": 68,
+      "notes": "The review surfaces concrete concerns about httpx per-phase timeout semantics, upstream nginx limits, high-timeout resource exhaustion, and the missing boundary test. Its largest omission is failing to detect the Settings-validation versus runtime-clamping contradiction, while describing the fallback chain as robust. It also dismisses the nginx concern without repository-backed evidence and converts an 'approved with changes' verdict into an optional recommendation. The token-binding and automatic UI-rendering claims are plausible from the named integration points but were not demonstrated in the review itself."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 9,
+      "specificity": 18,
+      "risk_awareness": 12,
+      "total": 54,
+      "notes": "The seven reader tests provide concrete inputs and expected values for defaults, precedence, boundaries, invalid input, and environment fallback. The proposed handler integration test never populates or asserts `captured_timeout`, so it would pass even if the handler retained `timeout=30.0`. The final `python -m unittest discover` command would not discover the submitted plain pytest-style class, and no test exercises real BaseSettings environment validation. Deployment checks only grep for presence and omit Compose parsing, Terraform validation, Helm rendering, and a meaningful admin-config oracle."
+    },
+    "implementation": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 75,
+      "notes": "The patch implements the valid-value path end to end: it adds the Settings field, resolves the timeout, passes it to `httpx.AsyncClient`, and wires all 18 listed configuration and documentation surfaces. The focused hunks match the named baseline symbols and preserve the existing 30-second default without unrelated functional churn. The principal defect is that `Field(ge=1)` and integer parsing can reject invalid, fractional, or sub-one environment values during Settings initialization, while the tests bypass the real Settings object and therefore falsely demonstrate clamping and fallback. The summary consequently overstates exact conformance, and the implementation lacks a test proving that the handler actually passes the configured timeout."
+    }
+  },
+  "task_score": 70.2,
+  "verdict": "The submission is highly specific and largely implements configurable valid timeouts, but its validation model contradicts promised clamping behavior and its testing would not catch failure to wire the timeout into the handler.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:40:42.308239Z",
+    "repo_ref": "1.25.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 259738,
+      "cached_input_tokens": 195275,
+      "cache_write_input_tokens": 39857,
+      "output_tokens": 10387,
+      "reasoning_output_tokens": 8591
+    },
+    "duration_ms": 163209
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.25.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "config",
+    "auth-server",
+    "httpx",
+    "proxy",
+    "timeouts",
+    "fixed-in-1.26.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 52.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4401,
+    "output_tokens": 34136,
+    "cache_read_tokens": 8437903,
+    "cache_write_tokens": 100312,
+    "total_tokens": 8576752,
+    "total_cost_usd": 5.7213065,
+    "latency_seconds": 645.0,
+    "num_turns": 89,
+    "generation_tokens_per_sec": 52.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4401,
+  "output_tokens": 34136,
+  "latency_seconds": 645.0,
+  "num_turns": 89,
+  "total_cost_usd": 5.7213065,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 8437903,
+  "cache_creation_tokens": 100312,
+  "run_started_at": "2026-09-01T04:16:02.042136Z",
+  "run_ended_at": "2026-09-01T04:26:47.039147Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4401,
+    "output_tokens": 34136,
+    "cache_read_tokens": 8437903,
+    "cache_write_tokens": 100312,
+    "total_tokens": 8576752,
+    "total_cost_usd": 5.7213065,
+    "latency_seconds": 645.0,
+    "num_turns": 89,
+    "generation_tokens_per_sec": 52.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-mcp-proxy-upstream-timeout",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 80,
+        "notes": "The issue clearly defines the hardcoded `httpx.AsyncClient(timeout=30.0)` problem, deployment scope, non-goals, and testable acceptance criteria. Its named files and `mcp_proxy_max_body_bytes` precedent align with the submitted baseline contexts. The largest flaw is requiring values below one to be clamped while also prescribing a Pydantic `int` field with `ge=1`, which can reject them during Settings construction before clamping occurs. No independent task statement was supplied, so the asserted production incidents and nginx sufficiency could not be independently established."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 15,
+        "specificity": 23,
+        "risk_awareness": 15,
+        "total": 74,
+        "notes": "The LLD is unusually concrete, identifying the handler, Settings field, admin configuration, and every Compose, Terraform, Helm, documentation, and test integration point. Its paths and surrounding symbols correspond to the patch contexts, and the valid-value flow into `httpx.AsyncClient` is feasible. Its major correctness defect is claiming that fractional, invalid, and below-floor environment values reach the reader, although the always-present Pydantic `int` field can validate or reject them first. It also understates resource growth from longer-lived requests and does not resolve the nginx timeout dependency raised elsewhere."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 15,
+        "specificity": 18,
+        "risk_awareness": 18,
+        "total": 68,
+        "notes": "The review surfaces concrete concerns about httpx per-phase timeout semantics, upstream nginx limits, high-timeout resource exhaustion, and the missing boundary test. Its largest omission is failing to detect the Settings-validation versus runtime-clamping contradiction, while describing the fallback chain as robust. It also dismisses the nginx concern without repository-backed evidence and converts an 'approved with changes' verdict into an optional recommendation. The token-binding and automatic UI-rendering claims are plausible from the named integration points but were not demonstrated in the review itself."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 9,
+        "specificity": 18,
+        "risk_awareness": 12,
+        "total": 54,
+        "notes": "The seven reader tests provide concrete inputs and expected values for defaults, precedence, boundaries, invalid input, and environment fallback. The proposed handler integration test never populates or asserts `captured_timeout`, so it would pass even if the handler retained `timeout=30.0`. The final `python -m unittest discover` command would not discover the submitted plain pytest-style class, and no test exercises real BaseSettings environment validation. Deployment checks only grep for presence and omit Compose parsing, Terraform validation, Helm rendering, and a meaningful admin-config oracle."
+      },
+      "implementation": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 75,
+        "notes": "The patch implements the valid-value path end to end: it adds the Settings field, resolves the timeout, passes it to `httpx.AsyncClient`, and wires all 18 listed configuration and documentation surfaces. The focused hunks match the named baseline symbols and preserve the existing 30-second default without unrelated functional churn. The principal defect is that `Field(ge=1)` and integer parsing can reject invalid, fractional, or sub-one environment values during Settings initialization, while the tests bypass the real Settings object and therefore falsely demonstrate clamping and fallback. The summary consequently overstates exact conformance, and the implementation lacks a test proving that the handler actually passes the configured timeout."
+      }
+    },
+    "task_score": 70.2,
+    "verdict": "The submission is highly specific and largely implements configurable valid timeouts, but its validation model contradicts promised clamping behavior and its testing would not catch failure to wire the timeout into the handler.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:40:42.308239Z",
+      "repo_ref": "1.25.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 259738,
+        "cached_input_tokens": 195275,
+        "cache_write_input_tokens": 39857,
+        "output_tokens": 10387,
+        "reasoning_output_tokens": 8591
+      },
+      "duration_ms": 163209
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-ui-title",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 80,
+      "notes": "The issue precisely identifies the affected UI locations, configuration behavior, deployment surfaces, and explicit non-goals. The submitted diff contains every named path and implements the stated Settings, API, frontend, Docker, Terraform, and Helm boundaries. Its largest defect is the contradictory acceptance criterion that unset UI_TITLE causes no current-behavior change even though registry-only deployments intentionally change from \"AI Gateway & Registry\" to \"AI Registry\". No independent task statement was supplied, and the linked issue could not be independently verified."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 83,
+      "notes": "The LLD is implementation-ready, naming concrete symbols such as Settings.effective_ui_title, get_config(), CONFIG_GROUPS, useRegistryConfig, and each deployment configuration path. Those integration points and surrounding contexts are represented consistently in the submitted patch. It repeats the false claim that all existing deployments see no change and describes the title as resolved once at startup even though the property is evaluated when accessed; it also understates the frontend bundle rollout requirement that it otherwise acknowledges. Cache-TTL, middleware-allowlist, and exact repository-convention claims could not be independently verified from the local checkout."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 77,
+      "notes": "The review raises concrete concerns about hook reuse, Helm reserved-name testing, title length, serialization, caching, and startup logging, and it causes the Login and Logout design to use the shared hook. Its resolution incorrectly says Logout.tsx needs an axios import for the hook, while the submitted patch correctly adds no such import. It also misses the issue's backward-compatibility contradiction and treats the missing backend and Helm tests as non-blocking despite their direct relevance. Assertions about the 60-second cache and docker-compose.dhi.yml could not be independently verified."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 68,
+      "notes": "The plan supplies useful oracles for explicit, with-gateway, and registry-only resolution and covers all four UI locations plus each deployment surface. The backward-compatibility jq command is invalid because jq's has function accepts one key argument, not the five arguments shown. Most deployment checks merely grep for text rather than running Docker Compose rendering, Terraform validation, Helm rendering, or the reserved-environment-name test, and the promised unit tests have no concrete test file or cases. The asserted /api/config/full response shape and session-cookie command could not be independently verified."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 82,
+      "notes": "The patch coherently implements the design end to end: Settings.effective_ui_title resolves the override, get_config() exposes it, four React surfaces consume useRegistryConfig, and Docker, Terraform, and Helm propagate UI_TITLE. The provided source contexts and symbols are internally consistent, including the CONFIG_GROUPS field and Helm reserved-name addition. Its largest deficiency is the absence of the directly relevant backend and Helm tests while the summary claims nothing remains unimplemented; the unresolved acceptance-criterion contradiction also makes that claim too strong. Independent git apply verification against the checkout was unavailable because the repository shell sandbox failed before command execution, so patch applicability could not be confirmed beyond the submitted unified-diff context."
+    }
+  },
+  "task_score": 78.0,
+  "verdict": "This is a strong, coherent design and implementation submission whose largest limitation is weak verification: the testing plan contains an invalid command, omits concrete automated coverage, and several repository claims could not be independently confirmed.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:42:19.498637Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 234425,
+      "cached_input_tokens": 191092,
+      "cache_write_input_tokens": 36578,
+      "output_tokens": 5853,
+      "reasoning_output_tokens": 4073
+    },
+    "duration_ms": 97179
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "configurable-ui-title",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "ui",
+    "react",
+    "config",
+    "branding",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 51.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5418,
+    "output_tokens": 32648,
+    "cache_read_tokens": 10085569,
+    "cache_write_tokens": 110228,
+    "total_tokens": 10233863,
+    "total_cost_usd": 6.5749995000000006,
+    "latency_seconds": 640.3,
+    "num_turns": 92,
+    "generation_tokens_per_sec": 51.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 5418,
+  "output_tokens": 32648,
+  "latency_seconds": 640.3,
+  "num_turns": 92,
+  "total_cost_usd": 6.5749995000000006,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 10085569,
+  "cache_creation_tokens": 110228,
+  "run_started_at": "2026-09-01T04:05:18.692137Z",
+  "run_ended_at": "2026-09-01T04:15:59.048465Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5418,
+    "output_tokens": 32648,
+    "cache_read_tokens": 10085569,
+    "cache_write_tokens": 110228,
+    "total_tokens": 10233863,
+    "total_cost_usd": 6.5749995000000006,
+    "latency_seconds": 640.3,
+    "num_turns": 92,
+    "generation_tokens_per_sec": 51.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-ui-title",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 80,
+        "notes": "The issue precisely identifies the affected UI locations, configuration behavior, deployment surfaces, and explicit non-goals. The submitted diff contains every named path and implements the stated Settings, API, frontend, Docker, Terraform, and Helm boundaries. Its largest defect is the contradictory acceptance criterion that unset UI_TITLE causes no current-behavior change even though registry-only deployments intentionally change from \"AI Gateway & Registry\" to \"AI Registry\". No independent task statement was supplied, and the linked issue could not be independently verified."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 83,
+        "notes": "The LLD is implementation-ready, naming concrete symbols such as Settings.effective_ui_title, get_config(), CONFIG_GROUPS, useRegistryConfig, and each deployment configuration path. Those integration points and surrounding contexts are represented consistently in the submitted patch. It repeats the false claim that all existing deployments see no change and describes the title as resolved once at startup even though the property is evaluated when accessed; it also understates the frontend bundle rollout requirement that it otherwise acknowledges. Cache-TTL, middleware-allowlist, and exact repository-convention claims could not be independently verified from the local checkout."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 77,
+        "notes": "The review raises concrete concerns about hook reuse, Helm reserved-name testing, title length, serialization, caching, and startup logging, and it causes the Login and Logout design to use the shared hook. Its resolution incorrectly says Logout.tsx needs an axios import for the hook, while the submitted patch correctly adds no such import. It also misses the issue's backward-compatibility contradiction and treats the missing backend and Helm tests as non-blocking despite their direct relevance. Assertions about the 60-second cache and docker-compose.dhi.yml could not be independently verified."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 68,
+        "notes": "The plan supplies useful oracles for explicit, with-gateway, and registry-only resolution and covers all four UI locations plus each deployment surface. The backward-compatibility jq command is invalid because jq's has function accepts one key argument, not the five arguments shown. Most deployment checks merely grep for text rather than running Docker Compose rendering, Terraform validation, Helm rendering, or the reserved-environment-name test, and the promised unit tests have no concrete test file or cases. The asserted /api/config/full response shape and session-cookie command could not be independently verified."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 82,
+        "notes": "The patch coherently implements the design end to end: Settings.effective_ui_title resolves the override, get_config() exposes it, four React surfaces consume useRegistryConfig, and Docker, Terraform, and Helm propagate UI_TITLE. The provided source contexts and symbols are internally consistent, including the CONFIG_GROUPS field and Helm reserved-name addition. Its largest deficiency is the absence of the directly relevant backend and Helm tests while the summary claims nothing remains unimplemented; the unresolved acceptance-criterion contradiction also makes that claim too strong. Independent git apply verification against the checkout was unavailable because the repository shell sandbox failed before command execution, so patch applicability could not be confirmed beyond the submitted unified-diff context."
+      }
+    },
+    "task_score": 78.0,
+    "verdict": "This is a strong, coherent design and implementation submission whose largest limitation is weak verification: the testing plan contains an invalid command, omits concrete automated coverage, and several repository claims could not be independently confirmed.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:42:19.498637Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 234425,
+        "cached_input_tokens": 191092,
+        "cache_write_input_tokens": 36578,
+        "output_tokens": 5853,
+        "reasoning_output_tokens": 4073
+      },
+      "duration_ms": 97179
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 78,
+      "notes": "The issue clearly inventories the five user-facing toggle routes, separates the internal route, and supplies testable cookie-versus-bearer acceptance criteria. Its largest defect is requiring bearer-token operation on every toggle while the submitted route evidence shows the server UI toggle still uses session-oriented enhanced_auth rather than nginx_proxied_auth. It also contradicts itself by saying to apply the dependency to all six endpoints while simultaneously excluding the internal endpoint. No independent task statement establishes the broader claim that every M2M registration pipeline is broken."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 70,
+      "notes": "The LLD names concrete files, symbols, route signatures, compatibility boundaries, and the intended cookie and token flows. Its major unresolved flaw is claiming bearer clients will succeed on the server UI toggle even though server_routes.py retains enhanced_auth, which the LLD itself describes as the session fallback rather than the nginx bearer path. It also incorrectly states that sibling FastAPI dependencies execute in parallel and overstates absence of a session cookie as proof of bearer authentication. Claims that nginx strips Authorization and that the cited frontend and line-level integration points behave exactly as described could not be independently verified."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 19,
+      "risk_awareness": 17,
+      "total": 66,
+      "notes": "The review usefully identifies browser compatibility risk on the newly protected routes and examines the both-cookie-and-proxy-headers case. It misses the more consequential enhanced_auth mismatch and resolves the frontend concern with an unsupported claim that virtual-server JSON toggles use the same form pattern as the server UI route. The security section also incorrectly treats HttpOnly and SameSite as making non-browser cookie replay impossible. The claimed frontend locations, global CSRF-header behavior, and JWT-only reachability were not substantiated by the submitted patch."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 9,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 57,
+      "notes": "The dependency unit cases have meaningful status, message, session-mismatch, form, and header-precedence oracles. Several HTTP tests are not executable against the shown interfaces: toggle_agent receives enabled as a scalar query parameter rather than the submitted JSON body, and the server UI bearer test expects 200 despite its enhanced_auth dependency. The proposed unittest discovery command also does not exercise the pytest-style fixtures shown in the existing test files. Route-wiring tests for all five endpoints and an unauthenticated no-cookie rejection test are missing, while the token script and agent verification endpoint remain unverified."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 20,
+      "risk_awareness": 15,
+      "total": 69,
+      "notes": "The patch concretely adds the session-aware dependency, wires it into all five intended route functions, preserves the old dependency for non-toggle routes, and adds focused unit coverage. It does not fully satisfy its own bearer-compatibility claim because toggle_service_route still depends on enhanced_auth, so skipping CSRF alone cannot make that endpoint accept nginx-authenticated M2M callers. The tests exercise the helper directly but do not prove that every route is wired correctly or that newly protected browser calls receive 403 without a token; the new test file also contains an unused patch import. Patch applicability against the baseline could not be independently confirmed in the available execution environment, although the submitted contexts and symbols are internally consistent."
+    }
+  },
+  "task_score": 68.0,
+  "verdict": "The submission presents a strong, concrete CSRF change, but overclaims universal bearer compatibility and supplies several HTTP tests that do not match the shown route interfaces.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:44:45.784200Z",
+    "repo_ref": "v1.0.20",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 181581,
+      "cached_input_tokens": 125257,
+      "cache_write_input_tokens": 37554,
+      "output_tokens": 9864,
+      "reasoning_output_tokens": 7964
+    },
+    "duration_ms": 139936
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.20",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "csrf",
+    "authentication",
+    "api",
+    "fastapi",
+    "m2m",
+    "fixed-in-1.0.21"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 52.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 3533,
+    "output_tokens": 30855,
+    "cache_read_tokens": 6925866,
+    "cache_write_tokens": 95679,
+    "total_tokens": 7055933,
+    "total_cost_usd": 4.849966749999999,
+    "latency_seconds": 593.6,
+    "num_turns": 73,
+    "generation_tokens_per_sec": 52.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 3533,
+  "output_tokens": 30855,
+  "latency_seconds": 593.6,
+  "num_turns": 73,
+  "total_cost_usd": 4.849966749999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 6925866,
+  "cache_creation_tokens": 95679,
+  "run_started_at": "2026-09-01T03:55:22.246965Z",
+  "run_ended_at": "2026-09-01T04:05:15.886465Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 3533,
+    "output_tokens": 30855,
+    "cache_read_tokens": 6925866,
+    "cache_write_tokens": 95679,
+    "total_tokens": 7055933,
+    "total_cost_usd": 4.849966749999999,
+    "latency_seconds": 593.6,
+    "num_turns": 73,
+    "generation_tokens_per_sec": 52.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "consistent-csrf-across-toggle-endpoints",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 78,
+        "notes": "The issue clearly inventories the five user-facing toggle routes, separates the internal route, and supplies testable cookie-versus-bearer acceptance criteria. Its largest defect is requiring bearer-token operation on every toggle while the submitted route evidence shows the server UI toggle still uses session-oriented enhanced_auth rather than nginx_proxied_auth. It also contradicts itself by saying to apply the dependency to all six endpoints while simultaneously excluding the internal endpoint. No independent task statement establishes the broader claim that every M2M registration pipeline is broken."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 70,
+        "notes": "The LLD names concrete files, symbols, route signatures, compatibility boundaries, and the intended cookie and token flows. Its major unresolved flaw is claiming bearer clients will succeed on the server UI toggle even though server_routes.py retains enhanced_auth, which the LLD itself describes as the session fallback rather than the nginx bearer path. It also incorrectly states that sibling FastAPI dependencies execute in parallel and overstates absence of a session cookie as proof of bearer authentication. Claims that nginx strips Authorization and that the cited frontend and line-level integration points behave exactly as described could not be independently verified."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 19,
+        "risk_awareness": 17,
+        "total": 66,
+        "notes": "The review usefully identifies browser compatibility risk on the newly protected routes and examines the both-cookie-and-proxy-headers case. It misses the more consequential enhanced_auth mismatch and resolves the frontend concern with an unsupported claim that virtual-server JSON toggles use the same form pattern as the server UI route. The security section also incorrectly treats HttpOnly and SameSite as making non-browser cookie replay impossible. The claimed frontend locations, global CSRF-header behavior, and JWT-only reachability were not substantiated by the submitted patch."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 9,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 57,
+        "notes": "The dependency unit cases have meaningful status, message, session-mismatch, form, and header-precedence oracles. Several HTTP tests are not executable against the shown interfaces: toggle_agent receives enabled as a scalar query parameter rather than the submitted JSON body, and the server UI bearer test expects 200 despite its enhanced_auth dependency. The proposed unittest discovery command also does not exercise the pytest-style fixtures shown in the existing test files. Route-wiring tests for all five endpoints and an unauthenticated no-cookie rejection test are missing, while the token script and agent verification endpoint remain unverified."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 20,
+        "risk_awareness": 15,
+        "total": 69,
+        "notes": "The patch concretely adds the session-aware dependency, wires it into all five intended route functions, preserves the old dependency for non-toggle routes, and adds focused unit coverage. It does not fully satisfy its own bearer-compatibility claim because toggle_service_route still depends on enhanced_auth, so skipping CSRF alone cannot make that endpoint accept nginx-authenticated M2M callers. The tests exercise the helper directly but do not prove that every route is wired correctly or that newly protected browser calls receive 403 without a token; the new test file also contains an unused patch import. Patch applicability against the baseline could not be independently confirmed in the available execution environment, although the submitted contexts and symbols are internally consistent."
+      }
+    },
+    "task_score": 68.0,
+    "verdict": "The submission presents a strong, concrete CSRF change, but overclaims universal bearer compatibility and supplies several HTTP tests that do not match the shown route interfaces.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:44:45.784200Z",
+      "repo_ref": "v1.0.20",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 181581,
+        "cached_input_tokens": 125257,
+        "cache_write_input_tokens": 37554,
+        "output_tokens": 9864,
+        "reasoning_output_tokens": 7964
+      },
+      "duration_ms": 139936
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 16,
+      "total": 80,
+      "notes": "The issue provides a clear motivation, explicit non-goals, and testable criteria covering initial state, reset behavior, omitted values, and explicit opt-in. Its named files and symbols correspond consistently with the submitted diff, including IAMGroups.tsx state and management_routes.py fallback changes. Its largest deficiency is calling the work self-contained while changing defaults on existing API endpoints, a potentially breaking behavior for callers that omit the field. No independent task statement establishes that the backend expansion is required, and repository shell failure prevented direct verification of its remaining repository claims."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 75,
+      "notes": "The LLD is implementation-ready in its enumeration of concrete defaults, integration paths, tests, and legacy import behavior. The submitted patch contains the named functions and matching contexts for management_create_group, internal_create_group, _create_group_impl, create_group_api, and import_group_definition. The main weakness is treating rollout as risk-free despite acknowledging changed behavior for omitted fields, with no compatibility mechanism or release-note requirement. It also misses the now-misleading internal_create_group docstring, and exact repository applicability could not be independently verified."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 19,
+      "risk_awareness": 16,
+      "total": 70,
+      "notes": "The review's strongest contribution is identifying the omitted-field API compatibility break and stale default documentation with concrete locations. Those findings are supported by the submitted patch, which updates two server_routes.py default descriptions but leaves internal_create_group documented as creating in both stores. The review then underweights its own compatibility finding and approves based on unsupported assertions about endpoint and CLI usage rather than requiring evidence or broader regression tests. Claims that affected callers always pass the field could not be verified against the repository."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 16,
+      "specificity": 19,
+      "risk_awareness": 17,
+      "total": 71,
+      "notes": "The plan covers omitted, explicit-true, explicit-false, legacy-key, UI reset, and lifecycle scenarios with concrete commands and expected outcomes. Its management test names align with the submitted test patch, and it correctly distinguishes local-only behavior through the absence of an IAM create call. The largest gap is that server_routes.py and import defaults receive no automated regression tests, while several manual checks merely reference logs or assert IdP state without a concrete query oracle. The frontend implementation also tests only initial checkbox state, not the preview or post-reset behavior promised by this plan, and command validity could not be independently executed."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 19,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 74,
+      "notes": "The patch consistently flips the submitted design's frontend state, reset, example value, management fallback, three server defaults, legacy fallback, and management regression test. The changes are internally plausible and explicit true values remain supported, but the new frontend test covers only initial state and does not verify preview or reset behavior. The summary incorrectly claims no deviations and complete implementation, while internal_create_group retains a misleading both-stores docstring and the compatibility-sensitive server/import changes lack dedicated automated tests or release guidance. The working-tree shell failed before every command, so git apply --check, import compatibility, and the test mocks could not be independently verified."
+    }
+  },
+  "task_score": 74.0,
+  "verdict": "This is a strong, concrete default-value change, but its broader backward-incompatible API-default expansion is insufficiently justified, mitigated, and tested.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:47:35.092266Z",
+    "repo_ref": "v1.0.21",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 281699,
+      "cached_input_tokens": 217322,
+      "cache_write_input_tokens": 34071,
+      "output_tokens": 10448,
+      "reasoning_output_tokens": 7996
+    },
+    "duration_ms": 163247
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.21",
+  "complexity": "low",
+  "tags": [
+    "ui",
+    "react",
+    "iam",
+    "groups",
+    "ux",
+    "fixed-in-1.0.22"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 50.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4146,
+    "output_tokens": 24296,
+    "cache_read_tokens": 5553615,
+    "cache_write_tokens": 111568,
+    "total_tokens": 5693625,
+    "total_cost_usd": 4.102237499999998,
+    "latency_seconds": 486.0,
+    "num_turns": 66,
+    "generation_tokens_per_sec": 50.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4146,
+  "output_tokens": 24296,
+  "latency_seconds": 486.0,
+  "num_turns": 66,
+  "total_cost_usd": 4.102237499999998,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 5553615,
+  "cache_creation_tokens": 111568,
+  "run_started_at": "2026-09-01T03:05:47.269148Z",
+  "run_ended_at": "2026-09-01T03:13:53.308512Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4146,
+    "output_tokens": 24296,
+    "cache_read_tokens": 5553615,
+    "cache_write_tokens": 111568,
+    "total_tokens": 5693625,
+    "total_cost_usd": 4.102237499999998,
+    "latency_seconds": 486.0,
+    "num_turns": 66,
+    "generation_tokens_per_sec": 50.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "default-create-in-idp-checkbox-unchecked",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 16,
+        "total": 80,
+        "notes": "The issue provides a clear motivation, explicit non-goals, and testable criteria covering initial state, reset behavior, omitted values, and explicit opt-in. Its named files and symbols correspond consistently with the submitted diff, including IAMGroups.tsx state and management_routes.py fallback changes. Its largest deficiency is calling the work self-contained while changing defaults on existing API endpoints, a potentially breaking behavior for callers that omit the field. No independent task statement establishes that the backend expansion is required, and repository shell failure prevented direct verification of its remaining repository claims."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 75,
+        "notes": "The LLD is implementation-ready in its enumeration of concrete defaults, integration paths, tests, and legacy import behavior. The submitted patch contains the named functions and matching contexts for management_create_group, internal_create_group, _create_group_impl, create_group_api, and import_group_definition. The main weakness is treating rollout as risk-free despite acknowledging changed behavior for omitted fields, with no compatibility mechanism or release-note requirement. It also misses the now-misleading internal_create_group docstring, and exact repository applicability could not be independently verified."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 19,
+        "risk_awareness": 16,
+        "total": 70,
+        "notes": "The review's strongest contribution is identifying the omitted-field API compatibility break and stale default documentation with concrete locations. Those findings are supported by the submitted patch, which updates two server_routes.py default descriptions but leaves internal_create_group documented as creating in both stores. The review then underweights its own compatibility finding and approves based on unsupported assertions about endpoint and CLI usage rather than requiring evidence or broader regression tests. Claims that affected callers always pass the field could not be verified against the repository."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 16,
+        "specificity": 19,
+        "risk_awareness": 17,
+        "total": 71,
+        "notes": "The plan covers omitted, explicit-true, explicit-false, legacy-key, UI reset, and lifecycle scenarios with concrete commands and expected outcomes. Its management test names align with the submitted test patch, and it correctly distinguishes local-only behavior through the absence of an IAM create call. The largest gap is that server_routes.py and import defaults receive no automated regression tests, while several manual checks merely reference logs or assert IdP state without a concrete query oracle. The frontend implementation also tests only initial checkbox state, not the preview or post-reset behavior promised by this plan, and command validity could not be independently executed."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 19,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 74,
+        "notes": "The patch consistently flips the submitted design's frontend state, reset, example value, management fallback, three server defaults, legacy fallback, and management regression test. The changes are internally plausible and explicit true values remain supported, but the new frontend test covers only initial state and does not verify preview or reset behavior. The summary incorrectly claims no deviations and complete implementation, while internal_create_group retains a misleading both-stores docstring and the compatibility-sensitive server/import changes lack dedicated automated tests or release guidance. The working-tree shell failed before every command, so git apply --check, import compatibility, and the test mocks could not be independently verified."
+      }
+    },
+    "task_score": 74.0,
+    "verdict": "This is a strong, concrete default-value change, but its broader backward-incompatible API-default expansion is insufficiently justified, mitigated, and tested.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:47:35.092266Z",
+      "repo_ref": "v1.0.21",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 281699,
+        "cached_input_tokens": 217322,
+        "cache_write_input_tokens": 34071,
+        "output_tokens": 10448,
+        "reasoning_output_tokens": 7996
+      },
+      "duration_ms": 163247
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 83,
+      "notes": "The issue clearly separates registration auto-fill from modal navigation and provides testable acceptance criteria, explicit URL shapes, and useful non-goals. The submitted diff corroborates the named integration points, including parse_skill_md, Dashboard.tsx, SkillCard.tsx, SemanticSearchResults.tsx, and both frontend interfaces. Its largest gap is limited treatment of malformed or ambiguous GitHub-like URLs and the state needed to distinguish a manual value from the previous auto-filled value. Local repository commands failed before execution because the read-only shell sandbox could not initialize loopback networking, so the stated tag, model field, and related issue could not be independently verified beyond the supplied patch context."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 13,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 67,
+      "notes": "The LLD is concrete about files, symbols, response fields, data flow, conditional rendering, and deployment impact, and its locations agree with the submitted diff. Its critical defect is the claim that data.repository_url || prev.repository_url preserves manual input: a truthy parse result always wins, so reparsing overwrites a custom value and cannot implement the stated previous-auto-fill rule. It also says the helper will emit debug logs although neither its proposed code nor the patch logs, and the review claims the import section was updated while this LLD still specifies a function-local import. Exact baseline source and existing test conventions could not be independently inspected because repository shell execution failed before running any command."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 8,
+      "specificity": 17,
+      "risk_awareness": 12,
+      "total": 53,
+      "notes": "The review raises concrete points about import placement, utility tests, duplicated JSX, optional links, and user-controlled URL components. Its largest failure is explicitly asserting that data.repository_url || prev.repository_url will not overwrite user input, which reverses JavaScript operand-selection semantics and approves the change's central UX regression. It also records the import issue as resolved although the submitted LLD remains unchanged and accepts omission of implementation tests based on an unsupported constraint. Repository-specific assertions about existing imports, stored documents, and hostname-helper behavior could not be independently verified after the local shell sandbox failed to initialize."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 10,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 64,
+      "notes": "The utility cases have concrete inputs and expected values, while the manual reparse test would directly expose the implementation's overwrite bug. Several API and end-to-end commands use placeholder or unproven remote SKILL.md paths, so an endpoint that fetches the URL may fail before producing the expected repository_url response; example.com is likewise not a controlled non-GitHub fixture. The plan also omits the distinct case where a value still matching the previous auto-fill should update after parsing a different URL, and it provides no automated frontend regression test. The proposed tests/unit path and uv run python -m unittest discover command could not be checked against the repository's actual test layout and runner because shell inspection was unavailable."
+    },
+    "implementation": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 20,
+      "risk_awareness": 12,
+      "total": 62,
+      "notes": "The patch covers the backend derivation and response path, both frontend types, form integration, and conditional links in both submitted modal locations. The largest defect is repository_url: data.repository_url || prev.repository_url in Dashboard.tsx, which overwrites any manually entered value whenever parsing returns a derived URL and therefore does not implement the issue's stated preservation rule. No tests are added despite the review and testing plan calling for utility coverage, while implementation.md inaccurately says that nothing was left out and all LLD work is present. The diff contexts and symbols are internally coherent, but git apply --check and comparison with the actual baseline could not be completed because every repository command failed during sandbox initialization."
+    }
+  },
+  "task_score": 65.8,
+  "verdict": "The submission is well-scoped and mostly end-to-end, but both the implementation and its review get the manual-override state semantics backwards, causing reparsing to overwrite user-entered repository URLs.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:49:48.275711Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 178085,
+      "cached_input_tokens": 141275,
+      "cache_write_input_tokens": 33101,
+      "output_tokens": 8834,
+      "reasoning_output_tokens": 7040
+    },
+    "duration_ms": 133172
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "skills",
+    "ui",
+    "react",
+    "api",
+    "ux",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 54.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 12318,
+    "output_tokens": 27880,
+    "cache_read_tokens": 5587822,
+    "cache_write_tokens": 92611,
+    "total_tokens": 5720631,
+    "total_cost_usd": 4.13131975,
+    "latency_seconds": 511.5,
+    "num_turns": 61,
+    "generation_tokens_per_sec": 54.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 12318,
+  "output_tokens": 27880,
+  "latency_seconds": 511.5,
+  "num_turns": 61,
+  "total_cost_usd": 4.13131975,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 5587822,
+  "cache_creation_tokens": 92611,
+  "run_started_at": "2026-09-01T03:46:48.031206Z",
+  "run_ended_at": "2026-09-01T03:55:19.572755Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 12318,
+    "output_tokens": 27880,
+    "cache_read_tokens": 5587822,
+    "cache_write_tokens": 92611,
+    "total_tokens": 5720631,
+    "total_cost_usd": 4.13131975,
+    "latency_seconds": 511.5,
+    "num_turns": 61,
+    "generation_tokens_per_sec": 54.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "derive-repo-url-from-skill-md",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 83,
+        "notes": "The issue clearly separates registration auto-fill from modal navigation and provides testable acceptance criteria, explicit URL shapes, and useful non-goals. The submitted diff corroborates the named integration points, including parse_skill_md, Dashboard.tsx, SkillCard.tsx, SemanticSearchResults.tsx, and both frontend interfaces. Its largest gap is limited treatment of malformed or ambiguous GitHub-like URLs and the state needed to distinguish a manual value from the previous auto-filled value. Local repository commands failed before execution because the read-only shell sandbox could not initialize loopback networking, so the stated tag, model field, and related issue could not be independently verified beyond the supplied patch context."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 13,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 67,
+        "notes": "The LLD is concrete about files, symbols, response fields, data flow, conditional rendering, and deployment impact, and its locations agree with the submitted diff. Its critical defect is the claim that data.repository_url || prev.repository_url preserves manual input: a truthy parse result always wins, so reparsing overwrites a custom value and cannot implement the stated previous-auto-fill rule. It also says the helper will emit debug logs although neither its proposed code nor the patch logs, and the review claims the import section was updated while this LLD still specifies a function-local import. Exact baseline source and existing test conventions could not be independently inspected because repository shell execution failed before running any command."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 8,
+        "specificity": 17,
+        "risk_awareness": 12,
+        "total": 53,
+        "notes": "The review raises concrete points about import placement, utility tests, duplicated JSX, optional links, and user-controlled URL components. Its largest failure is explicitly asserting that data.repository_url || prev.repository_url will not overwrite user input, which reverses JavaScript operand-selection semantics and approves the change's central UX regression. It also records the import issue as resolved although the submitted LLD remains unchanged and accepts omission of implementation tests based on an unsupported constraint. Repository-specific assertions about existing imports, stored documents, and hostname-helper behavior could not be independently verified after the local shell sandbox failed to initialize."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 10,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 64,
+        "notes": "The utility cases have concrete inputs and expected values, while the manual reparse test would directly expose the implementation's overwrite bug. Several API and end-to-end commands use placeholder or unproven remote SKILL.md paths, so an endpoint that fetches the URL may fail before producing the expected repository_url response; example.com is likewise not a controlled non-GitHub fixture. The plan also omits the distinct case where a value still matching the previous auto-fill should update after parsing a different URL, and it provides no automated frontend regression test. The proposed tests/unit path and uv run python -m unittest discover command could not be checked against the repository's actual test layout and runner because shell inspection was unavailable."
+      },
+      "implementation": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 20,
+        "risk_awareness": 12,
+        "total": 62,
+        "notes": "The patch covers the backend derivation and response path, both frontend types, form integration, and conditional links in both submitted modal locations. The largest defect is repository_url: data.repository_url || prev.repository_url in Dashboard.tsx, which overwrites any manually entered value whenever parsing returns a derived URL and therefore does not implement the issue's stated preservation rule. No tests are added despite the review and testing plan calling for utility coverage, while implementation.md inaccurately says that nothing was left out and all LLD work is present. The diff contexts and symbols are internally coherent, but git apply --check and comparison with the actual baseline could not be completed because every repository command failed during sandbox initialization."
+      }
+    },
+    "task_score": 65.8,
+    "verdict": "The submission is well-scoped and mostly end-to-end, but both the implementation and its review get the manual-override state semantics backwards, causing reparsing to overwrite user-entered repository URLs.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:49:48.275711Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 178085,
+        "cached_input_tokens": 141275,
+        "cache_write_input_tokens": 33101,
+        "output_tokens": 8834,
+        "reasoning_output_tokens": 7040
+      },
+      "duration_ms": 133172
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 84,
+      "notes": "The issue clearly identifies both scripts, the verify_setup functions, observable exit behavior, scope, non-goals, and testable acceptance criteria. The submitted patch contains the cited GROUPS assignments and scalar expansions at the described locations. Its main weakness is imprecise terminology: Bash documents GROUPS as a special array whose assignments have no effect, while the issue calls it read-only; the blanket prohibition on assigning numerous special variables is also broader than this defect.  No independent task statement was supplied, and the macos-setup impact and repository-wide sweep could not be independently verified."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 84,
+      "notes": "The LLD is highly implementation-ready, naming both files, four membership checks, exact variable changes, compatibility constraints, and the reason for separating local declaration from assignment. Its proposed edits correspond precisely to the symbols and preimage lines in the submitted patch. The largest technical deficiency is claiming that set -e will catch a failed curl within curl | jq even though no pipefail setting is established; only the final pipeline command controls that status. The Bash 3.2 clobbering claim, exhaustive nine-script inventory, and baseline line claims could not be independently verified."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 78,
+      "notes": "The review's strongest contribution is the concrete identification of substring false positives and its actionable resolution to use grep -qxF in all four membership checks. That resolution is reflected in both the final LLD and patch. It does not challenge the LLD's incomplete pipeline-error analysis or unsupported Bash 3.2 behavior, and Byte's discussion retains stale grep -qF wording after the design adopted -qxF. Claims about inspecting every setup script and filing follow-ups were not independently verifiable."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 75,
+      "notes": "The plan covers successful runs, missing groups, idempotency, exact matching, syntax, ShellCheck, token behavior, and both stated Bash versions with concrete expected outcomes. The standalone grep -qxF cases are particularly effective regression oracles. The reserved-variable count uses grep -c across multiple files, which produces per-file counts rather than one total, while the JWT check incorrectly treats base64url data as ordinary base64.  It also lacks cleanup and injected curl, jq, or mapper-failure cases, and the exact script flags and environment names could not be verified."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 86,
+      "notes": "The patch implements the central rename in both verify_setup functions and consistently updates both verification and assignment membership checks to exact fixed-string matching. Its contexts, symbols, variable references, and summary are internally consistent, and separate local declarations avoid masking command-substitution status at the assignment level. The additional mapper localization and assign_to_group behavior change are small, disclosed, and consistent with the revised design, although they extend beyond the narrow reserved-name fix. No material diff defect is apparent, but local source reads and git apply --check failed at sandbox initialization, so target-tree applicability and the claimed baseline commit remain unverified."
+    }
+  },
+  "task_score": 81.4,
+  "verdict": "This is a strong, likely correct small implementation backed by unusually specific artifacts, with its largest limitations being flawed test commands, incomplete pipeline-failure reasoning, and unavailable independent repository applicability verification.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:54:13.328952Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 511556,
+      "cached_input_tokens": 385533,
+      "cache_write_input_tokens": 40060,
+      "output_tokens": 16229,
+      "reasoning_output_tokens": 13210
+    },
+    "duration_ms": 265042
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "bash",
+    "keycloak",
+    "setup-scripts",
+    "shellcheck",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 53.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1072,
+    "output_tokens": 23284,
+    "cache_read_tokens": 3057579,
+    "cache_write_tokens": 67590,
+    "total_tokens": 3149525,
+    "total_cost_usd": 2.5386870000000012,
+    "latency_seconds": 437.3,
+    "num_turns": 42,
+    "generation_tokens_per_sec": 53.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1072,
+  "output_tokens": 23284,
+  "latency_seconds": 437.3,
+  "num_turns": 42,
+  "total_cost_usd": 2.5386870000000012,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3057579,
+  "cache_creation_tokens": 67590,
+  "run_started_at": "2026-09-01T03:32:37.315253Z",
+  "run_ended_at": "2026-09-01T03:39:54.572502Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1072,
+    "output_tokens": 23284,
+    "cache_read_tokens": 3057579,
+    "cache_write_tokens": 67590,
+    "total_tokens": 3149525,
+    "total_cost_usd": 2.5386870000000012,
+    "latency_seconds": 437.3,
+    "num_turns": 42,
+    "generation_tokens_per_sec": 53.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "fix-reserved-groups-var-in-service-account-script",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 84,
+        "notes": "The issue clearly identifies both scripts, the verify_setup functions, observable exit behavior, scope, non-goals, and testable acceptance criteria. The submitted patch contains the cited GROUPS assignments and scalar expansions at the described locations. Its main weakness is imprecise terminology: Bash documents GROUPS as a special array whose assignments have no effect, while the issue calls it read-only; the blanket prohibition on assigning numerous special variables is also broader than this defect.  No independent task statement was supplied, and the macos-setup impact and repository-wide sweep could not be independently verified."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 84,
+        "notes": "The LLD is highly implementation-ready, naming both files, four membership checks, exact variable changes, compatibility constraints, and the reason for separating local declaration from assignment. Its proposed edits correspond precisely to the symbols and preimage lines in the submitted patch. The largest technical deficiency is claiming that set -e will catch a failed curl within curl | jq even though no pipefail setting is established; only the final pipeline command controls that status. The Bash 3.2 clobbering claim, exhaustive nine-script inventory, and baseline line claims could not be independently verified."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 78,
+        "notes": "The review's strongest contribution is the concrete identification of substring false positives and its actionable resolution to use grep -qxF in all four membership checks. That resolution is reflected in both the final LLD and patch. It does not challenge the LLD's incomplete pipeline-error analysis or unsupported Bash 3.2 behavior, and Byte's discussion retains stale grep -qF wording after the design adopted -qxF. Claims about inspecting every setup script and filing follow-ups were not independently verifiable."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 75,
+        "notes": "The plan covers successful runs, missing groups, idempotency, exact matching, syntax, ShellCheck, token behavior, and both stated Bash versions with concrete expected outcomes. The standalone grep -qxF cases are particularly effective regression oracles. The reserved-variable count uses grep -c across multiple files, which produces per-file counts rather than one total, while the JWT check incorrectly treats base64url data as ordinary base64.  It also lacks cleanup and injected curl, jq, or mapper-failure cases, and the exact script flags and environment names could not be verified."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 86,
+        "notes": "The patch implements the central rename in both verify_setup functions and consistently updates both verification and assignment membership checks to exact fixed-string matching. Its contexts, symbols, variable references, and summary are internally consistent, and separate local declarations avoid masking command-substitution status at the assignment level. The additional mapper localization and assign_to_group behavior change are small, disclosed, and consistent with the revised design, although they extend beyond the narrow reserved-name fix. No material diff defect is apparent, but local source reads and git apply --check failed at sandbox initialization, so target-tree applicability and the claimed baseline commit remain unverified."
+      }
+    },
+    "task_score": 81.4,
+    "verdict": "This is a strong, likely correct small implementation backed by unusually specific artifacts, with its largest limitations being flawed test commands, incomplete pipeline-failure reasoning, and unavailable independent repository applicability verification.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:54:13.328952Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 511556,
+        "cached_input_tokens": 385533,
+        "cache_write_input_tokens": 40060,
+        "output_tokens": 16229,
+        "reasoning_output_tokens": 13210
+      },
+      "duration_ms": 265042
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 89,
+      "notes": "The issue clearly defines the conflicting CTAs, exact affected viewFilter values, preserved behavior on four other tabs, and explicit non-goals. Its acceptance criteria are directly testable and align with the task identifier. The largest limitation is that no independent task statement exists, so motivations such as the Register route being inappropriate cannot be confirmed beyond the internally consistent artifacts. Local repository inspection could not execute because the read-only sandbox failed during initialization, leaving Dashboard.tsx claims independently unverifiable."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 85,
+      "notes": "The LLD commits to a minimal, concrete JSX guard in frontend/src/pages/Dashboard.tsx and explains how the existing Discover condition remains intact. It also evaluates the important allowlist-versus-denylist tradeoff and identifies the future-tab behavior of each choice. Its weakest points are an unsupported assertion that VirtualServerCard.tsx and SkillCard.tsx confirm the CTAs, plus the later review's false claim that the LLD was updated to include an inline comment. Exact symbols, line numbers, and file context could not be independently verified because local command execution failed before reading the repository."
+    },
+    "review": {
+      "completeness": 19,
+      "correctness": 17,
+      "specificity": 19,
+      "risk_awareness": 18,
+      "total": 73,
+      "notes": "The review usefully surfaces the denylist's future-tab risk, distinguishes UI hiding from access control, and considers focus behavior during tab changes. Much of the multi-role structure is generic approval material for a two-line frontend change rather than substantive stress testing. It also asserts that /servers/register has server-side authorization without repository evidence and says the LLD was updated with a comment when the submitted LLD was not. The concrete viewFilter recommendation is internally sound, but the authentication and event-handler claims could not be verified."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The six-tab visibility matrix directly covers every acceptance criterion and adds checks for registration navigation, neighboring CTAs, search, health refresh, responsive layout, and direct-route compatibility. The strongest oracle is the explicit visible/not-visible expectation for each tab. Several other checks are weakly defined, such as verifying that forms function correctly or results are filtered, and the plan proposes no automated regression test for the render condition. The npm start command, permission names, Enter-key behavior, and /settings/virtual-mcp/servers destination could not be independently confirmed from the inaccessible working tree."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 89,
+      "notes": "The patch implements the requested behavior end to end by retaining the outer Discover guard and adding an exact virtual/skills guard around only the Register button. The JSX is syntactically coherent, preserves handleRegisterServer and adjacent Refresh Health markup, and the reported +10/-7 count matches the displayed diff. Its main limitation is the denylist's less-safe behavior for future tabs, while the summary's claim of no LLD deviation overlooks that the submitted LLD did not include the added comment. The sandbox failure prevented git apply --check and independent confirmation of the target blob, context, and symbols, so applicability remains an evidence gap rather than a demonstrated patch defect."
+    }
+  },
+  "task_score": 82.6,
+  "verdict": "This is a strong, narrowly scoped solution with a correct-looking implementation, limited mainly by unsupported repository-specific assertions and the inability to independently validate the patch against the working tree.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:56:07.953181Z",
+    "repo_ref": "v1.0.18",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 127490,
+      "cached_input_tokens": 75658,
+      "cache_write_input_tokens": 24357,
+      "output_tokens": 7556,
+      "reasoning_output_tokens": 5441
+    },
+    "duration_ms": 108561
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.18",
+  "complexity": "trivial",
+  "tags": [
+    "ui",
+    "react",
+    "dashboard",
+    "ux",
+    "fixed-in-v1.0.19"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 45.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 67,
+    "output_tokens": 12608,
+    "cache_read_tokens": 2426384,
+    "cache_write_tokens": 60540,
+    "total_tokens": 2499599,
+    "total_cost_usd": 1.9071020000000003,
+    "latency_seconds": 275.4,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 45.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 67,
+  "output_tokens": 12608,
+  "latency_seconds": 275.4,
+  "num_turns": 33,
+  "total_cost_usd": 1.9071020000000003,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2426384,
+  "cache_creation_tokens": 60540,
+  "run_started_at": "2026-09-01T05:58:07.812548Z",
+  "run_ended_at": "2026-09-01T06:02:43.236318Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 67,
+    "output_tokens": 12608,
+    "cache_read_tokens": 2426384,
+    "cache_write_tokens": 60540,
+    "total_tokens": 2499599,
+    "total_cost_usd": 1.9071020000000003,
+    "latency_seconds": 275.4,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 45.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "hide-register-button-on-virtual-and-skills-tabs",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 89,
+        "notes": "The issue clearly defines the conflicting CTAs, exact affected viewFilter values, preserved behavior on four other tabs, and explicit non-goals. Its acceptance criteria are directly testable and align with the task identifier. The largest limitation is that no independent task statement exists, so motivations such as the Register route being inappropriate cannot be confirmed beyond the internally consistent artifacts. Local repository inspection could not execute because the read-only sandbox failed during initialization, leaving Dashboard.tsx claims independently unverifiable."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 85,
+        "notes": "The LLD commits to a minimal, concrete JSX guard in frontend/src/pages/Dashboard.tsx and explains how the existing Discover condition remains intact. It also evaluates the important allowlist-versus-denylist tradeoff and identifies the future-tab behavior of each choice. Its weakest points are an unsupported assertion that VirtualServerCard.tsx and SkillCard.tsx confirm the CTAs, plus the later review's false claim that the LLD was updated to include an inline comment. Exact symbols, line numbers, and file context could not be independently verified because local command execution failed before reading the repository."
+      },
+      "review": {
+        "completeness": 19,
+        "correctness": 17,
+        "specificity": 19,
+        "risk_awareness": 18,
+        "total": 73,
+        "notes": "The review usefully surfaces the denylist's future-tab risk, distinguishes UI hiding from access control, and considers focus behavior during tab changes. Much of the multi-role structure is generic approval material for a two-line frontend change rather than substantive stress testing. It also asserts that /servers/register has server-side authorization without repository evidence and says the LLD was updated with a comment when the submitted LLD was not. The concrete viewFilter recommendation is internally sound, but the authentication and event-handler claims could not be verified."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The six-tab visibility matrix directly covers every acceptance criterion and adds checks for registration navigation, neighboring CTAs, search, health refresh, responsive layout, and direct-route compatibility. The strongest oracle is the explicit visible/not-visible expectation for each tab. Several other checks are weakly defined, such as verifying that forms function correctly or results are filtered, and the plan proposes no automated regression test for the render condition. The npm start command, permission names, Enter-key behavior, and /settings/virtual-mcp/servers destination could not be independently confirmed from the inaccessible working tree."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 89,
+        "notes": "The patch implements the requested behavior end to end by retaining the outer Discover guard and adding an exact virtual/skills guard around only the Register button. The JSX is syntactically coherent, preserves handleRegisterServer and adjacent Refresh Health markup, and the reported +10/-7 count matches the displayed diff. Its main limitation is the denylist's less-safe behavior for future tabs, while the summary's claim of no LLD deviation overlooks that the submitted LLD did not include the added comment. The sandbox failure prevented git apply --check and independent confirmation of the target blob, context, and symbols, so applicability remains an evidence gap rather than a demonstrated patch defect."
+      }
+    },
+    "task_score": 82.6,
+    "verdict": "This is a strong, narrowly scoped solution with a correct-looking implementation, limited mainly by unsupported repository-specific assertions and the inability to independently validate the patch against the working tree.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:56:07.953181Z",
+      "repo_ref": "v1.0.18",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 127490,
+        "cached_input_tokens": 75658,
+        "cache_write_input_tokens": 24357,
+        "output_tokens": 7556,
+        "reasoning_output_tokens": 5441
+      },
+      "duration_ms": 108561
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 85,
+      "notes": "The issue clearly identifies the inconsistent raw-versus-resolved cloud path and supplies testable override, fallback, and response-shape criteria. The submitted patch preimage corroborates that registry/api/system_routes.py calls _detect_cloud_provider_with_method() and returns the stated two fields. Its largest gap is limited discussion of the new operator-hint lookup, latency, and metrics side effects introduced by _resolve_cloud(). The AWS_REGION example, related issue history, and exact intended requirements could not be independently confirmed because no separate task statement was supplied."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 82,
+      "notes": "The LLD is unusually concrete for this small change, naming the route, resolver, fallback, frontend consumer, return tuple, and exact awaited replacement. Its proposed code agrees with the submitted source preimage and preserves the endpoint response shape. The largest design deficiency is that its regression strategy tests _resolve_cloud() directly rather than the changed endpoint integration, so those tests would pass with the original broken route unchanged. Claims about exact line numbers, storage backends, cache TTL, and ancillary management routes were not independently verifiable from the supplied task context."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 16,
+      "specificity": 18,
+      "risk_awareness": 15,
+      "total": 65,
+      "notes": "The review raises concrete concerns about operator-hint latency, caching semantics, information disclosure, endpoint naming, and UI presentation. Its largest failure is approving resolver-only tests as sufficient without noticing that they do not exercise get_telemetry_detection_info(), the actual changed integration point. The backend recommendation to mock settings and _get_operator_cloud_hint() directly preserves that blind spot, and all five reviewers approve without identifying a blocking defect. Assertions about authentication, management endpoints, graceful UI failure, and Prometheus behavior could not all be independently verified."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 66,
+      "notes": "The plan provides concrete expected JSON, explicit override precedence, fallback behavior, operator-hint coverage, response-shape checks, and UI observations. Its central automated tests call the pre-existing _resolve_cloud() function rather than the API route, so they cannot catch a regression where the endpoint continues calling the raw detector. The purported heartbeat E2E test invokes POST /api/management/telemetry/heartbeat even though the LLD identifies GET /api/management/telemetry/info, and it never inspects HEARTBEAT or compares its cloud value. The banner response field, token-file path, and several operational commands remain unverified, while the assertion that no frontend regression is possible is too absolute."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 22,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 77,
+      "notes": "The functional patch directly replaces the raw detector with await _resolve_cloud() in the existing async endpoint while retaining the exact cloud and cloud_detection_method response keys. Its context, imports, method constants, and test style are internally consistent with the supplied source preimage and design. The largest defect is that all three added tests exercise the already-existing resolver, so they would still pass if the crucial system_routes.py change were omitted or later reverted. The summary therefore overstates endpoint regression coverage, and patch applicability could not be independently dry-run because the repository shell was unavailable."
+    }
+  },
+  "task_score": 75.0,
+  "verdict": "The submission identifies and implements the likely correct minimal fix, but its tests and approving review miss the critical requirement to exercise the changed API endpoint itself.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:58:44.444658Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 210836,
+      "cached_input_tokens": 168871,
+      "cache_write_input_tokens": 27081,
+      "output_tokens": 8666,
+      "reasoning_output_tokens": 6740
+    },
+    "duration_ms": 156480
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "telemetry",
+    "api",
+    "ui",
+    "deployment",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 50.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2470,
+    "output_tokens": 19237,
+    "cache_read_tokens": 3622448,
+    "cache_write_tokens": 84440,
+    "total_tokens": 3728595,
+    "total_cost_usd": 2.8322489999999996,
+    "latency_seconds": 377.7,
+    "num_turns": 42,
+    "generation_tokens_per_sec": 50.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2470,
+  "output_tokens": 19237,
+  "latency_seconds": 377.7,
+  "num_turns": 42,
+  "total_cost_usd": 2.8322489999999996,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3622448,
+  "cache_creation_tokens": 84440,
+  "run_started_at": "2026-09-01T03:26:16.606218Z",
+  "run_ended_at": "2026-09-01T03:32:34.282553Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2470,
+    "output_tokens": 19237,
+    "cache_read_tokens": 3622448,
+    "cache_write_tokens": 84440,
+    "total_tokens": 3728595,
+    "total_cost_usd": 2.8322489999999996,
+    "latency_seconds": 377.7,
+    "num_turns": 42,
+    "generation_tokens_per_sec": 50.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "honor-cloud-provider-override-in-ui",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 85,
+        "notes": "The issue clearly identifies the inconsistent raw-versus-resolved cloud path and supplies testable override, fallback, and response-shape criteria. The submitted patch preimage corroborates that registry/api/system_routes.py calls _detect_cloud_provider_with_method() and returns the stated two fields. Its largest gap is limited discussion of the new operator-hint lookup, latency, and metrics side effects introduced by _resolve_cloud(). The AWS_REGION example, related issue history, and exact intended requirements could not be independently confirmed because no separate task statement was supplied."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 82,
+        "notes": "The LLD is unusually concrete for this small change, naming the route, resolver, fallback, frontend consumer, return tuple, and exact awaited replacement. Its proposed code agrees with the submitted source preimage and preserves the endpoint response shape. The largest design deficiency is that its regression strategy tests _resolve_cloud() directly rather than the changed endpoint integration, so those tests would pass with the original broken route unchanged. Claims about exact line numbers, storage backends, cache TTL, and ancillary management routes were not independently verifiable from the supplied task context."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 16,
+        "specificity": 18,
+        "risk_awareness": 15,
+        "total": 65,
+        "notes": "The review raises concrete concerns about operator-hint latency, caching semantics, information disclosure, endpoint naming, and UI presentation. Its largest failure is approving resolver-only tests as sufficient without noticing that they do not exercise get_telemetry_detection_info(), the actual changed integration point. The backend recommendation to mock settings and _get_operator_cloud_hint() directly preserves that blind spot, and all five reviewers approve without identifying a blocking defect. Assertions about authentication, management endpoints, graceful UI failure, and Prometheus behavior could not all be independently verified."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 66,
+        "notes": "The plan provides concrete expected JSON, explicit override precedence, fallback behavior, operator-hint coverage, response-shape checks, and UI observations. Its central automated tests call the pre-existing _resolve_cloud() function rather than the API route, so they cannot catch a regression where the endpoint continues calling the raw detector. The purported heartbeat E2E test invokes POST /api/management/telemetry/heartbeat even though the LLD identifies GET /api/management/telemetry/info, and it never inspects HEARTBEAT or compares its cloud value. The banner response field, token-file path, and several operational commands remain unverified, while the assertion that no frontend regression is possible is too absolute."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 22,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 77,
+        "notes": "The functional patch directly replaces the raw detector with await _resolve_cloud() in the existing async endpoint while retaining the exact cloud and cloud_detection_method response keys. Its context, imports, method constants, and test style are internally consistent with the supplied source preimage and design. The largest defect is that all three added tests exercise the already-existing resolver, so they would still pass if the crucial system_routes.py change were omitted or later reverted. The summary therefore overstates endpoint regression coverage, and patch applicability could not be independently dry-run because the repository shell was unavailable."
+      }
+    },
+    "task_score": 75.0,
+    "verdict": "The submission identifies and implements the likely correct minimal fix, but its tests and approving review miss the critical requirement to exercise the changed API endpoint itself.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T06:58:44.444658Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 210836,
+        "cached_input_tokens": 168871,
+        "cache_write_input_tokens": 27081,
+        "output_tokens": 8666,
+        "reasoning_output_tokens": 6740
+      },
+      "duration_ms": 156480
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The issue provides concrete configuration fields, integration surfaces, compatibility expectations, exclusions, and testable failure behavior. Its largest inconsistency is requiring a singleton EmbeddingsIdpTokenManager while the LLD and patch explicitly implement a non-singleton manager. The cited LiteLLMClient, Settings, FederationAuthManager, and deployment paths correspond to the submitted source contexts, but the Helm values.yaml and embeddings README criteria are not fulfilled by the implementation. No independent task statement was supplied, so broader requirement coverage cannot be verified."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 15,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 75,
+      "notes": "The LLD is unusually concrete about data flow, constructor changes, settings validation, token caching, error propagation, and named repository files. Its largest design miss is the interaction between strict partial-configuration validation and Terraform's unconditional client-secret injection: secrets.tf stores \"not-configured\" and ecs-services.tf always exposes it, causing default ECS configuration to appear partial. It also first says to mirror FederationAuthManager's singleton exactly and later rejects a singleton, while asserting without adequate support that embedding calls are serialized. Lifecycle cleanup, Terraform-state secret exposure, and client-authentication-method compatibility remain insufficiently resolved."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 20,
+      "total": 72,
+      "notes": "The review raises concrete concerns about lock contention, client lifetime, endpoint trust, secret handling, network reachability, retries, and metrics. Its largest failure is approving the design without noticing that the Terraform placeholder secret makes an unconfigured ECS deployment fail Settings validation. The security review also incorrectly claims the client secret never appears in Terraform state even though secrets.tf assigns the sensitive variable to secret_string. The claim that _embed_texts serializes all embedding calls is not established, and the review does not challenge the singleton contradiction or missing README and Helm deliverables."
+    },
+    "testing": {
+      "completeness": 14,
+      "correctness": 9,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 55,
+      "notes": "The plan supplies useful token-cache, expiry-buffer, scope, missing-token, compatibility, UI, and deployment scenarios with concrete expected outcomes. Its central LiteLLM tests patch litellm.embedding, but client.py calls its imported embedding alias, so those mocks would not reliably intercept the invocation. All startup-validator tests are placeholders containing pass, the static-key test merely asserts that a call occurred, and grep counts do not prove valid Terraform or ECS wiring. It also omits the critical default-Terraform placeholder case, meaningful concurrency coverage, and a forced refresh end-to-end oracle."
+    },
+    "implementation": {
+      "completeness": 17,
+      "correctness": 9,
+      "specificity": 21,
+      "risk_awareness": 12,
+      "total": 59,
+      "notes": "The patch implements the core token manager, per-call api_key injection, settings validation, secret masking, and broad Docker and Terraform wiring in the intended source locations. The largest defect is that Terraform always injects EMBEDDINGS_IDP_CLIENT_SECRET with value \"not-configured\" when unset, while the other required fields are empty, so the new model validator rejects default ECS deployments and breaks backward compatibility. No tests are added, the required embeddings README and stated Helm values guidance are omitted, and the summary's \"no deviations\" claim conflicts with its own follow-up section. Local git apply --check could not be executed because the repository command runner failed before command execution, so exact patch applicability remains unverified."
+    }
+  },
+  "task_score": 67.6,
+  "verdict": "The submission contains a strong, repository-specific design and mostly complete patch, but an overlooked Terraform secret placeholder breaks unconfigured ECS deployments and the proposed tests would not reliably catch it.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:01:49.302872Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 348239,
+      "cached_input_tokens": 270122,
+      "cache_write_input_tokens": 47539,
+      "output_tokens": 10922,
+      "reasoning_output_tokens": 8913
+    },
+    "duration_ms": 184846
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "high",
+  "tags": [
+    "semantic-search",
+    "embeddings",
+    "oauth",
+    "authentication",
+    "litellm",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 50.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 125,
+    "output_tokens": 43796,
+    "cache_read_tokens": 13859870,
+    "cache_write_tokens": 135566,
+    "total_tokens": 14039357,
+    "total_cost_usd": 8.8727475,
+    "latency_seconds": 875.6,
+    "num_turns": 121,
+    "generation_tokens_per_sec": 50.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 125,
+  "output_tokens": 43796,
+  "latency_seconds": 875.6,
+  "num_turns": 121,
+  "total_cost_usd": 8.8727475,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 13859870,
+  "cache_creation_tokens": 135566,
+  "run_started_at": "2026-09-01T05:37:33.801490Z",
+  "run_ended_at": "2026-09-01T05:52:09.455263Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 125,
+    "output_tokens": 43796,
+    "cache_read_tokens": 13859870,
+    "cache_write_tokens": 135566,
+    "total_tokens": 14039357,
+    "total_cost_usd": 8.8727475,
+    "latency_seconds": 875.6,
+    "num_turns": 121,
+    "generation_tokens_per_sec": 50.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "idp-authenticated-embedding-endpoint",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The issue provides concrete configuration fields, integration surfaces, compatibility expectations, exclusions, and testable failure behavior. Its largest inconsistency is requiring a singleton EmbeddingsIdpTokenManager while the LLD and patch explicitly implement a non-singleton manager. The cited LiteLLMClient, Settings, FederationAuthManager, and deployment paths correspond to the submitted source contexts, but the Helm values.yaml and embeddings README criteria are not fulfilled by the implementation. No independent task statement was supplied, so broader requirement coverage cannot be verified."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 15,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 75,
+        "notes": "The LLD is unusually concrete about data flow, constructor changes, settings validation, token caching, error propagation, and named repository files. Its largest design miss is the interaction between strict partial-configuration validation and Terraform's unconditional client-secret injection: secrets.tf stores \"not-configured\" and ecs-services.tf always exposes it, causing default ECS configuration to appear partial. It also first says to mirror FederationAuthManager's singleton exactly and later rejects a singleton, while asserting without adequate support that embedding calls are serialized. Lifecycle cleanup, Terraform-state secret exposure, and client-authentication-method compatibility remain insufficiently resolved."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 20,
+        "total": 72,
+        "notes": "The review raises concrete concerns about lock contention, client lifetime, endpoint trust, secret handling, network reachability, retries, and metrics. Its largest failure is approving the design without noticing that the Terraform placeholder secret makes an unconfigured ECS deployment fail Settings validation. The security review also incorrectly claims the client secret never appears in Terraform state even though secrets.tf assigns the sensitive variable to secret_string. The claim that _embed_texts serializes all embedding calls is not established, and the review does not challenge the singleton contradiction or missing README and Helm deliverables."
+      },
+      "testing": {
+        "completeness": 14,
+        "correctness": 9,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 55,
+        "notes": "The plan supplies useful token-cache, expiry-buffer, scope, missing-token, compatibility, UI, and deployment scenarios with concrete expected outcomes. Its central LiteLLM tests patch litellm.embedding, but client.py calls its imported embedding alias, so those mocks would not reliably intercept the invocation. All startup-validator tests are placeholders containing pass, the static-key test merely asserts that a call occurred, and grep counts do not prove valid Terraform or ECS wiring. It also omits the critical default-Terraform placeholder case, meaningful concurrency coverage, and a forced refresh end-to-end oracle."
+      },
+      "implementation": {
+        "completeness": 17,
+        "correctness": 9,
+        "specificity": 21,
+        "risk_awareness": 12,
+        "total": 59,
+        "notes": "The patch implements the core token manager, per-call api_key injection, settings validation, secret masking, and broad Docker and Terraform wiring in the intended source locations. The largest defect is that Terraform always injects EMBEDDINGS_IDP_CLIENT_SECRET with value \"not-configured\" when unset, while the other required fields are empty, so the new model validator rejects default ECS deployments and breaks backward compatibility. No tests are added, the required embeddings README and stated Helm values guidance are omitted, and the summary's \"no deviations\" claim conflicts with its own follow-up section. Local git apply --check could not be executed because the repository command runner failed before command execution, so exact patch applicability remains unverified."
+      }
+    },
+    "task_score": 67.6,
+    "verdict": "The submission contains a strong, repository-specific design and mostly complete patch, but an overlooked Terraform secret placeholder breaks unconfigured ECS deployments and the proposed tests would not reliably catch it.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:01:49.302872Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 348239,
+        "cached_input_tokens": 270122,
+        "cache_write_input_tokens": 47539,
+        "output_tokens": 10922,
+        "reasoning_output_tokens": 8913
+      },
+      "duration_ms": 184846
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 83,
+      "notes": "The issue provides testable acceptance criteria, explicit non-goals, and a tightly bounded documentation-only change. Its largest factual weakness is the claim of videos in \"a dozen\" docs files, while the LLD identifies eight docs files and ten Markdown sources overall. The requested README integration, new docs/demo-videos.md path, and additive preservation of existing links agree with the submitted patch context. No independent task statement was supplied, so the intended inventory boundary and categorization cannot be verified beyond the repository context and internally consistent artifacts."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 83,
+      "notes": "The strongest element is the decision-ready inventory of 13 URLs, their source files, grouping, and exact README integration point. Its largest deficiency is claiming the videos span eight Markdown files while its own Key Files Reviewed table names ten video-bearing sources, with no reproducible repository-wide extraction command resolving that discrepancy. The proposed page structure maps directly to the implementation, including docs/demo-videos.md and the existing README Demo Videos line. The asserted baseline line counts and exhaustiveness could not be independently checked because repository shell commands failed before execution in the provided sandbox."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 19,
+      "risk_awareness": 18,
+      "total": 72,
+      "notes": "The review usefully identifies index staleness, external-player UX, the GIF scope ambiguity, and the crowded README line, then gives actionable placement and contributor-guidance recommendations. Its largest weakness is that every reviewer approves without catching the LLD's source-count inconsistency or the testing plan's invalid untracked-file check. It also refers to grep patterns supposedly used for discovery even though the LLD documents no such command or pattern. Claims that the linked videos contain no PII and that the change has zero operational risk are not verifiable from URLs alone and are stated too absolutely."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 12,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 68,
+      "notes": "The plan is concrete about the 13 expected URLs, README preservation, section names, rendering, and link navigation. Its largest correctness defect is expecting plain `git diff --name-only HEAD` after `git apply` to list the newly created untracked docs/demo-videos.md; that command normally reports only tracked differences, so the stated exact two-file oracle is invalid. The hard-coded inventory cannot detect a video omitted during discovery, omits query strings from two Vidcast URL checks, and does not verify that every row has a title, platform, and description. The commands and referenced paths otherwise align with the submitted patch, but execution could not be independently performed because the repository shell sandbox failed to start."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 86,
+      "notes": "The patch implements the designed change end to end: it adds 13 linked entries across seven sections and inserts the index link before every preserved README video link. The new rows include platform, description, and related-doc columns, and the two-file diff stays within the declared documentation-only scope. The largest defect is the summary's contradiction between \"Verification (not executed)\" and its later assertion that `git apply --check` was verified; the claimed clean application and baseline commit could not be independently confirmed because shell execution failed before running commands. No substantive code defect is visible in the supplied diff, although completeness remains dependent on the unverified 13-URL inventory and future updates rely on a manual contributor note."
+    }
+  },
+  "task_score": 78.4,
+  "verdict": "This is a strong, proportionate documentation implementation supported by a detailed design, but the testing plan contains a materially incorrect git-diff oracle and does not independently prove the claimed exhaustive inventory.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:04:40.606338Z",
+    "repo_ref": "1.24.3",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 186858,
+      "cached_input_tokens": 119083,
+      "cache_write_input_tokens": 27515,
+      "output_tokens": 9777,
+      "reasoning_output_tokens": 7980
+    },
+    "duration_ms": 171292
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.3",
+  "complexity": "trivial",
+  "tags": [
+    "docs",
+    "markdown",
+    "readme",
+    "discoverability",
+    "fixed-in-1.24.4"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 54.6,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4294,
+    "output_tokens": 19289,
+    "cache_read_tokens": 2392205,
+    "cache_write_tokens": 61116,
+    "total_tokens": 2476904,
+    "total_cost_usd": 2.0817725,
+    "latency_seconds": 353.0,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 54.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4294,
+  "output_tokens": 19289,
+  "latency_seconds": 353.0,
+  "num_turns": 33,
+  "total_cost_usd": 2.0817725,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2392205,
+  "cache_creation_tokens": 61116,
+  "run_started_at": "2026-09-01T05:52:12.333594Z",
+  "run_ended_at": "2026-09-01T05:58:05.329185Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4294,
+    "output_tokens": 19289,
+    "cache_read_tokens": 2392205,
+    "cache_write_tokens": 61116,
+    "total_tokens": 2476904,
+    "total_cost_usd": 2.0817725,
+    "latency_seconds": 353.0,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 54.6,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "index-demo-videos-in-one-page",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 83,
+        "notes": "The issue provides testable acceptance criteria, explicit non-goals, and a tightly bounded documentation-only change. Its largest factual weakness is the claim of videos in \"a dozen\" docs files, while the LLD identifies eight docs files and ten Markdown sources overall. The requested README integration, new docs/demo-videos.md path, and additive preservation of existing links agree with the submitted patch context. No independent task statement was supplied, so the intended inventory boundary and categorization cannot be verified beyond the repository context and internally consistent artifacts."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 83,
+        "notes": "The strongest element is the decision-ready inventory of 13 URLs, their source files, grouping, and exact README integration point. Its largest deficiency is claiming the videos span eight Markdown files while its own Key Files Reviewed table names ten video-bearing sources, with no reproducible repository-wide extraction command resolving that discrepancy. The proposed page structure maps directly to the implementation, including docs/demo-videos.md and the existing README Demo Videos line. The asserted baseline line counts and exhaustiveness could not be independently checked because repository shell commands failed before execution in the provided sandbox."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 19,
+        "risk_awareness": 18,
+        "total": 72,
+        "notes": "The review usefully identifies index staleness, external-player UX, the GIF scope ambiguity, and the crowded README line, then gives actionable placement and contributor-guidance recommendations. Its largest weakness is that every reviewer approves without catching the LLD's source-count inconsistency or the testing plan's invalid untracked-file check. It also refers to grep patterns supposedly used for discovery even though the LLD documents no such command or pattern. Claims that the linked videos contain no PII and that the change has zero operational risk are not verifiable from URLs alone and are stated too absolutely."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 12,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 68,
+        "notes": "The plan is concrete about the 13 expected URLs, README preservation, section names, rendering, and link navigation. Its largest correctness defect is expecting plain `git diff --name-only HEAD` after `git apply` to list the newly created untracked docs/demo-videos.md; that command normally reports only tracked differences, so the stated exact two-file oracle is invalid. The hard-coded inventory cannot detect a video omitted during discovery, omits query strings from two Vidcast URL checks, and does not verify that every row has a title, platform, and description. The commands and referenced paths otherwise align with the submitted patch, but execution could not be independently performed because the repository shell sandbox failed to start."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 86,
+        "notes": "The patch implements the designed change end to end: it adds 13 linked entries across seven sections and inserts the index link before every preserved README video link. The new rows include platform, description, and related-doc columns, and the two-file diff stays within the declared documentation-only scope. The largest defect is the summary's contradiction between \"Verification (not executed)\" and its later assertion that `git apply --check` was verified; the claimed clean application and baseline commit could not be independently confirmed because shell execution failed before running commands. No substantive code defect is visible in the supplied diff, although completeness remains dependent on the unverified 13-URL inventory and future updates rely on a manual contributor note."
+      }
+    },
+    "task_score": 78.4,
+    "verdict": "This is a strong, proportionate documentation implementation supported by a detailed design, but the testing plan contains a materially incorrect git-diff oracle and does not independently prove the claimed exhaustive inventory.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:04:40.606338Z",
+      "repo_ref": "1.24.3",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 186858,
+        "cached_input_tokens": 119083,
+        "cache_write_input_tokens": 27515,
+        "output_tokens": 9777,
+        "reasoning_output_tokens": 7980
+      },
+      "duration_ms": 171292
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 82,
+      "notes": "The issue clearly defines five behaviors with concrete headers, environment variables, metrics, acceptance criteria, and non-goals. Its named dependencies correspond to symbols and files used by the submitted patch, including `send_registration_webhook`, the three scan helpers, `meters.py`, and `scopes.yml`. The largest flaw is its claim that every change applies uniformly despite the LLD establishing that skills have no PATCH endpoint; replay protection, pagination semantics, and overwrite behavior also remain unspecified. No independent task statement was supplied, so requirements beyond the identifier and internally established artifacts could not be verified."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 67,
+      "notes": "The LLD provides unusually concrete file, function, payload, configuration, permission, and HMAC-byte decisions that substantially reduce implementation ambiguity. Its critical omission is manual rescanning: it promises events after registration and rescans and even identifies a separate `rescan_server` path, but every implementation step hooks only `_perform_*_security_scan_on_registration`. It also fails to require status filtering before pagination, enabling the implementation's incorrect post-pagination skill filtering. Overwrite, federation, secret length, compatibility, and scaling receive useful treatment, but delivery loss, replay handling, and deployment wiring are mostly deferred."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 17,
+      "specificity": 20,
+      "risk_awareness": 18,
+      "total": 71,
+      "notes": "The review finds concrete issues involving overwrite semantics, secret strength, federation bypass, key rotation, payload consistency, and agent PATCH placement, and it records actionable resolutions. Its largest miss is the LLD's absent manual-rescan integration, despite repeatedly praising full parity and every-scan coverage. The SRE conclusion that unbounded tasks are acceptable because each creates its own `AsyncClient` is insufficiently justified and overlooks resource amplification under bursts. Overall it stress-tests several real boundaries but misses the most consequential requirement gap and the filtering/pagination hazard."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 11,
+      "specificity": 14,
+      "risk_awareness": 13,
+      "total": 51,
+      "notes": "The plan covers all five feature themes and includes a meaningful exact-body HMAC oracle, negative permission cases, configuration defaults, and an end-to-end workflow. However, its agent registration commands use `POST /api/agents`, while the project's published API documents `POST /api/agents/register`. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/a2a.md)) Manual comments replace executable assertions throughout, the skill status test creates no known draft fixture, and no pagination case would expose the implementation's skill-filter bug. It also tests rescanning only for servers, omits mandated-status parity for skills and most agent negative cases, and names no repository-native automated test files or commands."
+    },
+    "implementation": {
+      "completeness": 13,
+      "correctness": 10,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 52,
+      "notes": "The patch implements centralized exact-byte HMAC signing, default-off configuration, metrics, permission checks, documentation, and registration-scan events in targeted repository files. It does not implement the promised manual-rescan events: the diff adds webhook calls only to the three `_perform_*_security_scan_on_registration` helpers and contains no rescan-route hunk, while the summary claims every scan is covered. The skill filter is materially incorrect because it filters `page_skills` after pagination and replaces `total_count` with the current page's match count, causing missing results and broken `has_next` behavior. The summary's assertion that this deviation has identical behavior is false, and its clean-apply claim could not be independently confirmed because repository command execution failed during sandbox initialization."
+    }
+  },
+  "task_score": 64.6,
+  "verdict": "The submission is strong and concrete at the issue level but falls to mixed overall quality because the design, review, tests, and patch miss manual-rescan delivery and the implementation breaks skill status-filter pagination.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:09:47.011320Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 374721,
+      "cached_input_tokens": 272660,
+      "cache_write_input_tokens": 46602,
+      "output_tokens": 16148,
+      "reasoning_output_tokens": 14288
+    },
+    "duration_ms": 306393
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
@@ -1,0 +1,154 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "high",
+  "tags": [
+    "architecture",
+    "security",
+    "api",
+    "webhooks",
+    "hmac",
+    "lifecycle",
+    "permissions",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 46.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 17962,
+    "output_tokens": 47665,
+    "cache_read_tokens": 19772613,
+    "cache_write_tokens": 165702,
+    "total_tokens": 20003942,
+    "total_cost_usd": 12.203379,
+    "latency_seconds": 1017.1,
+    "num_turns": 137,
+    "generation_tokens_per_sec": 46.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 17962,
+  "output_tokens": 47665,
+  "latency_seconds": 1017.1,
+  "num_turns": 137,
+  "total_cost_usd": 12.203379,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 19772613,
+  "cache_creation_tokens": 165702,
+  "run_started_at": "2026-09-01T05:02:34.057426Z",
+  "run_ended_at": "2026-09-01T05:19:31.232719Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 17962,
+    "output_tokens": 47665,
+    "cache_read_tokens": 19772613,
+    "cache_write_tokens": 165702,
+    "total_tokens": 20003942,
+    "total_cost_usd": 12.203379,
+    "latency_seconds": 1017.1,
+    "num_turns": 137,
+    "generation_tokens_per_sec": 46.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "lifecycle-workflow-webhooks",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 82,
+        "notes": "The issue clearly defines five behaviors with concrete headers, environment variables, metrics, acceptance criteria, and non-goals. Its named dependencies correspond to symbols and files used by the submitted patch, including `send_registration_webhook`, the three scan helpers, `meters.py`, and `scopes.yml`. The largest flaw is its claim that every change applies uniformly despite the LLD establishing that skills have no PATCH endpoint; replay protection, pagination semantics, and overwrite behavior also remain unspecified. No independent task statement was supplied, so requirements beyond the identifier and internally established artifacts could not be verified."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 67,
+        "notes": "The LLD provides unusually concrete file, function, payload, configuration, permission, and HMAC-byte decisions that substantially reduce implementation ambiguity. Its critical omission is manual rescanning: it promises events after registration and rescans and even identifies a separate `rescan_server` path, but every implementation step hooks only `_perform_*_security_scan_on_registration`. It also fails to require status filtering before pagination, enabling the implementation's incorrect post-pagination skill filtering. Overwrite, federation, secret length, compatibility, and scaling receive useful treatment, but delivery loss, replay handling, and deployment wiring are mostly deferred."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 17,
+        "specificity": 20,
+        "risk_awareness": 18,
+        "total": 71,
+        "notes": "The review finds concrete issues involving overwrite semantics, secret strength, federation bypass, key rotation, payload consistency, and agent PATCH placement, and it records actionable resolutions. Its largest miss is the LLD's absent manual-rescan integration, despite repeatedly praising full parity and every-scan coverage. The SRE conclusion that unbounded tasks are acceptable because each creates its own `AsyncClient` is insufficiently justified and overlooks resource amplification under bursts. Overall it stress-tests several real boundaries but misses the most consequential requirement gap and the filtering/pagination hazard."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 11,
+        "specificity": 14,
+        "risk_awareness": 13,
+        "total": 51,
+        "notes": "The plan covers all five feature themes and includes a meaningful exact-body HMAC oracle, negative permission cases, configuration defaults, and an end-to-end workflow. However, its agent registration commands use `POST /api/agents`, while the project's published API documents `POST /api/agents/register`. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/a2a.md)) Manual comments replace executable assertions throughout, the skill status test creates no known draft fixture, and no pagination case would expose the implementation's skill-filter bug. It also tests rescanning only for servers, omits mandated-status parity for skills and most agent negative cases, and names no repository-native automated test files or commands."
+      },
+      "implementation": {
+        "completeness": 13,
+        "correctness": 10,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 52,
+        "notes": "The patch implements centralized exact-byte HMAC signing, default-off configuration, metrics, permission checks, documentation, and registration-scan events in targeted repository files. It does not implement the promised manual-rescan events: the diff adds webhook calls only to the three `_perform_*_security_scan_on_registration` helpers and contains no rescan-route hunk, while the summary claims every scan is covered. The skill filter is materially incorrect because it filters `page_skills` after pagination and replaces `total_count` with the current page's match count, causing missing results and broken `has_next` behavior. The summary's assertion that this deviation has identical behavior is false, and its clean-apply claim could not be independently confirmed because repository command execution failed during sandbox initialization."
+      }
+    },
+    "task_score": 64.6,
+    "verdict": "The submission is strong and concrete at the issue level but falls to mixed overall quality because the design, review, tests, and patch miss manual-rescan delivery and the implementation breaks skill status-filter pagination.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:09:47.011320Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 374721,
+        "cached_input_tokens": 272660,
+        "cache_write_input_tokens": 46602,
+        "output_tokens": 16148,
+        "reasoning_output_tokens": 14288
+      },
+      "duration_ms": 306393
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 72,
+      "notes": "The issue clearly defines the first-hop exposure, exact replacement parameter, fallback behavior, TTL, dependencies, and testable acceptance criteria. It correctly references the existing logout URL metrics and the supported IdP set, but incorrectly describes id_token_hint as a mandated query parameter and an ID token as a bearer credential that logout revokes. Its largest practical contradiction is promising fallback when the auth server is down, because the resulting browser redirect still targets that unavailable server. No independent task statement was supplied, so the proposed architecture and provider-wide requirements cannot be confirmed as required rather than candidate-selected."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 12,
+      "specificity": 23,
+      "risk_awareness": 15,
+      "total": 69,
+      "notes": "The LLD is unusually concrete about logout_handler, oauth2_logout, internal_router, MongoDB operations, encryption helpers, metrics, deployment order, and failure paths. Its central security defect is that provider is stored but never included in resolve_and_delete_hint, allowing a captured key to be consumed through another or even invalid provider route; resolution also occurs before provider validation. The proposed _get_collection swallows TTL-index creation failure and then caches the collection, preventing retries and potentially retaining abandoned encrypted tokens indefinitely. It also overstates OIDC requirements and the effectiveness of fallback when the auth server itself is unreachable."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 13,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 60,
+      "notes": "The review supplies concrete backend, SRE, and security observations about atomic consumption, rolling upgrades, latency, fallback exposure, and monitoring. Its largest deficiency is approving the design without detecting that the stored provider is not enforced and that an invalid-provider request consumes the one-time hint before validation. It also asserts without demonstrated repository evidence that internal JWTs are single-use and understates how proxies can observe the key before consumption. The verdicts therefore treat material security and retention defects as if only minor documentation changes remained."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 68,
+      "notes": "The plan has concrete HTTP, compatibility, deployment, end-to-end, and unit scenarios with meaningful redirect, metric, encryption, expiry, and one-time-use oracles. It does not cover provider mismatch, invalid-provider consumption, TTL-index creation failure, oversized deposits, or the issue's full six-provider acceptance criterion. The fallback E2E procedure stops the auth server and then claims logout still works, although the browser must subsequently redirect to that stopped service; deleting a document also does not test TTL expiration. The submitted unittest command and /api/auth/me path could not be independently verified because repository command execution failed in the read-only sandbox."
+    },
+    "implementation": {
+      "completeness": 17,
+      "correctness": 12,
+      "specificity": 21,
+      "risk_awareness": 11,
+      "total": 61,
+      "notes": "The patch implements the described deposit, opaque redirect key, atomic resolution, fallback metric, and legacy id_token_hint path across the four claimed files. The largest defect is that logout_hint_store records provider but resolution queries only _id, while oauth2_logout resolves and deletes the hint before checking whether the path provider exists, enabling cross-provider token forwarding or one-request denial of logout. A second concrete defect is that failed TTL-index creation is merely logged and _collection is then cached, so index creation is never retried and unconsumed hints may persist; no regression tests accompany the security-sensitive change. The visible diff is internally coherent, but git apply --check and signatures such as generate_internal_token could not be independently verified because the execution sandbox failed before running repository commands."
+    }
+  },
+  "task_score": 66.0,
+  "verdict": "The submission is detailed and mostly coherent, but provider-unbound hint consumption and non-guaranteed TTL cleanup leave material security and data-retention defects.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:13:52.391716Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 262541,
+      "cached_input_tokens": 196655,
+      "cache_write_input_tokens": 35149,
+      "output_tokens": 13043,
+      "reasoning_output_tokens": 11332
+    },
+    "duration_ms": 245369
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "auth",
+    "oidc",
+    "logout",
+    "security",
+    "waf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 48.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5531,
+    "output_tokens": 35921,
+    "cache_read_tokens": 7824470,
+    "cache_write_tokens": 116608,
+    "total_tokens": 7982530,
+    "total_cost_usd": 5.566714999999997,
+    "latency_seconds": 742.8,
+    "num_turns": 71,
+    "generation_tokens_per_sec": 48.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 5531,
+  "output_tokens": 35921,
+  "latency_seconds": 742.8,
+  "num_turns": 71,
+  "total_cost_usd": 5.566714999999997,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 7824470,
+  "cache_creation_tokens": 116608,
+  "run_started_at": "2026-09-01T06:20:44.516020Z",
+  "run_ended_at": "2026-09-01T06:33:07.305963Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5531,
+    "output_tokens": 35921,
+    "cache_read_tokens": 7824470,
+    "cache_write_tokens": 116608,
+    "total_tokens": 7982530,
+    "total_cost_usd": 5.566714999999997,
+    "latency_seconds": 742.8,
+    "num_turns": 71,
+    "generation_tokens_per_sec": 48.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "logout-id-token-hint-out-of-browser-url",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 72,
+        "notes": "The issue clearly defines the first-hop exposure, exact replacement parameter, fallback behavior, TTL, dependencies, and testable acceptance criteria. It correctly references the existing logout URL metrics and the supported IdP set, but incorrectly describes id_token_hint as a mandated query parameter and an ID token as a bearer credential that logout revokes. Its largest practical contradiction is promising fallback when the auth server is down, because the resulting browser redirect still targets that unavailable server. No independent task statement was supplied, so the proposed architecture and provider-wide requirements cannot be confirmed as required rather than candidate-selected."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 12,
+        "specificity": 23,
+        "risk_awareness": 15,
+        "total": 69,
+        "notes": "The LLD is unusually concrete about logout_handler, oauth2_logout, internal_router, MongoDB operations, encryption helpers, metrics, deployment order, and failure paths. Its central security defect is that provider is stored but never included in resolve_and_delete_hint, allowing a captured key to be consumed through another or even invalid provider route; resolution also occurs before provider validation. The proposed _get_collection swallows TTL-index creation failure and then caches the collection, preventing retries and potentially retaining abandoned encrypted tokens indefinitely. It also overstates OIDC requirements and the effectiveness of fallback when the auth server itself is unreachable."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 13,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 60,
+        "notes": "The review supplies concrete backend, SRE, and security observations about atomic consumption, rolling upgrades, latency, fallback exposure, and monitoring. Its largest deficiency is approving the design without detecting that the stored provider is not enforced and that an invalid-provider request consumes the one-time hint before validation. It also asserts without demonstrated repository evidence that internal JWTs are single-use and understates how proxies can observe the key before consumption. The verdicts therefore treat material security and retention defects as if only minor documentation changes remained."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 68,
+        "notes": "The plan has concrete HTTP, compatibility, deployment, end-to-end, and unit scenarios with meaningful redirect, metric, encryption, expiry, and one-time-use oracles. It does not cover provider mismatch, invalid-provider consumption, TTL-index creation failure, oversized deposits, or the issue's full six-provider acceptance criterion. The fallback E2E procedure stops the auth server and then claims logout still works, although the browser must subsequently redirect to that stopped service; deleting a document also does not test TTL expiration. The submitted unittest command and /api/auth/me path could not be independently verified because repository command execution failed in the read-only sandbox."
+      },
+      "implementation": {
+        "completeness": 17,
+        "correctness": 12,
+        "specificity": 21,
+        "risk_awareness": 11,
+        "total": 61,
+        "notes": "The patch implements the described deposit, opaque redirect key, atomic resolution, fallback metric, and legacy id_token_hint path across the four claimed files. The largest defect is that logout_hint_store records provider but resolution queries only _id, while oauth2_logout resolves and deletes the hint before checking whether the path provider exists, enabling cross-provider token forwarding or one-request denial of logout. A second concrete defect is that failed TTL-index creation is merely logged and _collection is then cached, so index creation is never retried and unconsumed hints may persist; no regression tests accompany the security-sensitive change. The visible diff is internally coherent, but git apply --check and signatures such as generate_internal_token could not be independently verified because the execution sandbox failed before running repository commands."
+      }
+    },
+    "task_score": 66.0,
+    "verdict": "The submission is detailed and mostly coherent, but provider-unbound hint consumption and non-guaranteed TTL cleanup leave material security and data-retention defects.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:13:52.391716Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 262541,
+        "cached_input_tokens": 196655,
+        "cache_write_input_tokens": 35149,
+        "output_tokens": 13043,
+        "reasoning_output_tokens": 11332
+      },
+      "duration_ms": 245369
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 12,
+      "total": 66,
+      "notes": "The issue names the affected skill, required metadata, preserved tokens, six testable acceptance criteria, and clear non-goals. Its largest deficiency is that reading the root pyproject.toml conflicts with the submission's own lifecycle in which Phase 1 precedes repository cloning, without defining a viable authoritative pre-clone source. The submitted patch context supports the existing Python check and remediation row, while the public guide confirms macOS 12+ and Python 3.14+ requirements. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md)) No independent task statement was supplied, and exact baseline line numbers and issue linkage could not be checked because local command execution failed before running."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 12,
+      "specificity": 20,
+      "risk_awareness": 13,
+      "total": 61,
+      "notes": "The LLD provides concrete shell logic, integration points, output behavior, failure branches, and alternatives. Its central source-selection design is flawed: the repository root is three ascents from .claude/skills/macos-setup, not two, and the proposed code never resolves relative to the skill anyway, checking only the current directory and INSTALL_DIR. Fresh pre-clone runs therefore use a hard-coded 3.14, while an unrelated current-directory pyproject.toml can override the intended minimum, contradicting the single-source requirement. It also retains stale sort-V claims and overstates failure handling when python3 -c produces an empty or nonnumeric version; the exact phase shell environment remained unverifiable."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 14,
+      "specificity": 17,
+      "risk_awareness": 12,
+      "total": 56,
+      "notes": "The review contributes one concrete portability finding and an actionable POSIX major/minor comparison that appears in the final design. Its largest failure is approving the hard-coded fallback without confronting the more fundamental pre-clone source-of-truth contradiction or the incorrect path-resolution claim. Most reviewer sections are generic approvals, and none identifies that an arbitrary current-directory pyproject.toml can control the result. The macOS 12 support premise is corroborated by the public guide, but claims about separate shell invocations and the baseline sort implementation could not be independently verified. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md))"
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 15,
+      "specificity": 20,
+      "risk_awareness": 14,
+      "total": 64,
+      "notes": "The plan supplies concrete inputs and expected outputs for missing, older, equal, newer, and higher-major interpreters, plus extraction and fallback cases. Its largest deficiency is that most tests duplicate fragments and assign _PY_VER directly rather than executing the actual block extracted from SKILL.md, so they could pass despite broken integration. It omits the critical fresh pre-clone case, an unrelated current-directory pyproject.toml, INSTALL_DIR precedence, and python3 -c failure, while Markdown validity and unchanged checks are only manual review instructions. The individual comparison and extraction commands have meaningful oracles, but their agreement with the real patched file could not be executed locally."
+    },
+    "implementation": {
+      "completeness": 15,
+      "correctness": 11,
+      "specificity": 19,
+      "risk_awareness": 11,
+      "total": 56,
+      "notes": "The patch directly replaces the existence check, preserves PYTHON_OK and PYTHON_FAIL behavior, reports both versions, and retains the documented Homebrew remediation. Its core defect is checking any current-directory pyproject.toml before INSTALL_DIR and falling back to hard-coded 3.14 during the established pre-clone flow, so it does not reliably satisfy the claimed authoritative dynamic requirement. The integer comparison handles ordinary major/minor versions, but patch-level requirements are truncated and failed or nonnumeric python3 -c output can emit shell comparison errors; the summary therefore overstates full realization of the LLD. The target path and hunk context are internally consistent with the submitted baseline snippets and public requirements, but the commit identity and git apply check could not be independently verified because the read-only command runner failed before execution. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md))"
+    }
+  },
+  "task_score": 60.6,
+  "verdict": "The submission is concrete and largely implements a current-version precheck, but the unresolved Phase-1-before-clone source-of-truth contradiction prevents reliable compliance with its central dynamic pyproject.toml requirement.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:16:09.950678Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 146595,
+      "cached_input_tokens": 94950,
+      "cache_write_input_tokens": 24800,
+      "output_tokens": 10291,
+      "reasoning_output_tokens": 8316
+    },
+    "duration_ms": 137548
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "setup",
+    "skill",
+    "developer-experience",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 52.3,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 117,
+    "output_tokens": 19309,
+    "cache_read_tokens": 2546183,
+    "cache_write_tokens": 57183,
+    "total_tokens": 2622792,
+    "total_cost_usd": 2.1137952500000003,
+    "latency_seconds": 369.5,
+    "num_turns": 38,
+    "generation_tokens_per_sec": 52.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 117,
+  "output_tokens": 19309,
+  "latency_seconds": 369.5,
+  "num_turns": 38,
+  "total_cost_usd": 2.1137952500000003,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2546183,
+  "cache_creation_tokens": 57183,
+  "run_started_at": "2026-09-01T06:08:09.181692Z",
+  "run_ended_at": "2026-09-01T06:14:18.690746Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 117,
+    "output_tokens": 19309,
+    "cache_read_tokens": 2546183,
+    "cache_write_tokens": 57183,
+    "total_tokens": 2622792,
+    "total_cost_usd": 2.1137952500000003,
+    "latency_seconds": 369.5,
+    "num_turns": 38,
+    "generation_tokens_per_sec": 52.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "macos-setup-python-version-precheck",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 12,
+        "total": 66,
+        "notes": "The issue names the affected skill, required metadata, preserved tokens, six testable acceptance criteria, and clear non-goals. Its largest deficiency is that reading the root pyproject.toml conflicts with the submission's own lifecycle in which Phase 1 precedes repository cloning, without defining a viable authoritative pre-clone source. The submitted patch context supports the existing Python check and remediation row, while the public guide confirms macOS 12+ and Python 3.14+ requirements. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md)) No independent task statement was supplied, and exact baseline line numbers and issue linkage could not be checked because local command execution failed before running."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 12,
+        "specificity": 20,
+        "risk_awareness": 13,
+        "total": 61,
+        "notes": "The LLD provides concrete shell logic, integration points, output behavior, failure branches, and alternatives. Its central source-selection design is flawed: the repository root is three ascents from .claude/skills/macos-setup, not two, and the proposed code never resolves relative to the skill anyway, checking only the current directory and INSTALL_DIR. Fresh pre-clone runs therefore use a hard-coded 3.14, while an unrelated current-directory pyproject.toml can override the intended minimum, contradicting the single-source requirement. It also retains stale sort-V claims and overstates failure handling when python3 -c produces an empty or nonnumeric version; the exact phase shell environment remained unverifiable."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 14,
+        "specificity": 17,
+        "risk_awareness": 12,
+        "total": 56,
+        "notes": "The review contributes one concrete portability finding and an actionable POSIX major/minor comparison that appears in the final design. Its largest failure is approving the hard-coded fallback without confronting the more fundamental pre-clone source-of-truth contradiction or the incorrect path-resolution claim. Most reviewer sections are generic approvals, and none identifies that an arbitrary current-directory pyproject.toml can control the result. The macOS 12 support premise is corroborated by the public guide, but claims about separate shell invocations and the baseline sort implementation could not be independently verified. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md))"
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 15,
+        "specificity": 20,
+        "risk_awareness": 14,
+        "total": 64,
+        "notes": "The plan supplies concrete inputs and expected outputs for missing, older, equal, newer, and higher-major interpreters, plus extraction and fallback cases. Its largest deficiency is that most tests duplicate fragments and assign _PY_VER directly rather than executing the actual block extracted from SKILL.md, so they could pass despite broken integration. It omits the critical fresh pre-clone case, an unrelated current-directory pyproject.toml, INSTALL_DIR precedence, and python3 -c failure, while Markdown validity and unchanged checks are only manual review instructions. The individual comparison and extraction commands have meaningful oracles, but their agreement with the real patched file could not be executed locally."
+      },
+      "implementation": {
+        "completeness": 15,
+        "correctness": 11,
+        "specificity": 19,
+        "risk_awareness": 11,
+        "total": 56,
+        "notes": "The patch directly replaces the existence check, preserves PYTHON_OK and PYTHON_FAIL behavior, reports both versions, and retains the documented Homebrew remediation. Its core defect is checking any current-directory pyproject.toml before INSTALL_DIR and falling back to hard-coded 3.14 during the established pre-clone flow, so it does not reliably satisfy the claimed authoritative dynamic requirement. The integer comparison handles ordinary major/minor versions, but patch-level requirements are truncated and failed or nonnumeric python3 -c output can emit shell comparison errors; the summary therefore overstates full realization of the LLD. The target path and hunk context are internally consistent with the submitted baseline snippets and public requirements, but the commit identity and git apply check could not be independently verified because the read-only command runner failed before execution. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md))"
+      }
+    },
+    "task_score": 60.6,
+    "verdict": "The submission is concrete and largely implements a current-version precheck, but the unresolved Phase-1-before-clone source-of-truth contradiction prevents reliable compliance with its central dynamic pyproject.toml requirement.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:16:09.950678Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 146595,
+        "cached_input_tokens": 94950,
+        "cache_write_input_tokens": 24800,
+        "output_tokens": 10291,
+        "reasoning_output_tokens": 8316
+      },
+      "duration_ms": 137548
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 79,
+      "notes": "The issue provides a concrete reproduction, explains nginx prefix collision behavior, defines testable acceptance criteria, and explicitly limits storage and authentication changes. Its largest inconsistency is proposing a version-map regex update while the LLD later argues the existing `~^{escaped_path}(/.*)?:` form requires no change. The submitted diff contains the cited `_create_location_block` context and corresponding tests, supporting the central diagnosis. No independent task statement was supplied, and sandbox failure prevented verification of the cited management-route lines, existing guards, and issue link against the working tree."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 16,
+      "total": 76,
+      "notes": "The LLD commits to exact generated directives, identifies callers and related regex handling, and explains why normalization belongs in `_create_location_block`. The principal gap is the redirect design: `return 301 $scheme://$host$uri/` is not analyzed for non-GET methods, query preservation, or the newly reflected host value. Its reasoning about `path.rstrip(\"/\") + \"/\"`, the version-map pattern, and the two-block return is concrete and internally consistent with the patch. Claims about validation, regeneration lifecycle, and exact surrounding repository patterns could not be independently verified because local repository reads were unavailable."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 15,
+      "specificity": 19,
+      "risk_awareness": 17,
+      "total": 69,
+      "notes": "The review usefully notices ROOT_PATH behavior, `$host`, config growth, exact-location precedence, and the changed two-block return shape. Its largest weakness is dismissing the host-based redirect as merely pre-existing because `proxy_set_header Host $host` exists; emitting that value in a client-visible Location header is a distinct behavior introduced by this design. It also calls the bug an authorization bypass although the described evidence establishes route hijacking and erroneous authentication responses, not bypass, and it misses method and query-string compatibility. Quantitative reload-window and config-size claims were not repository-verified."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 16,
+      "specificity": 20,
+      "risk_awareness": 13,
+      "total": 66,
+      "notes": "The plan supplies concrete unit setups and string oracles across transports, existing trailing slashes, special characters, proxy targets, and the `/a` collision case. The key deficiency is that it never validates a rendered configuration with nginx or exercises real routing, while declaring end-to-end testing inapplicable for an nginx-routing regression. Redirect tests assert only the presence of `return 301`, so an incorrect target, lost arguments, or unintended method behavior would pass; version-map and non-empty ROOT_PATH recommendations are also not implemented. The deployment command assumes `registry-container` and greps for literal `ROOT_PATH`, neither of which was established by available repository evidence."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 71,
+      "notes": "The patch implements the central fix directly by normalizing the prefix to `/path/`, adding an exact bare-path location, updating five existing assertions, and adding three focused regression tests. Its largest defect is the under-specified redirect: it applies to every HTTP method, embeds `$host`, and uses `$uri` without explicitly preserving arguments, while tests check neither the full target nor those edge cases. The supplied hunk contexts and symbols are internally consistent with the artifacts, but sandbox failure prevented `git apply --check`, caller inspection, and independent confirmation of the claimed baseline commit. The summary also overstates complete coverage because the issue's version-map acceptance criterion and the review's ROOT_PATH recommendation receive no implementation test."
+    }
+  },
+  "task_score": 72.2,
+  "verdict": "This is a strong and concrete core fix, but the newly introduced absolute 301 redirect lacks adequate compatibility and security analysis and testing, with repository verification further limited by unavailable local reads.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:21:03.704559Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 169208,
+      "cached_input_tokens": 102556,
+      "cache_write_input_tokens": 28750,
+      "output_tokens": 11965,
+      "reasoning_output_tokens": 10093
+    },
+    "duration_ms": 293742
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "medium",
+  "tags": [
+    "bug",
+    "security",
+    "nginx",
+    "routing",
+    "auth",
+    "python",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 49.3,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6568,
+    "output_tokens": 22262,
+    "cache_read_tokens": 4037614,
+    "cache_write_tokens": 84923,
+    "total_tokens": 4151367,
+    "total_cost_usd": 3.13896575,
+    "latency_seconds": 451.4,
+    "num_turns": 47,
+    "generation_tokens_per_sec": 49.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 6568,
+  "output_tokens": 22262,
+  "latency_seconds": 451.4,
+  "num_turns": 47,
+  "total_cost_usd": 3.13896575,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 4037614,
+  "cache_creation_tokens": 84923,
+  "run_started_at": "2026-09-01T04:26:50.046356Z",
+  "run_ended_at": "2026-09-01T04:34:21.497604Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6568,
+    "output_tokens": 22262,
+    "cache_read_tokens": 4037614,
+    "cache_write_tokens": 84923,
+    "total_tokens": 4151367,
+    "total_cost_usd": 3.13896575,
+    "latency_seconds": 451.4,
+    "num_turns": 47,
+    "generation_tokens_per_sec": 49.3,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "nginx-location-trailing-slash-route-hijack",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 79,
+        "notes": "The issue provides a concrete reproduction, explains nginx prefix collision behavior, defines testable acceptance criteria, and explicitly limits storage and authentication changes. Its largest inconsistency is proposing a version-map regex update while the LLD later argues the existing `~^{escaped_path}(/.*)?:` form requires no change. The submitted diff contains the cited `_create_location_block` context and corresponding tests, supporting the central diagnosis. No independent task statement was supplied, and sandbox failure prevented verification of the cited management-route lines, existing guards, and issue link against the working tree."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 16,
+        "total": 76,
+        "notes": "The LLD commits to exact generated directives, identifies callers and related regex handling, and explains why normalization belongs in `_create_location_block`. The principal gap is the redirect design: `return 301 $scheme://$host$uri/` is not analyzed for non-GET methods, query preservation, or the newly reflected host value. Its reasoning about `path.rstrip(\"/\") + \"/\"`, the version-map pattern, and the two-block return is concrete and internally consistent with the patch. Claims about validation, regeneration lifecycle, and exact surrounding repository patterns could not be independently verified because local repository reads were unavailable."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 15,
+        "specificity": 19,
+        "risk_awareness": 17,
+        "total": 69,
+        "notes": "The review usefully notices ROOT_PATH behavior, `$host`, config growth, exact-location precedence, and the changed two-block return shape. Its largest weakness is dismissing the host-based redirect as merely pre-existing because `proxy_set_header Host $host` exists; emitting that value in a client-visible Location header is a distinct behavior introduced by this design. It also calls the bug an authorization bypass although the described evidence establishes route hijacking and erroneous authentication responses, not bypass, and it misses method and query-string compatibility. Quantitative reload-window and config-size claims were not repository-verified."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 16,
+        "specificity": 20,
+        "risk_awareness": 13,
+        "total": 66,
+        "notes": "The plan supplies concrete unit setups and string oracles across transports, existing trailing slashes, special characters, proxy targets, and the `/a` collision case. The key deficiency is that it never validates a rendered configuration with nginx or exercises real routing, while declaring end-to-end testing inapplicable for an nginx-routing regression. Redirect tests assert only the presence of `return 301`, so an incorrect target, lost arguments, or unintended method behavior would pass; version-map and non-empty ROOT_PATH recommendations are also not implemented. The deployment command assumes `registry-container` and greps for literal `ROOT_PATH`, neither of which was established by available repository evidence."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 71,
+        "notes": "The patch implements the central fix directly by normalizing the prefix to `/path/`, adding an exact bare-path location, updating five existing assertions, and adding three focused regression tests. Its largest defect is the under-specified redirect: it applies to every HTTP method, embeds `$host`, and uses `$uri` without explicitly preserving arguments, while tests check neither the full target nor those edge cases. The supplied hunk contexts and symbols are internally consistent with the artifacts, but sandbox failure prevented `git apply --check`, caller inspection, and independent confirmation of the claimed baseline commit. The summary also overstates complete coverage because the issue's version-map acceptance criterion and the review's ROOT_PATH recommendation receive no implementation test."
+      }
+    },
+    "task_score": 72.2,
+    "verdict": "This is a strong and concrete core fix, but the newly introduced absolute 301 redirect lacks adequate compatibility and security analysis and testing, with repository verification further limited by unavailable local reads.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:21:03.704559Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 169208,
+        "cached_input_tokens": 102556,
+        "cache_write_input_tokens": 28750,
+        "output_tokens": 11965,
+        "reasoning_output_tokens": 10093
+      },
+      "duration_ms": 293742
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 24,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 91,
+      "notes": "The issue precisely identifies both affected compose files, the two variables, required substitution syntax, scope exclusions, and testable acceptance criteria. The submitted diff context corroborates that each target registry environment block reaches SECRET_KEY without these variables. Its largest limitation is the absent independent task statement; claims that Helm, Terraform, DHI inheritance, and every other compose surface were already correct could not all be independently verified. The public repository does confirm prebuilt Docker deployment and relevant 1.28.0 release context. ([github.com](https://github.com/agentic-community/mcp-gateway-registry))"
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 90,
+      "notes": "The LLD is implementation-ready for this small configuration change, naming exact files, insertion landmarks, syntax, data flow, exclusions, rollout, and alternatives. Its proposed edits align exactly with the submitted source context around REGISTRY_CONTACT_URL, BUILD_VERSION comments, and SECRET_KEY. The main deficiency is modest treatment of validation and fallback: it declares error handling inapplicable and provides no explicit rollback command or automated drift prevention. Exact line numbers, the asserted baseline commit, and the Helm and Terraform wiring remained independently unverifiable."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 21,
+      "specificity": 20,
+      "risk_awareness": 20,
+      "total": 81,
+      "notes": "The review surfaces two concrete maintainability risks: existing compose-file drift and the absence of an automated environment-key consistency check. It also correctly reasons that empty defaults preserve the secure default and that the patch introduces no new runtime path. Its largest weakness is that the five-persona format is mostly approval theater and does not independently challenge patch applicability, test-oracle scope, or the unverified Helm and Terraform claims. The A2A and DHI subjects it discusses are real repository features, although the exact 1.27.1 file state was not independently readable. ([github.com](https://github.com/agentic-community/mcp-gateway-registry), [github.com](https://github.com/agentic-community/mcp-gateway-registry/releases))"
+    },
+    "testing": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 82,
+      "notes": "The plan provides concrete commands and expected values for populated variables, empty defaults, the DHI overlay, and container-level printenv verification. These cases directly cover substitution and backward-compatible behavior across all named compose variants. Its largest defect is that grep searches the entire rendered configuration rather than scoping assertions to the registry service, so misplaced variables could produce false positives; only the podman variant receives runtime verification. The git diff --stat check is also a weak oracle, and the claim that existing conftest coverage makes an end-to-end health-check test unnecessary could not be verified."
+    },
+    "implementation": {
+      "completeness": 24,
+      "correctness": 23,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 93,
+      "notes": "The patch implements the full stated design by adding both passthroughs to both affected registry environment blocks with the established empty-default form and explanatory comment. The hunks are minimal, internally consistent with their supplied surrounding context, and introduce no unrelated behavior or default change. The largest limitation is the absence of an automated regression test, while the summary explicitly states that verification was not executed. Exact application against the local baseline and the claimed commit hash could not be independently confirmed because repository shell access was unavailable, so correctness is strong but not exceptional."
+    }
+  },
+  "task_score": 87.4,
+  "verdict": "This is a strong, highly specific solution to a small configuration defect, with the largest limitation being test commands that are not scoped tightly enough to prove the variables landed on the registry service.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:24:43.906717Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 241767,
+      "cached_input_tokens": 154330,
+      "cache_write_input_tokens": 25275,
+      "output_tokens": 12157,
+      "reasoning_output_tokens": 10362
+    },
+    "duration_ms": 220191
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "docker",
+    "compose",
+    "configuration",
+    "ssrf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 53.1,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 7080,
+    "output_tokens": 16993,
+    "cache_read_tokens": 2374765,
+    "cache_write_tokens": 55655,
+    "total_tokens": 2454493,
+    "total_cost_usd": 1.99545125,
+    "latency_seconds": 319.9,
+    "num_turns": 35,
+    "generation_tokens_per_sec": 53.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 7080,
+  "output_tokens": 16993,
+  "latency_seconds": 319.9,
+  "num_turns": 35,
+  "total_cost_usd": 1.99545125,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2374765,
+  "cache_creation_tokens": 55655,
+  "run_started_at": "2026-09-01T06:02:46.243294Z",
+  "run_ended_at": "2026-09-01T06:08:06.145348Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 7080,
+    "output_tokens": 16993,
+    "cache_read_tokens": 2374765,
+    "cache_write_tokens": 55655,
+    "total_tokens": 2454493,
+    "total_cost_usd": 1.99545125,
+    "latency_seconds": 319.9,
+    "num_turns": 35,
+    "generation_tokens_per_sec": 53.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "pass-ssrf-allowlist-env-to-registry-container",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 24,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 91,
+        "notes": "The issue precisely identifies both affected compose files, the two variables, required substitution syntax, scope exclusions, and testable acceptance criteria. The submitted diff context corroborates that each target registry environment block reaches SECRET_KEY without these variables. Its largest limitation is the absent independent task statement; claims that Helm, Terraform, DHI inheritance, and every other compose surface were already correct could not all be independently verified. The public repository does confirm prebuilt Docker deployment and relevant 1.28.0 release context. ([github.com](https://github.com/agentic-community/mcp-gateway-registry))"
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 90,
+        "notes": "The LLD is implementation-ready for this small configuration change, naming exact files, insertion landmarks, syntax, data flow, exclusions, rollout, and alternatives. Its proposed edits align exactly with the submitted source context around REGISTRY_CONTACT_URL, BUILD_VERSION comments, and SECRET_KEY. The main deficiency is modest treatment of validation and fallback: it declares error handling inapplicable and provides no explicit rollback command or automated drift prevention. Exact line numbers, the asserted baseline commit, and the Helm and Terraform wiring remained independently unverifiable."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 21,
+        "specificity": 20,
+        "risk_awareness": 20,
+        "total": 81,
+        "notes": "The review surfaces two concrete maintainability risks: existing compose-file drift and the absence of an automated environment-key consistency check. It also correctly reasons that empty defaults preserve the secure default and that the patch introduces no new runtime path. Its largest weakness is that the five-persona format is mostly approval theater and does not independently challenge patch applicability, test-oracle scope, or the unverified Helm and Terraform claims. The A2A and DHI subjects it discusses are real repository features, although the exact 1.27.1 file state was not independently readable. ([github.com](https://github.com/agentic-community/mcp-gateway-registry), [github.com](https://github.com/agentic-community/mcp-gateway-registry/releases))"
+      },
+      "testing": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 82,
+        "notes": "The plan provides concrete commands and expected values for populated variables, empty defaults, the DHI overlay, and container-level printenv verification. These cases directly cover substitution and backward-compatible behavior across all named compose variants. Its largest defect is that grep searches the entire rendered configuration rather than scoping assertions to the registry service, so misplaced variables could produce false positives; only the podman variant receives runtime verification. The git diff --stat check is also a weak oracle, and the claim that existing conftest coverage makes an end-to-end health-check test unnecessary could not be verified."
+      },
+      "implementation": {
+        "completeness": 24,
+        "correctness": 23,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 93,
+        "notes": "The patch implements the full stated design by adding both passthroughs to both affected registry environment blocks with the established empty-default form and explanatory comment. The hunks are minimal, internally consistent with their supplied surrounding context, and introduce no unrelated behavior or default change. The largest limitation is the absence of an automated regression test, while the summary explicitly states that verification was not executed. Exact application against the local baseline and the claimed commit hash could not be independently confirmed because repository shell access was unavailable, so correctness is strong but not exceptional."
+      }
+    },
+    "task_score": 87.4,
+    "verdict": "This is a strong, highly specific solution to a small configuration defect, with the largest limitation being test commands that are not scoped tightly enough to prove the variables landed on the registry service.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:24:43.906717Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 241767,
+        "cached_input_tokens": 154330,
+        "cache_write_input_tokens": 25275,
+        "output_tokens": 12157,
+        "reasoning_output_tokens": 10362
+      },
+      "duration_ms": 220191
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 79,
+      "notes": "The issue provides unusually concrete behavior, including the composite counter subject, admin bypass rules, response headers, compatibility requirements, and explicit non-goals. Its named integration points such as `RateLimiter.check()`, `rate_limit_routes.py`, and `IAMRateLimits.tsx` correspond to the submitted source diff. The largest defect is its contradictory quarantine model: it requires auto-seeded undeletable reserved groups while also introducing a separate quarantine-entry collection and deletion API, without defining how those concepts relate. No independent task statement was supplied, so requirement correctness beyond the task identifier and internally stated acceptance criteria could not be verified."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 72,
+      "notes": "The LLD is highly specific about real symbols and data flow, including `_build_caller_target_gates()`, `_enforce_rate_limit()`, repository queries, counter keys, failure policy, metrics, and frontend integration. Its central quarantine design is internally inconsistent: reserved groups are promised and declared as constants, but the implementation plan uses unrelated documents in `rate_limit_quarantine`, performs no startup seeding, and later reinterprets what undeletable means. The scaling claim that quarantine causes roughly one read per five seconds per replica is incorrect for the proposed per-subject caches, which can require reads for every distinct caller and target after expiration. Rollback is also reduced to the global rate-limiting switch, and the claimed immediate kill-switch behavior is weakened by an acknowledged five-second cross-replica cache delay."
+    },
+    "review": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 21,
+      "total": 79,
+      "notes": "The review finds several concrete issues with operational consequences, notably quarantine propagation delay, canonical identifier validation, monitoring visibility, compromised-admin behavior, and missing three-axis interaction coverage. Its recommendations are prioritized and actionable, and the five-second cache change plus integration-test requirement are explicitly carried forward. The largest omission is failure to challenge the fundamental mismatch between the promised reserved-group mechanism and the separate collection, despite declaring the design backward-compatible and coherent. It also accepts canonical IDs without considering delimiter ambiguity, client-controlled `created_at`, or acceptance of target types that the limiter does not enforce."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 9,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 56,
+      "notes": "The plan covers models, CRUD, authorization, backward compatibility, UI behavior, independent target counters, quarantine precedence, and counter non-consumption with concrete expected results. Its primary enforcement setup cannot work under its own prerequisites: it declares default user and agent floors of 20 and 10 per minute, then attempts to create 60-second limits of 3 and 2 that the preceding floor-validation test says must be rejected. The `call_mcp_tool.py` examples do not demonstrate use of `testuser` credentials, while several curl commands discard response headers yet claim to verify `X-Quarantined` and absence of `Retry-After`. Concrete fail-open/fail-closed outage tests, cache-propagation handling, control-plane exclusion, caller-target admin bypass, and executable unit-test commands are missing, and local sandbox failure prevented independent confirmation of the submitted script path and flags."
+    },
+    "implementation": {
+      "completeness": 13,
+      "correctness": 11,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 51,
+      "notes": "The patch implements the core caller-target gate, early quarantine checks, admin API CRUD, distinct denial headers, metrics, and frontend axis support in the expected subsystem files. It does not implement the required reserved-group seeding or semantics, leaves the quarantine constants unused, and explicitly omits the required quarantine management panel while the summary still describes the overall feature as added. Concrete defects include caller introspection checking the user identity before honoring `subject_type=client`, `upsert()` storing but not returning the generated `created_at` and replacing it on repeated PUTs, and accepting unenforced `mcp_tool` or `a2a_skill` quarantine entries through `TARGET_ENTITY_TYPES`. The summary also overstates UI completion and file-count consistency; the patch's applicability could not be independently dry-run because the read-only command sandbox failed before execution, so that claim remains unverified rather than penalized."
+    }
+  },
+  "task_score": 67.4,
+  "verdict": "The submission presents a detailed and mostly coherent design foundation, but the implementation materially diverges from its reserved-group contract and contains test setup and quarantine correctness defects that prevent production readiness.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:29:03.754494Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 309431,
+      "cached_input_tokens": 231899,
+      "cache_write_input_tokens": 57471,
+      "output_tokens": 12528,
+      "reasoning_output_tokens": 9773
+    },
+    "duration_ms": 259835
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "high",
+  "tags": [
+    "rate-limiting",
+    "security",
+    "auth-server",
+    "api",
+    "operations",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 54.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6453,
+    "output_tokens": 58147,
+    "cache_read_tokens": 13076465,
+    "cache_write_tokens": 162813,
+    "total_tokens": 13303878,
+    "total_cost_usd": 9.041753749999998,
+    "latency_seconds": 1076.3,
+    "num_turns": 93,
+    "generation_tokens_per_sec": 54.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 6453,
+  "output_tokens": 58147,
+  "latency_seconds": 1076.3,
+  "num_turns": 93,
+  "total_cost_usd": 9.041753749999998,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 13076465,
+  "cache_creation_tokens": 162813,
+  "run_started_at": "2026-09-01T05:19:34.282011Z",
+  "run_ended_at": "2026-09-01T05:37:30.638249Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6453,
+    "output_tokens": 58147,
+    "cache_read_tokens": 13076465,
+    "cache_write_tokens": 162813,
+    "total_tokens": 13303878,
+    "total_cost_usd": 9.041753749999998,
+    "latency_seconds": 1076.3,
+    "num_turns": 93,
+    "generation_tokens_per_sec": 54.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "per-caller-per-target-rate-limits-and-quarantine",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 79,
+        "notes": "The issue provides unusually concrete behavior, including the composite counter subject, admin bypass rules, response headers, compatibility requirements, and explicit non-goals. Its named integration points such as `RateLimiter.check()`, `rate_limit_routes.py`, and `IAMRateLimits.tsx` correspond to the submitted source diff. The largest defect is its contradictory quarantine model: it requires auto-seeded undeletable reserved groups while also introducing a separate quarantine-entry collection and deletion API, without defining how those concepts relate. No independent task statement was supplied, so requirement correctness beyond the task identifier and internally stated acceptance criteria could not be verified."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 72,
+        "notes": "The LLD is highly specific about real symbols and data flow, including `_build_caller_target_gates()`, `_enforce_rate_limit()`, repository queries, counter keys, failure policy, metrics, and frontend integration. Its central quarantine design is internally inconsistent: reserved groups are promised and declared as constants, but the implementation plan uses unrelated documents in `rate_limit_quarantine`, performs no startup seeding, and later reinterprets what undeletable means. The scaling claim that quarantine causes roughly one read per five seconds per replica is incorrect for the proposed per-subject caches, which can require reads for every distinct caller and target after expiration. Rollback is also reduced to the global rate-limiting switch, and the claimed immediate kill-switch behavior is weakened by an acknowledged five-second cross-replica cache delay."
+      },
+      "review": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 21,
+        "total": 79,
+        "notes": "The review finds several concrete issues with operational consequences, notably quarantine propagation delay, canonical identifier validation, monitoring visibility, compromised-admin behavior, and missing three-axis interaction coverage. Its recommendations are prioritized and actionable, and the five-second cache change plus integration-test requirement are explicitly carried forward. The largest omission is failure to challenge the fundamental mismatch between the promised reserved-group mechanism and the separate collection, despite declaring the design backward-compatible and coherent. It also accepts canonical IDs without considering delimiter ambiguity, client-controlled `created_at`, or acceptance of target types that the limiter does not enforce."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 9,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 56,
+        "notes": "The plan covers models, CRUD, authorization, backward compatibility, UI behavior, independent target counters, quarantine precedence, and counter non-consumption with concrete expected results. Its primary enforcement setup cannot work under its own prerequisites: it declares default user and agent floors of 20 and 10 per minute, then attempts to create 60-second limits of 3 and 2 that the preceding floor-validation test says must be rejected. The `call_mcp_tool.py` examples do not demonstrate use of `testuser` credentials, while several curl commands discard response headers yet claim to verify `X-Quarantined` and absence of `Retry-After`. Concrete fail-open/fail-closed outage tests, cache-propagation handling, control-plane exclusion, caller-target admin bypass, and executable unit-test commands are missing, and local sandbox failure prevented independent confirmation of the submitted script path and flags."
+      },
+      "implementation": {
+        "completeness": 13,
+        "correctness": 11,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 51,
+        "notes": "The patch implements the core caller-target gate, early quarantine checks, admin API CRUD, distinct denial headers, metrics, and frontend axis support in the expected subsystem files. It does not implement the required reserved-group seeding or semantics, leaves the quarantine constants unused, and explicitly omits the required quarantine management panel while the summary still describes the overall feature as added. Concrete defects include caller introspection checking the user identity before honoring `subject_type=client`, `upsert()` storing but not returning the generated `created_at` and replacing it on repeated PUTs, and accepting unenforced `mcp_tool` or `a2a_skill` quarantine entries through `TARGET_ENTITY_TYPES`. The summary also overstates UI completion and file-count consistency; the patch's applicability could not be independently dry-run because the read-only command sandbox failed before execution, so that claim remains unverified rather than penalized."
+      }
+    },
+    "task_score": 67.4,
+    "verdict": "The submission presents a detailed and mostly coherent design foundation, but the implementation materially diverges from its reserved-group contract and contains test setup and quarantine correctness defects that prevent production readiness.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:29:03.754494Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 309431,
+        "cached_input_tokens": 231899,
+        "cache_write_input_tokens": 57471,
+        "output_tokens": 12528,
+        "reasoning_output_tokens": 9773
+      },
+      "duration_ms": 259835
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The issue provides unusually concrete scope, non-goals, affected variables, and testable acceptance criteria. The submitted patch context corroborates the claimed ten static removals plus one dynamic metrics-token removal. Its largest correctness defect is claiming that shell sourcing uses the first duplicate assignment; sequential `source .env` processing leaves the later assignment effective, although the repository does instruct users to source this file.  No independent task statement or evidence verifies the linked issue or asserted crash-loop impact."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 22,
+      "risk_awareness": 12,
+      "total": 62,
+      "notes": "The design is highly specific about `build_and_run.sh`, `_remove_env_lines`, all eleven replacements, atomic rename, and rejected alternatives. Its central error is treating every nonzero `grep -v` result as “all lines matched”; grep distinguishes no-selection status 1 from error status 2, so an I/O error can trigger truncation and replacement of `.env`.  The early `! grep -q` similarly converts file-access errors into a successful no-op, contradicting the promised failure propagation. It also declares permission preservation a constraint but provides no mechanism to preserve the original mode, and never calls the identified `handle_error` integration point."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 10,
+      "specificity": 19,
+      "risk_awareness": 12,
+      "total": 57,
+      "notes": "The review identifies concrete concerns involving permissions, temporary files, atomic replacement, and dynamic regex construction. Its largest deficiency is approving the design without noticing that the helper conflates grep’s no-selection and error statuses, the failure most capable of corrupting `.env`.  It acknowledges changed file permissions but dismisses them as non-regressive without repository evidence, despite the LLD explicitly requiring preservation. The assertion that service-name conversion produces only `[A-Z0-9_]` is also unsupported because the described `tr` conversion does not remove periods."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 10,
+      "specificity": 20,
+      "risk_awareness": 11,
+      "total": 57,
+      "notes": "The plan gives concrete fixtures and expected content for matching, absent, quoted, duplicate, all-matching, populated, and dynamic-token cases. Its largest gap is complete omission of the acceptance-critical rewrite-failure tests, including grep errors, unwritable destinations, mode preservation, and temporary-file collisions. The tests copy a helper implementation into the test rather than execute the patched function, and most `echo \"FAIL\"` branches still exit successfully, so they can pass operationally while behavior is broken. The macOS check merely prints values for visual inspection and does not assert uniqueness, non-emptiness, or successful stack startup."
+    },
+    "implementation": {
+      "completeness": 17,
+      "correctness": 10,
+      "specificity": 21,
+      "risk_awareness": 9,
+      "total": 57,
+      "notes": "The patch consistently replaces the submitted ten static `sed -i` lines and one dynamic call, and places the helper beside the existing `handle_error` symbol. The critical defect is the `else` branch after `grep -v`: any grep error is interpreted as an empty result, allowing `: > \"$tmp\"` followed by `mv` to erase unrelated `.env` content instead of aborting.  Predictable `${file}.tmp.$$` naming permits stale-file or symlink collisions, while replacement through a newly created file can change restrictive permissions. The summary incorrectly claims no LLD deviations despite omitting permission preservation and explicit error reporting; local sandbox failure prevented independent confirmation of its `git apply --check` claim."
+    }
+  },
+  "task_score": 62.0,
+  "verdict": "The submission is concrete and largely aligned with the apparent portability task, but its core rewrite helper can silently mishandle grep errors and corrupt `.env`, a defect missed by both review and testing.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:32:44.401040Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 241404,
+      "cached_input_tokens": 173265,
+      "cache_write_input_tokens": 33500,
+      "output_tokens": 11290,
+      "reasoning_output_tokens": 9127
+    },
+    "duration_ms": 220635
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "portability",
+    "macos",
+    "secrets",
+    "setup",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 51.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1276,
+    "output_tokens": 19616,
+    "cache_read_tokens": 2759671,
+    "cache_write_tokens": 65827,
+    "total_tokens": 2846390,
+    "total_cost_usd": 2.28803425,
+    "latency_seconds": 379.7,
+    "num_turns": 37,
+    "generation_tokens_per_sec": 51.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1276,
+  "output_tokens": 19616,
+  "latency_seconds": 379.7,
+  "num_turns": 37,
+  "total_cost_usd": 2.28803425,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2759671,
+  "cache_creation_tokens": 65827,
+  "run_started_at": "2026-09-01T06:14:21.817470Z",
+  "run_ended_at": "2026-09-01T06:20:41.511994Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1276,
+    "output_tokens": 19616,
+    "cache_read_tokens": 2759671,
+    "cache_write_tokens": 65827,
+    "total_tokens": 2846390,
+    "total_cost_usd": 2.28803425,
+    "latency_seconds": 379.7,
+    "num_turns": 37,
+    "generation_tokens_per_sec": 51.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "portable-env-secret-generation-in-build-script",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The issue provides unusually concrete scope, non-goals, affected variables, and testable acceptance criteria. The submitted patch context corroborates the claimed ten static removals plus one dynamic metrics-token removal. Its largest correctness defect is claiming that shell sourcing uses the first duplicate assignment; sequential `source .env` processing leaves the later assignment effective, although the repository does instruct users to source this file.  No independent task statement or evidence verifies the linked issue or asserted crash-loop impact."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 22,
+        "risk_awareness": 12,
+        "total": 62,
+        "notes": "The design is highly specific about `build_and_run.sh`, `_remove_env_lines`, all eleven replacements, atomic rename, and rejected alternatives. Its central error is treating every nonzero `grep -v` result as “all lines matched”; grep distinguishes no-selection status 1 from error status 2, so an I/O error can trigger truncation and replacement of `.env`.  The early `! grep -q` similarly converts file-access errors into a successful no-op, contradicting the promised failure propagation. It also declares permission preservation a constraint but provides no mechanism to preserve the original mode, and never calls the identified `handle_error` integration point."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 10,
+        "specificity": 19,
+        "risk_awareness": 12,
+        "total": 57,
+        "notes": "The review identifies concrete concerns involving permissions, temporary files, atomic replacement, and dynamic regex construction. Its largest deficiency is approving the design without noticing that the helper conflates grep’s no-selection and error statuses, the failure most capable of corrupting `.env`.  It acknowledges changed file permissions but dismisses them as non-regressive without repository evidence, despite the LLD explicitly requiring preservation. The assertion that service-name conversion produces only `[A-Z0-9_]` is also unsupported because the described `tr` conversion does not remove periods."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 10,
+        "specificity": 20,
+        "risk_awareness": 11,
+        "total": 57,
+        "notes": "The plan gives concrete fixtures and expected content for matching, absent, quoted, duplicate, all-matching, populated, and dynamic-token cases. Its largest gap is complete omission of the acceptance-critical rewrite-failure tests, including grep errors, unwritable destinations, mode preservation, and temporary-file collisions. The tests copy a helper implementation into the test rather than execute the patched function, and most `echo \"FAIL\"` branches still exit successfully, so they can pass operationally while behavior is broken. The macOS check merely prints values for visual inspection and does not assert uniqueness, non-emptiness, or successful stack startup."
+      },
+      "implementation": {
+        "completeness": 17,
+        "correctness": 10,
+        "specificity": 21,
+        "risk_awareness": 9,
+        "total": 57,
+        "notes": "The patch consistently replaces the submitted ten static `sed -i` lines and one dynamic call, and places the helper beside the existing `handle_error` symbol. The critical defect is the `else` branch after `grep -v`: any grep error is interpreted as an empty result, allowing `: > \"$tmp\"` followed by `mv` to erase unrelated `.env` content instead of aborting.  Predictable `${file}.tmp.$$` naming permits stale-file or symlink collisions, while replacement through a newly created file can change restrictive permissions. The summary incorrectly claims no LLD deviations despite omitting permission preservation and explicit error reporting; local sandbox failure prevented independent confirmation of its `git apply --check` claim."
+      }
+    },
+    "task_score": 62.0,
+    "verdict": "The submission is concrete and largely aligned with the apparent portability task, but its core rewrite helper can silently mishandle grep errors and corrupt `.env`, a defect missed by both review and testing.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:32:44.401040Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 241404,
+        "cached_input_tokens": 173265,
+        "cache_write_input_tokens": 33500,
+        "output_tokens": 11290,
+        "reasoning_output_tokens": 9127
+      },
+      "duration_ms": 220635
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "registration-admission-control-gate",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 81,
+      "notes": "The issue provides unusually testable behavior, enumerating seven endpoints, four settings, status mappings, deployment surfaces, defaults, and explicit non-goals. Its named files and handlers are corroborated by the submitted diff contexts, including `register_agent`, `register_service_api`, and `update_skill`. Its largest omission is a contract for the exact post-validation payload representation and handling of potentially sensitive registration fields sent to the external service. No independent task statement was supplied, so broader requirement completeness cannot be verified beyond the task identifier and internally consistent artifacts."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 14,
+      "specificity": 23,
+      "risk_awareness": 14,
+      "total": 70,
+      "notes": "The LLD is highly concrete about files, payloads, errors, configuration, rollout, and all seven insertion points. Its central ordering claim is unsound: it places the skill gate before `service.register_skill(..., validate_url=True)` and the server API gate before the submitted source's existing-server overwrite/version logic, despite promising that internal validation and duplicate checks happen first. It also passes `server_entry` directly to `httpx` JSON immediately after `source_updated_at` parsing, without a JSON-normalization boundary for values such as datetimes. Sensitive-payload exposure, retry idempotency, response-message validation, and the required `main.py` startup change are inadequately addressed or omitted from the file-change inventory."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 13,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 59,
+      "notes": "The review produces actionable recommendations for JSON-mode serialization, startup validation, URL schemes, and maintaining the endpoint list. Its backend review incorrectly concludes that `server_entry` is safely JSON-serializable after checking only `provider`, overlooking the adjacent `source_updated_at` parsing and lack of normalization. It also misses the more consequential placement before skill validation and server duplicate/version handling, plus the plaintext ECS task-definition environment entry for `ADMISSION_GATE_AUTH_TOKEN`. The approval verdict is therefore insufficiently adversarial for a security admission boundary."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 15,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 63,
+      "notes": "The service-level cases have concrete oracles for allow, deny, timeout, connection failure, unexpected status, authentication headers, payload shape, and startup warnings. No executable route-level tests verify that any of the seven handlers calls the gate at the correct point or prevents persistence, while the end-to-end section supplies only five high-level sketches. The grep-count deployment checks can pass with commented, malformed, or incorrectly wired configuration and should be supplemented with Helm, Compose, and Terraform validation. Consequently, the plan would not catch the implementation's validation-order or server-payload serialization regressions."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 12,
+      "specificity": 21,
+      "risk_awareness": 11,
+      "total": 62,
+      "notes": "The patch implements the helper, configuration, startup warning, seven route calls, deployment wiring, and focused service tests with a truthful off-by-default path. The largest defects are that the server API gate precedes existing overwrite/version checks, skill registration precedes service-side URL validation, and raw `server_entry` values are passed to JSON without normalization. The tests never exercise route integration, and Terraform places the sensitive gate token in the ECS task definition's ordinary `environment` list rather than a secret reference. The submitted contexts match the named symbols, but local `git apply --check` and independent baseline inspection could not be completed because the provided read-only command sandbox failed before executing commands."
+    }
+  },
+  "task_score": 67.0,
+  "verdict": "The submission is specific and substantially implemented, but it is not merge-ready because the admission decision occurs before some promised validations and lacks a safe, tested serialization and secret-handling boundary.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:37:44.769690Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 396679,
+      "cached_input_tokens": 241046,
+      "cache_write_input_tokens": 97296,
+      "output_tokens": 14717,
+      "reasoning_output_tokens": 12582
+    },
+    "duration_ms": 300356
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "registration-admission-control-gate",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "architecture",
+    "api",
+    "fastapi",
+    "webhooks",
+    "admission-control",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 53.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 15769,
+    "output_tokens": 45749,
+    "cache_read_tokens": 14763057,
+    "cache_write_tokens": 153667,
+    "total_tokens": 14978242,
+    "total_cost_usd": 9.564517250000002,
+    "latency_seconds": 854.4,
+    "num_turns": 106,
+    "generation_tokens_per_sec": 53.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 15769,
+  "output_tokens": 45749,
+  "latency_seconds": 854.4,
+  "num_turns": 106,
+  "total_cost_usd": 9.564517250000002,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 14763057,
+  "cache_creation_tokens": 153667,
+  "run_started_at": "2026-09-01T04:34:24.727946Z",
+  "run_ended_at": "2026-09-01T04:48:39.213513Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 15769,
+    "output_tokens": 45749,
+    "cache_read_tokens": 14763057,
+    "cache_write_tokens": 153667,
+    "total_tokens": 14978242,
+    "total_cost_usd": 9.564517250000002,
+    "latency_seconds": 854.4,
+    "num_turns": 106,
+    "generation_tokens_per_sec": 53.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "registration-admission-control-gate",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 81,
+        "notes": "The issue provides unusually testable behavior, enumerating seven endpoints, four settings, status mappings, deployment surfaces, defaults, and explicit non-goals. Its named files and handlers are corroborated by the submitted diff contexts, including `register_agent`, `register_service_api`, and `update_skill`. Its largest omission is a contract for the exact post-validation payload representation and handling of potentially sensitive registration fields sent to the external service. No independent task statement was supplied, so broader requirement completeness cannot be verified beyond the task identifier and internally consistent artifacts."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 14,
+        "specificity": 23,
+        "risk_awareness": 14,
+        "total": 70,
+        "notes": "The LLD is highly concrete about files, payloads, errors, configuration, rollout, and all seven insertion points. Its central ordering claim is unsound: it places the skill gate before `service.register_skill(..., validate_url=True)` and the server API gate before the submitted source's existing-server overwrite/version logic, despite promising that internal validation and duplicate checks happen first. It also passes `server_entry` directly to `httpx` JSON immediately after `source_updated_at` parsing, without a JSON-normalization boundary for values such as datetimes. Sensitive-payload exposure, retry idempotency, response-message validation, and the required `main.py` startup change are inadequately addressed or omitted from the file-change inventory."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 13,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 59,
+        "notes": "The review produces actionable recommendations for JSON-mode serialization, startup validation, URL schemes, and maintaining the endpoint list. Its backend review incorrectly concludes that `server_entry` is safely JSON-serializable after checking only `provider`, overlooking the adjacent `source_updated_at` parsing and lack of normalization. It also misses the more consequential placement before skill validation and server duplicate/version handling, plus the plaintext ECS task-definition environment entry for `ADMISSION_GATE_AUTH_TOKEN`. The approval verdict is therefore insufficiently adversarial for a security admission boundary."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 15,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 63,
+        "notes": "The service-level cases have concrete oracles for allow, deny, timeout, connection failure, unexpected status, authentication headers, payload shape, and startup warnings. No executable route-level tests verify that any of the seven handlers calls the gate at the correct point or prevents persistence, while the end-to-end section supplies only five high-level sketches. The grep-count deployment checks can pass with commented, malformed, or incorrectly wired configuration and should be supplemented with Helm, Compose, and Terraform validation. Consequently, the plan would not catch the implementation's validation-order or server-payload serialization regressions."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 12,
+        "specificity": 21,
+        "risk_awareness": 11,
+        "total": 62,
+        "notes": "The patch implements the helper, configuration, startup warning, seven route calls, deployment wiring, and focused service tests with a truthful off-by-default path. The largest defects are that the server API gate precedes existing overwrite/version checks, skill registration precedes service-side URL validation, and raw `server_entry` values are passed to JSON without normalization. The tests never exercise route integration, and Terraform places the sensitive gate token in the ECS task definition's ordinary `environment` list rather than a secret reference. The submitted contexts match the named symbols, but local `git apply --check` and independent baseline inspection could not be completed because the provided read-only command sandbox failed before executing commands."
+      }
+    },
+    "task_score": 67.0,
+    "verdict": "The submission is specific and substantially implemented, but it is not merge-ready because the admission decision occurs before some promised validations and lacks a safe, tested serialization and secret-handling boundary.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:37:44.769690Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 396679,
+        "cached_input_tokens": 241046,
+        "cache_write_input_tokens": 97296,
+        "output_tokens": 14717,
+        "reasoning_output_tokens": 12582
+      },
+      "duration_ms": 300356
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/run-summary.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/run-summary.json
@@ -1,0 +1,1438 @@
+{
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry-v2",
+  "provider": "bedrock",
+  "ref": null,
+  "refs": [
+    "1.23.0",
+    "1.24.3",
+    "1.24.7",
+    "1.25.0",
+    "1.27.1",
+    "1.28.0",
+    "v1.0.18",
+    "v1.0.19",
+    "v1.0.20",
+    "v1.0.21"
+  ],
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T06:35:41.594936Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 246962,
+      "cached_input_tokens": 183277,
+      "cache_write_input_tokens": 39088,
+      "output_tokens": 10735,
+      "reasoning_output_tokens": 8427
+    },
+    "duration_ms": 153754
+  },
+  "num_tasks": 21,
+  "num_scored": 21,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 70.64,
+  "mean_cost_usd_excl_failed": 4.95,
+  "tasks": [
+    {
+      "task": "pass-ssrf-allowlist-env-to-registry-container",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 35,
+      "input_tokens": 7080,
+      "output_tokens": 16993,
+      "total_tokens": 2454493,
+      "latency_seconds": 319.9,
+      "total_cost_usd": 1.99545125,
+      "result_subtype": "success",
+      "task_score": 87.4,
+      "cache_read_tokens": 2374765,
+      "cache_write_tokens": 55655,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 53.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 24,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 91,
+          "notes": "The issue precisely identifies both affected compose files, the two variables, required substitution syntax, scope exclusions, and testable acceptance criteria. The submitted diff context corroborates that each target registry environment block reaches SECRET_KEY without these variables. Its largest limitation is the absent independent task statement; claims that Helm, Terraform, DHI inheritance, and every other compose surface were already correct could not all be independently verified. The public repository does confirm prebuilt Docker deployment and relevant 1.28.0 release context. ([github.com](https://github.com/agentic-community/mcp-gateway-registry))"
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 90,
+          "notes": "The LLD is implementation-ready for this small configuration change, naming exact files, insertion landmarks, syntax, data flow, exclusions, rollout, and alternatives. Its proposed edits align exactly with the submitted source context around REGISTRY_CONTACT_URL, BUILD_VERSION comments, and SECRET_KEY. The main deficiency is modest treatment of validation and fallback: it declares error handling inapplicable and provides no explicit rollback command or automated drift prevention. Exact line numbers, the asserted baseline commit, and the Helm and Terraform wiring remained independently unverifiable."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 21,
+          "specificity": 20,
+          "risk_awareness": 20,
+          "total": 81,
+          "notes": "The review surfaces two concrete maintainability risks: existing compose-file drift and the absence of an automated environment-key consistency check. It also correctly reasons that empty defaults preserve the secure default and that the patch introduces no new runtime path. Its largest weakness is that the five-persona format is mostly approval theater and does not independently challenge patch applicability, test-oracle scope, or the unverified Helm and Terraform claims. The A2A and DHI subjects it discusses are real repository features, although the exact 1.27.1 file state was not independently readable. ([github.com](https://github.com/agentic-community/mcp-gateway-registry), [github.com](https://github.com/agentic-community/mcp-gateway-registry/releases))"
+        },
+        "testing": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The plan provides concrete commands and expected values for populated variables, empty defaults, the DHI overlay, and container-level printenv verification. These cases directly cover substitution and backward-compatible behavior across all named compose variants. Its largest defect is that grep searches the entire rendered configuration rather than scoping assertions to the registry service, so misplaced variables could produce false positives; only the podman variant receives runtime verification. The git diff --stat check is also a weak oracle, and the claim that existing conftest coverage makes an end-to-end health-check test unnecessary could not be verified."
+        },
+        "implementation": {
+          "completeness": 24,
+          "correctness": 23,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 93,
+          "notes": "The patch implements the full stated design by adding both passthroughs to both affected registry environment blocks with the established empty-default form and explanatory comment. The hunks are minimal, internally consistent with their supplied surrounding context, and introduce no unrelated behavior or default change. The largest limitation is the absence of an automated regression test, while the summary explicitly states that verification was not executed. Exact application against the local baseline and the claimed commit hash could not be independently confirmed because repository shell access was unavailable, so correctness is strong but not exceptional."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "hide-register-button-on-virtual-and-skills-tabs",
+      "complexity": "trivial",
+      "ref": "v1.0.18",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 33,
+      "input_tokens": 67,
+      "output_tokens": 12608,
+      "total_tokens": 2499599,
+      "latency_seconds": 275.4,
+      "total_cost_usd": 1.9071020000000003,
+      "result_subtype": "success",
+      "task_score": 82.6,
+      "cache_read_tokens": 2426384,
+      "cache_write_tokens": 60540,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 45.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 89,
+          "notes": "The issue clearly defines the conflicting CTAs, exact affected viewFilter values, preserved behavior on four other tabs, and explicit non-goals. Its acceptance criteria are directly testable and align with the task identifier. The largest limitation is that no independent task statement exists, so motivations such as the Register route being inappropriate cannot be confirmed beyond the internally consistent artifacts. Local repository inspection could not execute because the read-only sandbox failed during initialization, leaving Dashboard.tsx claims independently unverifiable."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 85,
+          "notes": "The LLD commits to a minimal, concrete JSX guard in frontend/src/pages/Dashboard.tsx and explains how the existing Discover condition remains intact. It also evaluates the important allowlist-versus-denylist tradeoff and identifies the future-tab behavior of each choice. Its weakest points are an unsupported assertion that VirtualServerCard.tsx and SkillCard.tsx confirm the CTAs, plus the later review's false claim that the LLD was updated to include an inline comment. Exact symbols, line numbers, and file context could not be independently verified because local command execution failed before reading the repository."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 17,
+          "specificity": 19,
+          "risk_awareness": 18,
+          "total": 73,
+          "notes": "The review usefully surfaces the denylist's future-tab risk, distinguishes UI hiding from access control, and considers focus behavior during tab changes. Much of the multi-role structure is generic approval material for a two-line frontend change rather than substantive stress testing. It also asserts that /servers/register has server-side authorization without repository evidence and says the LLD was updated with a comment when the submitted LLD was not. The concrete viewFilter recommendation is internally sound, but the authentication and event-handler claims could not be verified."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The six-tab visibility matrix directly covers every acceptance criterion and adds checks for registration navigation, neighboring CTAs, search, health refresh, responsive layout, and direct-route compatibility. The strongest oracle is the explicit visible/not-visible expectation for each tab. Several other checks are weakly defined, such as verifying that forms function correctly or results are filtered, and the plan proposes no automated regression test for the render condition. The npm start command, permission names, Enter-key behavior, and /settings/virtual-mcp/servers destination could not be independently confirmed from the inaccessible working tree."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 89,
+          "notes": "The patch implements the requested behavior end to end by retaining the outer Discover guard and adding an exact virtual/skills guard around only the Register button. The JSX is syntactically coherent, preserves handleRegisterServer and adjacent Refresh Health markup, and the reported +10/-7 count matches the displayed diff. Its main limitation is the denylist's less-safe behavior for future tabs, while the summary's claim of no LLD deviation overlooks that the submitted LLD did not include the added comment. The sandbox failure prevented git apply --check and independent confirmation of the target blob, context, and symbols, so applicability remains an evidence gap rather than a demonstrated patch defect."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "fix-reserved-groups-var-in-service-account-script",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 42,
+      "input_tokens": 1072,
+      "output_tokens": 23284,
+      "total_tokens": 3149525,
+      "latency_seconds": 437.3,
+      "total_cost_usd": 2.5386870000000012,
+      "result_subtype": "success",
+      "task_score": 81.4,
+      "cache_read_tokens": 3057579,
+      "cache_write_tokens": 67590,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 53.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 84,
+          "notes": "The issue clearly identifies both scripts, the verify_setup functions, observable exit behavior, scope, non-goals, and testable acceptance criteria. The submitted patch contains the cited GROUPS assignments and scalar expansions at the described locations. Its main weakness is imprecise terminology: Bash documents GROUPS as a special array whose assignments have no effect, while the issue calls it read-only; the blanket prohibition on assigning numerous special variables is also broader than this defect.  No independent task statement was supplied, and the macos-setup impact and repository-wide sweep could not be independently verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 84,
+          "notes": "The LLD is highly implementation-ready, naming both files, four membership checks, exact variable changes, compatibility constraints, and the reason for separating local declaration from assignment. Its proposed edits correspond precisely to the symbols and preimage lines in the submitted patch. The largest technical deficiency is claiming that set -e will catch a failed curl within curl | jq even though no pipefail setting is established; only the final pipeline command controls that status. The Bash 3.2 clobbering claim, exhaustive nine-script inventory, and baseline line claims could not be independently verified."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 78,
+          "notes": "The review's strongest contribution is the concrete identification of substring false positives and its actionable resolution to use grep -qxF in all four membership checks. That resolution is reflected in both the final LLD and patch. It does not challenge the LLD's incomplete pipeline-error analysis or unsupported Bash 3.2 behavior, and Byte's discussion retains stale grep -qF wording after the design adopted -qxF. Claims about inspecting every setup script and filing follow-ups were not independently verifiable."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 75,
+          "notes": "The plan covers successful runs, missing groups, idempotency, exact matching, syntax, ShellCheck, token behavior, and both stated Bash versions with concrete expected outcomes. The standalone grep -qxF cases are particularly effective regression oracles. The reserved-variable count uses grep -c across multiple files, which produces per-file counts rather than one total, while the JWT check incorrectly treats base64url data as ordinary base64.  It also lacks cleanup and injected curl, jq, or mapper-failure cases, and the exact script flags and environment names could not be verified."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 86,
+          "notes": "The patch implements the central rename in both verify_setup functions and consistently updates both verification and assignment membership checks to exact fixed-string matching. Its contexts, symbols, variable references, and summary are internally consistent, and separate local declarations avoid masking command-substitution status at the assignment level. The additional mapper localization and assign_to_group behavior change are small, disclosed, and consistent with the revised design, although they extend beyond the narrow reserved-name fix. No material diff defect is apparent, but local source reads and git apply --check failed at sandbox initialization, so target-tree applicability and the claimed baseline commit remain unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "cli-custom-egress-oauth-provider-flags",
+      "complexity": "low",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 36,
+      "input_tokens": 214,
+      "output_tokens": 23492,
+      "total_tokens": 3086636,
+      "latency_seconds": 407.8,
+      "total_cost_usd": 2.5896215,
+      "result_subtype": "success",
+      "task_score": 80.6,
+      "cache_read_tokens": 2981228,
+      "cache_write_tokens": 81702,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 57.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 87,
+          "notes": "The issue clearly identifies the CLI-to-client gap, specifies all five fields, and provides testable acceptance criteria and explicit non-goals. Its named integration points align with the submitted patch's RegistryClient.configure_egress_auth and cmd_egress_configure changes. The statement that the server requires all five fields is imprecise because its own table identifies only the authorize and token URLs as required. No independent task statement was supplied, and repository-local execution was unavailable, so the UI, SSRF-validation, and persistence claims could not be independently verified."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 83,
+          "notes": "The LLD commits to exact files, method arguments, body keys, CLI flags, and conditional insertion behavior, making the core change implementation-ready. The submitted diff follows its named api/registry_management.py and api/registry_client.py integration points and the proposed non-None body construction. It inconsistently says registry/core/schemas.py stores four custom fields while listing five, and assertions about audit logging and detailed server URL validation are not substantiated within the available evidence. Compatibility and rollout are addressed proportionately, although the claim that no open questions remain is stronger than warranted without repository verification."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 19,
+          "risk_awareness": 16,
+          "total": 72,
+          "notes": "The review identifies actionable details, especially the missing client docstring update and the coupling created by hardcoded token-auth choices. It also considers secret exposure, server-side URL validation, migrations, dependencies, and rollback implications specific to this change. Its largest weakness is that it is predominantly approving role-play and does not challenge unconditional args.custom_* access, incomplete parser-level coverage, or the testing plan's questionable E2E hosts. Claims about SSRF checks, resource validation, and audit redaction could not be independently verified against the repository."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The plan provides concrete setups, actions, and value-level oracles for handler forwarding, request-body omission, complete body construction, valid choices, and non-custom compatibility. Test 5 calls registry_management.build_parser(), while the implementation instead exercises registry_management.main(), so the documented API is not corroborated by the submitted patch. The E2E success case uses idp.example.com and mcp.example.com despite claiming DNS-aware SSRF validation, making the expected successful result questionable, and parser-level mapping is not directly asserted for every flag. Negative choice coverage is useful, but backward compatibility and server response-field assertions rely substantially on inference."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 85,
+          "notes": "The diff implements the full stated data path: five argparse flags, five handler kwargs, five optional client parameters, conditional POST-body insertion, docstrings, and focused tests. The changes are internally coherent around RegistryClient.configure_egress_auth and cmd_egress_configure and preserve positional compatibility by appending defaulted parameters. The invalid-choice test asserts only SystemExit code 2 and could pass for an unrelated parse error, while unconditional args.custom_* reads can affect direct handler callers using older handcrafted Namespaces, contradicting the summary's absolute claim that existing behavior cannot break. The sandbox failed before local commands could run, so git apply --check, surrounding-source compatibility, and the claimed baseline commit could not be independently verified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "index-demo-videos-in-one-page",
+      "complexity": "trivial",
+      "ref": "1.24.3",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 33,
+      "input_tokens": 4294,
+      "output_tokens": 19289,
+      "total_tokens": 2476904,
+      "latency_seconds": 353.0,
+      "total_cost_usd": 2.0817725,
+      "result_subtype": "success",
+      "task_score": 78.4,
+      "cache_read_tokens": 2392205,
+      "cache_write_tokens": 61116,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 54.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 83,
+          "notes": "The issue provides testable acceptance criteria, explicit non-goals, and a tightly bounded documentation-only change. Its largest factual weakness is the claim of videos in \"a dozen\" docs files, while the LLD identifies eight docs files and ten Markdown sources overall. The requested README integration, new docs/demo-videos.md path, and additive preservation of existing links agree with the submitted patch context. No independent task statement was supplied, so the intended inventory boundary and categorization cannot be verified beyond the repository context and internally consistent artifacts."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 83,
+          "notes": "The strongest element is the decision-ready inventory of 13 URLs, their source files, grouping, and exact README integration point. Its largest deficiency is claiming the videos span eight Markdown files while its own Key Files Reviewed table names ten video-bearing sources, with no reproducible repository-wide extraction command resolving that discrepancy. The proposed page structure maps directly to the implementation, including docs/demo-videos.md and the existing README Demo Videos line. The asserted baseline line counts and exhaustiveness could not be independently checked because repository shell commands failed before execution in the provided sandbox."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 19,
+          "risk_awareness": 18,
+          "total": 72,
+          "notes": "The review usefully identifies index staleness, external-player UX, the GIF scope ambiguity, and the crowded README line, then gives actionable placement and contributor-guidance recommendations. Its largest weakness is that every reviewer approves without catching the LLD's source-count inconsistency or the testing plan's invalid untracked-file check. It also refers to grep patterns supposedly used for discovery even though the LLD documents no such command or pattern. Claims that the linked videos contain no PII and that the change has zero operational risk are not verifiable from URLs alone and are stated too absolutely."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 68,
+          "notes": "The plan is concrete about the 13 expected URLs, README preservation, section names, rendering, and link navigation. Its largest correctness defect is expecting plain `git diff --name-only HEAD` after `git apply` to list the newly created untracked docs/demo-videos.md; that command normally reports only tracked differences, so the stated exact two-file oracle is invalid. The hard-coded inventory cannot detect a video omitted during discovery, omits query strings from two Vidcast URL checks, and does not verify that every row has a title, platform, and description. The commands and referenced paths otherwise align with the submitted patch, but execution could not be independently performed because the repository shell sandbox failed to start."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 86,
+          "notes": "The patch implements the designed change end to end: it adds 13 linked entries across seven sections and inserts the index link before every preserved README video link. The new rows include platform, description, and related-doc columns, and the two-file diff stays within the declared documentation-only scope. The largest defect is the summary's contradiction between \"Verification (not executed)\" and its later assertion that `git apply --check` was verified; the claimed clean application and baseline commit could not be independently confirmed because shell execution failed before running commands. No substantive code defect is visible in the supplied diff, although completeness remains dependent on the unverified 13-URL inventory and future updates rely on a manual contributor note."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-ui-title",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 92,
+      "input_tokens": 5418,
+      "output_tokens": 32648,
+      "total_tokens": 10233863,
+      "latency_seconds": 640.3,
+      "total_cost_usd": 6.5749995000000006,
+      "result_subtype": "success",
+      "task_score": 78.0,
+      "cache_read_tokens": 10085569,
+      "cache_write_tokens": 110228,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 51.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 80,
+          "notes": "The issue precisely identifies the affected UI locations, configuration behavior, deployment surfaces, and explicit non-goals. The submitted diff contains every named path and implements the stated Settings, API, frontend, Docker, Terraform, and Helm boundaries. Its largest defect is the contradictory acceptance criterion that unset UI_TITLE causes no current-behavior change even though registry-only deployments intentionally change from \"AI Gateway & Registry\" to \"AI Registry\". No independent task statement was supplied, and the linked issue could not be independently verified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 83,
+          "notes": "The LLD is implementation-ready, naming concrete symbols such as Settings.effective_ui_title, get_config(), CONFIG_GROUPS, useRegistryConfig, and each deployment configuration path. Those integration points and surrounding contexts are represented consistently in the submitted patch. It repeats the false claim that all existing deployments see no change and describes the title as resolved once at startup even though the property is evaluated when accessed; it also understates the frontend bundle rollout requirement that it otherwise acknowledges. Cache-TTL, middleware-allowlist, and exact repository-convention claims could not be independently verified from the local checkout."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 77,
+          "notes": "The review raises concrete concerns about hook reuse, Helm reserved-name testing, title length, serialization, caching, and startup logging, and it causes the Login and Logout design to use the shared hook. Its resolution incorrectly says Logout.tsx needs an axios import for the hook, while the submitted patch correctly adds no such import. It also misses the issue's backward-compatibility contradiction and treats the missing backend and Helm tests as non-blocking despite their direct relevance. Assertions about the 60-second cache and docker-compose.dhi.yml could not be independently verified."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 68,
+          "notes": "The plan supplies useful oracles for explicit, with-gateway, and registry-only resolution and covers all four UI locations plus each deployment surface. The backward-compatibility jq command is invalid because jq's has function accepts one key argument, not the five arguments shown. Most deployment checks merely grep for text rather than running Docker Compose rendering, Terraform validation, Helm rendering, or the reserved-environment-name test, and the promised unit tests have no concrete test file or cases. The asserted /api/config/full response shape and session-cookie command could not be independently verified."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 82,
+          "notes": "The patch coherently implements the design end to end: Settings.effective_ui_title resolves the override, get_config() exposes it, four React surfaces consume useRegistryConfig, and Docker, Terraform, and Helm propagate UI_TITLE. The provided source contexts and symbols are internally consistent, including the CONFIG_GROUPS field and Helm reserved-name addition. Its largest deficiency is the absence of the directly relevant backend and Helm tests while the summary claims nothing remains unimplemented; the unresolved acceptance-criterion contradiction also makes that claim too strong. Independent git apply verification against the checkout was unavailable because the repository shell sandbox failed before command execution, so patch applicability could not be confirmed beyond the submitted unified-diff context."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "honor-cloud-provider-override-in-ui",
+      "complexity": "low",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 42,
+      "input_tokens": 2470,
+      "output_tokens": 19237,
+      "total_tokens": 3728595,
+      "latency_seconds": 377.7,
+      "total_cost_usd": 2.8322489999999996,
+      "result_subtype": "success",
+      "task_score": 75.0,
+      "cache_read_tokens": 3622448,
+      "cache_write_tokens": 84440,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 50.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 85,
+          "notes": "The issue clearly identifies the inconsistent raw-versus-resolved cloud path and supplies testable override, fallback, and response-shape criteria. The submitted patch preimage corroborates that registry/api/system_routes.py calls _detect_cloud_provider_with_method() and returns the stated two fields. Its largest gap is limited discussion of the new operator-hint lookup, latency, and metrics side effects introduced by _resolve_cloud(). The AWS_REGION example, related issue history, and exact intended requirements could not be independently confirmed because no separate task statement was supplied."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 82,
+          "notes": "The LLD is unusually concrete for this small change, naming the route, resolver, fallback, frontend consumer, return tuple, and exact awaited replacement. Its proposed code agrees with the submitted source preimage and preserves the endpoint response shape. The largest design deficiency is that its regression strategy tests _resolve_cloud() directly rather than the changed endpoint integration, so those tests would pass with the original broken route unchanged. Claims about exact line numbers, storage backends, cache TTL, and ancillary management routes were not independently verifiable from the supplied task context."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 16,
+          "specificity": 18,
+          "risk_awareness": 15,
+          "total": 65,
+          "notes": "The review raises concrete concerns about operator-hint latency, caching semantics, information disclosure, endpoint naming, and UI presentation. Its largest failure is approving resolver-only tests as sufficient without noticing that they do not exercise get_telemetry_detection_info(), the actual changed integration point. The backend recommendation to mock settings and _get_operator_cloud_hint() directly preserves that blind spot, and all five reviewers approve without identifying a blocking defect. Assertions about authentication, management endpoints, graceful UI failure, and Prometheus behavior could not all be independently verified."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 66,
+          "notes": "The plan provides concrete expected JSON, explicit override precedence, fallback behavior, operator-hint coverage, response-shape checks, and UI observations. Its central automated tests call the pre-existing _resolve_cloud() function rather than the API route, so they cannot catch a regression where the endpoint continues calling the raw detector. The purported heartbeat E2E test invokes POST /api/management/telemetry/heartbeat even though the LLD identifies GET /api/management/telemetry/info, and it never inspects HEARTBEAT or compares its cloud value. The banner response field, token-file path, and several operational commands remain unverified, while the assertion that no frontend regression is possible is too absolute."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 22,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 77,
+          "notes": "The functional patch directly replaces the raw detector with await _resolve_cloud() in the existing async endpoint while retaining the exact cloud and cloud_detection_method response keys. Its context, imports, method constants, and test style are internally consistent with the supplied source preimage and design. The largest defect is that all three added tests exercise the already-existing resolver, so they would still pass if the crucial system_routes.py change were omitted or later reverted. The summary therefore overstates endpoint regression coverage, and patch applicability could not be independently dry-run because the repository shell was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "default-create-in-idp-checkbox-unchecked",
+      "complexity": "low",
+      "ref": "v1.0.21",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 66,
+      "input_tokens": 4146,
+      "output_tokens": 24296,
+      "total_tokens": 5693625,
+      "latency_seconds": 486.0,
+      "total_cost_usd": 4.102237499999998,
+      "result_subtype": "success",
+      "task_score": 74.0,
+      "cache_read_tokens": 5553615,
+      "cache_write_tokens": 111568,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 50.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 16,
+          "total": 80,
+          "notes": "The issue provides a clear motivation, explicit non-goals, and testable criteria covering initial state, reset behavior, omitted values, and explicit opt-in. Its named files and symbols correspond consistently with the submitted diff, including IAMGroups.tsx state and management_routes.py fallback changes. Its largest deficiency is calling the work self-contained while changing defaults on existing API endpoints, a potentially breaking behavior for callers that omit the field. No independent task statement establishes that the backend expansion is required, and repository shell failure prevented direct verification of its remaining repository claims."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 75,
+          "notes": "The LLD is implementation-ready in its enumeration of concrete defaults, integration paths, tests, and legacy import behavior. The submitted patch contains the named functions and matching contexts for management_create_group, internal_create_group, _create_group_impl, create_group_api, and import_group_definition. The main weakness is treating rollout as risk-free despite acknowledging changed behavior for omitted fields, with no compatibility mechanism or release-note requirement. It also misses the now-misleading internal_create_group docstring, and exact repository applicability could not be independently verified."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 19,
+          "risk_awareness": 16,
+          "total": 70,
+          "notes": "The review's strongest contribution is identifying the omitted-field API compatibility break and stale default documentation with concrete locations. Those findings are supported by the submitted patch, which updates two server_routes.py default descriptions but leaves internal_create_group documented as creating in both stores. The review then underweights its own compatibility finding and approves based on unsupported assertions about endpoint and CLI usage rather than requiring evidence or broader regression tests. Claims that affected callers always pass the field could not be verified against the repository."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 16,
+          "specificity": 19,
+          "risk_awareness": 17,
+          "total": 71,
+          "notes": "The plan covers omitted, explicit-true, explicit-false, legacy-key, UI reset, and lifecycle scenarios with concrete commands and expected outcomes. Its management test names align with the submitted test patch, and it correctly distinguishes local-only behavior through the absence of an IAM create call. The largest gap is that server_routes.py and import defaults receive no automated regression tests, while several manual checks merely reference logs or assert IdP state without a concrete query oracle. The frontend implementation also tests only initial checkbox state, not the preview or post-reset behavior promised by this plan, and command validity could not be independently executed."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 19,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 74,
+          "notes": "The patch consistently flips the submitted design's frontend state, reset, example value, management fallback, three server defaults, legacy fallback, and management regression test. The changes are internally plausible and explicit true values remain supported, but the new frontend test covers only initial state and does not verify preview or reset behavior. The summary incorrectly claims no deviations and complete implementation, while internal_create_group retains a misleading both-stores docstring and the compatibility-sensitive server/import changes lack dedicated automated tests or release guidance. The working-tree shell failed before every command, so git apply --check, import compatibility, and the test mocks could not be independently verified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "nginx-location-trailing-slash-route-hijack",
+      "complexity": "medium",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 47,
+      "input_tokens": 6568,
+      "output_tokens": 22262,
+      "total_tokens": 4151367,
+      "latency_seconds": 451.4,
+      "total_cost_usd": 3.13896575,
+      "result_subtype": "success",
+      "task_score": 72.2,
+      "cache_read_tokens": 4037614,
+      "cache_write_tokens": 84923,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 49.3,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 79,
+          "notes": "The issue provides a concrete reproduction, explains nginx prefix collision behavior, defines testable acceptance criteria, and explicitly limits storage and authentication changes. Its largest inconsistency is proposing a version-map regex update while the LLD later argues the existing `~^{escaped_path}(/.*)?:` form requires no change. The submitted diff contains the cited `_create_location_block` context and corresponding tests, supporting the central diagnosis. No independent task statement was supplied, and sandbox failure prevented verification of the cited management-route lines, existing guards, and issue link against the working tree."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 16,
+          "total": 76,
+          "notes": "The LLD commits to exact generated directives, identifies callers and related regex handling, and explains why normalization belongs in `_create_location_block`. The principal gap is the redirect design: `return 301 $scheme://$host$uri/` is not analyzed for non-GET methods, query preservation, or the newly reflected host value. Its reasoning about `path.rstrip(\"/\") + \"/\"`, the version-map pattern, and the two-block return is concrete and internally consistent with the patch. Claims about validation, regeneration lifecycle, and exact surrounding repository patterns could not be independently verified because local repository reads were unavailable."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 19,
+          "risk_awareness": 17,
+          "total": 69,
+          "notes": "The review usefully notices ROOT_PATH behavior, `$host`, config growth, exact-location precedence, and the changed two-block return shape. Its largest weakness is dismissing the host-based redirect as merely pre-existing because `proxy_set_header Host $host` exists; emitting that value in a client-visible Location header is a distinct behavior introduced by this design. It also calls the bug an authorization bypass although the described evidence establishes route hijacking and erroneous authentication responses, not bypass, and it misses method and query-string compatibility. Quantitative reload-window and config-size claims were not repository-verified."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 16,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 66,
+          "notes": "The plan supplies concrete unit setups and string oracles across transports, existing trailing slashes, special characters, proxy targets, and the `/a` collision case. The key deficiency is that it never validates a rendered configuration with nginx or exercises real routing, while declaring end-to-end testing inapplicable for an nginx-routing regression. Redirect tests assert only the presence of `return 301`, so an incorrect target, lost arguments, or unintended method behavior would pass; version-map and non-empty ROOT_PATH recommendations are also not implemented. The deployment command assumes `registry-container` and greps for literal `ROOT_PATH`, neither of which was established by available repository evidence."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 71,
+          "notes": "The patch implements the central fix directly by normalizing the prefix to `/path/`, adding an exact bare-path location, updating five existing assertions, and adding three focused regression tests. Its largest defect is the under-specified redirect: it applies to every HTTP method, embeds `$host`, and uses `$uri` without explicitly preserving arguments, while tests check neither the full target nor those edge cases. The supplied hunk contexts and symbols are internally consistent with the artifacts, but sandbox failure prevented `git apply --check`, caller inspection, and independent confirmation of the claimed baseline commit. The summary also overstates complete coverage because the issue's version-map acceptance criterion and the review's ROOT_PATH recommendation receive no implementation test."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-mcp-proxy-upstream-timeout",
+      "complexity": "medium",
+      "ref": "1.25.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 89,
+      "input_tokens": 4401,
+      "output_tokens": 34136,
+      "total_tokens": 8576752,
+      "latency_seconds": 645.0,
+      "total_cost_usd": 5.7213065,
+      "result_subtype": "success",
+      "task_score": 70.2,
+      "cache_read_tokens": 8437903,
+      "cache_write_tokens": 100312,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 52.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 80,
+          "notes": "The issue clearly defines the hardcoded `httpx.AsyncClient(timeout=30.0)` problem, deployment scope, non-goals, and testable acceptance criteria. Its named files and `mcp_proxy_max_body_bytes` precedent align with the submitted baseline contexts. The largest flaw is requiring values below one to be clamped while also prescribing a Pydantic `int` field with `ge=1`, which can reject them during Settings construction before clamping occurs. No independent task statement was supplied, so the asserted production incidents and nginx sufficiency could not be independently established."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 15,
+          "specificity": 23,
+          "risk_awareness": 15,
+          "total": 74,
+          "notes": "The LLD is unusually concrete, identifying the handler, Settings field, admin configuration, and every Compose, Terraform, Helm, documentation, and test integration point. Its paths and surrounding symbols correspond to the patch contexts, and the valid-value flow into `httpx.AsyncClient` is feasible. Its major correctness defect is claiming that fractional, invalid, and below-floor environment values reach the reader, although the always-present Pydantic `int` field can validate or reject them first. It also understates resource growth from longer-lived requests and does not resolve the nginx timeout dependency raised elsewhere."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 15,
+          "specificity": 18,
+          "risk_awareness": 18,
+          "total": 68,
+          "notes": "The review surfaces concrete concerns about httpx per-phase timeout semantics, upstream nginx limits, high-timeout resource exhaustion, and the missing boundary test. Its largest omission is failing to detect the Settings-validation versus runtime-clamping contradiction, while describing the fallback chain as robust. It also dismisses the nginx concern without repository-backed evidence and converts an 'approved with changes' verdict into an optional recommendation. The token-binding and automatic UI-rendering claims are plausible from the named integration points but were not demonstrated in the review itself."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 9,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 54,
+          "notes": "The seven reader tests provide concrete inputs and expected values for defaults, precedence, boundaries, invalid input, and environment fallback. The proposed handler integration test never populates or asserts `captured_timeout`, so it would pass even if the handler retained `timeout=30.0`. The final `python -m unittest discover` command would not discover the submitted plain pytest-style class, and no test exercises real BaseSettings environment validation. Deployment checks only grep for presence and omit Compose parsing, Terraform validation, Helm rendering, and a meaningful admin-config oracle."
+        },
+        "implementation": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 75,
+          "notes": "The patch implements the valid-value path end to end: it adds the Settings field, resolves the timeout, passes it to `httpx.AsyncClient`, and wires all 18 listed configuration and documentation surfaces. The focused hunks match the named baseline symbols and preserve the existing 30-second default without unrelated functional churn. The principal defect is that `Field(ge=1)` and integer parsing can reject invalid, fractional, or sub-one environment values during Settings initialization, while the tests bypass the real Settings object and therefore falsely demonstrate clamping and fallback. The summary consequently overstates exact conformance, and the implementation lacks a test proving that the handler actually passes the configured timeout."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "consistent-csrf-across-toggle-endpoints",
+      "complexity": "medium",
+      "ref": "v1.0.20",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 73,
+      "input_tokens": 3533,
+      "output_tokens": 30855,
+      "total_tokens": 7055933,
+      "latency_seconds": 593.6,
+      "total_cost_usd": 4.849966749999999,
+      "result_subtype": "success",
+      "task_score": 68.0,
+      "cache_read_tokens": 6925866,
+      "cache_write_tokens": 95679,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 52.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 78,
+          "notes": "The issue clearly inventories the five user-facing toggle routes, separates the internal route, and supplies testable cookie-versus-bearer acceptance criteria. Its largest defect is requiring bearer-token operation on every toggle while the submitted route evidence shows the server UI toggle still uses session-oriented enhanced_auth rather than nginx_proxied_auth. It also contradicts itself by saying to apply the dependency to all six endpoints while simultaneously excluding the internal endpoint. No independent task statement establishes the broader claim that every M2M registration pipeline is broken."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 70,
+          "notes": "The LLD names concrete files, symbols, route signatures, compatibility boundaries, and the intended cookie and token flows. Its major unresolved flaw is claiming bearer clients will succeed on the server UI toggle even though server_routes.py retains enhanced_auth, which the LLD itself describes as the session fallback rather than the nginx bearer path. It also incorrectly states that sibling FastAPI dependencies execute in parallel and overstates absence of a session cookie as proof of bearer authentication. Claims that nginx strips Authorization and that the cited frontend and line-level integration points behave exactly as described could not be independently verified."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 19,
+          "risk_awareness": 17,
+          "total": 66,
+          "notes": "The review usefully identifies browser compatibility risk on the newly protected routes and examines the both-cookie-and-proxy-headers case. It misses the more consequential enhanced_auth mismatch and resolves the frontend concern with an unsupported claim that virtual-server JSON toggles use the same form pattern as the server UI route. The security section also incorrectly treats HttpOnly and SameSite as making non-browser cookie replay impossible. The claimed frontend locations, global CSRF-header behavior, and JWT-only reachability were not substantiated by the submitted patch."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 57,
+          "notes": "The dependency unit cases have meaningful status, message, session-mismatch, form, and header-precedence oracles. Several HTTP tests are not executable against the shown interfaces: toggle_agent receives enabled as a scalar query parameter rather than the submitted JSON body, and the server UI bearer test expects 200 despite its enhanced_auth dependency. The proposed unittest discovery command also does not exercise the pytest-style fixtures shown in the existing test files. Route-wiring tests for all five endpoints and an unauthenticated no-cookie rejection test are missing, while the token script and agent verification endpoint remain unverified."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 69,
+          "notes": "The patch concretely adds the session-aware dependency, wires it into all five intended route functions, preserves the old dependency for non-toggle routes, and adds focused unit coverage. It does not fully satisfy its own bearer-compatibility claim because toggle_service_route still depends on enhanced_auth, so skipping CSRF alone cannot make that endpoint accept nginx-authenticated M2M callers. The tests exercise the helper directly but do not prove that every route is wired correctly or that newly protected browser calls receive 403 without a token; the new test file also contains an unused patch import. Patch applicability against the baseline could not be independently confirmed in the available execution environment, although the submitted contexts and symbols are internally consistent."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "idp-authenticated-embedding-endpoint",
+      "complexity": "high",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 121,
+      "input_tokens": 125,
+      "output_tokens": 43796,
+      "total_tokens": 14039357,
+      "latency_seconds": 875.6,
+      "total_cost_usd": 8.8727475,
+      "result_subtype": "success",
+      "task_score": 67.6,
+      "cache_read_tokens": 13859870,
+      "cache_write_tokens": 135566,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 50.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The issue provides concrete configuration fields, integration surfaces, compatibility expectations, exclusions, and testable failure behavior. Its largest inconsistency is requiring a singleton EmbeddingsIdpTokenManager while the LLD and patch explicitly implement a non-singleton manager. The cited LiteLLMClient, Settings, FederationAuthManager, and deployment paths correspond to the submitted source contexts, but the Helm values.yaml and embeddings README criteria are not fulfilled by the implementation. No independent task statement was supplied, so broader requirement coverage cannot be verified."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 15,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 75,
+          "notes": "The LLD is unusually concrete about data flow, constructor changes, settings validation, token caching, error propagation, and named repository files. Its largest design miss is the interaction between strict partial-configuration validation and Terraform's unconditional client-secret injection: secrets.tf stores \"not-configured\" and ecs-services.tf always exposes it, causing default ECS configuration to appear partial. It also first says to mirror FederationAuthManager's singleton exactly and later rejects a singleton, while asserting without adequate support that embedding calls are serialized. Lifecycle cleanup, Terraform-state secret exposure, and client-authentication-method compatibility remain insufficiently resolved."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 20,
+          "total": 72,
+          "notes": "The review raises concrete concerns about lock contention, client lifetime, endpoint trust, secret handling, network reachability, retries, and metrics. Its largest failure is approving the design without noticing that the Terraform placeholder secret makes an unconfigured ECS deployment fail Settings validation. The security review also incorrectly claims the client secret never appears in Terraform state even though secrets.tf assigns the sensitive variable to secret_string. The claim that _embed_texts serializes all embedding calls is not established, and the review does not challenge the singleton contradiction or missing README and Helm deliverables."
+        },
+        "testing": {
+          "completeness": 14,
+          "correctness": 9,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 55,
+          "notes": "The plan supplies useful token-cache, expiry-buffer, scope, missing-token, compatibility, UI, and deployment scenarios with concrete expected outcomes. Its central LiteLLM tests patch litellm.embedding, but client.py calls its imported embedding alias, so those mocks would not reliably intercept the invocation. All startup-validator tests are placeholders containing pass, the static-key test merely asserts that a call occurred, and grep counts do not prove valid Terraform or ECS wiring. It also omits the critical default-Terraform placeholder case, meaningful concurrency coverage, and a forced refresh end-to-end oracle."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 9,
+          "specificity": 21,
+          "risk_awareness": 12,
+          "total": 59,
+          "notes": "The patch implements the core token manager, per-call api_key injection, settings validation, secret masking, and broad Docker and Terraform wiring in the intended source locations. The largest defect is that Terraform always injects EMBEDDINGS_IDP_CLIENT_SECRET with value \"not-configured\" when unset, while the other required fields are empty, so the new model validator rejects default ECS deployments and breaks backward compatibility. No tests are added, the required embeddings README and stated Helm values guidance are omitted, and the summary's \"no deviations\" claim conflicts with its own follow-up section. Local git apply --check could not be executed because the repository command runner failed before command execution, so exact patch applicability remains unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "per-caller-per-target-rate-limits-and-quarantine",
+      "complexity": "high",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 93,
+      "input_tokens": 6453,
+      "output_tokens": 58147,
+      "total_tokens": 13303878,
+      "latency_seconds": 1076.3,
+      "total_cost_usd": 9.041753749999998,
+      "result_subtype": "success",
+      "task_score": 67.4,
+      "cache_read_tokens": 13076465,
+      "cache_write_tokens": 162813,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 54.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 79,
+          "notes": "The issue provides unusually concrete behavior, including the composite counter subject, admin bypass rules, response headers, compatibility requirements, and explicit non-goals. Its named integration points such as `RateLimiter.check()`, `rate_limit_routes.py`, and `IAMRateLimits.tsx` correspond to the submitted source diff. The largest defect is its contradictory quarantine model: it requires auto-seeded undeletable reserved groups while also introducing a separate quarantine-entry collection and deletion API, without defining how those concepts relate. No independent task statement was supplied, so requirement correctness beyond the task identifier and internally stated acceptance criteria could not be verified."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 72,
+          "notes": "The LLD is highly specific about real symbols and data flow, including `_build_caller_target_gates()`, `_enforce_rate_limit()`, repository queries, counter keys, failure policy, metrics, and frontend integration. Its central quarantine design is internally inconsistent: reserved groups are promised and declared as constants, but the implementation plan uses unrelated documents in `rate_limit_quarantine`, performs no startup seeding, and later reinterprets what undeletable means. The scaling claim that quarantine causes roughly one read per five seconds per replica is incorrect for the proposed per-subject caches, which can require reads for every distinct caller and target after expiration. Rollback is also reduced to the global rate-limiting switch, and the claimed immediate kill-switch behavior is weakened by an acknowledged five-second cross-replica cache delay."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 21,
+          "total": 79,
+          "notes": "The review finds several concrete issues with operational consequences, notably quarantine propagation delay, canonical identifier validation, monitoring visibility, compromised-admin behavior, and missing three-axis interaction coverage. Its recommendations are prioritized and actionable, and the five-second cache change plus integration-test requirement are explicitly carried forward. The largest omission is failure to challenge the fundamental mismatch between the promised reserved-group mechanism and the separate collection, despite declaring the design backward-compatible and coherent. It also accepts canonical IDs without considering delimiter ambiguity, client-controlled `created_at`, or acceptance of target types that the limiter does not enforce."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 56,
+          "notes": "The plan covers models, CRUD, authorization, backward compatibility, UI behavior, independent target counters, quarantine precedence, and counter non-consumption with concrete expected results. Its primary enforcement setup cannot work under its own prerequisites: it declares default user and agent floors of 20 and 10 per minute, then attempts to create 60-second limits of 3 and 2 that the preceding floor-validation test says must be rejected. The `call_mcp_tool.py` examples do not demonstrate use of `testuser` credentials, while several curl commands discard response headers yet claim to verify `X-Quarantined` and absence of `Retry-After`. Concrete fail-open/fail-closed outage tests, cache-propagation handling, control-plane exclusion, caller-target admin bypass, and executable unit-test commands are missing, and local sandbox failure prevented independent confirmation of the submitted script path and flags."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 11,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 51,
+          "notes": "The patch implements the core caller-target gate, early quarantine checks, admin API CRUD, distinct denial headers, metrics, and frontend axis support in the expected subsystem files. It does not implement the required reserved-group seeding or semantics, leaves the quarantine constants unused, and explicitly omits the required quarantine management panel while the summary still describes the overall feature as added. Concrete defects include caller introspection checking the user identity before honoring `subject_type=client`, `upsert()` storing but not returning the generated `created_at` and replacing it on repeated PUTs, and accepting unenforced `mcp_tool` or `a2a_skill` quarantine entries through `TARGET_ENTITY_TYPES`. The summary also overstates UI completion and file-count consistency; the patch's applicability could not be independently dry-run because the read-only command sandbox failed before execution, so that claim remains unverified rather than penalized."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "registration-admission-control-gate",
+      "complexity": "high",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 106,
+      "input_tokens": 15769,
+      "output_tokens": 45749,
+      "total_tokens": 14978242,
+      "latency_seconds": 854.4,
+      "total_cost_usd": 9.564517250000002,
+      "result_subtype": "success",
+      "task_score": 67.0,
+      "cache_read_tokens": 14763057,
+      "cache_write_tokens": 153667,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 53.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 81,
+          "notes": "The issue provides unusually testable behavior, enumerating seven endpoints, four settings, status mappings, deployment surfaces, defaults, and explicit non-goals. Its named files and handlers are corroborated by the submitted diff contexts, including `register_agent`, `register_service_api`, and `update_skill`. Its largest omission is a contract for the exact post-validation payload representation and handling of potentially sensitive registration fields sent to the external service. No independent task statement was supplied, so broader requirement completeness cannot be verified beyond the task identifier and internally consistent artifacts."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 23,
+          "risk_awareness": 14,
+          "total": 70,
+          "notes": "The LLD is highly concrete about files, payloads, errors, configuration, rollout, and all seven insertion points. Its central ordering claim is unsound: it places the skill gate before `service.register_skill(..., validate_url=True)` and the server API gate before the submitted source's existing-server overwrite/version logic, despite promising that internal validation and duplicate checks happen first. It also passes `server_entry` directly to `httpx` JSON immediately after `source_updated_at` parsing, without a JSON-normalization boundary for values such as datetimes. Sensitive-payload exposure, retry idempotency, response-message validation, and the required `main.py` startup change are inadequately addressed or omitted from the file-change inventory."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 13,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 59,
+          "notes": "The review produces actionable recommendations for JSON-mode serialization, startup validation, URL schemes, and maintaining the endpoint list. Its backend review incorrectly concludes that `server_entry` is safely JSON-serializable after checking only `provider`, overlooking the adjacent `source_updated_at` parsing and lack of normalization. It also misses the more consequential placement before skill validation and server duplicate/version handling, plus the plaintext ECS task-definition environment entry for `ADMISSION_GATE_AUTH_TOKEN`. The approval verdict is therefore insufficiently adversarial for a security admission boundary."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 15,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 63,
+          "notes": "The service-level cases have concrete oracles for allow, deny, timeout, connection failure, unexpected status, authentication headers, payload shape, and startup warnings. No executable route-level tests verify that any of the seven handlers calls the gate at the correct point or prevents persistence, while the end-to-end section supplies only five high-level sketches. The grep-count deployment checks can pass with commented, malformed, or incorrectly wired configuration and should be supplemented with Helm, Compose, and Terraform validation. Consequently, the plan would not catch the implementation's validation-order or server-payload serialization regressions."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 12,
+          "specificity": 21,
+          "risk_awareness": 11,
+          "total": 62,
+          "notes": "The patch implements the helper, configuration, startup warning, seven route calls, deployment wiring, and focused service tests with a truthful off-by-default path. The largest defects are that the server API gate precedes existing overwrite/version checks, skill registration precedes service-side URL validation, and raw `server_entry` values are passed to JSON without normalization. The tests never exercise route integration, and Terraform places the sensitive gate token in the ECS task definition's ordinary `environment` list rather than a secret reference. The submitted contexts match the named symbols, but local `git apply --check` and independent baseline inspection could not be completed because the provided read-only command sandbox failed before executing commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "logout-id-token-hint-out-of-browser-url",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 71,
+      "input_tokens": 5531,
+      "output_tokens": 35921,
+      "total_tokens": 7982530,
+      "latency_seconds": 742.8,
+      "total_cost_usd": 5.566714999999997,
+      "result_subtype": "success",
+      "task_score": 66.0,
+      "cache_read_tokens": 7824470,
+      "cache_write_tokens": 116608,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 48.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 72,
+          "notes": "The issue clearly defines the first-hop exposure, exact replacement parameter, fallback behavior, TTL, dependencies, and testable acceptance criteria. It correctly references the existing logout URL metrics and the supported IdP set, but incorrectly describes id_token_hint as a mandated query parameter and an ID token as a bearer credential that logout revokes. Its largest practical contradiction is promising fallback when the auth server is down, because the resulting browser redirect still targets that unavailable server. No independent task statement was supplied, so the proposed architecture and provider-wide requirements cannot be confirmed as required rather than candidate-selected."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 12,
+          "specificity": 23,
+          "risk_awareness": 15,
+          "total": 69,
+          "notes": "The LLD is unusually concrete about logout_handler, oauth2_logout, internal_router, MongoDB operations, encryption helpers, metrics, deployment order, and failure paths. Its central security defect is that provider is stored but never included in resolve_and_delete_hint, allowing a captured key to be consumed through another or even invalid provider route; resolution also occurs before provider validation. The proposed _get_collection swallows TTL-index creation failure and then caches the collection, preventing retries and potentially retaining abandoned encrypted tokens indefinitely. It also overstates OIDC requirements and the effectiveness of fallback when the auth server itself is unreachable."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 13,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 60,
+          "notes": "The review supplies concrete backend, SRE, and security observations about atomic consumption, rolling upgrades, latency, fallback exposure, and monitoring. Its largest deficiency is approving the design without detecting that the stored provider is not enforced and that an invalid-provider request consumes the one-time hint before validation. It also asserts without demonstrated repository evidence that internal JWTs are single-use and understates how proxies can observe the key before consumption. The verdicts therefore treat material security and retention defects as if only minor documentation changes remained."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 68,
+          "notes": "The plan has concrete HTTP, compatibility, deployment, end-to-end, and unit scenarios with meaningful redirect, metric, encryption, expiry, and one-time-use oracles. It does not cover provider mismatch, invalid-provider consumption, TTL-index creation failure, oversized deposits, or the issue's full six-provider acceptance criterion. The fallback E2E procedure stops the auth server and then claims logout still works, although the browser must subsequently redirect to that stopped service; deleting a document also does not test TTL expiration. The submitted unittest command and /api/auth/me path could not be independently verified because repository command execution failed in the read-only sandbox."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 21,
+          "risk_awareness": 11,
+          "total": 61,
+          "notes": "The patch implements the described deposit, opaque redirect key, atomic resolution, fallback metric, and legacy id_token_hint path across the four claimed files. The largest defect is that logout_hint_store records provider but resolution queries only _id, while oauth2_logout resolves and deletes the hint before checking whether the path provider exists, enabling cross-provider token forwarding or one-request denial of logout. A second concrete defect is that failed TTL-index creation is merely logged and _collection is then cached, so index creation is never retried and unconsumed hints may persist; no regression tests accompany the security-sensitive change. The visible diff is internally coherent, but git apply --check and signatures such as generate_internal_token could not be independently verified because the execution sandbox failed before running repository commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "derive-repo-url-from-skill-md",
+      "complexity": "medium",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 61,
+      "input_tokens": 12318,
+      "output_tokens": 27880,
+      "total_tokens": 5720631,
+      "latency_seconds": 511.5,
+      "total_cost_usd": 4.13131975,
+      "result_subtype": "success",
+      "task_score": 65.8,
+      "cache_read_tokens": 5587822,
+      "cache_write_tokens": 92611,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 54.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 83,
+          "notes": "The issue clearly separates registration auto-fill from modal navigation and provides testable acceptance criteria, explicit URL shapes, and useful non-goals. The submitted diff corroborates the named integration points, including parse_skill_md, Dashboard.tsx, SkillCard.tsx, SemanticSearchResults.tsx, and both frontend interfaces. Its largest gap is limited treatment of malformed or ambiguous GitHub-like URLs and the state needed to distinguish a manual value from the previous auto-filled value. Local repository commands failed before execution because the read-only shell sandbox could not initialize loopback networking, so the stated tag, model field, and related issue could not be independently verified beyond the supplied patch context."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 13,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 67,
+          "notes": "The LLD is concrete about files, symbols, response fields, data flow, conditional rendering, and deployment impact, and its locations agree with the submitted diff. Its critical defect is the claim that data.repository_url || prev.repository_url preserves manual input: a truthy parse result always wins, so reparsing overwrites a custom value and cannot implement the stated previous-auto-fill rule. It also says the helper will emit debug logs although neither its proposed code nor the patch logs, and the review claims the import section was updated while this LLD still specifies a function-local import. Exact baseline source and existing test conventions could not be independently inspected because repository shell execution failed before running any command."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 12,
+          "total": 53,
+          "notes": "The review raises concrete points about import placement, utility tests, duplicated JSX, optional links, and user-controlled URL components. Its largest failure is explicitly asserting that data.repository_url || prev.repository_url will not overwrite user input, which reverses JavaScript operand-selection semantics and approves the change's central UX regression. It also records the import issue as resolved although the submitted LLD remains unchanged and accepts omission of implementation tests based on an unsupported constraint. Repository-specific assertions about existing imports, stored documents, and hostname-helper behavior could not be independently verified after the local shell sandbox failed to initialize."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 64,
+          "notes": "The utility cases have concrete inputs and expected values, while the manual reparse test would directly expose the implementation's overwrite bug. Several API and end-to-end commands use placeholder or unproven remote SKILL.md paths, so an endpoint that fetches the URL may fail before producing the expected repository_url response; example.com is likewise not a controlled non-GitHub fixture. The plan also omits the distinct case where a value still matching the previous auto-fill should update after parsing a different URL, and it provides no automated frontend regression test. The proposed tests/unit path and uv run python -m unittest discover command could not be checked against the repository's actual test layout and runner because shell inspection was unavailable."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 20,
+          "risk_awareness": 12,
+          "total": 62,
+          "notes": "The patch covers the backend derivation and response path, both frontend types, form integration, and conditional links in both submitted modal locations. The largest defect is repository_url: data.repository_url || prev.repository_url in Dashboard.tsx, which overwrites any manually entered value whenever parsing returns a derived URL and therefore does not implement the issue's stated preservation rule. No tests are added despite the review and testing plan calling for utility coverage, while implementation.md inaccurately says that nothing was left out and all LLD work is present. The diff contexts and symbols are internally coherent, but git apply --check and comparison with the actual baseline could not be completed because every repository command failed during sandbox initialization."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "lifecycle-workflow-webhooks",
+      "complexity": "high",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 137,
+      "input_tokens": 17962,
+      "output_tokens": 47665,
+      "total_tokens": 20003942,
+      "latency_seconds": 1017.1,
+      "total_cost_usd": 12.203379,
+      "result_subtype": "success",
+      "task_score": 64.6,
+      "cache_read_tokens": 19772613,
+      "cache_write_tokens": 165702,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 46.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 82,
+          "notes": "The issue clearly defines five behaviors with concrete headers, environment variables, metrics, acceptance criteria, and non-goals. Its named dependencies correspond to symbols and files used by the submitted patch, including `send_registration_webhook`, the three scan helpers, `meters.py`, and `scopes.yml`. The largest flaw is its claim that every change applies uniformly despite the LLD establishing that skills have no PATCH endpoint; replay protection, pagination semantics, and overwrite behavior also remain unspecified. No independent task statement was supplied, so requirements beyond the identifier and internally established artifacts could not be verified."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 67,
+          "notes": "The LLD provides unusually concrete file, function, payload, configuration, permission, and HMAC-byte decisions that substantially reduce implementation ambiguity. Its critical omission is manual rescanning: it promises events after registration and rescans and even identifies a separate `rescan_server` path, but every implementation step hooks only `_perform_*_security_scan_on_registration`. It also fails to require status filtering before pagination, enabling the implementation's incorrect post-pagination skill filtering. Overwrite, federation, secret length, compatibility, and scaling receive useful treatment, but delivery loss, replay handling, and deployment wiring are mostly deferred."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 17,
+          "specificity": 20,
+          "risk_awareness": 18,
+          "total": 71,
+          "notes": "The review finds concrete issues involving overwrite semantics, secret strength, federation bypass, key rotation, payload consistency, and agent PATCH placement, and it records actionable resolutions. Its largest miss is the LLD's absent manual-rescan integration, despite repeatedly praising full parity and every-scan coverage. The SRE conclusion that unbounded tasks are acceptable because each creates its own `AsyncClient` is insufficiently justified and overlooks resource amplification under bursts. Overall it stress-tests several real boundaries but misses the most consequential requirement gap and the filtering/pagination hazard."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 11,
+          "specificity": 14,
+          "risk_awareness": 13,
+          "total": 51,
+          "notes": "The plan covers all five feature themes and includes a meaningful exact-body HMAC oracle, negative permission cases, configuration defaults, and an end-to-end workflow. However, its agent registration commands use `POST /api/agents`, while the project's published API documents `POST /api/agents/register`. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/a2a.md)) Manual comments replace executable assertions throughout, the skill status test creates no known draft fixture, and no pagination case would expose the implementation's skill-filter bug. It also tests rescanning only for servers, omits mandated-status parity for skills and most agent negative cases, and names no repository-native automated test files or commands."
+        },
+        "implementation": {
+          "completeness": 13,
+          "correctness": 10,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 52,
+          "notes": "The patch implements centralized exact-byte HMAC signing, default-off configuration, metrics, permission checks, documentation, and registration-scan events in targeted repository files. It does not implement the promised manual-rescan events: the diff adds webhook calls only to the three `_perform_*_security_scan_on_registration` helpers and contains no rescan-route hunk, while the summary claims every scan is covered. The skill filter is materially incorrect because it filters `page_skills` after pagination and replaces `total_count` with the current page's match count, causing missing results and broken `has_next` behavior. The summary's assertion that this deviation has identical behavior is false, and its clean-apply claim could not be independently confirmed because repository command execution failed during sandbox initialization."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "portable-env-secret-generation-in-build-script",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 37,
+      "input_tokens": 1276,
+      "output_tokens": 19616,
+      "total_tokens": 2846390,
+      "latency_seconds": 379.7,
+      "total_cost_usd": 2.28803425,
+      "result_subtype": "success",
+      "task_score": 62.0,
+      "cache_read_tokens": 2759671,
+      "cache_write_tokens": 65827,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 51.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The issue provides unusually concrete scope, non-goals, affected variables, and testable acceptance criteria. The submitted patch context corroborates the claimed ten static removals plus one dynamic metrics-token removal. Its largest correctness defect is claiming that shell sourcing uses the first duplicate assignment; sequential `source .env` processing leaves the later assignment effective, although the repository does instruct users to source this file.  No independent task statement or evidence verifies the linked issue or asserted crash-loop impact."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 22,
+          "risk_awareness": 12,
+          "total": 62,
+          "notes": "The design is highly specific about `build_and_run.sh`, `_remove_env_lines`, all eleven replacements, atomic rename, and rejected alternatives. Its central error is treating every nonzero `grep -v` result as \u201call lines matched\u201d; grep distinguishes no-selection status 1 from error status 2, so an I/O error can trigger truncation and replacement of `.env`.  The early `! grep -q` similarly converts file-access errors into a successful no-op, contradicting the promised failure propagation. It also declares permission preservation a constraint but provides no mechanism to preserve the original mode, and never calls the identified `handle_error` integration point."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 10,
+          "specificity": 19,
+          "risk_awareness": 12,
+          "total": 57,
+          "notes": "The review identifies concrete concerns involving permissions, temporary files, atomic replacement, and dynamic regex construction. Its largest deficiency is approving the design without noticing that the helper conflates grep\u2019s no-selection and error statuses, the failure most capable of corrupting `.env`.  It acknowledges changed file permissions but dismisses them as non-regressive without repository evidence, despite the LLD explicitly requiring preservation. The assertion that service-name conversion produces only `[A-Z0-9_]` is also unsupported because the described `tr` conversion does not remove periods."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 10,
+          "specificity": 20,
+          "risk_awareness": 11,
+          "total": 57,
+          "notes": "The plan gives concrete fixtures and expected content for matching, absent, quoted, duplicate, all-matching, populated, and dynamic-token cases. Its largest gap is complete omission of the acceptance-critical rewrite-failure tests, including grep errors, unwritable destinations, mode preservation, and temporary-file collisions. The tests copy a helper implementation into the test rather than execute the patched function, and most `echo \"FAIL\"` branches still exit successfully, so they can pass operationally while behavior is broken. The macOS check merely prints values for visual inspection and does not assert uniqueness, non-emptiness, or successful stack startup."
+        },
+        "implementation": {
+          "completeness": 17,
+          "correctness": 10,
+          "specificity": 21,
+          "risk_awareness": 9,
+          "total": 57,
+          "notes": "The patch consistently replaces the submitted ten static `sed -i` lines and one dynamic call, and places the helper beside the existing `handle_error` symbol. The critical defect is the `else` branch after `grep -v`: any grep error is interpreted as an empty result, allowing `: > \"$tmp\"` followed by `mv` to erase unrelated `.env` content instead of aborting.  Predictable `${file}.tmp.$$` naming permits stale-file or symlink collisions, while replacement through a newly created file can change restrictive permissions. The summary incorrectly claims no LLD deviations despite omitting permission preservation and explicit error reporting; local sandbox failure prevented independent confirmation of its `git apply --check` claim."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "macos-setup-python-version-precheck",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 38,
+      "input_tokens": 117,
+      "output_tokens": 19309,
+      "total_tokens": 2622792,
+      "latency_seconds": 369.5,
+      "total_cost_usd": 2.1137952500000003,
+      "result_subtype": "success",
+      "task_score": 60.6,
+      "cache_read_tokens": 2546183,
+      "cache_write_tokens": 57183,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 52.3,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 12,
+          "total": 66,
+          "notes": "The issue names the affected skill, required metadata, preserved tokens, six testable acceptance criteria, and clear non-goals. Its largest deficiency is that reading the root pyproject.toml conflicts with the submission's own lifecycle in which Phase 1 precedes repository cloning, without defining a viable authoritative pre-clone source. The submitted patch context supports the existing Python check and remediation row, while the public guide confirms macOS 12+ and Python 3.14+ requirements. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md)) No independent task statement was supplied, and exact baseline line numbers and issue linkage could not be checked because local command execution failed before running."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 12,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 61,
+          "notes": "The LLD provides concrete shell logic, integration points, output behavior, failure branches, and alternatives. Its central source-selection design is flawed: the repository root is three ascents from .claude/skills/macos-setup, not two, and the proposed code never resolves relative to the skill anyway, checking only the current directory and INSTALL_DIR. Fresh pre-clone runs therefore use a hard-coded 3.14, while an unrelated current-directory pyproject.toml can override the intended minimum, contradicting the single-source requirement. It also retains stale sort-V claims and overstates failure handling when python3 -c produces an empty or nonnumeric version; the exact phase shell environment remained unverifiable."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 14,
+          "specificity": 17,
+          "risk_awareness": 12,
+          "total": 56,
+          "notes": "The review contributes one concrete portability finding and an actionable POSIX major/minor comparison that appears in the final design. Its largest failure is approving the hard-coded fallback without confronting the more fundamental pre-clone source-of-truth contradiction or the incorrect path-resolution claim. Most reviewer sections are generic approvals, and none identifies that an arbitrary current-directory pyproject.toml can control the result. The macOS 12 support premise is corroborated by the public guide, but claims about separate shell invocations and the baseline sort implementation could not be independently verified. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md))"
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 15,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 64,
+          "notes": "The plan supplies concrete inputs and expected outputs for missing, older, equal, newer, and higher-major interpreters, plus extraction and fallback cases. Its largest deficiency is that most tests duplicate fragments and assign _PY_VER directly rather than executing the actual block extracted from SKILL.md, so they could pass despite broken integration. It omits the critical fresh pre-clone case, an unrelated current-directory pyproject.toml, INSTALL_DIR precedence, and python3 -c failure, while Markdown validity and unchanged checks are only manual review instructions. The individual comparison and extraction commands have meaningful oracles, but their agreement with the real patched file could not be executed locally."
+        },
+        "implementation": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 11,
+          "total": 56,
+          "notes": "The patch directly replaces the existence check, preserves PYTHON_OK and PYTHON_FAIL behavior, reports both versions, and retains the documented Homebrew remediation. Its core defect is checking any current-directory pyproject.toml before INSTALL_DIR and falling back to hard-coded 3.14 during the established pre-clone flow, so it does not reliably satisfy the claimed authoritative dynamic requirement. The integer comparison handles ordinary major/minor versions, but patch-level requirements are truncated and failed or nonnumeric python3 -c output can emit shell comparison errors; the summary therefore overstates full realization of the LLD. The target path and hunk context are internally consistent with the submitted baseline snippets and public requirements, but the commit identity and git apply check could not be independently verified because the read-only command runner failed before execution. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md))"
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "server-side-oauth-token-storage",
+      "complexity": "high",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 75,
+      "input_tokens": 5153,
+      "output_tokens": 45647,
+      "total_tokens": 10353121,
+      "latency_seconds": 829.0,
+      "total_cost_usd": 7.169842249999997,
+      "result_subtype": "success",
+      "task_score": 58.8,
+      "cache_read_tokens": 10154192,
+      "cache_write_tokens": 148129,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 55.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 61,
+          "notes": "The issue provides concrete actors, status-code behavior, configuration, compatibility expectations, and explicit non-goals. Its largest defect is that the title and user story promise restoration of the existing Get JWT Token flow while changing `/internal/tokens` is explicitly out of scope, leaving no consumer for `/oauth2/tokens`. It also promises sub-4096-byte cookies while retaining potentially large groups and `id_token`; repository release evidence says the eventual #399 fix moved username, groups, and encrypted `id_token` server-side. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Exact token-size estimates and universal coverage across every named IdP were not substantiated, and risks from returning refresh tokens to a browser are omitted."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 10,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 63,
+          "notes": "The LLD is unusually concrete about `auth_server/server.py`, `mongodb_groups_enrichment._get_mongodb()`, MongoDB documents, indexes, endpoint responses, configuration files, and callback/logout data flow. Its central design does not reliably solve the stated cookie failure because it leaves both groups and `id_token` in the cookie and does not connect stored tokens to the existing token-generation flow. It knowingly hardcodes `oauth_token_store` despite identifying the repository's namespace helper, duplicates cookie validation with a hardcoded 28800-second age, and treats failed index creation as nonfatal without preserving the TTL guarantee. Rollout and failure behavior are discussed, but namespace isolation, exact expiry enforcement, key rotation, sensitive-response controls, and complete Terraform wiring remain unresolved."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 19,
+          "total": 65,
+          "notes": "The review finds several real, actionable issues, especially cross-session deletion on logout, immutable TTL-index configuration, umbrella-chart propagation, rate limiting, and test-singleton isolation. Its largest failure is recognizing that the frontend and `/internal/tokens` never consume the new endpoint while still approving the design as transparent to the existing flow. The resolution section claims the LLD was revised for targeted deletion, rate limiting, and audit logging, but the submitted LLD still contains the original username-wide deletion and unprotected endpoint snippets. It also misses the central residual cookie bloat, hardcoded session lifetime, namespace collision, delayed TTL deletion, and the security implications of returning refresh tokens over a GET response."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 18,
+          "risk_awareness": 15,
+          "total": 58,
+          "notes": "The plan supplies useful unit-test oracles for encryption, ownership, CRUD, index creation, missing refresh tokens, multiple sessions, authentication failures, and backward-compatible cookies. Much of the critical-path coverage is manual rather than executable, and `curl http://localhost:27017 | jq` cannot inspect MongoDB while invoking an OAuth callback with placeholder code cannot complete a real flow. The five-second TTL test expects deletion after ten seconds even though TTL cleanup is asynchronous, and the cookie decoder does not handle every `itsdangerous` serialized form. It never provides an automated callback, endpoint, logout, or provider-matrix cookie-size test, so its strongest acceptance claims could remain broken while the proposed unit suite passes."
+        },
+        "implementation": {
+          "completeness": 11,
+          "correctness": 8,
+          "specificity": 19,
+          "risk_awareness": 9,
+          "total": 47,
+          "notes": "The patch is internally detailed and adds a focused encrypted token-store module, targeted logout deletion, endpoint handling, deployment configuration, and substantial module-level tests. It does not implement the promised outcome end to end: access and refresh tokens were already excluded from cookies by default, large groups and `id_token` remain, and `/api/tokens/generate` still returns the existing self-signed token; repository evidence shows the eventual fix moved the entire OAuth session payload server-side. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) `ensure_indexes()` swallows failures while startup logs success, retrieval does not enforce expiry before the asynchronous TTL monitor deletes a record, cookie validation hardcodes 28800 seconds, and the collection ignores repository namespace conventions. Tests cover only `oauth_token_store.py`, not callback, endpoint, logout, cookie size, or backward compatibility, and patch applicability could not be independently confirmed because the provided local execution sandbox failed before command startup."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "build-docker-images-from-uv-lock",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 9398,
+      "output_tokens": 40742,
+      "total_tokens": 6044165,
+      "latency_seconds": 737.6,
+      "total_cost_usd": 4.68193675,
+      "result_subtype": "success",
+      "task_score": 55.8,
+      "cache_read_tokens": 5886306,
+      "cache_write_tokens": 107719,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 55.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 68,
+          "notes": "The issue is unusually concrete, identifying six Dockerfiles, missing lockfiles, CPU Torch handling, CI enforcement, explicit non-goals, and testable acceptance criteria. Its largest defect is the central claim that `uv sync --frozen` fails when the lockfile is stale; uv documents `--frozen` as using the lock without checking freshness, while `--locked` performs that check.  It also promises reproducible images although mutable base images, system packages, and the unpinned `uv` installation remain outside its controls. The asserted project inventory and claim that the root Dockerfile is unused could not be independently verified because local repository commands failed before execution."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 8,
+          "specificity": 21,
+          "risk_awareness": 11,
+          "total": 58,
+          "notes": "The LLD provides concrete file-level changes, installation flows, caching boundaries, index configuration, CI behavior, alternatives, and rollout steps. Its design rests on two incorrect assumptions: `--frozen` does not detect stale locks, and exact `uv sync` removes packages not declared by the project, so the MCP Dockerfiles can remove the separately installed Torch packages.  The lock-generation command `cd / && uv lock` targets the filesystem root, and the rollout orders merging Dockerfile changes before generating required lockfiles. Exact line-number and repository-pattern claims could not be locally confirmed because repository shell access failed."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 9,
+          "specificity": 19,
+          "risk_awareness": 16,
+          "total": 60,
+          "notes": "The review's strongest contribution is identifying omitted lockfiles as a merge-blocking defect, along with concrete CI-discovery, cache, fallback-security, documentation, and dependency-pin concerns. It nevertheless explicitly endorses the incorrect beliefs that `--frozen` catches stale locks and that syncing over the pre-existing MCP environment safely preserves undeclared Torch packages.  Its resolution accepts post-apply lock generation despite calling same-PR inclusion mandatory, and it says the LLD was revised for dynamic discovery although the submitted LLD still contains a hardcoded list. The cited repository-specific scanner pin and workflow conventions could not be independently checked due unavailable local command execution."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 6,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 57,
+          "notes": "The plan covers lock existence and freshness, image builds, runtime smoke checks, ports, entrypoints, user identity, CI wiring, rollback, and dependency-set comparison with concrete commands. Its stale-lock test appends an invalid bare dependency line at the end of TOML and merely greps generic error text, so it can pass on a syntax failure; moreover, `--frozen` would not reject a correctly formed stale manifest.  Image coverage omits an explicit `mcp-server-cpu` build, and `git diff HEAD` does not establish that existing workflows are unchanged from the baseline. Health endpoints, API response shapes, compose prerequisites, and entrypoint compatibility with the `pip freeze` command were not verified against local source."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 4,
+          "specificity": 18,
+          "risk_awareness": 7,
+          "total": 36,
+          "notes": "The patch is focused and concrete, modifying the six named Dockerfiles, root manifest, and a dynamically discovering CI workflow, while the summary clearly discloses that verification was not run. It omits every required generated lockfile and the regenerated root lock, so `Dockerfile.auth` references a missing file and the existing root lock cannot contain the new CPU-index resolution. The MCP full and CPU images retain a separate Torch installation that exact `uv sync` can remove, while comments incorrectly claim `--frozen` rejects stale locks.  Patch applicability and surrounding repository conventions could not be independently confirmed because the local sandbox failed before `git apply --check` or source reads could execute."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-09-01"
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "scores": {
+    "github_issue": {
+      "completeness": 16,
+      "correctness": 11,
+      "specificity": 20,
+      "risk_awareness": 14,
+      "total": 61,
+      "notes": "The issue provides concrete actors, status-code behavior, configuration, compatibility expectations, and explicit non-goals. Its largest defect is that the title and user story promise restoration of the existing Get JWT Token flow while changing `/internal/tokens` is explicitly out of scope, leaving no consumer for `/oauth2/tokens`. It also promises sub-4096-byte cookies while retaining potentially large groups and `id_token`; repository release evidence says the eventual #399 fix moved username, groups, and encrypted `id_token` server-side. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Exact token-size estimates and universal coverage across every named IdP were not substantiated, and risks from returning refresh tokens to a browser are omitted."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 10,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 63,
+      "notes": "The LLD is unusually concrete about `auth_server/server.py`, `mongodb_groups_enrichment._get_mongodb()`, MongoDB documents, indexes, endpoint responses, configuration files, and callback/logout data flow. Its central design does not reliably solve the stated cookie failure because it leaves both groups and `id_token` in the cookie and does not connect stored tokens to the existing token-generation flow. It knowingly hardcodes `oauth_token_store` despite identifying the repository's namespace helper, duplicates cookie validation with a hardcoded 28800-second age, and treats failed index creation as nonfatal without preserving the TTL guarantee. Rollout and failure behavior are discussed, but namespace isolation, exact expiry enforcement, key rotation, sensitive-response controls, and complete Terraform wiring remain unresolved."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 11,
+      "specificity": 19,
+      "risk_awareness": 19,
+      "total": 65,
+      "notes": "The review finds several real, actionable issues, especially cross-session deletion on logout, immutable TTL-index configuration, umbrella-chart propagation, rate limiting, and test-singleton isolation. Its largest failure is recognizing that the frontend and `/internal/tokens` never consume the new endpoint while still approving the design as transparent to the existing flow. The resolution section claims the LLD was revised for targeted deletion, rate limiting, and audit logging, but the submitted LLD still contains the original username-wide deletion and unprotected endpoint snippets. It also misses the central residual cookie bloat, hardcoded session lifetime, namespace collision, delayed TTL deletion, and the security implications of returning refresh tokens over a GET response."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 9,
+      "specificity": 18,
+      "risk_awareness": 15,
+      "total": 58,
+      "notes": "The plan supplies useful unit-test oracles for encryption, ownership, CRUD, index creation, missing refresh tokens, multiple sessions, authentication failures, and backward-compatible cookies. Much of the critical-path coverage is manual rather than executable, and `curl http://localhost:27017 | jq` cannot inspect MongoDB while invoking an OAuth callback with placeholder code cannot complete a real flow. The five-second TTL test expects deletion after ten seconds even though TTL cleanup is asynchronous, and the cookie decoder does not handle every `itsdangerous` serialized form. It never provides an automated callback, endpoint, logout, or provider-matrix cookie-size test, so its strongest acceptance claims could remain broken while the proposed unit suite passes."
+    },
+    "implementation": {
+      "completeness": 11,
+      "correctness": 8,
+      "specificity": 19,
+      "risk_awareness": 9,
+      "total": 47,
+      "notes": "The patch is internally detailed and adds a focused encrypted token-store module, targeted logout deletion, endpoint handling, deployment configuration, and substantial module-level tests. It does not implement the promised outcome end to end: access and refresh tokens were already excluded from cookies by default, large groups and `id_token` remain, and `/api/tokens/generate` still returns the existing self-signed token; repository evidence shows the eventual fix moved the entire OAuth session payload server-side. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) `ensure_indexes()` swallows failures while startup logs success, retrieval does not enforce expiry before the asynchronous TTL monitor deletes a record, cookie validation hardcodes 28800 seconds, and the collection ignores repository namespace conventions. Tests cover only `oauth_token_store.py`, not callback, endpoint, logout, cookie size, or backward compatibility, and patch applicability could not be independently confirmed because the provided local execution sandbox failed before command startup."
+    }
+  },
+  "task_score": 58.8,
+  "verdict": "The submission is concrete and thoughtfully structured, but its implementation stores tokens without solving the repository's full oversized-session problem or restoring the existing Get JWT Token path.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T07:40:12.086424Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 294656,
+      "cached_input_tokens": 220484,
+      "cache_write_input_tokens": 45196,
+      "output_tokens": 10812,
+      "reasoning_output_tokens": 8375
+    },
+    "duration_ms": 147304
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-6-v1/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "high",
+  "tags": [
+    "authentication",
+    "oauth",
+    "session",
+    "mongodb",
+    "encryption",
+    "auth-server",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "model_slug": "claude-opus-4-6-v1",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 55.1,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5153,
+    "output_tokens": 45647,
+    "cache_read_tokens": 10154192,
+    "cache_write_tokens": 148129,
+    "total_tokens": 10353121,
+    "total_cost_usd": 7.169842249999997,
+    "latency_seconds": 829.0,
+    "num_turns": 75,
+    "generation_tokens_per_sec": 55.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 5153,
+  "output_tokens": 45647,
+  "latency_seconds": 829.0,
+  "num_turns": 75,
+  "total_cost_usd": 7.169842249999997,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 10154192,
+  "cache_creation_tokens": 148129,
+  "run_started_at": "2026-09-01T04:48:41.925551Z",
+  "run_ended_at": "2026-09-01T05:02:30.980589Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5153,
+    "output_tokens": 45647,
+    "cache_read_tokens": 10154192,
+    "cache_write_tokens": 148129,
+    "total_tokens": 10353121,
+    "total_cost_usd": 7.169842249999997,
+    "latency_seconds": 829.0,
+    "num_turns": 75,
+    "generation_tokens_per_sec": 55.1,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "server-side-oauth-token-storage",
+    "model": "us.anthropic.claude-opus-4-6-v1",
+    "scores": {
+      "github_issue": {
+        "completeness": 16,
+        "correctness": 11,
+        "specificity": 20,
+        "risk_awareness": 14,
+        "total": 61,
+        "notes": "The issue provides concrete actors, status-code behavior, configuration, compatibility expectations, and explicit non-goals. Its largest defect is that the title and user story promise restoration of the existing Get JWT Token flow while changing `/internal/tokens` is explicitly out of scope, leaving no consumer for `/oauth2/tokens`. It also promises sub-4096-byte cookies while retaining potentially large groups and `id_token`; repository release evidence says the eventual #399 fix moved username, groups, and encrypted `id_token` server-side. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Exact token-size estimates and universal coverage across every named IdP were not substantiated, and risks from returning refresh tokens to a browser are omitted."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 10,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 63,
+        "notes": "The LLD is unusually concrete about `auth_server/server.py`, `mongodb_groups_enrichment._get_mongodb()`, MongoDB documents, indexes, endpoint responses, configuration files, and callback/logout data flow. Its central design does not reliably solve the stated cookie failure because it leaves both groups and `id_token` in the cookie and does not connect stored tokens to the existing token-generation flow. It knowingly hardcodes `oauth_token_store` despite identifying the repository's namespace helper, duplicates cookie validation with a hardcoded 28800-second age, and treats failed index creation as nonfatal without preserving the TTL guarantee. Rollout and failure behavior are discussed, but namespace isolation, exact expiry enforcement, key rotation, sensitive-response controls, and complete Terraform wiring remain unresolved."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 11,
+        "specificity": 19,
+        "risk_awareness": 19,
+        "total": 65,
+        "notes": "The review finds several real, actionable issues, especially cross-session deletion on logout, immutable TTL-index configuration, umbrella-chart propagation, rate limiting, and test-singleton isolation. Its largest failure is recognizing that the frontend and `/internal/tokens` never consume the new endpoint while still approving the design as transparent to the existing flow. The resolution section claims the LLD was revised for targeted deletion, rate limiting, and audit logging, but the submitted LLD still contains the original username-wide deletion and unprotected endpoint snippets. It also misses the central residual cookie bloat, hardcoded session lifetime, namespace collision, delayed TTL deletion, and the security implications of returning refresh tokens over a GET response."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 9,
+        "specificity": 18,
+        "risk_awareness": 15,
+        "total": 58,
+        "notes": "The plan supplies useful unit-test oracles for encryption, ownership, CRUD, index creation, missing refresh tokens, multiple sessions, authentication failures, and backward-compatible cookies. Much of the critical-path coverage is manual rather than executable, and `curl http://localhost:27017 | jq` cannot inspect MongoDB while invoking an OAuth callback with placeholder code cannot complete a real flow. The five-second TTL test expects deletion after ten seconds even though TTL cleanup is asynchronous, and the cookie decoder does not handle every `itsdangerous` serialized form. It never provides an automated callback, endpoint, logout, or provider-matrix cookie-size test, so its strongest acceptance claims could remain broken while the proposed unit suite passes."
+      },
+      "implementation": {
+        "completeness": 11,
+        "correctness": 8,
+        "specificity": 19,
+        "risk_awareness": 9,
+        "total": 47,
+        "notes": "The patch is internally detailed and adds a focused encrypted token-store module, targeted logout deletion, endpoint handling, deployment configuration, and substantial module-level tests. It does not implement the promised outcome end to end: access and refresh tokens were already excluded from cookies by default, large groups and `id_token` remain, and `/api/tokens/generate` still returns the existing self-signed token; repository evidence shows the eventual fix moved the entire OAuth session payload server-side. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) `ensure_indexes()` swallows failures while startup logs success, retrieval does not enforce expiry before the asynchronous TTL monitor deletes a record, cookie validation hardcodes 28800 seconds, and the collection ignores repository namespace conventions. Tests cover only `oauth_token_store.py`, not callback, endpoint, logout, cookie size, or backward compatibility, and patch applicability could not be independently confirmed because the provided local execution sandbox failed before command startup."
+      }
+    },
+    "task_score": 58.8,
+    "verdict": "The submission is concrete and thoughtfully structured, but its implementation stores tokens without solving the repository's full oversized-session problem or restoring the existing Get JWT Token path.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T07:40:12.086424Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 294656,
+        "cached_input_tokens": 220484,
+        "cache_write_input_tokens": 45196,
+        "output_tokens": 10812,
+        "reasoning_output_tokens": 8375
+      },
+      "duration_ms": 147304
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 14,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 73,
+      "notes": "The issue clearly identifies affected Dockerfiles, missing lockfiles, CPU-torch handling, CI enforcement, acceptance criteria, and non-goals. Its largest defect is claiming that `uv sync --frozen` rejects a stale lock; uv documents that frozen mode skips freshness checks, while `--locked` performs that validation.  It also promises unchanged behavior despite explicitly changing torch and removing torchvision, and excludes `Dockerfile.registry-cpu` from the stated image-wide objective. No independent task statement was supplied, so the candidate-defined scope cannot be fully validated."
+    },
+    "lld": {
+      "completeness": 19,
+      "correctness": 12,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 70,
+      "notes": "The LLD is unusually concrete about Dockerfiles, project roots, environment pruning, `--inexact`, editable installation, CI matrices, and the torch source pin. Its central failure-handling decision is wrong: `--frozen` installs from the existing lock without verifying manifest drift, invalidating repeated claims that Docker builds fail loudly on stale locks.  The design also overstates runtime equivalence while changing torch and removing torchvision, and leaves one registry image outside lock-based installation. Exact repository claims such as every project using `package = false` could not be independently verified because local repository command execution was unavailable."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 19,
+      "risk_awareness": 16,
+      "total": 65,
+      "notes": "The review raises concrete concerns about the torch version change, `--inexact` safety, matrix completeness, index isolation, and the `registry-cpu` deferral. Its largest deficiency is missing the design's most consequential technical error and explicitly approving the false assertion that frozen sync detects stale locks.  Several resolutions rely only on asserted grep and lock-generation results rather than evidence present in the review. The frontend persona contributes little, but the backend, SRE, and security sections otherwise provide actionable scrutiny."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 9,
+      "specificity": 20,
+      "risk_awareness": 14,
+      "total": 62,
+      "notes": "The plan covers lock presence, CI coverage, builds, CPU torch, CUDA absence, drift, rollback, and container smoke behavior with concrete commands and expected outcomes. The critical negative test expects `uv sync --frozen` to reject drift, contrary to uv semantics, so it cannot validate the promised build-time guard.  Its shell also fails to enforce several oracles: the drift commands can continue after unexpected success, and the server-lock test merely prints unexpected torch entries without failing. The image-size check lacks a captured baseline, while the health checks assume bare containers can become healthy without documenting required runtime configuration."
+    },
+    "implementation": {
+      "completeness": 16,
+      "correctness": 12,
+      "specificity": 19,
+      "risk_awareness": 13,
+      "total": 60,
+      "notes": "The submitted summary describes an end-to-end change across lockfiles, five Dockerfiles, root torch configuration, and a nine-project CI matrix, and the visible workflow and generated lock content are consistent with that intent. The implementation preserves the design's core defect by using `uv sync --frozen` where stale-lock rejection requires locked checking, although CI's separate `uv lock --check` partially mitigates it.  It also leaves `Dockerfile.registry-cpu` unresolved and knowingly changes the installed torch/torchvision surface without executed image or smoke validation. The supplied diff is truncated inside `auth_server/uv.lock`, so the Dockerfile and root-lock hunks and the claimed `git apply --check` result could not be independently inspected."
+    }
+  },
+  "task_score": 66.0,
+  "verdict": "The submission is concrete and broadly scoped, but its core stale-lock guarantee is based on incorrect `uv --frozen` semantics and the implementation diff is not fully verifiable.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T11:41:26.723624Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 1020452,
+      "cached_input_tokens": 863662,
+      "cache_write_input_tokens": 129390,
+      "output_tokens": 9778,
+      "reasoning_output_tokens": 7366
+    },
+    "duration_ms": 175772
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "docker",
+    "build",
+    "uv",
+    "dependencies",
+    "reproducibility",
+    "ci",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 73.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1115,
+    "output_tokens": 63602,
+    "cache_read_tokens": 4944269,
+    "cache_write_tokens": 128848,
+    "total_tokens": 5137834,
+    "total_cost_usd": 4.873059499999999,
+    "latency_seconds": 866.3,
+    "num_turns": 40,
+    "generation_tokens_per_sec": 73.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1115,
+  "output_tokens": 63602,
+  "latency_seconds": 866.3,
+  "num_turns": 40,
+  "total_cost_usd": 4.873059499999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 4944269,
+  "cache_creation_tokens": 128848,
+  "run_started_at": "2026-09-01T07:48:02.817492Z",
+  "run_ended_at": "2026-09-01T08:02:29.102192Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1115,
+    "output_tokens": 63602,
+    "cache_read_tokens": 4944269,
+    "cache_write_tokens": 128848,
+    "total_tokens": 5137834,
+    "total_cost_usd": 4.873059499999999,
+    "latency_seconds": 866.3,
+    "num_turns": 40,
+    "generation_tokens_per_sec": 73.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "build-docker-images-from-uv-lock",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 14,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 73,
+        "notes": "The issue clearly identifies affected Dockerfiles, missing lockfiles, CPU-torch handling, CI enforcement, acceptance criteria, and non-goals. Its largest defect is claiming that `uv sync --frozen` rejects a stale lock; uv documents that frozen mode skips freshness checks, while `--locked` performs that validation.  It also promises unchanged behavior despite explicitly changing torch and removing torchvision, and excludes `Dockerfile.registry-cpu` from the stated image-wide objective. No independent task statement was supplied, so the candidate-defined scope cannot be fully validated."
+      },
+      "lld": {
+        "completeness": 19,
+        "correctness": 12,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 70,
+        "notes": "The LLD is unusually concrete about Dockerfiles, project roots, environment pruning, `--inexact`, editable installation, CI matrices, and the torch source pin. Its central failure-handling decision is wrong: `--frozen` installs from the existing lock without verifying manifest drift, invalidating repeated claims that Docker builds fail loudly on stale locks.  The design also overstates runtime equivalence while changing torch and removing torchvision, and leaves one registry image outside lock-based installation. Exact repository claims such as every project using `package = false` could not be independently verified because local repository command execution was unavailable."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 19,
+        "risk_awareness": 16,
+        "total": 65,
+        "notes": "The review raises concrete concerns about the torch version change, `--inexact` safety, matrix completeness, index isolation, and the `registry-cpu` deferral. Its largest deficiency is missing the design's most consequential technical error and explicitly approving the false assertion that frozen sync detects stale locks.  Several resolutions rely only on asserted grep and lock-generation results rather than evidence present in the review. The frontend persona contributes little, but the backend, SRE, and security sections otherwise provide actionable scrutiny."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 9,
+        "specificity": 20,
+        "risk_awareness": 14,
+        "total": 62,
+        "notes": "The plan covers lock presence, CI coverage, builds, CPU torch, CUDA absence, drift, rollback, and container smoke behavior with concrete commands and expected outcomes. The critical negative test expects `uv sync --frozen` to reject drift, contrary to uv semantics, so it cannot validate the promised build-time guard.  Its shell also fails to enforce several oracles: the drift commands can continue after unexpected success, and the server-lock test merely prints unexpected torch entries without failing. The image-size check lacks a captured baseline, while the health checks assume bare containers can become healthy without documenting required runtime configuration."
+      },
+      "implementation": {
+        "completeness": 16,
+        "correctness": 12,
+        "specificity": 19,
+        "risk_awareness": 13,
+        "total": 60,
+        "notes": "The submitted summary describes an end-to-end change across lockfiles, five Dockerfiles, root torch configuration, and a nine-project CI matrix, and the visible workflow and generated lock content are consistent with that intent. The implementation preserves the design's core defect by using `uv sync --frozen` where stale-lock rejection requires locked checking, although CI's separate `uv lock --check` partially mitigates it.  It also leaves `Dockerfile.registry-cpu` unresolved and knowingly changes the installed torch/torchvision surface without executed image or smoke validation. The supplied diff is truncated inside `auth_server/uv.lock`, so the Dockerfile and root-lock hunks and the claimed `git apply --check` result could not be independently inspected."
+      }
+    },
+    "task_score": 66.0,
+    "verdict": "The submission is concrete and broadly scoped, but its core stale-lock guarantee is based on incorrect `uv --frozen` semantics and the implementation diff is not fully verifiable.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T11:41:26.723624Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 1020452,
+        "cached_input_tokens": 863662,
+        "cache_write_input_tokens": 129390,
+        "output_tokens": 9778,
+        "reasoning_output_tokens": 7366
+      },
+      "duration_ms": 175772
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 82,
+      "notes": "The issue precisely identifies the CLI-to-client plumbing gap and gives testable criteria for five named flags and body fields. Its largest defect is claiming omitted fields will preserve stored values during edits while its own Out of Scope section acknowledges that the server rebuilds `egress_oauth` and persists omitted fields as `None`. The proposed symbols and paths align with the submitted patch, including `cmd_egress_configure` and `RegistryClient.configure_egress_auth`. No independent task statement exists, and local shell failure prevented direct verification of every repository claim."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 23,
+      "total": 89,
+      "notes": "The LLD commits to concrete changes in `api/registry_client.py` and `api/registry_management.py`, including exact parameter names, body guards, argparse choices, failure handling, and tests. It correctly exposes the unresolved server-side edit behavior, but its overview inaccurately implies the React modal handles all five custom fields while later artifacts say it handles only the two URLs. Its strongest risk analysis covers SSRF validation ownership, secret logging, backward compatibility, and enum drift. Approximate line locations and repository-specific validation claims could not be independently checked because local command execution was unavailable."
+    },
+    "review": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 22,
+      "total": 86,
+      "notes": "The review catches the central design flaw: client-side omission does not satisfy the issue's partial-edit user story because the route materializes omitted values as `None`. It also provides actionable checks for request-body logging, enum-choice drift, and client docstrings rather than merely approving the design. Some assertions are unsupported or overstated, notably that the server ignores custom fields for built-in providers and that a test asserts this; the submitted tests only verify client-side omission. Repository claims about the FAQ and frontend behavior could not be independently verified."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 80,
+      "notes": "The plan supplies concrete commands, payloads, expected exit codes, exact request-body assertions, compatibility coverage, and both accepted auth-style values. Its principal correctness problem is repeatedly suggesting that omitted client fields prevent stored values from being nulled during edits, despite the documented server reconstruction behavior. The proposed unit tests target `RegistryClient.configure_egress_auth`, `_make_request`, and the existing POST endpoint with useful positive, omission, partial, and argparse oracles. It lacks an explicit regression test documenting the known destructive edit behavior, and the commands could not be executed in the unavailable local shell."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 19,
+      "total": 83,
+      "notes": "The patch implements all five flags through parser, handler, client signature, conditional request-body construction, docstrings, and focused client/CLI tests. The changes to `RegistryClient.configure_egress_auth` and `cmd_egress_configure` are internally coherent and match the LLD, while the summary honestly discloses that server-side partial-edit preservation remains unfixed. The largest defect is a misleading test-module and test-method claim that omission prevents stored-value nulling, which contradicts the acknowledged route semantics and could mislead maintainers. The claimed baseline commit, patch applicability, and test success were not independently verifiable because the managed shell failed before executing `git apply --check` or source inspection commands."
+    }
+  },
+  "task_score": 84.0,
+  "verdict": "This is a strong, focused CLI-plumbing submission whose largest limitation is that it promises partial-edit preservation while explicitly leaving the server behavior that defeats that promise unchanged.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T11:44:30.192234Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 241709,
+      "cached_input_tokens": 169531,
+      "cache_write_input_tokens": 35320,
+      "output_tokens": 10407,
+      "reasoning_output_tokens": 8554
+    },
+    "duration_ms": 183457
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "cli",
+    "python",
+    "egress-auth",
+    "oauth",
+    "api-parity",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 73.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 3018,
+    "output_tokens": 36910,
+    "cache_read_tokens": 4145883,
+    "cache_write_tokens": 99002,
+    "total_tokens": 4284813,
+    "total_cost_usd": 3.6295439999999997,
+    "latency_seconds": 502.8,
+    "num_turns": 38,
+    "generation_tokens_per_sec": 73.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 3018,
+  "output_tokens": 36910,
+  "latency_seconds": 502.8,
+  "num_turns": 38,
+  "total_cost_usd": 3.6295439999999997,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 4145883,
+  "cache_creation_tokens": 99002,
+  "run_started_at": "2026-09-01T08:15:25.194655Z",
+  "run_ended_at": "2026-09-01T08:23:48.033675Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 3018,
+    "output_tokens": 36910,
+    "cache_read_tokens": 4145883,
+    "cache_write_tokens": 99002,
+    "total_tokens": 4284813,
+    "total_cost_usd": 3.6295439999999997,
+    "latency_seconds": 502.8,
+    "num_turns": 38,
+    "generation_tokens_per_sec": 73.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "cli-custom-egress-oauth-provider-flags",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 82,
+        "notes": "The issue precisely identifies the CLI-to-client plumbing gap and gives testable criteria for five named flags and body fields. Its largest defect is claiming omitted fields will preserve stored values during edits while its own Out of Scope section acknowledges that the server rebuilds `egress_oauth` and persists omitted fields as `None`. The proposed symbols and paths align with the submitted patch, including `cmd_egress_configure` and `RegistryClient.configure_egress_auth`. No independent task statement exists, and local shell failure prevented direct verification of every repository claim."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 23,
+        "total": 89,
+        "notes": "The LLD commits to concrete changes in `api/registry_client.py` and `api/registry_management.py`, including exact parameter names, body guards, argparse choices, failure handling, and tests. It correctly exposes the unresolved server-side edit behavior, but its overview inaccurately implies the React modal handles all five custom fields while later artifacts say it handles only the two URLs. Its strongest risk analysis covers SSRF validation ownership, secret logging, backward compatibility, and enum drift. Approximate line locations and repository-specific validation claims could not be independently checked because local command execution was unavailable."
+      },
+      "review": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 22,
+        "total": 86,
+        "notes": "The review catches the central design flaw: client-side omission does not satisfy the issue's partial-edit user story because the route materializes omitted values as `None`. It also provides actionable checks for request-body logging, enum-choice drift, and client docstrings rather than merely approving the design. Some assertions are unsupported or overstated, notably that the server ignores custom fields for built-in providers and that a test asserts this; the submitted tests only verify client-side omission. Repository claims about the FAQ and frontend behavior could not be independently verified."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 80,
+        "notes": "The plan supplies concrete commands, payloads, expected exit codes, exact request-body assertions, compatibility coverage, and both accepted auth-style values. Its principal correctness problem is repeatedly suggesting that omitted client fields prevent stored values from being nulled during edits, despite the documented server reconstruction behavior. The proposed unit tests target `RegistryClient.configure_egress_auth`, `_make_request`, and the existing POST endpoint with useful positive, omission, partial, and argparse oracles. It lacks an explicit regression test documenting the known destructive edit behavior, and the commands could not be executed in the unavailable local shell."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 19,
+        "total": 83,
+        "notes": "The patch implements all five flags through parser, handler, client signature, conditional request-body construction, docstrings, and focused client/CLI tests. The changes to `RegistryClient.configure_egress_auth` and `cmd_egress_configure` are internally coherent and match the LLD, while the summary honestly discloses that server-side partial-edit preservation remains unfixed. The largest defect is a misleading test-module and test-method claim that omission prevents stored-value nulling, which contradicts the acknowledged route semantics and could mislead maintainers. The claimed baseline commit, patch applicability, and test success were not independently verifiable because the managed shell failed before executing `git apply --check` or source inspection commands."
+      }
+    },
+    "task_score": 84.0,
+    "verdict": "This is a strong, focused CLI-plumbing submission whose largest limitation is that it promises partial-edit preservation while explicitly leaving the server behavior that defeats that promise unchanged.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T11:44:30.192234Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 241709,
+        "cached_input_tokens": 169531,
+        "cache_write_input_tokens": 35320,
+        "output_tokens": 10407,
+        "reasoning_output_tokens": 8554
+      },
+      "duration_ms": 183457
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 78,
+      "notes": "The strongest aspect is its testable scope: it identifies the settings field, proxy call site, deployment surfaces, defaults, exclusions, and compatibility behavior. Its largest technical error is describing the scalar HTTPX timeout as a total wall-clock limit; HTTPX applies it to network-operation inactivity, while disabling timeouts uses None rather than zero.  The requirement that sub-floor values clamp without crashing conflicts with Field(ge=1), because BaseSettings validates environment-derived values during construction before the reader can clamp them.  No independent task statement establishes the reported production scenario, and the local sandbox failure prevented independent verification of the cited baseline source."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 13,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 76,
+      "notes": "The design is unusually concrete about files, integration points, precedence, deployment wiring, observability, rollback, and the exact implementation shape. Its largest defect is the unresolved conflict between Pydantic ge=1 validation and the promised runtime clamp: an invalid compose or Helm environment value can fail Settings construction before _read_mcp_proxy_upstream_timeout_seconds executes.  It also repeatedly calls the HTTPX scalar value a total timeout and treats zero as disabling timeouts, neither of which matches HTTPX's documented behavior.  Claims that the admin surface supports PUT and that edits take effect without restart were not substantiated by a named route or state-update mechanism, and exact source verification was unavailable because the repository shell could not initialize."
+    },
+    "review": {
+      "completeness": 16,
+      "correctness": 8,
+      "specificity": 17,
+      "risk_awareness": 15,
+      "total": 56,
+      "notes": "The review's strongest contribution is identifying concrete operational concerns such as held-open connections, deployment-surface drift, unit labeling, and duplicated readers. Its largest failure is approving the design without catching that Field(ge=1) can reject an environment value before the proposed clamp runs, which directly defeats an acceptance criterion.  Multiple personas reinforce the incorrect assertion that timeout zero disables HTTPX timeouts, although HTTPX documents None as the disabling value.  The live-edit/no-restart conclusion is also asserted without repository evidence, making the largely approving verdict less defensible than its detail suggests."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 11,
+      "specificity": 20,
+      "risk_awareness": 13,
+      "total": 61,
+      "notes": "The plan provides specific reader branch tests, expected values, HTTP status oracles, compatibility checks, and deployment-surface coverage. Its largest gap is that the zero-environment test replaces server.settings with an attribute-less mock, bypassing the real Settings construction path where ge=1 can raise validation failure before clamping.  It lacks an automated assertion that mcp_proxy passes the resolved value to AsyncClient, while grep-based wiring checks establish textual presence rather than valid placement or rendered configuration. The proposed public proxy and config API URLs, Helm command, and full unittest-discovery command could not be verified against the baseline because local repository execution was unavailable."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 12,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 71,
+      "notes": "The submitted diff comprehensively changes the settings model, helper, AsyncClient call, admin tuple, three compose files, Terraform, Helm, documentation, and focused unit tests. Its largest defect is functional: MCP_PROXY_UPSTREAM_TIMEOUT_SECONDS=0 can be rejected while constructing Settings because of ge=1, so the helper's clamp and its mocked test do not satisfy the promised non-crashing deployment behavior.  The summary's claim of no deviations therefore overstates correctness, and the documentation also mischaracterizes HTTPX's operation-specific inactivity limits as a total request timeout.  Diff paths and contexts are internally coherent with the cited symbols, but git apply --check and exact baseline inspection could not be performed because the managed shell failed before command execution."
+    }
+  },
+  "task_score": 68.4,
+  "verdict": "The submission is comprehensive and implementation-oriented, but it misses a startup-validation path that violates its explicit clamping guarantee and propagates that error through the design, review, tests, and patch.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T11:48:12.196126Z",
+    "repo_ref": "1.25.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 313763,
+      "cached_input_tokens": 188272,
+      "cache_write_input_tokens": 39054,
+      "output_tokens": 13255,
+      "reasoning_output_tokens": 11081
+    },
+    "duration_ms": 221992
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.25.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "config",
+    "auth-server",
+    "httpx",
+    "proxy",
+    "timeouts",
+    "fixed-in-1.26.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5967,
+    "output_tokens": 39801,
+    "cache_read_tokens": 3305645,
+    "cache_write_tokens": 92915,
+    "total_tokens": 3444328,
+    "total_cost_usd": 3.2584012500000004,
+    "latency_seconds": 511.1,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 77.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 5967,
+  "output_tokens": 39801,
+  "latency_seconds": 511.1,
+  "num_turns": 33,
+  "total_cost_usd": 3.2584012500000004,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3305645,
+  "cache_creation_tokens": 92915,
+  "run_started_at": "2026-09-01T08:52:42.930957Z",
+  "run_ended_at": "2026-09-01T09:01:14.018998Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5967,
+    "output_tokens": 39801,
+    "cache_read_tokens": 3305645,
+    "cache_write_tokens": 92915,
+    "total_tokens": 3444328,
+    "total_cost_usd": 3.2584012500000004,
+    "latency_seconds": 511.1,
+    "num_turns": 33,
+    "generation_tokens_per_sec": 77.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-mcp-proxy-upstream-timeout",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 78,
+        "notes": "The strongest aspect is its testable scope: it identifies the settings field, proxy call site, deployment surfaces, defaults, exclusions, and compatibility behavior. Its largest technical error is describing the scalar HTTPX timeout as a total wall-clock limit; HTTPX applies it to network-operation inactivity, while disabling timeouts uses None rather than zero.  The requirement that sub-floor values clamp without crashing conflicts with Field(ge=1), because BaseSettings validates environment-derived values during construction before the reader can clamp them.  No independent task statement establishes the reported production scenario, and the local sandbox failure prevented independent verification of the cited baseline source."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 13,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 76,
+        "notes": "The design is unusually concrete about files, integration points, precedence, deployment wiring, observability, rollback, and the exact implementation shape. Its largest defect is the unresolved conflict between Pydantic ge=1 validation and the promised runtime clamp: an invalid compose or Helm environment value can fail Settings construction before _read_mcp_proxy_upstream_timeout_seconds executes.  It also repeatedly calls the HTTPX scalar value a total timeout and treats zero as disabling timeouts, neither of which matches HTTPX's documented behavior.  Claims that the admin surface supports PUT and that edits take effect without restart were not substantiated by a named route or state-update mechanism, and exact source verification was unavailable because the repository shell could not initialize."
+      },
+      "review": {
+        "completeness": 16,
+        "correctness": 8,
+        "specificity": 17,
+        "risk_awareness": 15,
+        "total": 56,
+        "notes": "The review's strongest contribution is identifying concrete operational concerns such as held-open connections, deployment-surface drift, unit labeling, and duplicated readers. Its largest failure is approving the design without catching that Field(ge=1) can reject an environment value before the proposed clamp runs, which directly defeats an acceptance criterion.  Multiple personas reinforce the incorrect assertion that timeout zero disables HTTPX timeouts, although HTTPX documents None as the disabling value.  The live-edit/no-restart conclusion is also asserted without repository evidence, making the largely approving verdict less defensible than its detail suggests."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 11,
+        "specificity": 20,
+        "risk_awareness": 13,
+        "total": 61,
+        "notes": "The plan provides specific reader branch tests, expected values, HTTP status oracles, compatibility checks, and deployment-surface coverage. Its largest gap is that the zero-environment test replaces server.settings with an attribute-less mock, bypassing the real Settings construction path where ge=1 can raise validation failure before clamping.  It lacks an automated assertion that mcp_proxy passes the resolved value to AsyncClient, while grep-based wiring checks establish textual presence rather than valid placement or rendered configuration. The proposed public proxy and config API URLs, Helm command, and full unittest-discovery command could not be verified against the baseline because local repository execution was unavailable."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 12,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 71,
+        "notes": "The submitted diff comprehensively changes the settings model, helper, AsyncClient call, admin tuple, three compose files, Terraform, Helm, documentation, and focused unit tests. Its largest defect is functional: MCP_PROXY_UPSTREAM_TIMEOUT_SECONDS=0 can be rejected while constructing Settings because of ge=1, so the helper's clamp and its mocked test do not satisfy the promised non-crashing deployment behavior.  The summary's claim of no deviations therefore overstates correctness, and the documentation also mischaracterizes HTTPX's operation-specific inactivity limits as a total request timeout.  Diff paths and contexts are internally coherent with the cited symbols, but git apply --check and exact baseline inspection could not be performed because the managed shell failed before command execution."
+      }
+    },
+    "task_score": 68.4,
+    "verdict": "The submission is comprehensive and implementation-oriented, but it misses a startup-validation path that violates its explicit clamping guarantee and propagates that error through the design, review, tests, and patch.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T11:48:12.196126Z",
+      "repo_ref": "1.25.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 313763,
+        "cached_input_tokens": 188272,
+        "cache_write_input_tokens": 39054,
+        "output_tokens": 13255,
+        "reasoning_output_tokens": 11081
+      },
+      "duration_ms": 221992
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-ui-title",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 88,
+      "notes": "The issue's strongest aspect is its testable behavior matrix for explicit, with-gateway, and registry-only titles, accompanied by precise deployment-surface and UI-consumer criteria. Referenced paths and symbols such as Settings, GET /api/config, useRegistryConfig, Layout.tsx, and the three packaging systems correspond to the submitted source contexts. Its main gap is limited treatment of operational edge cases such as blank values, asynchronous fallback behavior, and length or presentation constraints. No independent task statement was supplied, and the related issue number could not be independently verified, so broader requirement completeness remains unconfirmed."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 81,
+      "notes": "The design is unusually concrete about Settings.effective_ui_title, CONFIG_GROUPS, useRegistryConfig, Helm reserved names, and every deployment file, making most implementation decisions explicit. Its largest flaw is contradicting the requirement that the effective title appear in the System Config panel: it ultimately exposes raw ui_title, which is blank when registry-only relies on the derived default. It also claims untouched deployments gain no UI_TITLE environment variable, while its own Compose and ECS design supplies an empty variable rather than omitting it. The public-endpoint exposure, JSX escaping, blank-value fallback, conditional Helm rendering, compatibility behavior, and rollback are otherwise addressed proportionately."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 82,
+      "notes": "The review's strongest contribution is finding concrete design defects around CONFIG_GROUPS export naming and conditional Helm rendering, then prescribing implementable corrections. However, resolving the export concern by showing raw ui_title preserves a direct acceptance-criteria violation because administrators cannot see the effective derived value in that panel. It also fails to challenge the false claim that Compose and Terraform defaults omit UI_TITLE and overstates the hook as guaranteeing one request without demonstrating in-flight request deduplication. Security, FOUC, test-cache leakage, chart validation, compatibility, and tooltip wording receive specific rather than generic scrutiny."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 13,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 72,
+      "notes": "The plan provides strong concrete oracles for resolver precedence, API values, all four UI surfaces, Helm rendering, Terraform validation, and rollback behavior. Its Compose negative test is incorrect because UI_TITLE=${UI_TITLE:-} creates an empty environment variable, so printenv succeeds rather than reaching the claimed unset branch; the ECS configuration similarly always emits the variable. The assertion that prior API keys are byte-for-byte unchanged is not established by listing keys, and the with-gateway compatibility statement overlooks the intentional UptimeDisplay change from 'and' to '&'. Automated component and endpoint tests are only sketched or replaced with manual checks, and the stated unittest and admin-response commands could not be independently executed against the repository."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 75,
+      "notes": "The patch implements the central runtime path coherently: Settings resolves the title, GET /api/config exposes it, the hook types it, four React consumers render it safely, and Docker, Terraform, and Helm receive configuration wiring. The largest functional omission is that CONFIG_GROUPS exposes raw ui_title rather than the effective value required by the issue, and no proposed backend or frontend tests are included despite the LLD estimating new tests and the summary claiming nothing was left out. The patch also renders empty UI_TITLE variables in Compose and ECS, while its summary overstates omission behavior and reports +94/-10 even though the submitted hunks total +90/-5. Diff contexts are internally consistent with the named symbols, but the claimed git apply checks could not be independently repeated because repository shell execution failed before commands ran."
+    }
+  },
+  "task_score": 79.6,
+  "verdict": "This is a strong and highly specific submission whose main limitation is an end-to-end acceptance miss for displaying the effective admin-panel value, compounded by inaccurate deployment and testing claims.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T11:51:45.035893Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 273568,
+      "cached_input_tokens": 195754,
+      "cache_write_input_tokens": 39680,
+      "output_tokens": 10758,
+      "reasoning_output_tokens": 8483
+    },
+    "duration_ms": 212828
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "configurable-ui-title",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "ui",
+    "react",
+    "config",
+    "branding",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 74.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 13442,
+    "output_tokens": 46966,
+    "cache_read_tokens": 7267469,
+    "cache_write_tokens": 126958,
+    "total_tokens": 7454835,
+    "total_cost_usd": 5.668582000000001,
+    "latency_seconds": 631.3,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 74.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 13442,
+  "output_tokens": 46966,
+  "latency_seconds": 631.3,
+  "num_turns": 56,
+  "total_cost_usd": 5.668582000000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 7267469,
+  "cache_creation_tokens": 126958,
+  "run_started_at": "2026-09-01T08:42:08.440856Z",
+  "run_ended_at": "2026-09-01T08:52:39.745249Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 13442,
+    "output_tokens": 46966,
+    "cache_read_tokens": 7267469,
+    "cache_write_tokens": 126958,
+    "total_tokens": 7454835,
+    "total_cost_usd": 5.668582000000001,
+    "latency_seconds": 631.3,
+    "num_turns": 56,
+    "generation_tokens_per_sec": 74.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "configurable-ui-title",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 88,
+        "notes": "The issue's strongest aspect is its testable behavior matrix for explicit, with-gateway, and registry-only titles, accompanied by precise deployment-surface and UI-consumer criteria. Referenced paths and symbols such as Settings, GET /api/config, useRegistryConfig, Layout.tsx, and the three packaging systems correspond to the submitted source contexts. Its main gap is limited treatment of operational edge cases such as blank values, asynchronous fallback behavior, and length or presentation constraints. No independent task statement was supplied, and the related issue number could not be independently verified, so broader requirement completeness remains unconfirmed."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 81,
+        "notes": "The design is unusually concrete about Settings.effective_ui_title, CONFIG_GROUPS, useRegistryConfig, Helm reserved names, and every deployment file, making most implementation decisions explicit. Its largest flaw is contradicting the requirement that the effective title appear in the System Config panel: it ultimately exposes raw ui_title, which is blank when registry-only relies on the derived default. It also claims untouched deployments gain no UI_TITLE environment variable, while its own Compose and ECS design supplies an empty variable rather than omitting it. The public-endpoint exposure, JSX escaping, blank-value fallback, conditional Helm rendering, compatibility behavior, and rollback are otherwise addressed proportionately."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 82,
+        "notes": "The review's strongest contribution is finding concrete design defects around CONFIG_GROUPS export naming and conditional Helm rendering, then prescribing implementable corrections. However, resolving the export concern by showing raw ui_title preserves a direct acceptance-criteria violation because administrators cannot see the effective derived value in that panel. It also fails to challenge the false claim that Compose and Terraform defaults omit UI_TITLE and overstates the hook as guaranteeing one request without demonstrating in-flight request deduplication. Security, FOUC, test-cache leakage, chart validation, compatibility, and tooltip wording receive specific rather than generic scrutiny."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 13,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 72,
+        "notes": "The plan provides strong concrete oracles for resolver precedence, API values, all four UI surfaces, Helm rendering, Terraform validation, and rollback behavior. Its Compose negative test is incorrect because UI_TITLE=${UI_TITLE:-} creates an empty environment variable, so printenv succeeds rather than reaching the claimed unset branch; the ECS configuration similarly always emits the variable. The assertion that prior API keys are byte-for-byte unchanged is not established by listing keys, and the with-gateway compatibility statement overlooks the intentional UptimeDisplay change from 'and' to '&'. Automated component and endpoint tests are only sketched or replaced with manual checks, and the stated unittest and admin-response commands could not be independently executed against the repository."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 75,
+        "notes": "The patch implements the central runtime path coherently: Settings resolves the title, GET /api/config exposes it, the hook types it, four React consumers render it safely, and Docker, Terraform, and Helm receive configuration wiring. The largest functional omission is that CONFIG_GROUPS exposes raw ui_title rather than the effective value required by the issue, and no proposed backend or frontend tests are included despite the LLD estimating new tests and the summary claiming nothing was left out. The patch also renders empty UI_TITLE variables in Compose and ECS, while its summary overstates omission behavior and reports +94/-10 even though the submitted hunks total +90/-5. Diff contexts are internally consistent with the named symbols, but the claimed git apply checks could not be independently repeated because repository shell execution failed before commands ran."
+      }
+    },
+    "task_score": 79.6,
+    "verdict": "This is a strong and highly specific submission whose main limitation is an end-to-end acceptance miss for displaying the effective admin-panel value, compounded by inaccurate deployment and testing claims.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T11:51:45.035893Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 273568,
+        "cached_input_tokens": 195754,
+        "cache_write_input_tokens": 39680,
+        "output_tokens": 10758,
+        "reasoning_output_tokens": 8483
+      },
+      "duration_ms": 212828
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 85,
+      "notes": "The issue's strongest aspect is its concrete six-endpoint matrix, explicit session-versus-bearer behavior, testable acceptance criteria, and bounded non-goals. Its largest flaw is claiming bearer-token requests succeed on all six endpoints despite its own table showing session-only `enhanced_auth` and separate `validate_internal_auth` paths; the authorization qualifier only partly resolves that inconsistency. The named route functions and CSRF dependency agree with the submitted patch contexts. With no independent task statement, the intended endpoint set and exact scope cannot be independently confirmed."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 86,
+      "notes": "The LLD commits to precise control flow in `verify_csrf_token_flexible`, names concrete route functions, preserves mixed-credential fail-closed behavior, and documents the shared dependency's wider caller impact. Its largest deficiency is treating that wider behavior change and newly protected browser callers as safely backward-compatible without a demonstrated caller audit or rollout validation. The proposed signatures and edits align internally with the patch contexts for `csrf.py`, `server_routes.py`, and `virtual_server_routes.py`, although the claim that `request.form()` is reached only for genuine form posts overstates what the shown control flow guarantees. Claims about every caller, proxy header sanitization, and the absence of other toggle routes could not be independently verified."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 20,
+      "total": 79,
+      "notes": "The review's strongest contribution is identifying concrete risks around uninstrumented browser callers, shared-dependency side effects, mixed credentials, request-body handling, and the internal endpoint's effectively no-op CSRF wiring. Its largest weakness is resolving several findings through unsupported assertions, notably that the SPA is the only browser caller and that JSON requests never reach `request.form()`, rather than through source evidence or tests. It correctly requests route-level regression coverage for `/api/servers/toggle` and the virtual-server toggle, but that coverage is absent from the submitted patch. The asserted frontend exclusivity and complete six-route inventory remain unverifiable."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 16,
+      "risk_awareness": 17,
+      "total": 64,
+      "notes": "The dependency unit tests are the strongest portion: they provide specific 403 details, valid header and form cases, session binding, and an early-return body-read oracle. The route-level plan's central assertion, `status_code != 403`, can pass on 401, 404, 422, or unrelated failures and cannot distinguish a handler authorization 403 from a CSRF 403. It also treats six routes with different auth dependencies and payload shapes as one generic setup, while the end-to-end registration example contains a non-executable `...` payload. The claimed cookie default, registration command, and full-suite command were not independently verified."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 21,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 81,
+      "notes": "The patch coherently implements the proposed session-cookie gate, preserves token validation for cookie-bearing requests, and wires the dependency into `internal_toggle_service`, `toggle_service_api`, and `toggle_virtual_server`. Its largest deficiency is omitting the route-level tests promised by the LLD and review, leaving the six-endpoint wiring and newly closed browser gaps without executable regression coverage. The summary is also internally inconsistent when it says there are no deviations or follow-ups and then recommends the omitted route tests. The claimed baseline commit and successful `git apply --check` could not be independently verified from the available repository access."
+    }
+  },
+  "task_score": 79.0,
+  "verdict": "The submission presents a strong, coherent CSRF design and plausible focused patch, but weak route-level test oracles and omitted integration tests leave its end-to-end six-endpoint guarantees insufficiently demonstrated.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T11:56:39.063920Z",
+    "repo_ref": "v1.0.20",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 310447,
+      "cached_input_tokens": 226186,
+      "cache_write_input_tokens": 37178,
+      "output_tokens": 13488,
+      "reasoning_output_tokens": 11339
+    },
+    "duration_ms": 294016
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.20",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "csrf",
+    "authentication",
+    "api",
+    "fastapi",
+    "m2m",
+    "fixed-in-1.0.21"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8884,
+    "output_tokens": 44500,
+    "cache_read_tokens": 3829497,
+    "cache_write_tokens": 116727,
+    "total_tokens": 3999608,
+    "total_cost_usd": 3.8012122500000007,
+    "latency_seconds": 571.2,
+    "num_turns": 32,
+    "generation_tokens_per_sec": 77.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 8884,
+  "output_tokens": 44500,
+  "latency_seconds": 571.2,
+  "num_turns": 32,
+  "total_cost_usd": 3.8012122500000007,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3829497,
+  "cache_creation_tokens": 116727,
+  "run_started_at": "2026-09-01T08:32:34.342662Z",
+  "run_ended_at": "2026-09-01T08:42:05.526540Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 8884,
+    "output_tokens": 44500,
+    "cache_read_tokens": 3829497,
+    "cache_write_tokens": 116727,
+    "total_tokens": 3999608,
+    "total_cost_usd": 3.8012122500000007,
+    "latency_seconds": 571.2,
+    "num_turns": 32,
+    "generation_tokens_per_sec": 77.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "consistent-csrf-across-toggle-endpoints",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 85,
+        "notes": "The issue's strongest aspect is its concrete six-endpoint matrix, explicit session-versus-bearer behavior, testable acceptance criteria, and bounded non-goals. Its largest flaw is claiming bearer-token requests succeed on all six endpoints despite its own table showing session-only `enhanced_auth` and separate `validate_internal_auth` paths; the authorization qualifier only partly resolves that inconsistency. The named route functions and CSRF dependency agree with the submitted patch contexts. With no independent task statement, the intended endpoint set and exact scope cannot be independently confirmed."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 86,
+        "notes": "The LLD commits to precise control flow in `verify_csrf_token_flexible`, names concrete route functions, preserves mixed-credential fail-closed behavior, and documents the shared dependency's wider caller impact. Its largest deficiency is treating that wider behavior change and newly protected browser callers as safely backward-compatible without a demonstrated caller audit or rollout validation. The proposed signatures and edits align internally with the patch contexts for `csrf.py`, `server_routes.py`, and `virtual_server_routes.py`, although the claim that `request.form()` is reached only for genuine form posts overstates what the shown control flow guarantees. Claims about every caller, proxy header sanitization, and the absence of other toggle routes could not be independently verified."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 20,
+        "total": 79,
+        "notes": "The review's strongest contribution is identifying concrete risks around uninstrumented browser callers, shared-dependency side effects, mixed credentials, request-body handling, and the internal endpoint's effectively no-op CSRF wiring. Its largest weakness is resolving several findings through unsupported assertions, notably that the SPA is the only browser caller and that JSON requests never reach `request.form()`, rather than through source evidence or tests. It correctly requests route-level regression coverage for `/api/servers/toggle` and the virtual-server toggle, but that coverage is absent from the submitted patch. The asserted frontend exclusivity and complete six-route inventory remain unverifiable."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 16,
+        "risk_awareness": 17,
+        "total": 64,
+        "notes": "The dependency unit tests are the strongest portion: they provide specific 403 details, valid header and form cases, session binding, and an early-return body-read oracle. The route-level plan's central assertion, `status_code != 403`, can pass on 401, 404, 422, or unrelated failures and cannot distinguish a handler authorization 403 from a CSRF 403. It also treats six routes with different auth dependencies and payload shapes as one generic setup, while the end-to-end registration example contains a non-executable `...` payload. The claimed cookie default, registration command, and full-suite command were not independently verified."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 21,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 81,
+        "notes": "The patch coherently implements the proposed session-cookie gate, preserves token validation for cookie-bearing requests, and wires the dependency into `internal_toggle_service`, `toggle_service_api`, and `toggle_virtual_server`. Its largest deficiency is omitting the route-level tests promised by the LLD and review, leaving the six-endpoint wiring and newly closed browser gaps without executable regression coverage. The summary is also internally inconsistent when it says there are no deviations or follow-ups and then recommends the omitted route tests. The claimed baseline commit and successful `git apply --check` could not be independently verified from the available repository access."
+      }
+    },
+    "task_score": 79.0,
+    "verdict": "The submission presents a strong, coherent CSRF design and plausible focused patch, but weak route-level test oracles and omitted integration tests leave its end-to-end six-endpoint guarantees insufficiently demonstrated.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T11:56:39.063920Z",
+      "repo_ref": "v1.0.20",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 310447,
+        "cached_input_tokens": 226186,
+        "cache_write_input_tokens": 37178,
+        "output_tokens": 13488,
+        "reasoning_output_tokens": 11339
+      },
+      "duration_ms": 294016
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 88,
+      "notes": "The issue clearly defines initial, reset, opt-in, JSON-import, and omitted-field behavior, with concrete acceptance criteria and explicit CLI non-goals. The submitted diff corroborates its named frontend state, reset, example JSON, and management endpoint targets. Its largest weakness is expanding a checkbox-default task into a compatibility-affecting backend fallback change without an independent task statement establishing that requirement. Repository inspection was unavailable because the read-only shell sandbox failed before executing commands, so provider support and failure-mode claims could not be independently verified."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 88,
+      "notes": "The LLD is unusually concrete about IAMGroups.tsx, management_create_group, payload flow, reset behavior, test selection, rollout, and the intentionally unchanged CLI path. Its described symbols and line contexts agree internally with the submitted patch, including createInIdp, EXAMPLE_SCOPE_JSON, and the scope_config override. The main deficiency is changing the management API fallback used by non-UI callers without stronger compatibility evidence or an automated backend test; reset behavior likewise receives only manual coverage. Exact repository conventions and dependency claims could not be independently verified because local source inspection was unavailable."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 21,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 84,
+      "notes": "The review surfaces several specific concerns: initializer/reset coupling, checkbox selector ambiguity, CLI-default divergence, truthy-string coercion, and the need for release notes. These findings correspond directly to the submitted patch and design rather than being purely generic reviewer role-play. Its largest omission is failing to challenge whether changing the backend omission default is justified by the checkbox task or to require automated coverage for that API contract and reset behavior. Claims about existing logs, authorization, hook APIs, and package dependencies remained unverified against the repository."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 85,
+      "notes": "The plan supplies concrete request bodies and meaningful oracles for local-only, explicit-false, opt-in, JSON-import, read-only-IdP, and initial UI behavior. The proposed Jest test targets the submitted DOM structure specifically and avoids confusing the IdP control with other checkboxes. Its largest weakness is that only initial state is automated: reset, payload generation, and the changed backend fallback remain manual, while the curl examples do not themselves enforce the claimed HTTP status and use reusable names that can collide. The token path, test command, hook mock shapes, and delete behavior could not be independently confirmed from the repository."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 77,
+      "notes": "The patch implements every element of its own design: initializer, reset, example JSON, backend fallback and documentation, plus a focused initial-state test. The unified diff is internally coherent, uses precise existing-looking symbols, and the summary accurately accounts for its 54 additions and 7 deletions. The largest risk is the unproven change from True to False for omitted create_in_idp on a callable management API, which can alter existing non-UI clients and has no automated backend test; the reset acceptance criterion is also untested. Git applicability, surrounding source, TypeScript mock compatibility, and test execution could not be independently verified because the repository command sandbox failed before running."
+    }
+  },
+  "task_score": 84.4,
+  "verdict": "Strong, concrete design and a focused patch, limited chiefly by an insufficiently justified and untested backend API-default change beyond the explicitly evidenced checkbox requirement.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T11:59:15.877400Z",
+    "repo_ref": "v1.0.21",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 160522,
+      "cached_input_tokens": 100937,
+      "cache_write_input_tokens": 28078,
+      "output_tokens": 8567,
+      "reasoning_output_tokens": 7102
+    },
+    "duration_ms": 156802
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.21",
+  "complexity": "low",
+  "tags": [
+    "ui",
+    "react",
+    "iam",
+    "groups",
+    "ux",
+    "fixed-in-1.0.22"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 68.7,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6719,
+    "output_tokens": 31808,
+    "cache_read_tokens": 3767247,
+    "cache_write_tokens": 126177,
+    "total_tokens": 3931951,
+    "total_cost_usd": 3.501024750000001,
+    "latency_seconds": 463.1,
+    "num_turns": 38,
+    "generation_tokens_per_sec": 68.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 6719,
+  "output_tokens": 31808,
+  "latency_seconds": 463.1,
+  "num_turns": 38,
+  "total_cost_usd": 3.501024750000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 3767247,
+  "cache_creation_tokens": 126177,
+  "run_started_at": "2026-09-01T07:40:16.917409Z",
+  "run_ended_at": "2026-09-01T07:48:00.018825Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 6719,
+    "output_tokens": 31808,
+    "cache_read_tokens": 3767247,
+    "cache_write_tokens": 126177,
+    "total_tokens": 3931951,
+    "total_cost_usd": 3.501024750000001,
+    "latency_seconds": 463.1,
+    "num_turns": 38,
+    "generation_tokens_per_sec": 68.7,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "default-create-in-idp-checkbox-unchecked",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 88,
+        "notes": "The issue clearly defines initial, reset, opt-in, JSON-import, and omitted-field behavior, with concrete acceptance criteria and explicit CLI non-goals. The submitted diff corroborates its named frontend state, reset, example JSON, and management endpoint targets. Its largest weakness is expanding a checkbox-default task into a compatibility-affecting backend fallback change without an independent task statement establishing that requirement. Repository inspection was unavailable because the read-only shell sandbox failed before executing commands, so provider support and failure-mode claims could not be independently verified."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 88,
+        "notes": "The LLD is unusually concrete about IAMGroups.tsx, management_create_group, payload flow, reset behavior, test selection, rollout, and the intentionally unchanged CLI path. Its described symbols and line contexts agree internally with the submitted patch, including createInIdp, EXAMPLE_SCOPE_JSON, and the scope_config override. The main deficiency is changing the management API fallback used by non-UI callers without stronger compatibility evidence or an automated backend test; reset behavior likewise receives only manual coverage. Exact repository conventions and dependency claims could not be independently verified because local source inspection was unavailable."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 21,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 84,
+        "notes": "The review surfaces several specific concerns: initializer/reset coupling, checkbox selector ambiguity, CLI-default divergence, truthy-string coercion, and the need for release notes. These findings correspond directly to the submitted patch and design rather than being purely generic reviewer role-play. Its largest omission is failing to challenge whether changing the backend omission default is justified by the checkbox task or to require automated coverage for that API contract and reset behavior. Claims about existing logs, authorization, hook APIs, and package dependencies remained unverified against the repository."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 85,
+        "notes": "The plan supplies concrete request bodies and meaningful oracles for local-only, explicit-false, opt-in, JSON-import, read-only-IdP, and initial UI behavior. The proposed Jest test targets the submitted DOM structure specifically and avoids confusing the IdP control with other checkboxes. Its largest weakness is that only initial state is automated: reset, payload generation, and the changed backend fallback remain manual, while the curl examples do not themselves enforce the claimed HTTP status and use reusable names that can collide. The token path, test command, hook mock shapes, and delete behavior could not be independently confirmed from the repository."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 77,
+        "notes": "The patch implements every element of its own design: initializer, reset, example JSON, backend fallback and documentation, plus a focused initial-state test. The unified diff is internally coherent, uses precise existing-looking symbols, and the summary accurately accounts for its 54 additions and 7 deletions. The largest risk is the unproven change from True to False for omitted create_in_idp on a callable management API, which can alter existing non-UI clients and has no automated backend test; the reset acceptance criterion is also untested. Git applicability, surrounding source, TypeScript mock compatibility, and test execution could not be independently verified because the repository command sandbox failed before running."
+      }
+    },
+    "task_score": 84.4,
+    "verdict": "Strong, concrete design and a focused patch, limited chiefly by an insufficiently justified and untested backend API-default change beyond the explicitly evidenced checkbox requirement.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T11:59:15.877400Z",
+      "repo_ref": "v1.0.21",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 160522,
+        "cached_input_tokens": 100937,
+        "cache_write_input_tokens": 28078,
+        "output_tokens": 8567,
+        "reasoning_output_tokens": 7102
+      },
+      "duration_ms": 156802
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 86,
+      "notes": "The issue provides unusually concrete URL examples, testable acceptance criteria, and clear exclusions for network verification, non-GitHub providers, and backfilling. Its largest gap is that the semantic-search requirement does not explicitly require that search results actually populate repository_url, enabling the later implementation to add only a dormant optional field. Submitted patch context supports the named Dashboard, SkillInfo, modal, and parse-response integration points. No independent task statement was supplied, and the sandbox prevented direct source or tag verification."
+    },
+    "lld": {
+      "completeness": 16,
+      "correctness": 12,
+      "specificity": 19,
+      "risk_awareness": 13,
+      "total": 60,
+      "notes": "The LLD is concrete about files, symbols, constructors, response fields, and frontend state flow. Its largest defect is declaring the semantic-search change safe even if that path never populates repository_url, which cannot deliver the promised View Repo behavior. It also specifies data.repository_url || prev.repository_url, retaining a stale repository after parsing a non-GitHub URL, and accepts a hostname-substring heuristic that can classify non-GitHub domains as GitHub. Exact line locations and repository conventions could not be independently verified because local read commands were blocked."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 11,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 56,
+      "notes": "The review raises concrete concerns about hostname classification, link security attributes, compatibility, deployment, and the need for focused unit tests. Its largest failure is approving end-to-end completeness while overlooking the LLD's explicit admission that semantic-search results may not contain repository_url. It also fails to identify the stale-form-state behavior caused by data.repository_url || prev.repository_url, despite reviewing that expression directly. File and symbol references align with the submitted diff, but could not be checked against the local working tree."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 17,
+      "risk_awareness": 15,
+      "total": 60,
+      "notes": "The plan covers derivation variants, API payloads, listing behavior, backward compatibility, both modals, and concrete expected values. Its primary command, uv run python -m unittest, will not collect the submitted plain pytest class and parametrized methods, allowing the new tests to run zero cases successfully. Several manual Parse scenarios use placeholder org/repo URLs that are unlikely to be fetchable, and no setup ensures semantic hits contain repository_url. It also omits the important transition test from a previously derived GitHub value to a non-GitHub parse, which would expose stale state."
+    },
+    "implementation": {
+      "completeness": 14,
+      "correctness": 11,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 56,
+      "notes": "The patch concretely wires derivation through the parse response and listing model, updates frontend types, and replaces both modal labels with guarded links. It does not populate repository_url in the semantic-search backend, which the summary admits, so a central acceptance criterion remains unimplemented. Dashboard retains an old repository value when derivation returns null, while the helper's acknowledged substring host test can derive values for non-GitHub domains; the advertised +99/-4 total also contradicts the per-file counts in the summary. Patch applicability and exact source context could not be independently confirmed because the read-only command runner failed before executing git apply --check."
+    }
+  },
+  "task_score": 63.6,
+  "verdict": "The submission has a strong issue and detailed design, but the implementation leaves the semantic-search data path incomplete and can preserve an incorrect repository URL after a non-GitHub parse.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:03:12.191036Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 282452,
+      "cached_input_tokens": 214071,
+      "cache_write_input_tokens": 39198,
+      "output_tokens": 12540,
+      "reasoning_output_tokens": 10421
+    },
+    "duration_ms": 236302
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "skills",
+    "ui",
+    "react",
+    "api",
+    "ux",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5049,
+    "output_tokens": 40365,
+    "cache_read_tokens": 4123346,
+    "cache_write_tokens": 115107,
+    "total_tokens": 4283867,
+    "total_cost_usd": 3.8154617499999994,
+    "latency_seconds": 520.6,
+    "num_turns": 35,
+    "generation_tokens_per_sec": 77.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 5049,
+  "output_tokens": 40365,
+  "latency_seconds": 520.6,
+  "num_turns": 35,
+  "total_cost_usd": 3.8154617499999994,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 4123346,
+  "cache_creation_tokens": 115107,
+  "run_started_at": "2026-09-01T08:23:50.980644Z",
+  "run_ended_at": "2026-09-01T08:32:31.598540Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5049,
+    "output_tokens": 40365,
+    "cache_read_tokens": 4123346,
+    "cache_write_tokens": 115107,
+    "total_tokens": 4283867,
+    "total_cost_usd": 3.8154617499999994,
+    "latency_seconds": 520.6,
+    "num_turns": 35,
+    "generation_tokens_per_sec": 77.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "derive-repo-url-from-skill-md",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 86,
+        "notes": "The issue provides unusually concrete URL examples, testable acceptance criteria, and clear exclusions for network verification, non-GitHub providers, and backfilling. Its largest gap is that the semantic-search requirement does not explicitly require that search results actually populate repository_url, enabling the later implementation to add only a dormant optional field. Submitted patch context supports the named Dashboard, SkillInfo, modal, and parse-response integration points. No independent task statement was supplied, and the sandbox prevented direct source or tag verification."
+      },
+      "lld": {
+        "completeness": 16,
+        "correctness": 12,
+        "specificity": 19,
+        "risk_awareness": 13,
+        "total": 60,
+        "notes": "The LLD is concrete about files, symbols, constructors, response fields, and frontend state flow. Its largest defect is declaring the semantic-search change safe even if that path never populates repository_url, which cannot deliver the promised View Repo behavior. It also specifies data.repository_url || prev.repository_url, retaining a stale repository after parsing a non-GitHub URL, and accepts a hostname-substring heuristic that can classify non-GitHub domains as GitHub. Exact line locations and repository conventions could not be independently verified because local read commands were blocked."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 11,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 56,
+        "notes": "The review raises concrete concerns about hostname classification, link security attributes, compatibility, deployment, and the need for focused unit tests. Its largest failure is approving end-to-end completeness while overlooking the LLD's explicit admission that semantic-search results may not contain repository_url. It also fails to identify the stale-form-state behavior caused by data.repository_url || prev.repository_url, despite reviewing that expression directly. File and symbol references align with the submitted diff, but could not be checked against the local working tree."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 17,
+        "risk_awareness": 15,
+        "total": 60,
+        "notes": "The plan covers derivation variants, API payloads, listing behavior, backward compatibility, both modals, and concrete expected values. Its primary command, uv run python -m unittest, will not collect the submitted plain pytest class and parametrized methods, allowing the new tests to run zero cases successfully. Several manual Parse scenarios use placeholder org/repo URLs that are unlikely to be fetchable, and no setup ensures semantic hits contain repository_url. It also omits the important transition test from a previously derived GitHub value to a non-GitHub parse, which would expose stale state."
+      },
+      "implementation": {
+        "completeness": 14,
+        "correctness": 11,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 56,
+        "notes": "The patch concretely wires derivation through the parse response and listing model, updates frontend types, and replaces both modal labels with guarded links. It does not populate repository_url in the semantic-search backend, which the summary admits, so a central acceptance criterion remains unimplemented. Dashboard retains an old repository value when derivation returns null, while the helper's acknowledged substring host test can derive values for non-GitHub domains; the advertised +99/-4 total also contradicts the per-file counts in the summary. Patch applicability and exact source context could not be independently confirmed because the read-only command runner failed before executing git apply --check."
+      }
+    },
+    "task_score": 63.6,
+    "verdict": "The submission has a strong issue and detailed design, but the implementation leaves the semantic-search data path incomplete and can preserve an incorrect repository URL after a non-GitHub parse.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:03:12.191036Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 282452,
+        "cached_input_tokens": 214071,
+        "cache_write_input_tokens": 39198,
+        "output_tokens": 12540,
+        "reasoning_output_tokens": 10421
+      },
+      "duration_ms": 236302
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 88,
+      "notes": "The issue clearly identifies the reserved GROUPS assignment, set -e interaction, affected scripts, desired exit behavior, compatibility constraints, and explicit non-goals. The submitted patch context corroborates the verify_setup() locations and GROUPS usage in both keycloak/setup scripts. Its largest weakness is asserting the macos-setup caller behavior and a complete reserved-variable sweep without independently reproducible evidence in the issue. The acceptance criteria are otherwise unusually concrete and testable for this small defect."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 91,
+      "notes": "The LLD commits to exact edits in both verify_setup() functions, including separate local declaration, unchanged REST calls, and fixed-string whole-line matching. Its named files, function contexts, and before/after snippets agree with the submitted source hunks. The main deficiency is that it presents the directory-wide reserved-variable sweep and several caller details as completed facts without preserving verifiable output. It otherwise handles portability, set -e behavior, compatibility, failure paths, rollout, and follow-ups proportionately."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 19,
+      "specificity": 20,
+      "risk_awareness": 19,
+      "total": 78,
+      "notes": "The strongest review work is the shell-specific analysis of local assignment status masking, zero-group behavior, exact matching, and consistency with CURRENT_GROUPS. These observations directly inspect the proposed printf and grep -Fxq changes rather than merely approving the design. Its largest technical flaw is linking the Admin API's group-name representation to the protocol mapper's full.path setting, which controls token mapping rather than that endpoint. It also declares the testing recommendations resolved without noticing that the resulting exact-match and negative tests do not actually create discriminating conditions."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 14,
+      "specificity": 17,
+      "risk_awareness": 18,
+      "total": 69,
+      "notes": "The plan covers successful execution, idempotency, both scripts, static analysis, Bash-version compatibility, downstream chaining, and genuine failure behavior. However, after instructing the tester to cd into keycloak/setup, its shellcheck and reserved-variable commands incorrectly retain the keycloak/setup prefix and therefore address nonexistent nested paths. The exact-match case would also pass the old substring implementation, while the negative case vaguely requests revoking membership during execution without specifying an executable setup. The tests were not run, and the portability command invokes generic bash rather than each displayed interpreter path."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 87,
+      "notes": "The patch implements the central fix in both affected verify_setup() functions and consistently updates capture, display, and membership-check uses. Declaring local sa_groups separately preserves the substitution status, while printf with grep -Fxq -- correctly avoids array expansion, regex interpretation, substring matches, and option-like group names. The largest gap is the absence of an automated regression test, and the summary's claims that git apply --check and the full reserved-variable sweep succeeded are not demonstrated by included output. The implementation otherwise matches the LLD and keeps the change narrowly scoped."
+    }
+  },
+  "task_score": 82.6,
+  "verdict": "This is a strong, technically sound small bug fix with an implementation-ready design, but the testing artifact contains incorrect commands and key cases that would not reliably catch the regression.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:05:58.188261Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 163172,
+      "cached_input_tokens": 99496,
+      "cache_write_input_tokens": 27464,
+      "output_tokens": 10175,
+      "reasoning_output_tokens": 8591
+    },
+    "duration_ms": 165985
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "bash",
+    "keycloak",
+    "setup-scripts",
+    "shellcheck",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 76.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1608,
+    "output_tokens": 28227,
+    "cache_read_tokens": 1453684,
+    "cache_write_tokens": 68135,
+    "total_tokens": 1551654,
+    "total_cost_usd": 1.86640075,
+    "latency_seconds": 371.4,
+    "num_turns": 17,
+    "generation_tokens_per_sec": 76.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1608,
+  "output_tokens": 28227,
+  "latency_seconds": 371.4,
+  "num_turns": 17,
+  "total_cost_usd": 1.86640075,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 1453684,
+  "cache_creation_tokens": 68135,
+  "run_started_at": "2026-09-01T08:09:10.728488Z",
+  "run_ended_at": "2026-09-01T08:15:22.121413Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1608,
+    "output_tokens": 28227,
+    "cache_read_tokens": 1453684,
+    "cache_write_tokens": 68135,
+    "total_tokens": 1551654,
+    "total_cost_usd": 1.86640075,
+    "latency_seconds": 371.4,
+    "num_turns": 17,
+    "generation_tokens_per_sec": 76.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "fix-reserved-groups-var-in-service-account-script",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 88,
+        "notes": "The issue clearly identifies the reserved GROUPS assignment, set -e interaction, affected scripts, desired exit behavior, compatibility constraints, and explicit non-goals. The submitted patch context corroborates the verify_setup() locations and GROUPS usage in both keycloak/setup scripts. Its largest weakness is asserting the macos-setup caller behavior and a complete reserved-variable sweep without independently reproducible evidence in the issue. The acceptance criteria are otherwise unusually concrete and testable for this small defect."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 91,
+        "notes": "The LLD commits to exact edits in both verify_setup() functions, including separate local declaration, unchanged REST calls, and fixed-string whole-line matching. Its named files, function contexts, and before/after snippets agree with the submitted source hunks. The main deficiency is that it presents the directory-wide reserved-variable sweep and several caller details as completed facts without preserving verifiable output. It otherwise handles portability, set -e behavior, compatibility, failure paths, rollout, and follow-ups proportionately."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 19,
+        "specificity": 20,
+        "risk_awareness": 19,
+        "total": 78,
+        "notes": "The strongest review work is the shell-specific analysis of local assignment status masking, zero-group behavior, exact matching, and consistency with CURRENT_GROUPS. These observations directly inspect the proposed printf and grep -Fxq changes rather than merely approving the design. Its largest technical flaw is linking the Admin API's group-name representation to the protocol mapper's full.path setting, which controls token mapping rather than that endpoint. It also declares the testing recommendations resolved without noticing that the resulting exact-match and negative tests do not actually create discriminating conditions."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 14,
+        "specificity": 17,
+        "risk_awareness": 18,
+        "total": 69,
+        "notes": "The plan covers successful execution, idempotency, both scripts, static analysis, Bash-version compatibility, downstream chaining, and genuine failure behavior. However, after instructing the tester to cd into keycloak/setup, its shellcheck and reserved-variable commands incorrectly retain the keycloak/setup prefix and therefore address nonexistent nested paths. The exact-match case would also pass the old substring implementation, while the negative case vaguely requests revoking membership during execution without specifying an executable setup. The tests were not run, and the portability command invokes generic bash rather than each displayed interpreter path."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 87,
+        "notes": "The patch implements the central fix in both affected verify_setup() functions and consistently updates capture, display, and membership-check uses. Declaring local sa_groups separately preserves the substitution status, while printf with grep -Fxq -- correctly avoids array expansion, regex interpretation, substring matches, and option-like group names. The largest gap is the absence of an automated regression test, and the summary's claims that git apply --check and the full reserved-variable sweep succeeded are not demonstrated by included output. The implementation otherwise matches the LLD and keeps the change narrowly scoped."
+      }
+    },
+    "task_score": 82.6,
+    "verdict": "This is a strong, technically sound small bug fix with an implementation-ready design, but the testing artifact contains incorrect commands and key cases that would not reliably catch the regression.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:05:58.188261Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 163172,
+        "cached_input_tokens": 99496,
+        "cache_write_input_tokens": 27464,
+        "output_tokens": 10175,
+        "reasoning_output_tokens": 8591
+      },
+      "duration_ms": 165985
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 24,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 91,
+      "notes": "The issue precisely defines tab-specific visibility, preserved controls, navigation behavior, and explicit non-goals. Its acceptance criteria are directly testable and align with the task identifier and submitted patch. The largest evidence gap is the absent independent task statement; claims about Dashboard.tsx, /servers/register, and issue #793 could not be independently confirmed. Local repository inspection failed before command execution because of the read-only sandbox, so those source-level claims remain unverified rather than contradicted."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 20,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 89,
+      "notes": "The design commits to the crucial implementation decision: guard only the button so the enclosing search and refresh controls remain intact. It gives an exact conditional, explains external-tab compatibility, and analyzes whitelist and outer-wrapper alternatives proportionately. Its largest deficiency is that exact line numbers, the viewFilter union, handler references, test paths, and react-scripts tooling could not be verified against the baseline repository. The optional treatment of automated testing also leaves regression protection undecided, although the implementation itself is sufficiently specified."
+    },
+    "review": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 20,
+      "risk_awareness": 18,
+      "total": 75,
+      "notes": "The review identifies concrete concerns about the enclosing header condition, flex layout, DOM accessibility, authorization boundaries, and the future maintenance cost of a negative-list guard. Its strongest finding is that changing the outer wrapper would incorrectly remove unrelated controls. The largest weakness is that the unanimous persona-based approval does not challenge the missing automated test or validate asserted repository details such as /api/register and the build workflow. Claims about exact CSS structure and backend routes remained unverifiable because repository commands could not execute."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 18,
+      "risk_awareness": 20,
+      "total": 76,
+      "notes": "The manual matrix covers every named tab, live switching, navigation, sibling controls, per-tab actions, and layout integrity with concrete expected outcomes. It provides useful backward-compatibility and negative checks rather than merely asserting that rendering succeeds. The largest deficiency is that the automated test is only illustrative: it omits provider and mock setup, tab-selection mechanics, and reliable header scoping, while a broad /register/i query could match another registration CTA. The npm command, test-directory convention, feature configuration, and tab labels could not be independently verified."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 20,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 83,
+      "notes": "The submitted diff implements the designed behavior directly by conditionally rendering the existing button for every view except virtual and skills, without changing its handler or markup. The patch and summary are internally consistent, including the intentional preservation of external and the disclosure that no tests were added or run. The largest material weakness is the absence of automated regression coverage, compounded by a negative-list condition that will expose Register on future tabs by default. The sandbox failed before local reads or git apply --check could execute, so the claimed baseline hash, source context, and clean applicability remain unverified."
+    }
+  },
+  "task_score": 82.8,
+  "verdict": "This is a strong, tightly scoped solution whose main limitation is missing automated regression coverage, with exact repository applicability remaining unverified because local inspection could not execute.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:07:52.965858Z",
+    "repo_ref": "v1.0.18",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 160596,
+      "cached_input_tokens": 107637,
+      "cache_write_input_tokens": 27414,
+      "output_tokens": 7659,
+      "reasoning_output_tokens": 5704
+    },
+    "duration_ms": 114766
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.18",
+  "complexity": "trivial",
+  "tags": [
+    "ui",
+    "react",
+    "dashboard",
+    "ux",
+    "fixed-in-v1.0.19"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 72.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 136,
+    "output_tokens": 25350,
+    "cache_read_tokens": 2081102,
+    "cache_write_tokens": 63302,
+    "total_tokens": 2169890,
+    "total_cost_usd": 2.0706185,
+    "latency_seconds": 352.3,
+    "num_turns": 26,
+    "generation_tokens_per_sec": 72.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 136,
+  "output_tokens": 25350,
+  "latency_seconds": 352.3,
+  "num_turns": 26,
+  "total_cost_usd": 2.0706185,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2081102,
+  "cache_creation_tokens": 63302,
+  "run_started_at": "2026-09-01T10:58:35.894331Z",
+  "run_ended_at": "2026-09-01T11:04:28.159337Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 136,
+    "output_tokens": 25350,
+    "cache_read_tokens": 2081102,
+    "cache_write_tokens": 63302,
+    "total_tokens": 2169890,
+    "total_cost_usd": 2.0706185,
+    "latency_seconds": 352.3,
+    "num_turns": 26,
+    "generation_tokens_per_sec": 72.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "hide-register-button-on-virtual-and-skills-tabs",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 24,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 91,
+        "notes": "The issue precisely defines tab-specific visibility, preserved controls, navigation behavior, and explicit non-goals. Its acceptance criteria are directly testable and align with the task identifier and submitted patch. The largest evidence gap is the absent independent task statement; claims about Dashboard.tsx, /servers/register, and issue #793 could not be independently confirmed. Local repository inspection failed before command execution because of the read-only sandbox, so those source-level claims remain unverified rather than contradicted."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 20,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 89,
+        "notes": "The design commits to the crucial implementation decision: guard only the button so the enclosing search and refresh controls remain intact. It gives an exact conditional, explains external-tab compatibility, and analyzes whitelist and outer-wrapper alternatives proportionately. Its largest deficiency is that exact line numbers, the viewFilter union, handler references, test paths, and react-scripts tooling could not be verified against the baseline repository. The optional treatment of automated testing also leaves regression protection undecided, although the implementation itself is sufficiently specified."
+      },
+      "review": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 20,
+        "risk_awareness": 18,
+        "total": 75,
+        "notes": "The review identifies concrete concerns about the enclosing header condition, flex layout, DOM accessibility, authorization boundaries, and the future maintenance cost of a negative-list guard. Its strongest finding is that changing the outer wrapper would incorrectly remove unrelated controls. The largest weakness is that the unanimous persona-based approval does not challenge the missing automated test or validate asserted repository details such as /api/register and the build workflow. Claims about exact CSS structure and backend routes remained unverifiable because repository commands could not execute."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 18,
+        "risk_awareness": 20,
+        "total": 76,
+        "notes": "The manual matrix covers every named tab, live switching, navigation, sibling controls, per-tab actions, and layout integrity with concrete expected outcomes. It provides useful backward-compatibility and negative checks rather than merely asserting that rendering succeeds. The largest deficiency is that the automated test is only illustrative: it omits provider and mock setup, tab-selection mechanics, and reliable header scoping, while a broad /register/i query could match another registration CTA. The npm command, test-directory convention, feature configuration, and tab labels could not be independently verified."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 20,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 83,
+        "notes": "The submitted diff implements the designed behavior directly by conditionally rendering the existing button for every view except virtual and skills, without changing its handler or markup. The patch and summary are internally consistent, including the intentional preservation of external and the disclosure that no tests were added or run. The largest material weakness is the absence of automated regression coverage, compounded by a negative-list condition that will expose Register on future tabs by default. The sandbox failed before local reads or git apply --check could execute, so the claimed baseline hash, source context, and clean applicability remain unverified."
+      }
+    },
+    "task_score": 82.8,
+    "verdict": "This is a strong, tightly scoped solution whose main limitation is missing automated regression coverage, with exact repository applicability remaining unverified because local inspection could not execute.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:07:52.965858Z",
+      "repo_ref": "v1.0.18",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 160596,
+        "cached_input_tokens": 107637,
+        "cache_write_input_tokens": 27414,
+        "output_tokens": 7659,
+        "reasoning_output_tokens": 5704
+      },
+      "duration_ms": 114766
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 89,
+      "notes": "The issue clearly defines the UI-versus-telemetry inconsistency, testable override and fallback behavior, unchanged response keys, and explicit non-goals. Its strongest evidence is the named `get_telemetry_detection_info`, `_resolve_cloud`, and `_detect_cloud_provider_with_method` integration reflected in the submitted diff. The main limitation is that claims about `.env.example`, validator values, and the complete resolver precedence could not be independently confirmed from the baseline source. No independent task statement was supplied, but the issue is internally consistent with the task identifier and repository tags."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 85,
+      "notes": "The LLD commits to concrete files, call flow, response behavior, tests, compatibility boundaries, and a proportionate rollout for a small change. It correctly identifies the asynchronous call-site change in `registry/api/system_routes.py` and specifies isolated override and fallback tests in `tests/unit/test_stats_endpoint.py`. Its largest weakness is an internal contradiction: it acknowledges a newly reachable cached registry-card read but later claims there are no new network calls, and it recommends production constants as API-test oracles, which can hide a contract-value regression. Exact cache, logging, deployment-surface, and fail-silent implementation claims could not be independently verified from the baseline source."
+    },
+    "review": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 20,
+      "risk_awareness": 18,
+      "total": 75,
+      "notes": "The review raises concrete concerns about the stale endpoint docstring, the newly reachable operator-hint read, cache isolation, authentication, and constrained configuration values. Its strongest contribution is checking that an async `_resolve_cloud()` call fits the existing async handler while preserving the response schema. The largest deficiency is that every persona approves the design and the review endorses importing production method constants for compatibility assertions, an oracle that could change alongside broken production behavior. Claims that grep finds only `UptimeDisplay.tsx` and that every deployment surface is already wired were not independently verifiable."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 77,
+      "notes": "The plan provides concrete HTTP and unit-test setup, actions, status checks, exact response dictionaries, authentication coverage, and an unchanged-fallback oracle. The automated tests directly target `/api/system/telemetry-detection` and use dependency overrides matching the submitted implementation. Its largest gaps are no coverage for the newly exposed operator-declared, operator-declined, or repository-error paths, plus reliance on production constants rather than literal contract values; the telemetry-event parity check also lacks a concrete observation procedure. The final `uv run python -m unittest`/`pytest tests/` notation is not one executable command, and the authoritative repository test command could not be verified."
+    },
+    "implementation": {
+      "completeness": 19,
+      "correctness": 15,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 71,
+      "notes": "The production hunk implements the stated scope by changing the deferred import and awaiting `_resolve_cloud()` while preserving the two response keys, and the test hunk covers override and fallback cases. The largest defect is that the added fallback test calls `AsyncMock(...)` but the patch contains no import change; the testing artifact itself says that import must be added if missing, so the test can fail with `NameError` and the summary's claim of no deviations is overstated. The diff context targets the named handler and existing unauthenticated test location, but local `git apply --check` and the baseline import list could not be independently verified because repository commands failed before execution in the sandbox. Apart from the test-import defect, the handler change is internally consistent with the LLD and does not alter the JSON schema."
+    }
+  },
+  "task_score": 79.4,
+  "verdict": "Strong, repository-specific design work supports a small and plausible production fix, but the implementation likely leaves a regression test broken by omitting the required `AsyncMock` import.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:11:09.575698Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 318900,
+      "cached_input_tokens": 242503,
+      "cache_write_input_tokens": 34350,
+      "output_tokens": 11834,
+      "reasoning_output_tokens": 9715
+    },
+    "duration_ms": 196598
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "telemetry",
+    "api",
+    "ui",
+    "deployment",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1835,
+    "output_tokens": 30708,
+    "cache_read_tokens": 2200315,
+    "cache_write_tokens": 97341,
+    "total_tokens": 2330199,
+    "total_cost_usd": 2.4854137499999993,
+    "latency_seconds": 394.4,
+    "num_turns": 21,
+    "generation_tokens_per_sec": 77.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1835,
+  "output_tokens": 30708,
+  "latency_seconds": 394.4,
+  "num_turns": 21,
+  "total_cost_usd": 2.4854137499999993,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2200315,
+  "cache_creation_tokens": 97341,
+  "run_started_at": "2026-09-01T08:02:32.282340Z",
+  "run_ended_at": "2026-09-01T08:09:06.641684Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1835,
+    "output_tokens": 30708,
+    "cache_read_tokens": 2200315,
+    "cache_write_tokens": 97341,
+    "total_tokens": 2330199,
+    "total_cost_usd": 2.4854137499999993,
+    "latency_seconds": 394.4,
+    "num_turns": 21,
+    "generation_tokens_per_sec": 77.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "honor-cloud-provider-override-in-ui",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 89,
+        "notes": "The issue clearly defines the UI-versus-telemetry inconsistency, testable override and fallback behavior, unchanged response keys, and explicit non-goals. Its strongest evidence is the named `get_telemetry_detection_info`, `_resolve_cloud`, and `_detect_cloud_provider_with_method` integration reflected in the submitted diff. The main limitation is that claims about `.env.example`, validator values, and the complete resolver precedence could not be independently confirmed from the baseline source. No independent task statement was supplied, but the issue is internally consistent with the task identifier and repository tags."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 85,
+        "notes": "The LLD commits to concrete files, call flow, response behavior, tests, compatibility boundaries, and a proportionate rollout for a small change. It correctly identifies the asynchronous call-site change in `registry/api/system_routes.py` and specifies isolated override and fallback tests in `tests/unit/test_stats_endpoint.py`. Its largest weakness is an internal contradiction: it acknowledges a newly reachable cached registry-card read but later claims there are no new network calls, and it recommends production constants as API-test oracles, which can hide a contract-value regression. Exact cache, logging, deployment-surface, and fail-silent implementation claims could not be independently verified from the baseline source."
+      },
+      "review": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 20,
+        "risk_awareness": 18,
+        "total": 75,
+        "notes": "The review raises concrete concerns about the stale endpoint docstring, the newly reachable operator-hint read, cache isolation, authentication, and constrained configuration values. Its strongest contribution is checking that an async `_resolve_cloud()` call fits the existing async handler while preserving the response schema. The largest deficiency is that every persona approves the design and the review endorses importing production method constants for compatibility assertions, an oracle that could change alongside broken production behavior. Claims that grep finds only `UptimeDisplay.tsx` and that every deployment surface is already wired were not independently verifiable."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 77,
+        "notes": "The plan provides concrete HTTP and unit-test setup, actions, status checks, exact response dictionaries, authentication coverage, and an unchanged-fallback oracle. The automated tests directly target `/api/system/telemetry-detection` and use dependency overrides matching the submitted implementation. Its largest gaps are no coverage for the newly exposed operator-declared, operator-declined, or repository-error paths, plus reliance on production constants rather than literal contract values; the telemetry-event parity check also lacks a concrete observation procedure. The final `uv run python -m unittest`/`pytest tests/` notation is not one executable command, and the authoritative repository test command could not be verified."
+      },
+      "implementation": {
+        "completeness": 19,
+        "correctness": 15,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 71,
+        "notes": "The production hunk implements the stated scope by changing the deferred import and awaiting `_resolve_cloud()` while preserving the two response keys, and the test hunk covers override and fallback cases. The largest defect is that the added fallback test calls `AsyncMock(...)` but the patch contains no import change; the testing artifact itself says that import must be added if missing, so the test can fail with `NameError` and the summary's claim of no deviations is overstated. The diff context targets the named handler and existing unauthenticated test location, but local `git apply --check` and the baseline import list could not be independently verified because repository commands failed before execution in the sandbox. Apart from the test-import defect, the handler change is internally consistent with the LLD and does not alter the JSON schema."
+      }
+    },
+    "task_score": 79.4,
+    "verdict": "Strong, repository-specific design work supports a small and plausible production fix, but the implementation likely leaves a regression test broken by omitting the required `AsyncMock` import.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:11:09.575698Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 318900,
+        "cached_input_tokens": 242503,
+        "cache_write_input_tokens": 34350,
+        "output_tokens": 11834,
+        "reasoning_output_tokens": 9715
+      },
+      "duration_ms": 196598
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 90,
+      "notes": "The issue provides unusually testable acceptance criteria, explicit non-goals, deployment scope, compatibility expectations, and security requirements. Its named integration points—`LiteLLMClient`, `registry/services/federation/federation_auth.py`, `/api/config`, and the documented deployment surfaces—match the submitted repository structure and patch context. Its largest gap is that it does not specify recovery behavior after a transient refresh failure, despite uninterrupted operation being the motivation. No independent task statement was supplied, so the requirement origin and related issue linkage could not be independently verified."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 76,
+      "notes": "The design is strongly repository-specific, naming the factory, sole documented construction site, configuration model, masking route, deployment files, token data flow, and default-off branching. It correctly commits to per-call `api_key` injection, locking, buffered expiry, startup validation, secret handling, and a dedicated provider rather than reusing the federation singleton. Its largest flaw is accepting the existing `_embedding_unavailable` latch after refresh errors: one transient IdP outage can permanently suppress further token retries until restart, contradicting the assertion that automatic refresh makes manual clearing unnecessary. It also fails to make conditional Docker/ECS environment rendering a design requirement, and the claimed LiteLLM authorization behavior could not be independently verified from the local dependency."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 19,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 74,
+      "notes": "The review raises concrete design concerns rather than merely approving: opaque `None` failures, a lock held across network I/O, SSRF trust boundaries, static-key shadowing, Terraform secret cost, and dimension changes. Its recommendations directly influenced identifiable design decisions, including raising `RuntimeError` and skipping `_set_api_key_env()` when a provider is attached. The largest deficiency is declaring every blocker resolved while missing the permanent unavailable-latch behavior and the acceptance requirement that default deployments set no new environment variables. It also did not expose the later Terraform placeholder-secret or Helm existing-secret failure modes, although those details were not fully specified in the reviewed LLD."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 15,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 69,
+      "notes": "The plan supplies concrete oracles for caching, buffered refresh, HTTP and network failures, scope propagation, bearer injection, startup validation, static-key compatibility, masking, and token-lifetime E2E behavior. However, it describes the suite as plain pytest while its principal examples use `unittest.TestCase`, and the thread test checks only POST count without collecting thread results or exceptions. Its largest coverage gap is that grep-based deployment checks would pass the submitted unconditional ECS/Compose wiring and would not detect Terraform's `not-configured` secret bypassing fail-fast validation. The proposed `/api/search`, `_format_value`, Helm, and re-index commands were not established by available repository evidence, and no malformed token response or transient-refresh recovery test is specified."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 13,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 66,
+      "notes": "The patch implements the central Python flow end to end: settings reach `create_embeddings_client`, the provider caches under a lock, and `LiteLLMClient.encode()` injects the token while preserving the static-key branch. The largest defect is Terraform's unconditional secret value `not-configured`: when IdP mode is enabled without a supplied secret, that nonempty sentinel defeats the promised startup validation; ECS and all Compose files also set new variables unconditionally despite the explicit default-inert acceptance criterion. Helm additionally loses an inline `embeddings.idp.clientSecret` when `app.existingSecret` suppresses the generated secret, while token JSON decoding and `expires_in` conversion can escape as unhandled raw exceptions. The summary also reports 24 files although the displayed diff contains 25, and its `git apply --check` claim could not be independently rerun because local command execution was unavailable."
+    }
+  },
+  "task_score": 75.0,
+  "verdict": "This is strong, repository-specific design work with a substantial implementation, but deployment wiring—especially Terraform's unconditional placeholder secret—breaks the promised fail-fast and default-inert behavior.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:14:20.055378Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 373651,
+      "cached_input_tokens": 312273,
+      "cache_write_input_tokens": 56880,
+      "output_tokens": 7582,
+      "reasoning_output_tokens": 5317
+    },
+    "duration_ms": 190468
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
@@ -1,0 +1,155 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "high",
+  "tags": [
+    "semantic-search",
+    "embeddings",
+    "oauth",
+    "authentication",
+    "litellm",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.29.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 71.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 13290,
+    "output_tokens": 84671,
+    "cache_read_tokens": 20522675,
+    "cache_write_tokens": 232323,
+    "total_tokens": 20852959,
+    "total_cost_usd": 13.896581249999999,
+    "latency_seconds": 1184.3,
+    "num_turns": 103,
+    "generation_tokens_per_sec": 71.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 13290,
+  "output_tokens": 84671,
+  "latency_seconds": 1184.3,
+  "num_turns": 103,
+  "total_cost_usd": 13.896581249999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 20522675,
+  "cache_creation_tokens": 232323,
+  "run_started_at": "2026-09-01T10:31:59.167862Z",
+  "run_ended_at": "2026-09-01T10:51:43.503244Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 13290,
+    "output_tokens": 84671,
+    "cache_read_tokens": 20522675,
+    "cache_write_tokens": 232323,
+    "total_tokens": 20852959,
+    "total_cost_usd": 13.896581249999999,
+    "latency_seconds": 1184.3,
+    "num_turns": 103,
+    "generation_tokens_per_sec": 71.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "idp-authenticated-embedding-endpoint",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 90,
+        "notes": "The issue provides unusually testable acceptance criteria, explicit non-goals, deployment scope, compatibility expectations, and security requirements. Its named integration points—`LiteLLMClient`, `registry/services/federation/federation_auth.py`, `/api/config`, and the documented deployment surfaces—match the submitted repository structure and patch context. Its largest gap is that it does not specify recovery behavior after a transient refresh failure, despite uninterrupted operation being the motivation. No independent task statement was supplied, so the requirement origin and related issue linkage could not be independently verified."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 76,
+        "notes": "The design is strongly repository-specific, naming the factory, sole documented construction site, configuration model, masking route, deployment files, token data flow, and default-off branching. It correctly commits to per-call `api_key` injection, locking, buffered expiry, startup validation, secret handling, and a dedicated provider rather than reusing the federation singleton. Its largest flaw is accepting the existing `_embedding_unavailable` latch after refresh errors: one transient IdP outage can permanently suppress further token retries until restart, contradicting the assertion that automatic refresh makes manual clearing unnecessary. It also fails to make conditional Docker/ECS environment rendering a design requirement, and the claimed LiteLLM authorization behavior could not be independently verified from the local dependency."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 19,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 74,
+        "notes": "The review raises concrete design concerns rather than merely approving: opaque `None` failures, a lock held across network I/O, SSRF trust boundaries, static-key shadowing, Terraform secret cost, and dimension changes. Its recommendations directly influenced identifiable design decisions, including raising `RuntimeError` and skipping `_set_api_key_env()` when a provider is attached. The largest deficiency is declaring every blocker resolved while missing the permanent unavailable-latch behavior and the acceptance requirement that default deployments set no new environment variables. It also did not expose the later Terraform placeholder-secret or Helm existing-secret failure modes, although those details were not fully specified in the reviewed LLD."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 15,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 69,
+        "notes": "The plan supplies concrete oracles for caching, buffered refresh, HTTP and network failures, scope propagation, bearer injection, startup validation, static-key compatibility, masking, and token-lifetime E2E behavior. However, it describes the suite as plain pytest while its principal examples use `unittest.TestCase`, and the thread test checks only POST count without collecting thread results or exceptions. Its largest coverage gap is that grep-based deployment checks would pass the submitted unconditional ECS/Compose wiring and would not detect Terraform's `not-configured` secret bypassing fail-fast validation. The proposed `/api/search`, `_format_value`, Helm, and re-index commands were not established by available repository evidence, and no malformed token response or transient-refresh recovery test is specified."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 13,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 66,
+        "notes": "The patch implements the central Python flow end to end: settings reach `create_embeddings_client`, the provider caches under a lock, and `LiteLLMClient.encode()` injects the token while preserving the static-key branch. The largest defect is Terraform's unconditional secret value `not-configured`: when IdP mode is enabled without a supplied secret, that nonempty sentinel defeats the promised startup validation; ECS and all Compose files also set new variables unconditionally despite the explicit default-inert acceptance criterion. Helm additionally loses an inline `embeddings.idp.clientSecret` when `app.existingSecret` suppresses the generated secret, while token JSON decoding and `expires_in` conversion can escape as unhandled raw exceptions. The summary also reports 24 files although the displayed diff contains 25, and its `git apply --check` claim could not be independently rerun because local command execution was unavailable."
+      }
+    },
+    "task_score": 75.0,
+    "verdict": "This is strong, repository-specific design work with a substantial implementation, but deployment wiring—especially Terraform's unconditional placeholder secret—breaks the promised fail-fast and default-inert behavior.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:14:20.055378Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 373651,
+        "cached_input_tokens": 312273,
+        "cache_write_input_tokens": 56880,
+        "output_tokens": 7582,
+        "reasoning_output_tokens": 5317
+      },
+      "duration_ms": 190468
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 18,
+      "specificity": 22,
+      "risk_awareness": 19,
+      "total": 81,
+      "notes": "The issue provides unusually testable acceptance criteria, explicit exclusions, grouping requirements, duplicate handling, and a precise README integration point. Its largest defect is the claim of 13 videos across nine source files: the artifacts themselves identify ten, including README.md, eight docs files, and release-notes/v1.0.3.md. The named examples, docs/demo-videos.md target, and no-removal constraint are concrete and internally supported. No independent task statement exists, and the tag-specific inventory could not be independently re-run because repository shell access failed."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 18,
+      "specificity": 24,
+      "risk_awareness": 19,
+      "total": 84,
+      "notes": "The LLD is implementation-ready for this small change, providing exact paths, URLs, topic placement, duplicate sources, README placement, and the important distinction between the two dynamic-discovery recordings. Its verified-scan claim is internally inconsistent because the Key Files table names ten matching source files while repeatedly reporting nine. It also incorrectly connects inability to validate external links with clone depth; network availability, not shallow history, controls that validation. Exact baseline line numbers and external URL behavior could not be independently verified."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 14,
+      "specificity": 20,
+      "risk_awareness": 17,
+      "total": 69,
+      "notes": "The strongest review findings are specific to this change: README wrapping, explicit MkDocs navigation, exhaustive inventory verification, GIF exclusion, and duplicate handling. The review nevertheless endorses the impossible nine-file count despite the LLD naming ten sources, then claims that the resulting grep expectation was resolved. It also calls operational risk zero and fails to catch the testing plan's undefined BASE_SHA and incomplete duplicate checks. Assertions that the scan, navigation check, and resolutions were executed are supported only by the candidate's own later summary."
+    },
+    "testing": {
+      "completeness": 18,
+      "correctness": 10,
+      "specificity": 21,
+      "risk_awareness": 16,
+      "total": 65,
+      "notes": "The plan has concrete per-video presence oracles, backward-compatibility checks, rendering checks, and a patch applicability check appropriate to a documentation change. Its principal expected result is wrong: the inventory described across the artifacts spans ten source files, not nine. The git diff command uses an undefined BASE_SHA, the patch path is not established, and duplicate counting covers only GitHub attachments rather than YouTube and Vidcast entries. Rendered MkDocs anchors and remote-link availability are delegated to manual review and could not be independently verified."
+    },
+    "implementation": {
+      "completeness": 23,
+      "correctness": 18,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 82,
+      "notes": "The submitted patch implements the requested page end to end: it contains 13 distinct entries in seven groups, records hosts and source pages, preserves existing content, and adds a prominent README link. The largest defect is the summary's false claim that nine files matched its scan while the generated page names ten source files and includes docs/federation-operational-guide.md, which the summary omits. The patch is otherwise focused and its README deviation is clearly justified, although hard-coded double-hyphen anchors may not match MkDocs slug generation for headings containing ampersands. Local source-context and git apply --check verification could not be completed because the repository shell sandbox failed before executing commands."
+    }
+  },
+  "task_score": 76.2,
+  "verdict": "A strong and likely functional documentation patch is undermined by an internally contradictory inventory count and a testing plan containing commands and expectations that would not pass as written.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:17:00.134986Z",
+    "repo_ref": "1.24.3",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 265362,
+      "cached_input_tokens": 197060,
+      "cache_write_input_tokens": 31968,
+      "output_tokens": 10484,
+      "reasoning_output_tokens": 8419
+    },
+    "duration_ms": 160068
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.3",
+  "complexity": "trivial",
+  "tags": [
+    "docs",
+    "markdown",
+    "readme",
+    "discoverability",
+    "fixed-in-1.24.4"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 70.8,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 223,
+    "output_tokens": 28813,
+    "cache_read_tokens": 2196618,
+    "cache_write_tokens": 66972,
+    "total_tokens": 2292626,
+    "total_cost_usd": 2.238324,
+    "latency_seconds": 406.8,
+    "num_turns": 26,
+    "generation_tokens_per_sec": 70.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 223,
+  "output_tokens": 28813,
+  "latency_seconds": 406.8,
+  "num_turns": 26,
+  "total_cost_usd": 2.238324,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2196618,
+  "cache_creation_tokens": 66972,
+  "run_started_at": "2026-09-01T10:51:46.437301Z",
+  "run_ended_at": "2026-09-01T10:58:33.292984Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 223,
+    "output_tokens": 28813,
+    "cache_read_tokens": 2196618,
+    "cache_write_tokens": 66972,
+    "total_tokens": 2292626,
+    "total_cost_usd": 2.238324,
+    "latency_seconds": 406.8,
+    "num_turns": 26,
+    "generation_tokens_per_sec": 70.8,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "index-demo-videos-in-one-page",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 18,
+        "specificity": 22,
+        "risk_awareness": 19,
+        "total": 81,
+        "notes": "The issue provides unusually testable acceptance criteria, explicit exclusions, grouping requirements, duplicate handling, and a precise README integration point. Its largest defect is the claim of 13 videos across nine source files: the artifacts themselves identify ten, including README.md, eight docs files, and release-notes/v1.0.3.md. The named examples, docs/demo-videos.md target, and no-removal constraint are concrete and internally supported. No independent task statement exists, and the tag-specific inventory could not be independently re-run because repository shell access failed."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 18,
+        "specificity": 24,
+        "risk_awareness": 19,
+        "total": 84,
+        "notes": "The LLD is implementation-ready for this small change, providing exact paths, URLs, topic placement, duplicate sources, README placement, and the important distinction between the two dynamic-discovery recordings. Its verified-scan claim is internally inconsistent because the Key Files table names ten matching source files while repeatedly reporting nine. It also incorrectly connects inability to validate external links with clone depth; network availability, not shallow history, controls that validation. Exact baseline line numbers and external URL behavior could not be independently verified."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 14,
+        "specificity": 20,
+        "risk_awareness": 17,
+        "total": 69,
+        "notes": "The strongest review findings are specific to this change: README wrapping, explicit MkDocs navigation, exhaustive inventory verification, GIF exclusion, and duplicate handling. The review nevertheless endorses the impossible nine-file count despite the LLD naming ten sources, then claims that the resulting grep expectation was resolved. It also calls operational risk zero and fails to catch the testing plan's undefined BASE_SHA and incomplete duplicate checks. Assertions that the scan, navigation check, and resolutions were executed are supported only by the candidate's own later summary."
+      },
+      "testing": {
+        "completeness": 18,
+        "correctness": 10,
+        "specificity": 21,
+        "risk_awareness": 16,
+        "total": 65,
+        "notes": "The plan has concrete per-video presence oracles, backward-compatibility checks, rendering checks, and a patch applicability check appropriate to a documentation change. Its principal expected result is wrong: the inventory described across the artifacts spans ten source files, not nine. The git diff command uses an undefined BASE_SHA, the patch path is not established, and duplicate counting covers only GitHub attachments rather than YouTube and Vidcast entries. Rendered MkDocs anchors and remote-link availability are delegated to manual review and could not be independently verified."
+      },
+      "implementation": {
+        "completeness": 23,
+        "correctness": 18,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 82,
+        "notes": "The submitted patch implements the requested page end to end: it contains 13 distinct entries in seven groups, records hosts and source pages, preserves existing content, and adds a prominent README link. The largest defect is the summary's false claim that nine files matched its scan while the generated page names ten source files and includes docs/federation-operational-guide.md, which the summary omits. The patch is otherwise focused and its README deviation is clearly justified, although hard-coded double-hyphen anchors may not match MkDocs slug generation for headings containing ampersands. Local source-context and git apply --check verification could not be completed because the repository shell sandbox failed before executing commands."
+      }
+    },
+    "task_score": 76.2,
+    "verdict": "A strong and likely functional documentation patch is undermined by an internally contradictory inventory count and a testing plan containing commands and expectations that would not pass as written.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:17:00.134986Z",
+      "repo_ref": "1.24.3",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 265362,
+        "cached_input_tokens": 197060,
+        "cache_write_input_tokens": 31968,
+        "output_tokens": 10484,
+        "reasoning_output_tokens": 8419
+      },
+      "duration_ms": 160068
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 89,
+      "notes": "The issue clearly defines five cross-entity deliverables, measurable acceptance criteria, dependencies, and explicit non-goals. Its named route modules, webhook service, lifecycle enum, and scopes file correspond to targets and symbols present in the submitted diff. The largest evidence gap is the absence of an independent task statement, so claims such as the existing polling endpoints and exact intended scope cannot be independently confirmed. Security, compatibility, and delivery risks are handled unusually well for an issue, though signing-key rotation is not addressed."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 19,
+      "total": 78,
+      "notes": "The LLD is strongly repository-shaped, naming concrete functions such as send_registration_webhook and all three scan handlers while committing to exact-body signing and additive authorization. The submitted source context supports the central chokepoint and PUT-versus-PATCH distinctions. Its largest correctness gap is failure to establish how request-model defaults preserve the required distinction between omitted and explicitly mismatched initial statuses; it also claims validation while leaving registration_initial_status as an unchecked string until request handling. The threat model covers forgery, replay, and least privilege, but omits coordinated key rotation and unsuccessful HTTP response classification."
+    },
+    "review": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 21,
+      "total": 80,
+      "notes": "The review identifies concrete defects with consequences, notably json= reserialization breaking HMAC verification, skill authorization needing to remain additive, replay handling, and unsigned-send observability. Those findings correspond directly to code paths shown in webhook_service.py and skill_routes.py. Its largest omission is failing to challenge initial-status omission semantics, configuration-value validation, and treating HTTP error responses as successful sends. The statement that every finding was resolved is overstated because detailed LLD steps still use ad hoc normalized comparisons rather than the promised shared validator."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 12,
+      "specificity": 15,
+      "risk_awareness": 19,
+      "total": 63,
+      "notes": "The strongest tests use the raw received body as the HMAC oracle and exercise least privilege, forged payloads, compatibility defaults, and all entity types. The plan also specifies meaningful expected status codes and scan fields rather than merely asserting execution. Its ordering expectation for registration followed by scan_complete conflicts with its own contract stating that independently scheduled events are unordered, while unsafe targets and raw-body capture are not concretely provisioned. The proposed unittest discovery command, exact fixtures, and several configuration commands remain unverified, and no corresponding tests appear in the patch."
+    },
+    "implementation": {
+      "completeness": 14,
+      "correctness": 11,
+      "specificity": 19,
+      "risk_awareness": 14,
+      "total": 58,
+      "notes": "The patch implements the main architecture coherently: webhook_service.py serializes once and posts content=body, permission checks cover server, agent, and skill updates, and scopes, metrics, environment documentation, and the consumer contract are included. Concrete defects remain: registration_initial_status is not validated at configuration load, and every HTTP response—including 4xx or 5xx—is recorded as success. Enforcement operates on already-materialized request.status values without checking field presence, risking rejection rather than forcing when an omitted field has an existing non-null default. No automated tests are included, and the claimed clean git application could not be independently verified because local repository command execution was unavailable."
+    }
+  },
+  "task_score": 73.6,
+  "verdict": "Strong, repository-shaped design work is undermined by material implementation and testing gaps around initial-status defaults, invalid configuration, webhook failure accounting, and executable regression coverage.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:21:34.095962Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 425819,
+      "cached_input_tokens": 325379,
+      "cache_write_input_tokens": 52149,
+      "output_tokens": 16592,
+      "reasoning_output_tokens": 14452
+    },
+    "duration_ms": 273949
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
@@ -1,0 +1,154 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "high",
+  "tags": [
+    "architecture",
+    "security",
+    "api",
+    "webhooks",
+    "hmac",
+    "lifecycle",
+    "permissions",
+    "fixed-in-1.25.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 65.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4248,
+    "output_tokens": 84432,
+    "cache_read_tokens": 22461382,
+    "cache_write_tokens": 218648,
+    "total_tokens": 22768710,
+    "total_cost_usd": 14.729281000000002,
+    "latency_seconds": 1280.9,
+    "num_turns": 121,
+    "generation_tokens_per_sec": 65.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4248,
+  "output_tokens": 84432,
+  "latency_seconds": 1280.9,
+  "num_turns": 121,
+  "total_cost_usd": 14.729281000000002,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 22461382,
+  "cache_creation_tokens": 218648,
+  "run_started_at": "2026-09-01T09:43:59.089360Z",
+  "run_ended_at": "2026-09-01T10:05:20.000680Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4248,
+    "output_tokens": 84432,
+    "cache_read_tokens": 22461382,
+    "cache_write_tokens": 218648,
+    "total_tokens": 22768710,
+    "total_cost_usd": 14.729281000000002,
+    "latency_seconds": 1280.9,
+    "num_turns": 121,
+    "generation_tokens_per_sec": 65.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "lifecycle-workflow-webhooks",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 89,
+        "notes": "The issue clearly defines five cross-entity deliverables, measurable acceptance criteria, dependencies, and explicit non-goals. Its named route modules, webhook service, lifecycle enum, and scopes file correspond to targets and symbols present in the submitted diff. The largest evidence gap is the absence of an independent task statement, so claims such as the existing polling endpoints and exact intended scope cannot be independently confirmed. Security, compatibility, and delivery risks are handled unusually well for an issue, though signing-key rotation is not addressed."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 19,
+        "total": 78,
+        "notes": "The LLD is strongly repository-shaped, naming concrete functions such as send_registration_webhook and all three scan handlers while committing to exact-body signing and additive authorization. The submitted source context supports the central chokepoint and PUT-versus-PATCH distinctions. Its largest correctness gap is failure to establish how request-model defaults preserve the required distinction between omitted and explicitly mismatched initial statuses; it also claims validation while leaving registration_initial_status as an unchecked string until request handling. The threat model covers forgery, replay, and least privilege, but omits coordinated key rotation and unsuccessful HTTP response classification."
+      },
+      "review": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 21,
+        "total": 80,
+        "notes": "The review identifies concrete defects with consequences, notably json= reserialization breaking HMAC verification, skill authorization needing to remain additive, replay handling, and unsigned-send observability. Those findings correspond directly to code paths shown in webhook_service.py and skill_routes.py. Its largest omission is failing to challenge initial-status omission semantics, configuration-value validation, and treating HTTP error responses as successful sends. The statement that every finding was resolved is overstated because detailed LLD steps still use ad hoc normalized comparisons rather than the promised shared validator."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 12,
+        "specificity": 15,
+        "risk_awareness": 19,
+        "total": 63,
+        "notes": "The strongest tests use the raw received body as the HMAC oracle and exercise least privilege, forged payloads, compatibility defaults, and all entity types. The plan also specifies meaningful expected status codes and scan fields rather than merely asserting execution. Its ordering expectation for registration followed by scan_complete conflicts with its own contract stating that independently scheduled events are unordered, while unsafe targets and raw-body capture are not concretely provisioned. The proposed unittest discovery command, exact fixtures, and several configuration commands remain unverified, and no corresponding tests appear in the patch."
+      },
+      "implementation": {
+        "completeness": 14,
+        "correctness": 11,
+        "specificity": 19,
+        "risk_awareness": 14,
+        "total": 58,
+        "notes": "The patch implements the main architecture coherently: webhook_service.py serializes once and posts content=body, permission checks cover server, agent, and skill updates, and scopes, metrics, environment documentation, and the consumer contract are included. Concrete defects remain: registration_initial_status is not validated at configuration load, and every HTTP response—including 4xx or 5xx—is recorded as success. Enforcement operates on already-materialized request.status values without checking field presence, risking rejection rather than forcing when an omitted field has an existing non-null default. No automated tests are included, and the claimed clean git application could not be independently verified because local repository command execution was unavailable."
+      }
+    },
+    "task_score": 73.6,
+    "verdict": "Strong, repository-shaped design work is undermined by material implementation and testing gaps around initial-status defaults, invalid configuration, webhook failure accounting, and executable regression coverage.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:21:34.095962Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 425819,
+        "cached_input_tokens": 325379,
+        "cache_write_input_tokens": 52149,
+        "output_tokens": 16592,
+        "reasoning_output_tokens": 14452
+      },
+      "duration_ms": 273949
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 20,
+      "total": 81,
+      "notes": "The issue clearly defines the WAF failure, security motivation, rolling-upgrade behavior, non-goals, and testable acceptance criteria. Its named integration points align internally with the submitted diff, including `registry/auth/routes.py::logout_handler`, `settings.auth_server_url`, and the existing direct `id_token_hint` path. The largest deficiency is that it promises to remove the token from any browser-facing URL and browser history, while its proposed flow still sends the browser to the IdP with `id_token_hint` in that URL. No independent task statement was supplied, and the claimed line numbers and upstream issue could not be independently verified because repository shell execution was unavailable."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 16,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 78,
+      "notes": "The LLD is unusually concrete about APIs, data flow, storage, encryption, metrics, failure behavior, files, and backward-compatible request precedence. Its major correctness gap is the claim that deployment order is fully safe: during a rolling auth-server upgrade, ticket creation can hit a new replica while the browser's consume request hits an old replica that ignores `logout_ticket`, intermittently losing IdP logout. The proposed `_get_collection` also caches the collection after an index-creation failure, preventing retries and allowing abandoned encrypted tokens to persist without the promised TTL cleanup; `encrypt_id_token` is outside `create_ticket`'s exception boundary despite the stated never-raise contract. There is also a minor internal inconsistency between the three-second implementation timeout and the five-second scaling discussion, while exact repository conventions could not be independently inspected."
+    },
+    "review": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 71,
+      "notes": "The review finds concrete issues—provider binding, secret-safe logging, user-path timeout, write/read consistency, and fallback observability—and records actionable resolutions that appear in the patch. It specifically drove `consume_ticket(..., provider=provider)`, the three-second timeout, and the two new counters. Its largest omission is the mixed-replica rolling-upgrade race, and its assertion that TTL cleanup prevents unbounded growth overlooks the LLD's swallowed index failure and non-retrying cache. It also accepts the broad browser-URL security claim despite acknowledging that the subsequent IdP redirect still contains the JWT."
+    },
+    "testing": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 18,
+      "total": 76,
+      "notes": "The plan covers endpoint authentication, opacity, single use, provider binding, direct-hint compatibility, fallback, metrics, rollback, and an end-to-end IdP-session oracle rather than merely checking status codes. Strong concrete assertions include excluding `id_token_hint` from the registry redirect and requiring it in the IdP `Location`. It omits the critical mixed old/new auth-server replica scenario, failed TTL-index creation, encryption failure, and malformed successful ticket responses. Several unit cases remain pseudocode with ellipses, and the proposed test paths and `uv run pytest tests/` command could not be independently verified against the repository."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 15,
+      "specificity": 22,
+      "risk_awareness": 14,
+      "total": 69,
+      "notes": "The patch implements the stable all-new flow end to end: authenticated ticket creation, encrypted shared storage, atomic consumption, provider binding, registry fallback, direct-hint compatibility, and metrics. The largest operational defect is the unhandled mixed-replica upgrade race; additionally, `_get_collection` never retries failed TTL-index creation, and encryption occurs outside the advertised failure-catching block. No tests accompany the production changes, and the summary overstates removal from browser-facing URLs because the IdP redirect still contains `id_token_hint`. The diff is internally coherent with the named symbols and contexts, but its claimed clean application to commit `5f725c1d` could not be independently confirmed because local shell execution failed before running `git apply --check`."
+    }
+  },
+  "task_score": 75.0,
+  "verdict": "The submission is detailed and largely implementation-ready, but its rollout safety is incomplete and its security claim exceeds what the browser-mediated IdP redirect actually achieves.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:25:14.600142Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 345928,
+      "cached_input_tokens": 250006,
+      "cache_write_input_tokens": 45940,
+      "output_tokens": 13920,
+      "reasoning_output_tokens": 11944
+    },
+    "duration_ms": 220492
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "auth",
+    "oidc",
+    "logout",
+    "security",
+    "waf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 75.4,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 9662,
+    "output_tokens": 58134,
+    "cache_read_tokens": 6117663,
+    "cache_write_tokens": 128955,
+    "total_tokens": 6314414,
+    "total_cost_usd": 5.366460249999999,
+    "latency_seconds": 771.1,
+    "num_turns": 48,
+    "generation_tokens_per_sec": 75.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 9662,
+  "output_tokens": 58134,
+  "latency_seconds": 771.1,
+  "num_turns": 48,
+  "total_cost_usd": 5.366460249999999,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 6117663,
+  "cache_creation_tokens": 128955,
+  "run_started_at": "2026-09-01T11:25:39.270364Z",
+  "run_ended_at": "2026-09-01T11:38:30.415871Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 9662,
+    "output_tokens": 58134,
+    "cache_read_tokens": 6117663,
+    "cache_write_tokens": 128955,
+    "total_tokens": 6314414,
+    "total_cost_usd": 5.366460249999999,
+    "latency_seconds": 771.1,
+    "num_turns": 48,
+    "generation_tokens_per_sec": 75.4,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "logout-id-token-hint-out-of-browser-url",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 20,
+        "total": 81,
+        "notes": "The issue clearly defines the WAF failure, security motivation, rolling-upgrade behavior, non-goals, and testable acceptance criteria. Its named integration points align internally with the submitted diff, including `registry/auth/routes.py::logout_handler`, `settings.auth_server_url`, and the existing direct `id_token_hint` path. The largest deficiency is that it promises to remove the token from any browser-facing URL and browser history, while its proposed flow still sends the browser to the IdP with `id_token_hint` in that URL. No independent task statement was supplied, and the claimed line numbers and upstream issue could not be independently verified because repository shell execution was unavailable."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 16,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 78,
+        "notes": "The LLD is unusually concrete about APIs, data flow, storage, encryption, metrics, failure behavior, files, and backward-compatible request precedence. Its major correctness gap is the claim that deployment order is fully safe: during a rolling auth-server upgrade, ticket creation can hit a new replica while the browser's consume request hits an old replica that ignores `logout_ticket`, intermittently losing IdP logout. The proposed `_get_collection` also caches the collection after an index-creation failure, preventing retries and allowing abandoned encrypted tokens to persist without the promised TTL cleanup; `encrypt_id_token` is outside `create_ticket`'s exception boundary despite the stated never-raise contract. There is also a minor internal inconsistency between the three-second implementation timeout and the five-second scaling discussion, while exact repository conventions could not be independently inspected."
+      },
+      "review": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 71,
+        "notes": "The review finds concrete issues—provider binding, secret-safe logging, user-path timeout, write/read consistency, and fallback observability—and records actionable resolutions that appear in the patch. It specifically drove `consume_ticket(..., provider=provider)`, the three-second timeout, and the two new counters. Its largest omission is the mixed-replica rolling-upgrade race, and its assertion that TTL cleanup prevents unbounded growth overlooks the LLD's swallowed index failure and non-retrying cache. It also accepts the broad browser-URL security claim despite acknowledging that the subsequent IdP redirect still contains the JWT."
+      },
+      "testing": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 18,
+        "total": 76,
+        "notes": "The plan covers endpoint authentication, opacity, single use, provider binding, direct-hint compatibility, fallback, metrics, rollback, and an end-to-end IdP-session oracle rather than merely checking status codes. Strong concrete assertions include excluding `id_token_hint` from the registry redirect and requiring it in the IdP `Location`. It omits the critical mixed old/new auth-server replica scenario, failed TTL-index creation, encryption failure, and malformed successful ticket responses. Several unit cases remain pseudocode with ellipses, and the proposed test paths and `uv run pytest tests/` command could not be independently verified against the repository."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 15,
+        "specificity": 22,
+        "risk_awareness": 14,
+        "total": 69,
+        "notes": "The patch implements the stable all-new flow end to end: authenticated ticket creation, encrypted shared storage, atomic consumption, provider binding, registry fallback, direct-hint compatibility, and metrics. The largest operational defect is the unhandled mixed-replica upgrade race; additionally, `_get_collection` never retries failed TTL-index creation, and encryption occurs outside the advertised failure-catching block. No tests accompany the production changes, and the summary overstates removal from browser-facing URLs because the IdP redirect still contains `id_token_hint`. The diff is internally coherent with the named symbols and contexts, but its claimed clean application to commit `5f725c1d` could not be independently confirmed because local shell execution failed before running `git apply --check`."
+      }
+    },
+    "task_score": 75.0,
+    "verdict": "The submission is detailed and largely implementation-ready, but its rollout safety is incomplete and its security claim exceeds what the browser-mediated IdP redirect actually achieves.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:25:14.600142Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 345928,
+        "cached_input_tokens": 250006,
+        "cache_write_input_tokens": 45940,
+        "output_tokens": 13920,
+        "reasoning_output_tokens": 11944
+      },
+      "duration_ms": 220492
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 7,
+      "specificity": 21,
+      "risk_awareness": 11,
+      "total": 57,
+      "notes": "The issue provides precise scope, non-goals, phase references, and directly testable acceptance criteria. Its central diagnosis is incorrect: the repository's post-fix skill checks `uv python find '>=3.14'` because Phase 5 uses uv-managed interpreters, so rejecting an older `python3` on PATH can block a valid setup. The original skill does contain the quoted permissive probe and existing remediation table, grounding those repository claims. No independent task statement or verified issue #1568 text establishes the proposed dynamic-metadata requirement."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 6,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 59,
+      "notes": "The LLD is concrete about the real skill file, phase ordering, marker tokens, output, fallback branches, and known parsing assumptions. Its load-bearing interface is wrong because it compares the system `python3` rather than the interpreter uv will select, contrary to the repository's post-fix implementation. The first-version regex also does not generally follow `requires-python`: patch releases, upper bounds, exclusions, and reordered constraints can be evaluated incorrectly. It discusses offline fallback and ref drift, but understates the false-failure risk and the new Phase 1 network dependency."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 7,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 53,
+      "notes": "The review raises specific concerns about equality, constraint parsing, offline degradation, ref drift, output vocabulary, and trust boundaries. However, every reviewer misses the decisive architectural question of whether PATH's `python3` is the interpreter used by `uv sync`; the repository's actual corrected approach shows it is not necessarily so. Consequently the approval verdict preserves a design that can reject setups already possessing a suitable uv-managed Python. Its claim that all findings were resolved also overstates matters because parsing and offline behavior remain acknowledged limitations."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 7,
+      "specificity": 19,
+      "risk_awareness": 11,
+      "total": 54,
+      "notes": "The plan supplies concrete scenarios and output oracles for below-minimum, equal, newer, absent, and unavailable-metadata cases, plus token-shape and UX checks. All primary tests stub `python3` rather than uv's selected interpreter, so they can pass while the implementation still rejects a valid uv-managed Python configuration. The absent-interpreter command is not deterministic because `/usr/bin:/bin` may contain `python3`, and the manually copied script can diverge from the skill block. It also omits remote-success, local-precedence, and meaningful PEP 440 constraint cases that would expose the parser's limitations."
+    },
+    "implementation": {
+      "completeness": 14,
+      "correctness": 6,
+      "specificity": 20,
+      "risk_awareness": 10,
+      "total": 50,
+      "notes": "The patch targets the exact original Python probe context, stays within Phase 1, and faithfully implements the submitted LLD's local-or-remote metadata flow and output details. It does not implement the repository's actual required behavior because it gates PATH's `python3` instead of asking uv whether a compatible interpreter is available, producing false failures. Its extraction of only the first `X.Y` also fails to enforce general `requires-python` specifications, despite the summary claiming the gate automatically follows metadata changes. The textual hunk context matches the original source, but the exact commit hash and asserted `git apply --check` execution could not be independently rerun because local command execution was unavailable."
+    }
+  },
+  "task_score": 54.6,
+  "verdict": "The submission is unusually detailed and internally consistent, but it solves the wrong interpreter-selection problem and therefore risks rejecting valid uv-managed setups.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:26:49.982390Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 196297,
+      "cached_input_tokens": 128510,
+      "cache_write_input_tokens": 30891,
+      "output_tokens": 7530,
+      "reasoning_output_tokens": 5515
+    },
+    "duration_ms": 95371
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "setup",
+    "skill",
+    "developer-experience",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 75.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4377,
+    "output_tokens": 35517,
+    "cache_read_tokens": 2722997,
+    "cache_write_tokens": 78298,
+    "total_tokens": 2841189,
+    "total_cost_usd": 2.7606709999999985,
+    "latency_seconds": 470.3,
+    "num_turns": 29,
+    "generation_tokens_per_sec": 75.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 4377,
+  "output_tokens": 35517,
+  "latency_seconds": 470.3,
+  "num_turns": 29,
+  "total_cost_usd": 2.7606709999999985,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2722997,
+  "cache_creation_tokens": 78298,
+  "run_started_at": "2026-09-01T11:09:58.103154Z",
+  "run_ended_at": "2026-09-01T11:17:48.388414Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 4377,
+    "output_tokens": 35517,
+    "cache_read_tokens": 2722997,
+    "cache_write_tokens": 78298,
+    "total_tokens": 2841189,
+    "total_cost_usd": 2.7606709999999985,
+    "latency_seconds": 470.3,
+    "num_turns": 29,
+    "generation_tokens_per_sec": 75.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "macos-setup-python-version-precheck",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 7,
+        "specificity": 21,
+        "risk_awareness": 11,
+        "total": 57,
+        "notes": "The issue provides precise scope, non-goals, phase references, and directly testable acceptance criteria. Its central diagnosis is incorrect: the repository's post-fix skill checks `uv python find '>=3.14'` because Phase 5 uses uv-managed interpreters, so rejecting an older `python3` on PATH can block a valid setup. The original skill does contain the quoted permissive probe and existing remediation table, grounding those repository claims. No independent task statement or verified issue #1568 text establishes the proposed dynamic-metadata requirement."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 6,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 59,
+        "notes": "The LLD is concrete about the real skill file, phase ordering, marker tokens, output, fallback branches, and known parsing assumptions. Its load-bearing interface is wrong because it compares the system `python3` rather than the interpreter uv will select, contrary to the repository's post-fix implementation. The first-version regex also does not generally follow `requires-python`: patch releases, upper bounds, exclusions, and reordered constraints can be evaluated incorrectly. It discusses offline fallback and ref drift, but understates the false-failure risk and the new Phase 1 network dependency."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 7,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 53,
+        "notes": "The review raises specific concerns about equality, constraint parsing, offline degradation, ref drift, output vocabulary, and trust boundaries. However, every reviewer misses the decisive architectural question of whether PATH's `python3` is the interpreter used by `uv sync`; the repository's actual corrected approach shows it is not necessarily so. Consequently the approval verdict preserves a design that can reject setups already possessing a suitable uv-managed Python. Its claim that all findings were resolved also overstates matters because parsing and offline behavior remain acknowledged limitations."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 7,
+        "specificity": 19,
+        "risk_awareness": 11,
+        "total": 54,
+        "notes": "The plan supplies concrete scenarios and output oracles for below-minimum, equal, newer, absent, and unavailable-metadata cases, plus token-shape and UX checks. All primary tests stub `python3` rather than uv's selected interpreter, so they can pass while the implementation still rejects a valid uv-managed Python configuration. The absent-interpreter command is not deterministic because `/usr/bin:/bin` may contain `python3`, and the manually copied script can diverge from the skill block. It also omits remote-success, local-precedence, and meaningful PEP 440 constraint cases that would expose the parser's limitations."
+      },
+      "implementation": {
+        "completeness": 14,
+        "correctness": 6,
+        "specificity": 20,
+        "risk_awareness": 10,
+        "total": 50,
+        "notes": "The patch targets the exact original Python probe context, stays within Phase 1, and faithfully implements the submitted LLD's local-or-remote metadata flow and output details. It does not implement the repository's actual required behavior because it gates PATH's `python3` instead of asking uv whether a compatible interpreter is available, producing false failures. Its extraction of only the first `X.Y` also fails to enforce general `requires-python` specifications, despite the summary claiming the gate automatically follows metadata changes. The textual hunk context matches the original source, but the exact commit hash and asserted `git apply --check` execution could not be independently rerun because local command execution was unavailable."
+      }
+    },
+    "task_score": 54.6,
+    "verdict": "The submission is unusually detailed and internally consistent, but it solves the wrong interpreter-selection problem and therefore risks rejecting valid uv-managed setups.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:26:49.982390Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 196297,
+        "cached_input_tokens": 128510,
+        "cache_write_input_tokens": 30891,
+        "output_tokens": 7530,
+        "reasoning_output_tokens": 5515
+      },
+      "duration_ms": 95371
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 87,
+      "notes": "The strongest aspect is the precise problem statement and testable acceptance criteria around `_create_location_block`, trailing-slash matching, authentication, normalization, and deployment regeneration. The submitted diff preimage contains the cited bare-prefix location tail, and the proposed exact-match redirect plus slash-terminated prefix is technically coherent with nginx routing semantics. The largest limitation is that the issue deliberately leaves the similarly shaped `_add_virtual_server_location` path unresolved, while no independent task statement establishes whether that exclusion is complete. The exact auth response, startup regeneration behavior, and repository line references could not be independently verified because the repository sandbox failed before command execution."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 21,
+      "total": 85,
+      "notes": "The strongest aspect is an implementation-ready data-flow design naming `_create_location_block`, the proxy target, template substitution, tests, rollout, and compatibility behavior. Its proposed output correctly pairs `location = {{ROOT_PATH}}/name` with `location {{ROOT_PATH}}/name/` and preserves the submitted `mcp-proxy/name/` target. The largest defect is that the empty-segment guard returns the original block for `/`, producing `location {{ROOT_PATH}}/`, which is itself a root-capturing prefix and contradicts the guard's stated rationale; reserved-prefix registrations also remain an operationally disruptive follow-up. Exact source line numbers, validator behavior, and the claim that failed nginx validation retains the prior configuration could not be independently confirmed because repository commands were unavailable."
+    },
+    "review": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 22,
+      "risk_awareness": 22,
+      "total": 85,
+      "notes": "The strongest aspect is that the review identifies concrete risks rather than merely approving the design, especially reserved-route collisions, empty paths, redirect authentication, proxy URI substitution, caching, and reload behavior. It provides actionable resolutions tied to `ServerInfo._validate_path`, `_RESERVED_SERVER_PATH_NAMES`, `_write_and_validate_config`, and specific proposed tests. Its largest deficiency is accepting the empty-segment resolution without noticing that the fallback still emits a root prefix, and it declares all blocking findings resolved while the reserved-prefix risk remains explicitly unmitigated. The review's claimed investigation of repository validators and reload internals could not be independently verified due the unavailable repository shell."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 21,
+      "risk_awareness": 19,
+      "total": 78,
+      "notes": "The strongest aspect is the concrete unit coverage for the emitted location shape, unauthenticated redirect, normalization, sibling-prefix removal, proxy target preservation, and existing-test compatibility. The primary regression would be caught by assertions excluding `location {{ROOT_PATH}}/a {` and requiring `location {{ROOT_PATH}}/a/ {`. The largest defects are weak or incorrect oracles: the empty-path test permits the actual fallback `location {{ROOT_PATH}}/`, the `/demo` setup cannot collide with `/api`, and `/mn` does not prefix `/manage`. The pytest fixture compatibility and stated commands could not be executed or independently verified because the repository sandbox failed to launch commands."
+    },
+    "implementation": {
+      "completeness": 22,
+      "correctness": 19,
+      "specificity": 23,
+      "risk_awareness": 18,
+      "total": 82,
+      "notes": "The patch directly implements the central design in `registry/core/nginx_service.py` and adds six focused tests in `tests/unit/core/test_nginx_service.py`. The normal-path output is internally correct: `/name` and `/name/` normalize identically, the redirect contains no `auth_request`, and the proxied prefix ends in `/`. The largest defect is the purported defense-in-depth branch for `/`, which returns `location {{ROOT_PATH}}/` and therefore still captures the root namespace, while its test only excludes an exact block and a double-slash block. Patch applicability, real surrounding symbols, and the summary's `git apply --check` claim could not be independently confirmed because the read-only sandbox failed before command execution; that harness failure was not treated as a candidate defect."
+    }
+  },
+  "task_score": 83.4,
+  "verdict": "This is a strong and largely implementation-ready routing fix, with the largest material limitation being that its claimed empty-path defense still emits a root-capturing prefix and the accompanying test would not detect it.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:30:24.530950Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 272281,
+      "cached_input_tokens": 184728,
+      "cache_write_input_tokens": 40742,
+      "output_tokens": 13562,
+      "reasoning_output_tokens": 11527
+    },
+    "duration_ms": 214537
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "medium",
+  "tags": [
+    "bug",
+    "security",
+    "nginx",
+    "routing",
+    "auth",
+    "python",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 74.2,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2554,
+    "output_tokens": 57756,
+    "cache_read_tokens": 5822699,
+    "cache_write_tokens": 139205,
+    "total_tokens": 6022214,
+    "total_cost_usd": 5.23805075,
+    "latency_seconds": 778.6,
+    "num_turns": 43,
+    "generation_tokens_per_sec": 74.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 2554,
+  "output_tokens": 57756,
+  "latency_seconds": 778.6,
+  "num_turns": 43,
+  "total_cost_usd": 5.23805075,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 5822699,
+  "cache_creation_tokens": 139205,
+  "run_started_at": "2026-09-01T09:01:17.252365Z",
+  "run_ended_at": "2026-09-01T09:14:15.903041Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 2554,
+    "output_tokens": 57756,
+    "cache_read_tokens": 5822699,
+    "cache_write_tokens": 139205,
+    "total_tokens": 6022214,
+    "total_cost_usd": 5.23805075,
+    "latency_seconds": 778.6,
+    "num_turns": 43,
+    "generation_tokens_per_sec": 74.2,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "nginx-location-trailing-slash-route-hijack",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 87,
+        "notes": "The strongest aspect is the precise problem statement and testable acceptance criteria around `_create_location_block`, trailing-slash matching, authentication, normalization, and deployment regeneration. The submitted diff preimage contains the cited bare-prefix location tail, and the proposed exact-match redirect plus slash-terminated prefix is technically coherent with nginx routing semantics. The largest limitation is that the issue deliberately leaves the similarly shaped `_add_virtual_server_location` path unresolved, while no independent task statement establishes whether that exclusion is complete. The exact auth response, startup regeneration behavior, and repository line references could not be independently verified because the repository sandbox failed before command execution."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 21,
+        "total": 85,
+        "notes": "The strongest aspect is an implementation-ready data-flow design naming `_create_location_block`, the proxy target, template substitution, tests, rollout, and compatibility behavior. Its proposed output correctly pairs `location = {{ROOT_PATH}}/name` with `location {{ROOT_PATH}}/name/` and preserves the submitted `mcp-proxy/name/` target. The largest defect is that the empty-segment guard returns the original block for `/`, producing `location {{ROOT_PATH}}/`, which is itself a root-capturing prefix and contradicts the guard's stated rationale; reserved-prefix registrations also remain an operationally disruptive follow-up. Exact source line numbers, validator behavior, and the claim that failed nginx validation retains the prior configuration could not be independently confirmed because repository commands were unavailable."
+      },
+      "review": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 22,
+        "risk_awareness": 22,
+        "total": 85,
+        "notes": "The strongest aspect is that the review identifies concrete risks rather than merely approving the design, especially reserved-route collisions, empty paths, redirect authentication, proxy URI substitution, caching, and reload behavior. It provides actionable resolutions tied to `ServerInfo._validate_path`, `_RESERVED_SERVER_PATH_NAMES`, `_write_and_validate_config`, and specific proposed tests. Its largest deficiency is accepting the empty-segment resolution without noticing that the fallback still emits a root prefix, and it declares all blocking findings resolved while the reserved-prefix risk remains explicitly unmitigated. The review's claimed investigation of repository validators and reload internals could not be independently verified due the unavailable repository shell."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 21,
+        "risk_awareness": 19,
+        "total": 78,
+        "notes": "The strongest aspect is the concrete unit coverage for the emitted location shape, unauthenticated redirect, normalization, sibling-prefix removal, proxy target preservation, and existing-test compatibility. The primary regression would be caught by assertions excluding `location {{ROOT_PATH}}/a {` and requiring `location {{ROOT_PATH}}/a/ {`. The largest defects are weak or incorrect oracles: the empty-path test permits the actual fallback `location {{ROOT_PATH}}/`, the `/demo` setup cannot collide with `/api`, and `/mn` does not prefix `/manage`. The pytest fixture compatibility and stated commands could not be executed or independently verified because the repository sandbox failed to launch commands."
+      },
+      "implementation": {
+        "completeness": 22,
+        "correctness": 19,
+        "specificity": 23,
+        "risk_awareness": 18,
+        "total": 82,
+        "notes": "The patch directly implements the central design in `registry/core/nginx_service.py` and adds six focused tests in `tests/unit/core/test_nginx_service.py`. The normal-path output is internally correct: `/name` and `/name/` normalize identically, the redirect contains no `auth_request`, and the proxied prefix ends in `/`. The largest defect is the purported defense-in-depth branch for `/`, which returns `location {{ROOT_PATH}}/` and therefore still captures the root namespace, while its test only excludes an exact block and a double-slash block. Patch applicability, real surrounding symbols, and the summary's `git apply --check` claim could not be independently confirmed because the read-only sandbox failed before command execution; that harness failure was not treated as a candidate defect."
+      }
+    },
+    "task_score": 83.4,
+    "verdict": "This is a strong and largely implementation-ready routing fix, with the largest material limitation being that its claimed empty-path defense still emits a root-capturing prefix and the accompanying test would not detect it.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:30:24.530950Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 272281,
+        "cached_input_tokens": 184728,
+        "cache_write_input_tokens": 40742,
+        "output_tokens": 13562,
+        "reasoning_output_tokens": 11527
+      },
+      "duration_ms": 214537
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 20,
+      "total": 89,
+      "notes": "The issue precisely identifies the two affected compose files, variables, defaults, reproduction, non-goals, and testable acceptance criteria. The submitted patch context corroborates the named registry environment locations and the requested change aligns directly with the task identifier. The largest evidence gap is the absent independent task statement, while claims about Helm, Terraform, DHI inheritance, and URL-guard behavior could not all be independently verified. Risk coverage is appropriate for an issue, though container recreation and overly broad operator allowlists are not discussed here."
+    },
+    "lld": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 24,
+      "risk_awareness": 21,
+      "total": 90,
+      "notes": "The LLD is unusually concrete for a small configuration fix, naming exact files, insertion anchors, syntax, data flow, rollout, and rejected alternatives. Its implementation steps match the submitted diff, including insertion before the registry-service SECRET_KEY rather than the auth-server occurrence. Its main weakness is the categorical claim that there are no new failure modes; malformed or overbroad allowlists and future compose drift deserve more explicit treatment. The asserted immutable metadata-address behavior and exact deployment-surface inventory were not fully independently verifiable."
+    },
+    "review": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 21,
+      "total": 84,
+      "notes": "The review surfaces actionable concerns specific to this change: duplicate SECRET_KEY anchors, container recreation, deployment parity drift, and preservation of default-deny behavior. The patch's distinct REGISTRY_CONTACT_URL and BUILD_VERSION contexts support its anchor recommendation. It misses important testing weaknesses, including unscoped rendered-config greps, .env interference in the empty-default test, and weak end-to-end oracles. Several persona sections are ceremonial, and claims that the admin UI reads these settings or exposes the allowlists were not verified."
+    },
+    "testing": {
+      "completeness": 19,
+      "correctness": 17,
+      "specificity": 18,
+      "risk_awareness": 17,
+      "total": 71,
+      "notes": "The plan covers both edited stacks, YAML rendering, container environment inspection, unchanged files, correct service placement, rollback, and operator-visible health behavior. However, unsetting shell variables in section 2.1 does not ensure empty values when Compose still reads a populated .env, and the grep assertions are not scoped specifically to the registry service. The end-to-end case lacks concrete fixture, registration, health-check, and proxy commands; absence of a log message or any non-405 response could pass when the feature is still broken. The referenced compose paths match the patch, but the proposed internal-mcp setup and API workflow remain unverifiable."
+    },
+    "implementation": {
+      "completeness": 24,
+      "correctness": 23,
+      "specificity": 24,
+      "risk_awareness": 22,
+      "total": 93,
+      "notes": "The patch implements the requested wiring end to end by adding both SSRF variables with the established empty-string default to the registry service in exactly the two identified compose files. Its REGISTRY_CONTACT_URL and BUILD_VERSION contexts make an accidental auth-server edit unlikely, and it contains no unrelated churn. The main limitation is the lack of an automated parity or regression test, leaving the same cross-compose drift class possible later. The diff is syntactically coherent, but the claimed baseline commit and git apply verification could not be independently confirmed because the local command runner was unavailable."
+    }
+  },
+  "task_score": 85.4,
+  "verdict": "This is a strong, narrowly correct submission whose largest limitation is a testing plan with incomplete end-to-end setup and several assertions capable of passing without proving registry-specific behavior.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:32:19.629163Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 143496,
+      "cached_input_tokens": 94786,
+      "cache_write_input_tokens": 25927,
+      "output_tokens": 8455,
+      "reasoning_output_tokens": 6418
+    },
+    "duration_ms": 115087
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
@@ -1,0 +1,151 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "docker",
+    "compose",
+    "configuration",
+    "ssrf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 78.9,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 871,
+    "output_tokens": 25528,
+    "cache_read_tokens": 1688898,
+    "cache_write_tokens": 68597,
+    "total_tokens": 1783894,
+    "total_cost_usd": 1.9157352500000002,
+    "latency_seconds": 323.4,
+    "num_turns": 20,
+    "generation_tokens_per_sec": 78.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 871,
+  "output_tokens": 25528,
+  "latency_seconds": 323.4,
+  "num_turns": 20,
+  "total_cost_usd": 1.9157352500000002,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 1688898,
+  "cache_creation_tokens": 68597,
+  "run_started_at": "2026-09-01T11:04:31.163410Z",
+  "run_ended_at": "2026-09-01T11:09:54.569632Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 871,
+    "output_tokens": 25528,
+    "cache_read_tokens": 1688898,
+    "cache_write_tokens": 68597,
+    "total_tokens": 1783894,
+    "total_cost_usd": 1.9157352500000002,
+    "latency_seconds": 323.4,
+    "num_turns": 20,
+    "generation_tokens_per_sec": 78.9,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "pass-ssrf-allowlist-env-to-registry-container",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 20,
+        "total": 89,
+        "notes": "The issue precisely identifies the two affected compose files, variables, defaults, reproduction, non-goals, and testable acceptance criteria. The submitted patch context corroborates the named registry environment locations and the requested change aligns directly with the task identifier. The largest evidence gap is the absent independent task statement, while claims about Helm, Terraform, DHI inheritance, and URL-guard behavior could not all be independently verified. Risk coverage is appropriate for an issue, though container recreation and overly broad operator allowlists are not discussed here."
+      },
+      "lld": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 24,
+        "risk_awareness": 21,
+        "total": 90,
+        "notes": "The LLD is unusually concrete for a small configuration fix, naming exact files, insertion anchors, syntax, data flow, rollout, and rejected alternatives. Its implementation steps match the submitted diff, including insertion before the registry-service SECRET_KEY rather than the auth-server occurrence. Its main weakness is the categorical claim that there are no new failure modes; malformed or overbroad allowlists and future compose drift deserve more explicit treatment. The asserted immutable metadata-address behavior and exact deployment-surface inventory were not fully independently verifiable."
+      },
+      "review": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 21,
+        "total": 84,
+        "notes": "The review surfaces actionable concerns specific to this change: duplicate SECRET_KEY anchors, container recreation, deployment parity drift, and preservation of default-deny behavior. The patch's distinct REGISTRY_CONTACT_URL and BUILD_VERSION contexts support its anchor recommendation. It misses important testing weaknesses, including unscoped rendered-config greps, .env interference in the empty-default test, and weak end-to-end oracles. Several persona sections are ceremonial, and claims that the admin UI reads these settings or exposes the allowlists were not verified."
+      },
+      "testing": {
+        "completeness": 19,
+        "correctness": 17,
+        "specificity": 18,
+        "risk_awareness": 17,
+        "total": 71,
+        "notes": "The plan covers both edited stacks, YAML rendering, container environment inspection, unchanged files, correct service placement, rollback, and operator-visible health behavior. However, unsetting shell variables in section 2.1 does not ensure empty values when Compose still reads a populated .env, and the grep assertions are not scoped specifically to the registry service. The end-to-end case lacks concrete fixture, registration, health-check, and proxy commands; absence of a log message or any non-405 response could pass when the feature is still broken. The referenced compose paths match the patch, but the proposed internal-mcp setup and API workflow remain unverifiable."
+      },
+      "implementation": {
+        "completeness": 24,
+        "correctness": 23,
+        "specificity": 24,
+        "risk_awareness": 22,
+        "total": 93,
+        "notes": "The patch implements the requested wiring end to end by adding both SSRF variables with the established empty-string default to the registry service in exactly the two identified compose files. Its REGISTRY_CONTACT_URL and BUILD_VERSION contexts make an accidental auth-server edit unlikely, and it contains no unrelated churn. The main limitation is the lack of an automated parity or regression test, leaving the same cross-compose drift class possible later. The diff is syntactically coherent, but the claimed baseline commit and git apply verification could not be independently confirmed because the local command runner was unavailable."
+      }
+    },
+    "task_score": 85.4,
+    "verdict": "This is a strong, narrowly correct submission whose largest limitation is a testing plan with incomplete end-to-end setup and several assertions capable of passing without proving registry-specific behavior.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:32:19.629163Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 143496,
+        "cached_input_tokens": 94786,
+        "cache_write_input_tokens": 25927,
+        "output_tokens": 8455,
+        "reasoning_output_tokens": 6418
+      },
+      "duration_ms": 115087
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 20,
+      "total": 86,
+      "notes": "The issue clearly defines both missing behaviors, explicit exclusions, response/admin/failure decisions, and testable acceptance criteria across backend and management surfaces. Referenced paths and symbols such as `RateLimiter.check()`, `registry/api/rate_limit_routes.py`, and `IAMRateLimits.tsx` correspond to patch targets. Its largest gap is calling quarantine an absolute immediate block while leaving store-outage semantics undecided, which could qualify that guarantee. No independent task statement was supplied, so issue-number and operator-demand claims could not be independently validated."
+    },
+    "lld": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 73,
+      "notes": "The LLD is unusually concrete about repository files, data flow, counter keys, response semantics, admin asymmetry, caching, rollout, and management surfaces. Its reserved-marker design does not preserve its own invariants: a general PUT can submit `quarantine=true, enabled=false`, while the proposed validator also accepts arbitrary quarantine markers without restricting them to the two reserved identities. It also misses delimiter collisions in `identity|entity_type:name` and lost updates from read-modify-write membership changes. Claims about fail-open metrics and complete marker immutability are therefore stronger than the specified mechanics support."
+    },
+    "review": {
+      "completeness": 19,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 17,
+      "total": 75,
+      "notes": "The review identifies concrete repository-specific problems including marker rows with no numeric limit, caller-like floor validation, bounded metric labels, seed clobbering, and admin-bypass asymmetry. Its recommendations are prioritized and traceable to revisions in the LLD. The declaration that all blocking findings are resolved is not defensible because it misses the reserved-marker PUT bypass, arbitrary `quarantine=true` definitions, membership update races, and composite-key delimiter collisions. It also accepts observability and fail-open resolutions without checking whether their proposed control flow actually emits the promised error metric."
+    },
+    "testing": {
+      "completeness": 21,
+      "correctness": 13,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 74,
+      "notes": "The plan covers unit, API, CLI, UI, compatibility, deployment, and end-to-end behavior with strong oracles for pairwise counter independence and quarantine response semantics. Its primary command, `python -m unittest discover`, will not collect the submitted pytest-style `TestRateLimiter` class with plain async methods, making the advertised execution path unreliable. The integration setup maps `$(whoami)` while later quarantining `alice`, and the E2E sequence expects an allowed post-unquarantine call immediately after exhausting the same window. Several named route, repository, model, and fail-open tests were planned but not included in the implementation, and the referenced `tests/scripts/call_mcp_tool.py` could not be verified."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 11,
+      "specificity": 20,
+      "risk_awareness": 11,
+      "total": 60,
+      "notes": "The patch broadly implements the new axis, enforcement branch, persistence helpers, API, CLI, UI, documentation, and core limiter tests using plausible existing files and symbols. The largest defect is that reserved markers remain mutable through ordinary PUT requests using `quarantine=true`, including setting `enabled=false`, while arbitrary names can also bypass normal entity and numeric-limit validation. Caller quarantine uses `get_groups_for` directly rather than the supplied fail-open predicate, promised error metrics are absent, and `add_group`/`remove_group` use race-prone read-modify-write operations. Only `test_limiter.py` is changed, its `test_reserved_group_not_gated` merely proves quarantine denial rather than group stripping, and the claimed baseline/apply check could not be independently verified because repository command access failed."
+    }
+  },
+  "task_score": 73.6,
+  "verdict": "Strong, repository-specific design work supports a broad implementation, but quarantine invariants remain bypassable through ordinary definition updates and verification is materially incomplete.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:35:10.748994Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 380891,
+      "cached_input_tokens": 299919,
+      "cache_write_input_tokens": 52520,
+      "output_tokens": 10285,
+      "reasoning_output_tokens": 9068
+    },
+    "duration_ms": 171107
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "high",
+  "tags": [
+    "rate-limiting",
+    "security",
+    "auth-server",
+    "api",
+    "operations",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 70.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 17849,
+    "output_tokens": 112234,
+    "cache_read_tokens": 20241955,
+    "cache_write_tokens": 267962,
+    "total_tokens": 20640000,
+    "total_cost_usd": 14.690835000000003,
+    "latency_seconds": 1591.7,
+    "num_turns": 97,
+    "generation_tokens_per_sec": 70.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 17849,
+  "output_tokens": 112234,
+  "latency_seconds": 1591.7,
+  "num_turns": 97,
+  "total_cost_usd": 14.690835000000003,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 20241955,
+  "cache_creation_tokens": 267962,
+  "run_started_at": "2026-09-01T10:05:22.976189Z",
+  "run_ended_at": "2026-09-01T10:31:54.731276Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 17849,
+    "output_tokens": 112234,
+    "cache_read_tokens": 20241955,
+    "cache_write_tokens": 267962,
+    "total_tokens": 20640000,
+    "total_cost_usd": 14.690835000000003,
+    "latency_seconds": 1591.7,
+    "num_turns": 97,
+    "generation_tokens_per_sec": 70.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "per-caller-per-target-rate-limits-and-quarantine",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 20,
+        "total": 86,
+        "notes": "The issue clearly defines both missing behaviors, explicit exclusions, response/admin/failure decisions, and testable acceptance criteria across backend and management surfaces. Referenced paths and symbols such as `RateLimiter.check()`, `registry/api/rate_limit_routes.py`, and `IAMRateLimits.tsx` correspond to patch targets. Its largest gap is calling quarantine an absolute immediate block while leaving store-outage semantics undecided, which could qualify that guarantee. No independent task statement was supplied, so issue-number and operator-demand claims could not be independently validated."
+      },
+      "lld": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 73,
+        "notes": "The LLD is unusually concrete about repository files, data flow, counter keys, response semantics, admin asymmetry, caching, rollout, and management surfaces. Its reserved-marker design does not preserve its own invariants: a general PUT can submit `quarantine=true, enabled=false`, while the proposed validator also accepts arbitrary quarantine markers without restricting them to the two reserved identities. It also misses delimiter collisions in `identity|entity_type:name` and lost updates from read-modify-write membership changes. Claims about fail-open metrics and complete marker immutability are therefore stronger than the specified mechanics support."
+      },
+      "review": {
+        "completeness": 19,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 17,
+        "total": 75,
+        "notes": "The review identifies concrete repository-specific problems including marker rows with no numeric limit, caller-like floor validation, bounded metric labels, seed clobbering, and admin-bypass asymmetry. Its recommendations are prioritized and traceable to revisions in the LLD. The declaration that all blocking findings are resolved is not defensible because it misses the reserved-marker PUT bypass, arbitrary `quarantine=true` definitions, membership update races, and composite-key delimiter collisions. It also accepts observability and fail-open resolutions without checking whether their proposed control flow actually emits the promised error metric."
+      },
+      "testing": {
+        "completeness": 21,
+        "correctness": 13,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 74,
+        "notes": "The plan covers unit, API, CLI, UI, compatibility, deployment, and end-to-end behavior with strong oracles for pairwise counter independence and quarantine response semantics. Its primary command, `python -m unittest discover`, will not collect the submitted pytest-style `TestRateLimiter` class with plain async methods, making the advertised execution path unreliable. The integration setup maps `$(whoami)` while later quarantining `alice`, and the E2E sequence expects an allowed post-unquarantine call immediately after exhausting the same window. Several named route, repository, model, and fail-open tests were planned but not included in the implementation, and the referenced `tests/scripts/call_mcp_tool.py` could not be verified."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 11,
+        "specificity": 20,
+        "risk_awareness": 11,
+        "total": 60,
+        "notes": "The patch broadly implements the new axis, enforcement branch, persistence helpers, API, CLI, UI, documentation, and core limiter tests using plausible existing files and symbols. The largest defect is that reserved markers remain mutable through ordinary PUT requests using `quarantine=true`, including setting `enabled=false`, while arbitrary names can also bypass normal entity and numeric-limit validation. Caller quarantine uses `get_groups_for` directly rather than the supplied fail-open predicate, promised error metrics are absent, and `add_group`/`remove_group` use race-prone read-modify-write operations. Only `test_limiter.py` is changed, its `test_reserved_group_not_gated` merely proves quarantine denial rather than group stripping, and the claimed baseline/apply check could not be independently verified because repository command access failed."
+      }
+    },
+    "task_score": 73.6,
+    "verdict": "Strong, repository-specific design work supports a broad implementation, but quarantine invariants remain bypassable through ordinary definition updates and verification is materially incomplete.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:35:10.748994Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 380891,
+        "cached_input_tokens": 299919,
+        "cache_write_input_tokens": 52520,
+        "output_tokens": 10285,
+        "reasoning_output_tokens": 9068
+      },
+      "duration_ms": 171107
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 22,
+      "correctness": 16,
+      "specificity": 22,
+      "risk_awareness": 18,
+      "total": 78,
+      "notes": "The issue tightly scopes build_and_run.sh, identifies the five named secret blocks plus the metrics-key loop, and provides testable count, value, failure, and preservation criteria. Its largest weakness is the asserted operational consequence: source .env uses the later appended assignment, and no evidence establishes a first-assignment consumer or resulting crash-loop. The BSD sed failure and duplicate-line creation are credible from the submitted source contexts, but the proposed literal grep gate conflicts with the later implementation comment containing 'sed -i'. No independent task statement was supplied, and the linked issue and documentation claims could not be independently confirmed."
+    },
+    "lld": {
+      "completeness": 22,
+      "correctness": 16,
+      "specificity": 23,
+      "risk_awareness": 17,
+      "total": 78,
+      "notes": "The LLD is unusually concrete about build_and_run.sh integration points, grep exit status 1 under set -e, same-directory temporary files, and all six replacement sites. The helper is implementation-ready for the common path, and its contexts align with the submitted handle_error and generation-block hunks. Its largest correctness gap is the claim that unchanged guards protect operator values: if both NAME= and NAME=operator-value exist, the empty-line guard fires and set_env_var deletes both before writing a generated value. It also claims interrupted runs cannot leave temporary secrets despite defining no signal trap, and it does not address the permission change caused by replacing .env with a mode-0600 mktemp file."
+    },
+    "review": {
+      "completeness": 17,
+      "correctness": 14,
+      "specificity": 18,
+      "risk_awareness": 15,
+      "total": 64,
+      "notes": "The review's strongest contribution is the concrete temporary-secret residue finding and its recommendation to clean up printf and mv failure paths. However, it incorrectly treats that change as resolving interruption leakage even though SIGINT between mktemp and mv bypasses those branches without a trap. It misses the mixed empty/non-empty duplicate case that can overwrite an operator value and claims secrets are not logged despite the shown metrics loop logging a token prefix with ${NEW_TOKEN:0:20}. The frontend role contributes little, while several repository-document and dependency assertions remain unsupported."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 11,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 60,
+      "notes": "The plan provides useful exact oracles for one-line replacement, non-empty values, unrelated-line preservation, nonzero failure, and temporary-file cleanup. Its primary static gate is invalid for the submitted patch because grep -n 'sed -i' matches the helper's explanatory comment, so the stated expected exit 1 cannot occur. Several tests are sketches rather than runnable checks: source_helper_and_call is undefined, the helper must be pasted manually, the operator test never executes the generation block, and the help grep does not prove all four options exist. It also omits the mixed duplicate state that exposes operator-value clobbering and does not directly exercise all six real call sites."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 71,
+      "notes": "The patch targets the correct five named generation blocks and metrics-key loop shown in build_and_run.sh, and the temporary-file helper avoids GNU-specific in-place sed while handling grep's normal status 1. Its largest defect is preservation behavior: an empty duplicate causes the unchanged guard to run, after which grep -v removes any non-empty operator assignment and replaces it with a generated secret. The added comment also violates the issue's literal no-'sed -i' grep criterion, and explicit command-failure cleanup does not support the summary's claim that interrupted runs leave no temporary secret. The asserted baseline commit and successful git apply --check could not be independently verified, so applicability beyond the matching submitted hunk contexts remains unconfirmed."
+    }
+  },
+  "task_score": 70.2,
+  "verdict": "The submission is specific and largely implements the portability fix, but it overstates its safety and misses an operator-secret clobbering edge case while its own patch fails a stated acceptance gate.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:37:33.726692Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 222211,
+      "cached_input_tokens": 169426,
+      "cache_write_input_tokens": 34361,
+      "output_tokens": 9443,
+      "reasoning_output_tokens": 7397
+    },
+    "duration_ms": 142966
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
@@ -1,0 +1,152 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "portability",
+    "macos",
+    "secrets",
+    "setup",
+    "fixed-in-1.28.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 73.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1201,
+    "output_tokens": 34159,
+    "cache_read_tokens": 2936978,
+    "cache_write_tokens": 84561,
+    "total_tokens": 3056899,
+    "total_cost_usd": 2.85697525,
+    "latency_seconds": 464.6,
+    "num_turns": 30,
+    "generation_tokens_per_sec": 73.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 1201,
+  "output_tokens": 34159,
+  "latency_seconds": 464.6,
+  "num_turns": 30,
+  "total_cost_usd": 2.85697525,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 2936978,
+  "cache_creation_tokens": 84561,
+  "run_started_at": "2026-09-01T11:17:51.558888Z",
+  "run_ended_at": "2026-09-01T11:25:36.168394Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 1201,
+    "output_tokens": 34159,
+    "cache_read_tokens": 2936978,
+    "cache_write_tokens": 84561,
+    "total_tokens": 3056899,
+    "total_cost_usd": 2.85697525,
+    "latency_seconds": 464.6,
+    "num_turns": 30,
+    "generation_tokens_per_sec": 73.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "portable-env-secret-generation-in-build-script",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 22,
+        "correctness": 16,
+        "specificity": 22,
+        "risk_awareness": 18,
+        "total": 78,
+        "notes": "The issue tightly scopes build_and_run.sh, identifies the five named secret blocks plus the metrics-key loop, and provides testable count, value, failure, and preservation criteria. Its largest weakness is the asserted operational consequence: source .env uses the later appended assignment, and no evidence establishes a first-assignment consumer or resulting crash-loop. The BSD sed failure and duplicate-line creation are credible from the submitted source contexts, but the proposed literal grep gate conflicts with the later implementation comment containing 'sed -i'. No independent task statement was supplied, and the linked issue and documentation claims could not be independently confirmed."
+      },
+      "lld": {
+        "completeness": 22,
+        "correctness": 16,
+        "specificity": 23,
+        "risk_awareness": 17,
+        "total": 78,
+        "notes": "The LLD is unusually concrete about build_and_run.sh integration points, grep exit status 1 under set -e, same-directory temporary files, and all six replacement sites. The helper is implementation-ready for the common path, and its contexts align with the submitted handle_error and generation-block hunks. Its largest correctness gap is the claim that unchanged guards protect operator values: if both NAME= and NAME=operator-value exist, the empty-line guard fires and set_env_var deletes both before writing a generated value. It also claims interrupted runs cannot leave temporary secrets despite defining no signal trap, and it does not address the permission change caused by replacing .env with a mode-0600 mktemp file."
+      },
+      "review": {
+        "completeness": 17,
+        "correctness": 14,
+        "specificity": 18,
+        "risk_awareness": 15,
+        "total": 64,
+        "notes": "The review's strongest contribution is the concrete temporary-secret residue finding and its recommendation to clean up printf and mv failure paths. However, it incorrectly treats that change as resolving interruption leakage even though SIGINT between mktemp and mv bypasses those branches without a trap. It misses the mixed empty/non-empty duplicate case that can overwrite an operator value and claims secrets are not logged despite the shown metrics loop logging a token prefix with ${NEW_TOKEN:0:20}. The frontend role contributes little, while several repository-document and dependency assertions remain unsupported."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 11,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 60,
+        "notes": "The plan provides useful exact oracles for one-line replacement, non-empty values, unrelated-line preservation, nonzero failure, and temporary-file cleanup. Its primary static gate is invalid for the submitted patch because grep -n 'sed -i' matches the helper's explanatory comment, so the stated expected exit 1 cannot occur. Several tests are sketches rather than runnable checks: source_helper_and_call is undefined, the helper must be pasted manually, the operator test never executes the generation block, and the help grep does not prove all four options exist. It also omits the mixed duplicate state that exposes operator-value clobbering and does not directly exercise all six real call sites."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 71,
+        "notes": "The patch targets the correct five named generation blocks and metrics-key loop shown in build_and_run.sh, and the temporary-file helper avoids GNU-specific in-place sed while handling grep's normal status 1. Its largest defect is preservation behavior: an empty duplicate causes the unchanged guard to run, after which grep -v removes any non-empty operator assignment and replaces it with a generated secret. The added comment also violates the issue's literal no-'sed -i' grep criterion, and explicit command-failure cleanup does not support the summary's claim that interrupted runs leave no temporary secret. The asserted baseline commit and successful git apply --check could not be independently verified, so applicability beyond the matching submitted hunk contexts remains unconfirmed."
+      }
+    },
+    "task_score": 70.2,
+    "verdict": "The submission is specific and largely implements the portability fix, but it overstates its safety and misses an operator-secret clobbering edge case while its own patch fails a stated acceptance gate.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:37:33.726692Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 222211,
+        "cached_input_tokens": 169426,
+        "cache_write_input_tokens": 34361,
+        "output_tokens": 9443,
+        "reasoning_output_tokens": 7397
+      },
+      "duration_ms": 142966
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "registration-admission-control-gate",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 21,
+      "specificity": 23,
+      "risk_awareness": 22,
+      "total": 89,
+      "notes": "The issue strongly defines configuration, failure semantics, redaction, deployment surfaces, acceptance criteria, and explicit non-goals. It says “all six paths” while enumerating seven routes: two agent, three server, and two skill paths. Its largest ambiguity is that it promises every update is gated while excluding server edit paths and never defines whether overwrite-through-register must carry action `update`. No independent task statement was supplied, so the proposed webhook contract itself cannot be verified beyond the task identifier and repository-shaped evidence."
+    },
+    "lld": {
+      "completeness": 21,
+      "correctness": 17,
+      "specificity": 22,
+      "risk_awareness": 19,
+      "total": 79,
+      "notes": "The LLD is unusually concrete about real symbols such as `register_agent`, `internal_register_service`, `Settings`, and the three compose variants, with useful rollout and failure handling. Its largest design defect is labeling both server overwrite branches with `action=\"register\"`, despite explicitly recognizing that those branches perform updates. It also passes arbitrary server dictionaries directly through `httpx` JSON encoding and catches only `httpx.HTTPError`, overlooking serialization failures from values such as the parsed `source_updated_at` datetime. Exact line-number and baseline claims could not be independently reproduced because the local command runner failed before executing read-only commands."
+    },
+    "review": {
+      "completeness": 19,
+      "correctness": 18,
+      "specificity": 20,
+      "risk_awareness": 20,
+      "total": 77,
+      "notes": "The review finds substantive defects, particularly credential leakage, branch-placement bypasses, missing server entry points, and fail-closed misconfiguration behavior. Its largest omission is failing to notice that overwrite operations are still reported to policy as registrations, and it also misses the raw-JSON serialization risk. The claim that logs contain only endpoint, actor, and decision conflicts with the patch, which logs the configured URL and denial message. Claims about existing frontend `detail` handling and Helm precedent were not independently verifiable from the available local tooling."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 16,
+      "risk_awareness": 17,
+      "total": 63,
+      "notes": "The helper-level unit matrix has concrete oracles for allow, deny, timeout, connection failure, disabled mode, redaction, and authentication headers. The integration setup writes `/tmp/stub_gate.py` but launches `uvicorn stub_gate:app` without changing directory or specifying `--app-dir`, and its stub checks `payload.name` although the proposed server payload uses `server_name`. It provides no automated route-wiring tests and merely says to repeat requests for six remaining paths without supplying their exact payloads and authentication. The plan explicitly states that tests were not executed, so its repository-wide commands and expected statuses remain unverified."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 16,
+      "specificity": 21,
+      "risk_awareness": 17,
+      "total": 74,
+      "notes": "The patch implements settings, exception mapping, recursive redaction, deployment wiring, helper tests, and gate calls at all seven submitted route locations before persistence. Its largest correctness defect is that `register_service_api` and `internal_register_service` always send `action=\"register\"` even when the subsequent branch performs an overwrite or `update_server`. The gate service sends raw dictionaries through `json=` and catches only `httpx.HTTPError`, so non-JSON-native server values can produce an uncaught serialization error instead of the promised 502. The summary’s claimed total of +399 lines contradicts its own +157-line service and +231-line test file plus all other additions, and its claimed `git apply --check` result could not be independently reproduced."
+    }
+  },
+  "task_score": 76.4,
+  "verdict": "Strong, repository-shaped work with a mostly complete patch, but server overwrites are misclassified as registrations and the proposed verification does not reliably test that integration contract.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:41:17.648198Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 297968,
+      "cached_input_tokens": 222175,
+      "cache_write_input_tokens": 46289,
+      "output_tokens": 12746,
+      "reasoning_output_tokens": 11056
+    },
+    "duration_ms": 223909
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "registration-admission-control-gate",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "architecture",
+    "api",
+    "fastapi",
+    "webhooks",
+    "admission-control",
+    "fixed-in-1.0.20"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 77.5,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5465,
+    "output_tokens": 69168,
+    "cache_read_tokens": 8545477,
+    "cache_write_tokens": 160646,
+    "total_tokens": 8780756,
+    "total_cost_usd": 7.033301,
+    "latency_seconds": 892.5,
+    "num_turns": 58,
+    "generation_tokens_per_sec": 77.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 5465,
+  "output_tokens": 69168,
+  "latency_seconds": 892.5,
+  "num_turns": 58,
+  "total_cost_usd": 7.033301,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 8545477,
+  "cache_creation_tokens": 160646,
+  "run_started_at": "2026-09-01T09:14:18.637568Z",
+  "run_ended_at": "2026-09-01T09:29:11.162506Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 5465,
+    "output_tokens": 69168,
+    "cache_read_tokens": 8545477,
+    "cache_write_tokens": 160646,
+    "total_tokens": 8780756,
+    "total_cost_usd": 7.033301,
+    "latency_seconds": 892.5,
+    "num_turns": 58,
+    "generation_tokens_per_sec": 77.5,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "registration-admission-control-gate",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 21,
+        "specificity": 23,
+        "risk_awareness": 22,
+        "total": 89,
+        "notes": "The issue strongly defines configuration, failure semantics, redaction, deployment surfaces, acceptance criteria, and explicit non-goals. It says “all six paths” while enumerating seven routes: two agent, three server, and two skill paths. Its largest ambiguity is that it promises every update is gated while excluding server edit paths and never defines whether overwrite-through-register must carry action `update`. No independent task statement was supplied, so the proposed webhook contract itself cannot be verified beyond the task identifier and repository-shaped evidence."
+      },
+      "lld": {
+        "completeness": 21,
+        "correctness": 17,
+        "specificity": 22,
+        "risk_awareness": 19,
+        "total": 79,
+        "notes": "The LLD is unusually concrete about real symbols such as `register_agent`, `internal_register_service`, `Settings`, and the three compose variants, with useful rollout and failure handling. Its largest design defect is labeling both server overwrite branches with `action=\"register\"`, despite explicitly recognizing that those branches perform updates. It also passes arbitrary server dictionaries directly through `httpx` JSON encoding and catches only `httpx.HTTPError`, overlooking serialization failures from values such as the parsed `source_updated_at` datetime. Exact line-number and baseline claims could not be independently reproduced because the local command runner failed before executing read-only commands."
+      },
+      "review": {
+        "completeness": 19,
+        "correctness": 18,
+        "specificity": 20,
+        "risk_awareness": 20,
+        "total": 77,
+        "notes": "The review finds substantive defects, particularly credential leakage, branch-placement bypasses, missing server entry points, and fail-closed misconfiguration behavior. Its largest omission is failing to notice that overwrite operations are still reported to policy as registrations, and it also misses the raw-JSON serialization risk. The claim that logs contain only endpoint, actor, and decision conflicts with the patch, which logs the configured URL and denial message. Claims about existing frontend `detail` handling and Helm precedent were not independently verifiable from the available local tooling."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 16,
+        "risk_awareness": 17,
+        "total": 63,
+        "notes": "The helper-level unit matrix has concrete oracles for allow, deny, timeout, connection failure, disabled mode, redaction, and authentication headers. The integration setup writes `/tmp/stub_gate.py` but launches `uvicorn stub_gate:app` without changing directory or specifying `--app-dir`, and its stub checks `payload.name` although the proposed server payload uses `server_name`. It provides no automated route-wiring tests and merely says to repeat requests for six remaining paths without supplying their exact payloads and authentication. The plan explicitly states that tests were not executed, so its repository-wide commands and expected statuses remain unverified."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 16,
+        "specificity": 21,
+        "risk_awareness": 17,
+        "total": 74,
+        "notes": "The patch implements settings, exception mapping, recursive redaction, deployment wiring, helper tests, and gate calls at all seven submitted route locations before persistence. Its largest correctness defect is that `register_service_api` and `internal_register_service` always send `action=\"register\"` even when the subsequent branch performs an overwrite or `update_server`. The gate service sends raw dictionaries through `json=` and catches only `httpx.HTTPError`, so non-JSON-native server values can produce an uncaught serialization error instead of the promised 502. The summary’s claimed total of +399 lines contradicts its own +157-line service and +231-line test file plus all other additions, and its claimed `git apply --check` result could not be independently reproduced."
+      }
+    },
+    "task_score": 76.4,
+    "verdict": "Strong, repository-shaped work with a mostly complete patch, but server overwrites are misclassified as registrations and the proposed verification does not reliably test that integration contract.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:41:17.648198Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 297968,
+        "cached_input_tokens": 222175,
+        "cache_write_input_tokens": 46289,
+        "output_tokens": 12746,
+        "reasoning_output_tokens": 11056
+      },
+      "duration_ms": 223909
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/run-summary.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/run-summary.json
@@ -1,0 +1,1438 @@
+{
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry-v2",
+  "provider": "bedrock",
+  "ref": null,
+  "refs": [
+    "1.23.0",
+    "1.24.3",
+    "1.24.7",
+    "1.25.0",
+    "1.27.1",
+    "1.28.0",
+    "v1.0.18",
+    "v1.0.19",
+    "v1.0.20",
+    "v1.0.21"
+  ],
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T11:41:26.723624Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 1020452,
+      "cached_input_tokens": 863662,
+      "cache_write_input_tokens": 129390,
+      "output_tokens": 9778,
+      "reasoning_output_tokens": 7366
+    },
+    "duration_ms": 175772
+  },
+  "num_tasks": 21,
+  "num_scored": 21,
+  "num_failed": 0,
+  "failed_tasks": [],
+  "mean_task_score_excl_failed": 74.69,
+  "mean_cost_usd_excl_failed": 5.32,
+  "tasks": [
+    {
+      "task": "pass-ssrf-allowlist-env-to-registry-container",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 20,
+      "input_tokens": 871,
+      "output_tokens": 25528,
+      "total_tokens": 1783894,
+      "latency_seconds": 323.4,
+      "total_cost_usd": 1.9157352500000002,
+      "result_subtype": "success",
+      "task_score": 85.4,
+      "cache_read_tokens": 1688898,
+      "cache_write_tokens": 68597,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 78.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 89,
+          "notes": "The issue precisely identifies the two affected compose files, variables, defaults, reproduction, non-goals, and testable acceptance criteria. The submitted patch context corroborates the named registry environment locations and the requested change aligns directly with the task identifier. The largest evidence gap is the absent independent task statement, while claims about Helm, Terraform, DHI inheritance, and URL-guard behavior could not all be independently verified. Risk coverage is appropriate for an issue, though container recreation and overly broad operator allowlists are not discussed here."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 90,
+          "notes": "The LLD is unusually concrete for a small configuration fix, naming exact files, insertion anchors, syntax, data flow, rollout, and rejected alternatives. Its implementation steps match the submitted diff, including insertion before the registry-service SECRET_KEY rather than the auth-server occurrence. Its main weakness is the categorical claim that there are no new failure modes; malformed or overbroad allowlists and future compose drift deserve more explicit treatment. The asserted immutable metadata-address behavior and exact deployment-surface inventory were not fully independently verifiable."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 84,
+          "notes": "The review surfaces actionable concerns specific to this change: duplicate SECRET_KEY anchors, container recreation, deployment parity drift, and preservation of default-deny behavior. The patch's distinct REGISTRY_CONTACT_URL and BUILD_VERSION contexts support its anchor recommendation. It misses important testing weaknesses, including unscoped rendered-config greps, .env interference in the empty-default test, and weak end-to-end oracles. Several persona sections are ceremonial, and claims that the admin UI reads these settings or exposes the allowlists were not verified."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 17,
+          "specificity": 18,
+          "risk_awareness": 17,
+          "total": 71,
+          "notes": "The plan covers both edited stacks, YAML rendering, container environment inspection, unchanged files, correct service placement, rollback, and operator-visible health behavior. However, unsetting shell variables in section 2.1 does not ensure empty values when Compose still reads a populated .env, and the grep assertions are not scoped specifically to the registry service. The end-to-end case lacks concrete fixture, registration, health-check, and proxy commands; absence of a log message or any non-405 response could pass when the feature is still broken. The referenced compose paths match the patch, but the proposed internal-mcp setup and API workflow remain unverifiable."
+        },
+        "implementation": {
+          "completeness": 24,
+          "correctness": 23,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 93,
+          "notes": "The patch implements the requested wiring end to end by adding both SSRF variables with the established empty-string default to the registry service in exactly the two identified compose files. Its REGISTRY_CONTACT_URL and BUILD_VERSION contexts make an accidental auth-server edit unlikely, and it contains no unrelated churn. The main limitation is the lack of an automated parity or regression test, leaving the same cross-compose drift class possible later. The diff is syntactically coherent, but the claimed baseline commit and git apply verification could not be independently confirmed because the local command runner was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "default-create-in-idp-checkbox-unchecked",
+      "complexity": "low",
+      "ref": "v1.0.21",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 38,
+      "input_tokens": 6719,
+      "output_tokens": 31808,
+      "total_tokens": 3931951,
+      "latency_seconds": 463.1,
+      "total_cost_usd": 3.501024750000001,
+      "result_subtype": "success",
+      "task_score": 84.4,
+      "cache_read_tokens": 3767247,
+      "cache_write_tokens": 126177,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 68.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 88,
+          "notes": "The issue clearly defines initial, reset, opt-in, JSON-import, and omitted-field behavior, with concrete acceptance criteria and explicit CLI non-goals. The submitted diff corroborates its named frontend state, reset, example JSON, and management endpoint targets. Its largest weakness is expanding a checkbox-default task into a compatibility-affecting backend fallback change without an independent task statement establishing that requirement. Repository inspection was unavailable because the read-only shell sandbox failed before executing commands, so provider support and failure-mode claims could not be independently verified."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 88,
+          "notes": "The LLD is unusually concrete about IAMGroups.tsx, management_create_group, payload flow, reset behavior, test selection, rollout, and the intentionally unchanged CLI path. Its described symbols and line contexts agree internally with the submitted patch, including createInIdp, EXAMPLE_SCOPE_JSON, and the scope_config override. The main deficiency is changing the management API fallback used by non-UI callers without stronger compatibility evidence or an automated backend test; reset behavior likewise receives only manual coverage. Exact repository conventions and dependency claims could not be independently verified because local source inspection was unavailable."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 21,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 84,
+          "notes": "The review surfaces several specific concerns: initializer/reset coupling, checkbox selector ambiguity, CLI-default divergence, truthy-string coercion, and the need for release notes. These findings correspond directly to the submitted patch and design rather than being purely generic reviewer role-play. Its largest omission is failing to challenge whether changing the backend omission default is justified by the checkbox task or to require automated coverage for that API contract and reset behavior. Claims about existing logs, authorization, hook APIs, and package dependencies remained unverified against the repository."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 85,
+          "notes": "The plan supplies concrete request bodies and meaningful oracles for local-only, explicit-false, opt-in, JSON-import, read-only-IdP, and initial UI behavior. The proposed Jest test targets the submitted DOM structure specifically and avoids confusing the IdP control with other checkboxes. Its largest weakness is that only initial state is automated: reset, payload generation, and the changed backend fallback remain manual, while the curl examples do not themselves enforce the claimed HTTP status and use reusable names that can collide. The token path, test command, hook mock shapes, and delete behavior could not be independently confirmed from the repository."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 77,
+          "notes": "The patch implements every element of its own design: initializer, reset, example JSON, backend fallback and documentation, plus a focused initial-state test. The unified diff is internally coherent, uses precise existing-looking symbols, and the summary accurately accounts for its 54 additions and 7 deletions. The largest risk is the unproven change from True to False for omitted create_in_idp on a callable management API, which can alter existing non-UI clients and has no automated backend test; the reset acceptance criterion is also untested. Git applicability, surrounding source, TypeScript mock compatibility, and test execution could not be independently verified because the repository command sandbox failed before running."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "cli-custom-egress-oauth-provider-flags",
+      "complexity": "low",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 38,
+      "input_tokens": 3018,
+      "output_tokens": 36910,
+      "total_tokens": 4284813,
+      "latency_seconds": 502.8,
+      "total_cost_usd": 3.6295439999999997,
+      "result_subtype": "success",
+      "task_score": 84.0,
+      "cache_read_tokens": 4145883,
+      "cache_write_tokens": 99002,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 73.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 82,
+          "notes": "The issue precisely identifies the CLI-to-client plumbing gap and gives testable criteria for five named flags and body fields. Its largest defect is claiming omitted fields will preserve stored values during edits while its own Out of Scope section acknowledges that the server rebuilds `egress_oauth` and persists omitted fields as `None`. The proposed symbols and paths align with the submitted patch, including `cmd_egress_configure` and `RegistryClient.configure_egress_auth`. No independent task statement exists, and local shell failure prevented direct verification of every repository claim."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 23,
+          "total": 89,
+          "notes": "The LLD commits to concrete changes in `api/registry_client.py` and `api/registry_management.py`, including exact parameter names, body guards, argparse choices, failure handling, and tests. It correctly exposes the unresolved server-side edit behavior, but its overview inaccurately implies the React modal handles all five custom fields while later artifacts say it handles only the two URLs. Its strongest risk analysis covers SSRF validation ownership, secret logging, backward compatibility, and enum drift. Approximate line locations and repository-specific validation claims could not be independently checked because local command execution was unavailable."
+        },
+        "review": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 22,
+          "total": 86,
+          "notes": "The review catches the central design flaw: client-side omission does not satisfy the issue's partial-edit user story because the route materializes omitted values as `None`. It also provides actionable checks for request-body logging, enum-choice drift, and client docstrings rather than merely approving the design. Some assertions are unsupported or overstated, notably that the server ignores custom fields for built-in providers and that a test asserts this; the submitted tests only verify client-side omission. Repository claims about the FAQ and frontend behavior could not be independently verified."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 80,
+          "notes": "The plan supplies concrete commands, payloads, expected exit codes, exact request-body assertions, compatibility coverage, and both accepted auth-style values. Its principal correctness problem is repeatedly suggesting that omitted client fields prevent stored values from being nulled during edits, despite the documented server reconstruction behavior. The proposed unit tests target `RegistryClient.configure_egress_auth`, `_make_request`, and the existing POST endpoint with useful positive, omission, partial, and argparse oracles. It lacks an explicit regression test documenting the known destructive edit behavior, and the commands could not be executed in the unavailable local shell."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 83,
+          "notes": "The patch implements all five flags through parser, handler, client signature, conditional request-body construction, docstrings, and focused client/CLI tests. The changes to `RegistryClient.configure_egress_auth` and `cmd_egress_configure` are internally coherent and match the LLD, while the summary honestly discloses that server-side partial-edit preservation remains unfixed. The largest defect is a misleading test-module and test-method claim that omission prevents stored-value nulling, which contradicts the acknowledged route semantics and could mislead maintainers. The claimed baseline commit, patch applicability, and test success were not independently verifiable because the managed shell failed before executing `git apply --check` or source inspection commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "nginx-location-trailing-slash-route-hijack",
+      "complexity": "medium",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 43,
+      "input_tokens": 2554,
+      "output_tokens": 57756,
+      "total_tokens": 6022214,
+      "latency_seconds": 778.6,
+      "total_cost_usd": 5.23805075,
+      "result_subtype": "success",
+      "task_score": 83.4,
+      "cache_read_tokens": 5822699,
+      "cache_write_tokens": 139205,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 74.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 87,
+          "notes": "The strongest aspect is the precise problem statement and testable acceptance criteria around `_create_location_block`, trailing-slash matching, authentication, normalization, and deployment regeneration. The submitted diff preimage contains the cited bare-prefix location tail, and the proposed exact-match redirect plus slash-terminated prefix is technically coherent with nginx routing semantics. The largest limitation is that the issue deliberately leaves the similarly shaped `_add_virtual_server_location` path unresolved, while no independent task statement establishes whether that exclusion is complete. The exact auth response, startup regeneration behavior, and repository line references could not be independently verified because the repository sandbox failed before command execution."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 85,
+          "notes": "The strongest aspect is an implementation-ready data-flow design naming `_create_location_block`, the proxy target, template substitution, tests, rollout, and compatibility behavior. Its proposed output correctly pairs `location = {{ROOT_PATH}}/name` with `location {{ROOT_PATH}}/name/` and preserves the submitted `mcp-proxy/name/` target. The largest defect is that the empty-segment guard returns the original block for `/`, producing `location {{ROOT_PATH}}/`, which is itself a root-capturing prefix and contradicts the guard's stated rationale; reserved-prefix registrations also remain an operationally disruptive follow-up. Exact source line numbers, validator behavior, and the claim that failed nginx validation retains the prior configuration could not be independently confirmed because repository commands were unavailable."
+        },
+        "review": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 22,
+          "risk_awareness": 22,
+          "total": 85,
+          "notes": "The strongest aspect is that the review identifies concrete risks rather than merely approving the design, especially reserved-route collisions, empty paths, redirect authentication, proxy URI substitution, caching, and reload behavior. It provides actionable resolutions tied to `ServerInfo._validate_path`, `_RESERVED_SERVER_PATH_NAMES`, `_write_and_validate_config`, and specific proposed tests. Its largest deficiency is accepting the empty-segment resolution without noticing that the fallback still emits a root prefix, and it declares all blocking findings resolved while the reserved-prefix risk remains explicitly unmitigated. The review's claimed investigation of repository validators and reload internals could not be independently verified due the unavailable repository shell."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 78,
+          "notes": "The strongest aspect is the concrete unit coverage for the emitted location shape, unauthenticated redirect, normalization, sibling-prefix removal, proxy target preservation, and existing-test compatibility. The primary regression would be caught by assertions excluding `location {{ROOT_PATH}}/a {` and requiring `location {{ROOT_PATH}}/a/ {`. The largest defects are weak or incorrect oracles: the empty-path test permits the actual fallback `location {{ROOT_PATH}}/`, the `/demo` setup cannot collide with `/api`, and `/mn` does not prefix `/manage`. The pytest fixture compatibility and stated commands could not be executed or independently verified because the repository sandbox failed to launch commands."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 82,
+          "notes": "The patch directly implements the central design in `registry/core/nginx_service.py` and adds six focused tests in `tests/unit/core/test_nginx_service.py`. The normal-path output is internally correct: `/name` and `/name/` normalize identically, the redirect contains no `auth_request`, and the proxied prefix ends in `/`. The largest defect is the purported defense-in-depth branch for `/`, which returns `location {{ROOT_PATH}}/` and therefore still captures the root namespace, while its test only excludes an exact block and a double-slash block. Patch applicability, real surrounding symbols, and the summary's `git apply --check` claim could not be independently confirmed because the read-only sandbox failed before command execution; that harness failure was not treated as a candidate defect."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "hide-register-button-on-virtual-and-skills-tabs",
+      "complexity": "trivial",
+      "ref": "v1.0.18",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 26,
+      "input_tokens": 136,
+      "output_tokens": 25350,
+      "total_tokens": 2169890,
+      "latency_seconds": 352.3,
+      "total_cost_usd": 2.0706185,
+      "result_subtype": "success",
+      "task_score": 82.8,
+      "cache_read_tokens": 2081102,
+      "cache_write_tokens": 63302,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 72.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 24,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 91,
+          "notes": "The issue precisely defines tab-specific visibility, preserved controls, navigation behavior, and explicit non-goals. Its acceptance criteria are directly testable and align with the task identifier and submitted patch. The largest evidence gap is the absent independent task statement; claims about Dashboard.tsx, /servers/register, and issue #793 could not be independently confirmed. Local repository inspection failed before command execution because of the read-only sandbox, so those source-level claims remain unverified rather than contradicted."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 20,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 89,
+          "notes": "The design commits to the crucial implementation decision: guard only the button so the enclosing search and refresh controls remain intact. It gives an exact conditional, explains external-tab compatibility, and analyzes whitelist and outer-wrapper alternatives proportionately. Its largest deficiency is that exact line numbers, the viewFilter union, handler references, test paths, and react-scripts tooling could not be verified against the baseline repository. The optional treatment of automated testing also leaves regression protection undecided, although the implementation itself is sufficiently specified."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 18,
+          "total": 75,
+          "notes": "The review identifies concrete concerns about the enclosing header condition, flex layout, DOM accessibility, authorization boundaries, and the future maintenance cost of a negative-list guard. Its strongest finding is that changing the outer wrapper would incorrectly remove unrelated controls. The largest weakness is that the unanimous persona-based approval does not challenge the missing automated test or validate asserted repository details such as /api/register and the build workflow. Claims about exact CSS structure and backend routes remained unverifiable because repository commands could not execute."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 18,
+          "risk_awareness": 20,
+          "total": 76,
+          "notes": "The manual matrix covers every named tab, live switching, navigation, sibling controls, per-tab actions, and layout integrity with concrete expected outcomes. It provides useful backward-compatibility and negative checks rather than merely asserting that rendering succeeds. The largest deficiency is that the automated test is only illustrative: it omits provider and mock setup, tab-selection mechanics, and reliable header scoping, while a broad /register/i query could match another registration CTA. The npm command, test-directory convention, feature configuration, and tab labels could not be independently verified."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 83,
+          "notes": "The submitted diff implements the designed behavior directly by conditionally rendering the existing button for every view except virtual and skills, without changing its handler or markup. The patch and summary are internally consistent, including the intentional preservation of external and the disclosure that no tests were added or run. The largest material weakness is the absence of automated regression coverage, compounded by a negative-list condition that will expose Register on future tabs by default. The sandbox failed before local reads or git apply --check could execute, so the claimed baseline hash, source context, and clean applicability remain unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "fix-reserved-groups-var-in-service-account-script",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 17,
+      "input_tokens": 1608,
+      "output_tokens": 28227,
+      "total_tokens": 1551654,
+      "latency_seconds": 371.4,
+      "total_cost_usd": 1.86640075,
+      "result_subtype": "success",
+      "task_score": 82.6,
+      "cache_read_tokens": 1453684,
+      "cache_write_tokens": 68135,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 76.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 88,
+          "notes": "The issue clearly identifies the reserved GROUPS assignment, set -e interaction, affected scripts, desired exit behavior, compatibility constraints, and explicit non-goals. The submitted patch context corroborates the verify_setup() locations and GROUPS usage in both keycloak/setup scripts. Its largest weakness is asserting the macos-setup caller behavior and a complete reserved-variable sweep without independently reproducible evidence in the issue. The acceptance criteria are otherwise unusually concrete and testable for this small defect."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 24,
+          "risk_awareness": 22,
+          "total": 91,
+          "notes": "The LLD commits to exact edits in both verify_setup() functions, including separate local declaration, unchanged REST calls, and fixed-string whole-line matching. Its named files, function contexts, and before/after snippets agree with the submitted source hunks. The main deficiency is that it presents the directory-wide reserved-variable sweep and several caller details as completed facts without preserving verifiable output. It otherwise handles portability, set -e behavior, compatibility, failure paths, rollout, and follow-ups proportionately."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 19,
+          "specificity": 20,
+          "risk_awareness": 19,
+          "total": 78,
+          "notes": "The strongest review work is the shell-specific analysis of local assignment status masking, zero-group behavior, exact matching, and consistency with CURRENT_GROUPS. These observations directly inspect the proposed printf and grep -Fxq changes rather than merely approving the design. Its largest technical flaw is linking the Admin API's group-name representation to the protocol mapper's full.path setting, which controls token mapping rather than that endpoint. It also declares the testing recommendations resolved without noticing that the resulting exact-match and negative tests do not actually create discriminating conditions."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 17,
+          "risk_awareness": 18,
+          "total": 69,
+          "notes": "The plan covers successful execution, idempotency, both scripts, static analysis, Bash-version compatibility, downstream chaining, and genuine failure behavior. However, after instructing the tester to cd into keycloak/setup, its shellcheck and reserved-variable commands incorrectly retain the keycloak/setup prefix and therefore address nonexistent nested paths. The exact-match case would also pass the old substring implementation, while the negative case vaguely requests revoking membership during execution without specifying an executable setup. The tests were not run, and the portability command invokes generic bash rather than each displayed interpreter path."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 87,
+          "notes": "The patch implements the central fix in both affected verify_setup() functions and consistently updates capture, display, and membership-check uses. Declaring local sa_groups separately preserves the substitution status, while printf with grep -Fxq -- correctly avoids array expansion, regex interpretation, substring matches, and option-like group names. The largest gap is the absence of an automated regression test, and the summary's claims that git apply --check and the full reserved-variable sweep succeeded are not demonstrated by included output. The implementation otherwise matches the LLD and keeps the change narrowly scoped."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-ui-title",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 56,
+      "input_tokens": 13442,
+      "output_tokens": 46966,
+      "total_tokens": 7454835,
+      "latency_seconds": 631.3,
+      "total_cost_usd": 5.668582000000001,
+      "result_subtype": "success",
+      "task_score": 79.6,
+      "cache_read_tokens": 7267469,
+      "cache_write_tokens": 126958,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 74.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 88,
+          "notes": "The issue's strongest aspect is its testable behavior matrix for explicit, with-gateway, and registry-only titles, accompanied by precise deployment-surface and UI-consumer criteria. Referenced paths and symbols such as Settings, GET /api/config, useRegistryConfig, Layout.tsx, and the three packaging systems correspond to the submitted source contexts. Its main gap is limited treatment of operational edge cases such as blank values, asynchronous fallback behavior, and length or presentation constraints. No independent task statement was supplied, and the related issue number could not be independently verified, so broader requirement completeness remains unconfirmed."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 81,
+          "notes": "The design is unusually concrete about Settings.effective_ui_title, CONFIG_GROUPS, useRegistryConfig, Helm reserved names, and every deployment file, making most implementation decisions explicit. Its largest flaw is contradicting the requirement that the effective title appear in the System Config panel: it ultimately exposes raw ui_title, which is blank when registry-only relies on the derived default. It also claims untouched deployments gain no UI_TITLE environment variable, while its own Compose and ECS design supplies an empty variable rather than omitting it. The public-endpoint exposure, JSX escaping, blank-value fallback, conditional Helm rendering, compatibility behavior, and rollback are otherwise addressed proportionately."
+        },
+        "review": {
+          "completeness": 21,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 21,
+          "total": 82,
+          "notes": "The review's strongest contribution is finding concrete design defects around CONFIG_GROUPS export naming and conditional Helm rendering, then prescribing implementable corrections. However, resolving the export concern by showing raw ui_title preserves a direct acceptance-criteria violation because administrators cannot see the effective derived value in that panel. It also fails to challenge the false claim that Compose and Terraform defaults omit UI_TITLE and overstates the hook as guaranteeing one request without demonstrating in-flight request deduplication. Security, FOUC, test-cache leakage, chart validation, compatibility, and tooltip wording receive specific rather than generic scrutiny."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 13,
+          "specificity": 21,
+          "risk_awareness": 19,
+          "total": 72,
+          "notes": "The plan provides strong concrete oracles for resolver precedence, API values, all four UI surfaces, Helm rendering, Terraform validation, and rollback behavior. Its Compose negative test is incorrect because UI_TITLE=${UI_TITLE:-} creates an empty environment variable, so printenv succeeds rather than reaching the claimed unset branch; the ECS configuration similarly always emits the variable. The assertion that prior API keys are byte-for-byte unchanged is not established by listing keys, and the with-gateway compatibility statement overlooks the intentional UptimeDisplay change from 'and' to '&'. Automated component and endpoint tests are only sketched or replaced with manual checks, and the stated unittest and admin-response commands could not be independently executed against the repository."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 75,
+          "notes": "The patch implements the central runtime path coherently: Settings resolves the title, GET /api/config exposes it, the hook types it, four React consumers render it safely, and Docker, Terraform, and Helm receive configuration wiring. The largest functional omission is that CONFIG_GROUPS exposes raw ui_title rather than the effective value required by the issue, and no proposed backend or frontend tests are included despite the LLD estimating new tests and the summary claiming nothing was left out. The patch also renders empty UI_TITLE variables in Compose and ECS, while its summary overstates omission behavior and reports +94/-10 even though the submitted hunks total +90/-5. Diff contexts are internally consistent with the named symbols, but the claimed git apply checks could not be independently repeated because repository shell execution failed before commands ran."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "honor-cloud-provider-override-in-ui",
+      "complexity": "low",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 21,
+      "input_tokens": 1835,
+      "output_tokens": 30708,
+      "total_tokens": 2330199,
+      "latency_seconds": 394.4,
+      "total_cost_usd": 2.4854137499999993,
+      "result_subtype": "success",
+      "task_score": 79.4,
+      "cache_read_tokens": 2200315,
+      "cache_write_tokens": 97341,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 24,
+          "risk_awareness": 21,
+          "total": 89,
+          "notes": "The issue clearly defines the UI-versus-telemetry inconsistency, testable override and fallback behavior, unchanged response keys, and explicit non-goals. Its strongest evidence is the named `get_telemetry_detection_info`, `_resolve_cloud`, and `_detect_cloud_provider_with_method` integration reflected in the submitted diff. The main limitation is that claims about `.env.example`, validator values, and the complete resolver precedence could not be independently confirmed from the baseline source. No independent task statement was supplied, but the issue is internally consistent with the task identifier and repository tags."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 19,
+          "specificity": 24,
+          "risk_awareness": 20,
+          "total": 85,
+          "notes": "The LLD commits to concrete files, call flow, response behavior, tests, compatibility boundaries, and a proportionate rollout for a small change. It correctly identifies the asynchronous call-site change in `registry/api/system_routes.py` and specifies isolated override and fallback tests in `tests/unit/test_stats_endpoint.py`. Its largest weakness is an internal contradiction: it acknowledges a newly reachable cached registry-card read but later claims there are no new network calls, and it recommends production constants as API-test oracles, which can hide a contract-value regression. Exact cache, logging, deployment-surface, and fail-silent implementation claims could not be independently verified from the baseline source."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 18,
+          "total": 75,
+          "notes": "The review raises concrete concerns about the stale endpoint docstring, the newly reachable operator-hint read, cache isolation, authentication, and constrained configuration values. Its strongest contribution is checking that an async `_resolve_cloud()` call fits the existing async handler while preserving the response schema. The largest deficiency is that every persona approves the design and the review endorses importing production method constants for compatibility assertions, an oracle that could change alongside broken production behavior. Claims that grep finds only `UptimeDisplay.tsx` and that every deployment surface is already wired were not independently verifiable."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 77,
+          "notes": "The plan provides concrete HTTP and unit-test setup, actions, status checks, exact response dictionaries, authentication coverage, and an unchanged-fallback oracle. The automated tests directly target `/api/system/telemetry-detection` and use dependency overrides matching the submitted implementation. Its largest gaps are no coverage for the newly exposed operator-declared, operator-declined, or repository-error paths, plus reliance on production constants rather than literal contract values; the telemetry-event parity check also lacks a concrete observation procedure. The final `uv run python -m unittest`/`pytest tests/` notation is not one executable command, and the authoritative repository test command could not be verified."
+        },
+        "implementation": {
+          "completeness": 19,
+          "correctness": 15,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 71,
+          "notes": "The production hunk implements the stated scope by changing the deferred import and awaiting `_resolve_cloud()` while preserving the two response keys, and the test hunk covers override and fallback cases. The largest defect is that the added fallback test calls `AsyncMock(...)` but the patch contains no import change; the testing artifact itself says that import must be added if missing, so the test can fail with `NameError` and the summary's claim of no deviations is overstated. The diff context targets the named handler and existing unauthenticated test location, but local `git apply --check` and the baseline import list could not be independently verified because repository commands failed before execution in the sandbox. Apart from the test-import defect, the handler change is internally consistent with the LLD and does not alter the JSON schema."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "consistent-csrf-across-toggle-endpoints",
+      "complexity": "medium",
+      "ref": "v1.0.20",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 32,
+      "input_tokens": 8884,
+      "output_tokens": 44500,
+      "total_tokens": 3999608,
+      "latency_seconds": 571.2,
+      "total_cost_usd": 3.8012122500000007,
+      "result_subtype": "success",
+      "task_score": 79.0,
+      "cache_read_tokens": 3829497,
+      "cache_write_tokens": 116727,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 85,
+          "notes": "The issue's strongest aspect is its concrete six-endpoint matrix, explicit session-versus-bearer behavior, testable acceptance criteria, and bounded non-goals. Its largest flaw is claiming bearer-token requests succeed on all six endpoints despite its own table showing session-only `enhanced_auth` and separate `validate_internal_auth` paths; the authorization qualifier only partly resolves that inconsistency. The named route functions and CSRF dependency agree with the submitted patch contexts. With no independent task statement, the intended endpoint set and exact scope cannot be independently confirmed."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 20,
+          "specificity": 23,
+          "risk_awareness": 21,
+          "total": 86,
+          "notes": "The LLD commits to precise control flow in `verify_csrf_token_flexible`, names concrete route functions, preserves mixed-credential fail-closed behavior, and documents the shared dependency's wider caller impact. Its largest deficiency is treating that wider behavior change and newly protected browser callers as safely backward-compatible without a demonstrated caller audit or rollout validation. The proposed signatures and edits align internally with the patch contexts for `csrf.py`, `server_routes.py`, and `virtual_server_routes.py`, although the claim that `request.form()` is reached only for genuine form posts overstates what the shown control flow guarantees. Claims about every caller, proxy header sanitization, and the absence of other toggle routes could not be independently verified."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 20,
+          "total": 79,
+          "notes": "The review's strongest contribution is identifying concrete risks around uninstrumented browser callers, shared-dependency side effects, mixed credentials, request-body handling, and the internal endpoint's effectively no-op CSRF wiring. Its largest weakness is resolving several findings through unsupported assertions, notably that the SPA is the only browser caller and that JSON requests never reach `request.form()`, rather than through source evidence or tests. It correctly requests route-level regression coverage for `/api/servers/toggle` and the virtual-server toggle, but that coverage is absent from the submitted patch. The asserted frontend exclusivity and complete six-route inventory remain unverifiable."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 16,
+          "risk_awareness": 17,
+          "total": 64,
+          "notes": "The dependency unit tests are the strongest portion: they provide specific 403 details, valid header and form cases, session binding, and an early-return body-read oracle. The route-level plan's central assertion, `status_code != 403`, can pass on 401, 404, 422, or unrelated failures and cannot distinguish a handler authorization 403 from a CSRF 403. It also treats six routes with different auth dependencies and payload shapes as one generic setup, while the end-to-end registration example contains a non-executable `...` payload. The claimed cookie default, registration command, and full-suite command were not independently verified."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 21,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 81,
+          "notes": "The patch coherently implements the proposed session-cookie gate, preserves token validation for cookie-bearing requests, and wires the dependency into `internal_toggle_service`, `toggle_service_api`, and `toggle_virtual_server`. Its largest deficiency is omitting the route-level tests promised by the LLD and review, leaving the six-endpoint wiring and newly closed browser gaps without executable regression coverage. The summary is also internally inconsistent when it says there are no deviations or follow-ups and then recommends the omitted route tests. The claimed baseline commit and successful `git apply --check` could not be independently verified from the available repository access."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "registration-admission-control-gate",
+      "complexity": "high",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 58,
+      "input_tokens": 5465,
+      "output_tokens": 69168,
+      "total_tokens": 8780756,
+      "latency_seconds": 892.5,
+      "total_cost_usd": 7.033301,
+      "result_subtype": "success",
+      "task_score": 76.4,
+      "cache_read_tokens": 8545477,
+      "cache_write_tokens": 160646,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 89,
+          "notes": "The issue strongly defines configuration, failure semantics, redaction, deployment surfaces, acceptance criteria, and explicit non-goals. It says \u201call six paths\u201d while enumerating seven routes: two agent, three server, and two skill paths. Its largest ambiguity is that it promises every update is gated while excluding server edit paths and never defines whether overwrite-through-register must carry action `update`. No independent task statement was supplied, so the proposed webhook contract itself cannot be verified beyond the task identifier and repository-shaped evidence."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 79,
+          "notes": "The LLD is unusually concrete about real symbols such as `register_agent`, `internal_register_service`, `Settings`, and the three compose variants, with useful rollout and failure handling. Its largest design defect is labeling both server overwrite branches with `action=\"register\"`, despite explicitly recognizing that those branches perform updates. It also passes arbitrary server dictionaries directly through `httpx` JSON encoding and catches only `httpx.HTTPError`, overlooking serialization failures from values such as the parsed `source_updated_at` datetime. Exact line-number and baseline claims could not be independently reproduced because the local command runner failed before executing read-only commands."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 18,
+          "specificity": 20,
+          "risk_awareness": 20,
+          "total": 77,
+          "notes": "The review finds substantive defects, particularly credential leakage, branch-placement bypasses, missing server entry points, and fail-closed misconfiguration behavior. Its largest omission is failing to notice that overwrite operations are still reported to policy as registrations, and it also misses the raw-JSON serialization risk. The claim that logs contain only endpoint, actor, and decision conflicts with the patch, which logs the configured URL and denial message. Claims about existing frontend `detail` handling and Helm precedent were not independently verifiable from the available local tooling."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 16,
+          "risk_awareness": 17,
+          "total": 63,
+          "notes": "The helper-level unit matrix has concrete oracles for allow, deny, timeout, connection failure, disabled mode, redaction, and authentication headers. The integration setup writes `/tmp/stub_gate.py` but launches `uvicorn stub_gate:app` without changing directory or specifying `--app-dir`, and its stub checks `payload.name` although the proposed server payload uses `server_name`. It provides no automated route-wiring tests and merely says to repeat requests for six remaining paths without supplying their exact payloads and authentication. The plan explicitly states that tests were not executed, so its repository-wide commands and expected statuses remain unverified."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 74,
+          "notes": "The patch implements settings, exception mapping, recursive redaction, deployment wiring, helper tests, and gate calls at all seven submitted route locations before persistence. Its largest correctness defect is that `register_service_api` and `internal_register_service` always send `action=\"register\"` even when the subsequent branch performs an overwrite or `update_server`. The gate service sends raw dictionaries through `json=` and catches only `httpx.HTTPError`, so non-JSON-native server values can produce an uncaught serialization error instead of the promised 502. The summary\u2019s claimed total of +399 lines contradicts its own +157-line service and +231-line test file plus all other additions, and its claimed `git apply --check` result could not be independently reproduced."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "index-demo-videos-in-one-page",
+      "complexity": "trivial",
+      "ref": "1.24.3",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 26,
+      "input_tokens": 223,
+      "output_tokens": 28813,
+      "total_tokens": 2292626,
+      "latency_seconds": 406.8,
+      "total_cost_usd": 2.238324,
+      "result_subtype": "success",
+      "task_score": 76.2,
+      "cache_read_tokens": 2196618,
+      "cache_write_tokens": 66972,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 70.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 18,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 81,
+          "notes": "The issue provides unusually testable acceptance criteria, explicit exclusions, grouping requirements, duplicate handling, and a precise README integration point. Its largest defect is the claim of 13 videos across nine source files: the artifacts themselves identify ten, including README.md, eight docs files, and release-notes/v1.0.3.md. The named examples, docs/demo-videos.md target, and no-removal constraint are concrete and internally supported. No independent task statement exists, and the tag-specific inventory could not be independently re-run because repository shell access failed."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 18,
+          "specificity": 24,
+          "risk_awareness": 19,
+          "total": 84,
+          "notes": "The LLD is implementation-ready for this small change, providing exact paths, URLs, topic placement, duplicate sources, README placement, and the important distinction between the two dynamic-discovery recordings. Its verified-scan claim is internally inconsistent because the Key Files table names ten matching source files while repeatedly reporting nine. It also incorrectly connects inability to validate external links with clone depth; network availability, not shallow history, controls that validation. Exact baseline line numbers and external URL behavior could not be independently verified."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 14,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 69,
+          "notes": "The strongest review findings are specific to this change: README wrapping, explicit MkDocs navigation, exhaustive inventory verification, GIF exclusion, and duplicate handling. The review nevertheless endorses the impossible nine-file count despite the LLD naming ten sources, then claims that the resulting grep expectation was resolved. It also calls operational risk zero and fails to catch the testing plan's undefined BASE_SHA and incomplete duplicate checks. Assertions that the scan, navigation check, and resolutions were executed are supported only by the candidate's own later summary."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 21,
+          "risk_awareness": 16,
+          "total": 65,
+          "notes": "The plan has concrete per-video presence oracles, backward-compatibility checks, rendering checks, and a patch applicability check appropriate to a documentation change. Its principal expected result is wrong: the inventory described across the artifacts spans ten source files, not nine. The git diff command uses an undefined BASE_SHA, the patch path is not established, and duplicate counting covers only GitHub attachments rather than YouTube and Vidcast entries. Rendered MkDocs anchors and remote-link availability are delegated to manual review and could not be independently verified."
+        },
+        "implementation": {
+          "completeness": 23,
+          "correctness": 18,
+          "specificity": 23,
+          "risk_awareness": 18,
+          "total": 82,
+          "notes": "The submitted patch implements the requested page end to end: it contains 13 distinct entries in seven groups, records hosts and source pages, preserves existing content, and adds a prominent README link. The largest defect is the summary's false claim that nine files matched its scan while the generated page names ten source files and includes docs/federation-operational-guide.md, which the summary omits. The patch is otherwise focused and its README deviation is clearly justified, although hard-coded double-hyphen anchors may not match MkDocs slug generation for headings containing ampersands. Local source-context and git apply --check verification could not be completed because the repository shell sandbox failed before executing commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "idp-authenticated-embedding-endpoint",
+      "complexity": "high",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 103,
+      "input_tokens": 13290,
+      "output_tokens": 84671,
+      "total_tokens": 20852959,
+      "latency_seconds": 1184.3,
+      "total_cost_usd": 13.896581249999999,
+      "result_subtype": "success",
+      "task_score": 75.0,
+      "cache_read_tokens": 20522675,
+      "cache_write_tokens": 232323,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 71.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 90,
+          "notes": "The issue provides unusually testable acceptance criteria, explicit non-goals, deployment scope, compatibility expectations, and security requirements. Its named integration points\u2014`LiteLLMClient`, `registry/services/federation/federation_auth.py`, `/api/config`, and the documented deployment surfaces\u2014match the submitted repository structure and patch context. Its largest gap is that it does not specify recovery behavior after a transient refresh failure, despite uninterrupted operation being the motivation. No independent task statement was supplied, so the requirement origin and related issue linkage could not be independently verified."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The design is strongly repository-specific, naming the factory, sole documented construction site, configuration model, masking route, deployment files, token data flow, and default-off branching. It correctly commits to per-call `api_key` injection, locking, buffered expiry, startup validation, secret handling, and a dedicated provider rather than reusing the federation singleton. Its largest flaw is accepting the existing `_embedding_unavailable` latch after refresh errors: one transient IdP outage can permanently suppress further token retries until restart, contradicting the assertion that automatic refresh makes manual clearing unnecessary. It also fails to make conditional Docker/ECS environment rendering a design requirement, and the claimed LiteLLM authorization behavior could not be independently verified from the local dependency."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 19,
+          "specificity": 20,
+          "risk_awareness": 17,
+          "total": 74,
+          "notes": "The review raises concrete design concerns rather than merely approving: opaque `None` failures, a lock held across network I/O, SSRF trust boundaries, static-key shadowing, Terraform secret cost, and dimension changes. Its recommendations directly influenced identifiable design decisions, including raising `RuntimeError` and skipping `_set_api_key_env()` when a provider is attached. The largest deficiency is declaring every blocker resolved while missing the permanent unavailable-latch behavior and the acceptance requirement that default deployments set no new environment variables. It also did not expose the later Terraform placeholder-secret or Helm existing-secret failure modes, although those details were not fully specified in the reviewed LLD."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 69,
+          "notes": "The plan supplies concrete oracles for caching, buffered refresh, HTTP and network failures, scope propagation, bearer injection, startup validation, static-key compatibility, masking, and token-lifetime E2E behavior. However, it describes the suite as plain pytest while its principal examples use `unittest.TestCase`, and the thread test checks only POST count without collecting thread results or exceptions. Its largest coverage gap is that grep-based deployment checks would pass the submitted unconditional ECS/Compose wiring and would not detect Terraform's `not-configured` secret bypassing fail-fast validation. The proposed `/api/search`, `_format_value`, Helm, and re-index commands were not established by available repository evidence, and no malformed token response or transient-refresh recovery test is specified."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 13,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 66,
+          "notes": "The patch implements the central Python flow end to end: settings reach `create_embeddings_client`, the provider caches under a lock, and `LiteLLMClient.encode()` injects the token while preserving the static-key branch. The largest defect is Terraform's unconditional secret value `not-configured`: when IdP mode is enabled without a supplied secret, that nonempty sentinel defeats the promised startup validation; ECS and all Compose files also set new variables unconditionally despite the explicit default-inert acceptance criterion. Helm additionally loses an inline `embeddings.idp.clientSecret` when `app.existingSecret` suppresses the generated secret, while token JSON decoding and `expires_in` conversion can escape as unhandled raw exceptions. The summary also reports 24 files although the displayed diff contains 25, and its `git apply --check` claim could not be independently rerun because local command execution was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "logout-id-token-hint-out-of-browser-url",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 48,
+      "input_tokens": 9662,
+      "output_tokens": 58134,
+      "total_tokens": 6314414,
+      "latency_seconds": 771.1,
+      "total_cost_usd": 5.366460249999999,
+      "result_subtype": "success",
+      "task_score": 75.0,
+      "cache_read_tokens": 6117663,
+      "cache_write_tokens": 128955,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 75.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 20,
+          "total": 81,
+          "notes": "The issue clearly defines the WAF failure, security motivation, rolling-upgrade behavior, non-goals, and testable acceptance criteria. Its named integration points align internally with the submitted diff, including `registry/auth/routes.py::logout_handler`, `settings.auth_server_url`, and the existing direct `id_token_hint` path. The largest deficiency is that it promises to remove the token from any browser-facing URL and browser history, while its proposed flow still sends the browser to the IdP with `id_token_hint` in that URL. No independent task statement was supplied, and the claimed line numbers and upstream issue could not be independently verified because repository shell execution was unavailable."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 78,
+          "notes": "The LLD is unusually concrete about APIs, data flow, storage, encryption, metrics, failure behavior, files, and backward-compatible request precedence. Its major correctness gap is the claim that deployment order is fully safe: during a rolling auth-server upgrade, ticket creation can hit a new replica while the browser's consume request hits an old replica that ignores `logout_ticket`, intermittently losing IdP logout. The proposed `_get_collection` also caches the collection after an index-creation failure, preventing retries and allowing abandoned encrypted tokens to persist without the promised TTL cleanup; `encrypt_id_token` is outside `create_ticket`'s exception boundary despite the stated never-raise contract. There is also a minor internal inconsistency between the three-second implementation timeout and the five-second scaling discussion, while exact repository conventions could not be independently inspected."
+        },
+        "review": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 71,
+          "notes": "The review finds concrete issues\u2014provider binding, secret-safe logging, user-path timeout, write/read consistency, and fallback observability\u2014and records actionable resolutions that appear in the patch. It specifically drove `consume_ticket(..., provider=provider)`, the three-second timeout, and the two new counters. Its largest omission is the mixed-replica rolling-upgrade race, and its assertion that TTL cleanup prevents unbounded growth overlooks the LLD's swallowed index failure and non-retrying cache. It also accepts the broad browser-URL security claim despite acknowledging that the subsequent IdP redirect still contains the JWT."
+        },
+        "testing": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 21,
+          "risk_awareness": 18,
+          "total": 76,
+          "notes": "The plan covers endpoint authentication, opacity, single use, provider binding, direct-hint compatibility, fallback, metrics, rollback, and an end-to-end IdP-session oracle rather than merely checking status codes. Strong concrete assertions include excluding `id_token_hint` from the registry redirect and requiring it in the IdP `Location`. It omits the critical mixed old/new auth-server replica scenario, failed TTL-index creation, encryption failure, and malformed successful ticket responses. Several unit cases remain pseudocode with ellipses, and the proposed test paths and `uv run pytest tests/` command could not be independently verified against the repository."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 22,
+          "risk_awareness": 14,
+          "total": 69,
+          "notes": "The patch implements the stable all-new flow end to end: authenticated ticket creation, encrypted shared storage, atomic consumption, provider binding, registry fallback, direct-hint compatibility, and metrics. The largest operational defect is the unhandled mixed-replica upgrade race; additionally, `_get_collection` never retries failed TTL-index creation, and encryption occurs outside the advertised failure-catching block. No tests accompany the production changes, and the summary overstates removal from browser-facing URLs because the IdP redirect still contains `id_token_hint`. The diff is internally coherent with the named symbols and contexts, but its claimed clean application to commit `5f725c1d` could not be independently confirmed because local shell execution failed before running `git apply --check`."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "lifecycle-workflow-webhooks",
+      "complexity": "high",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 121,
+      "input_tokens": 4248,
+      "output_tokens": 84432,
+      "total_tokens": 22768710,
+      "latency_seconds": 1280.9,
+      "total_cost_usd": 14.729281000000002,
+      "result_subtype": "success",
+      "task_score": 73.6,
+      "cache_read_tokens": 22461382,
+      "cache_write_tokens": 218648,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 65.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 22,
+          "total": 89,
+          "notes": "The issue clearly defines five cross-entity deliverables, measurable acceptance criteria, dependencies, and explicit non-goals. Its named route modules, webhook service, lifecycle enum, and scopes file correspond to targets and symbols present in the submitted diff. The largest evidence gap is the absence of an independent task statement, so claims such as the existing polling endpoints and exact intended scope cannot be independently confirmed. Security, compatibility, and delivery risks are handled unusually well for an issue, though signing-key rotation is not addressed."
+        },
+        "lld": {
+          "completeness": 21,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 19,
+          "total": 78,
+          "notes": "The LLD is strongly repository-shaped, naming concrete functions such as send_registration_webhook and all three scan handlers while committing to exact-body signing and additive authorization. The submitted source context supports the central chokepoint and PUT-versus-PATCH distinctions. Its largest correctness gap is failure to establish how request-model defaults preserve the required distinction between omitted and explicitly mismatched initial statuses; it also claims validation while leaving registration_initial_status as an unchecked string until request handling. The threat model covers forgery, replay, and least privilege, but omits coordinated key rotation and unsuccessful HTTP response classification."
+        },
+        "review": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 21,
+          "total": 80,
+          "notes": "The review identifies concrete defects with consequences, notably json= reserialization breaking HMAC verification, skill authorization needing to remain additive, replay handling, and unsigned-send observability. Those findings correspond directly to code paths shown in webhook_service.py and skill_routes.py. Its largest omission is failing to challenge initial-status omission semantics, configuration-value validation, and treating HTTP error responses as successful sends. The statement that every finding was resolved is overstated because detailed LLD steps still use ad hoc normalized comparisons rather than the promised shared validator."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 15,
+          "risk_awareness": 19,
+          "total": 63,
+          "notes": "The strongest tests use the raw received body as the HMAC oracle and exercise least privilege, forged payloads, compatibility defaults, and all entity types. The plan also specifies meaningful expected status codes and scan fields rather than merely asserting execution. Its ordering expectation for registration followed by scan_complete conflicts with its own contract stating that independently scheduled events are unordered, while unsafe targets and raw-body capture are not concretely provisioned. The proposed unittest discovery command, exact fixtures, and several configuration commands remain unverified, and no corresponding tests appear in the patch."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 58,
+          "notes": "The patch implements the main architecture coherently: webhook_service.py serializes once and posts content=body, permission checks cover server, agent, and skill updates, and scopes, metrics, environment documentation, and the consumer contract are included. Concrete defects remain: registration_initial_status is not validated at configuration load, and every HTTP response\u2014including 4xx or 5xx\u2014is recorded as success. Enforcement operates on already-materialized request.status values without checking field presence, risking rejection rather than forcing when an omitted field has an existing non-null default. No automated tests are included, and the claimed clean git application could not be independently verified because local repository command execution was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "per-caller-per-target-rate-limits-and-quarantine",
+      "complexity": "high",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 97,
+      "input_tokens": 17849,
+      "output_tokens": 112234,
+      "total_tokens": 20640000,
+      "latency_seconds": 1591.7,
+      "total_cost_usd": 14.690835000000003,
+      "result_subtype": "success",
+      "task_score": 73.6,
+      "cache_read_tokens": 20241955,
+      "cache_write_tokens": 267962,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 70.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 86,
+          "notes": "The issue clearly defines both missing behaviors, explicit exclusions, response/admin/failure decisions, and testable acceptance criteria across backend and management surfaces. Referenced paths and symbols such as `RateLimiter.check()`, `registry/api/rate_limit_routes.py`, and `IAMRateLimits.tsx` correspond to patch targets. Its largest gap is calling quarantine an absolute immediate block while leaving store-outage semantics undecided, which could qualify that guarantee. No independent task statement was supplied, so issue-number and operator-demand claims could not be independently validated."
+        },
+        "lld": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 73,
+          "notes": "The LLD is unusually concrete about repository files, data flow, counter keys, response semantics, admin asymmetry, caching, rollout, and management surfaces. Its reserved-marker design does not preserve its own invariants: a general PUT can submit `quarantine=true, enabled=false`, while the proposed validator also accepts arbitrary quarantine markers without restricting them to the two reserved identities. It also misses delimiter collisions in `identity|entity_type:name` and lost updates from read-modify-write membership changes. Claims about fail-open metrics and complete marker immutability are therefore stronger than the specified mechanics support."
+        },
+        "review": {
+          "completeness": 19,
+          "correctness": 17,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 75,
+          "notes": "The review identifies concrete repository-specific problems including marker rows with no numeric limit, caller-like floor validation, bounded metric labels, seed clobbering, and admin-bypass asymmetry. Its recommendations are prioritized and traceable to revisions in the LLD. The declaration that all blocking findings are resolved is not defensible because it misses the reserved-marker PUT bypass, arbitrary `quarantine=true` definitions, membership update races, and composite-key delimiter collisions. It also accepts observability and fail-open resolutions without checking whether their proposed control flow actually emits the promised error metric."
+        },
+        "testing": {
+          "completeness": 21,
+          "correctness": 13,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 74,
+          "notes": "The plan covers unit, API, CLI, UI, compatibility, deployment, and end-to-end behavior with strong oracles for pairwise counter independence and quarantine response semantics. Its primary command, `python -m unittest discover`, will not collect the submitted pytest-style `TestRateLimiter` class with plain async methods, making the advertised execution path unreliable. The integration setup maps `$(whoami)` while later quarantining `alice`, and the E2E sequence expects an allowed post-unquarantine call immediately after exhausting the same window. Several named route, repository, model, and fail-open tests were planned but not included in the implementation, and the referenced `tests/scripts/call_mcp_tool.py` could not be verified."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 11,
+          "specificity": 20,
+          "risk_awareness": 11,
+          "total": 60,
+          "notes": "The patch broadly implements the new axis, enforcement branch, persistence helpers, API, CLI, UI, documentation, and core limiter tests using plausible existing files and symbols. The largest defect is that reserved markers remain mutable through ordinary PUT requests using `quarantine=true`, including setting `enabled=false`, while arbitrary names can also bypass normal entity and numeric-limit validation. Caller quarantine uses `get_groups_for` directly rather than the supplied fail-open predicate, promised error metrics are absent, and `add_group`/`remove_group` use race-prone read-modify-write operations. Only `test_limiter.py` is changed, its `test_reserved_group_not_gated` merely proves quarantine denial rather than group stripping, and the claimed baseline/apply check could not be independently verified because repository command access failed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "portable-env-secret-generation-in-build-script",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 30,
+      "input_tokens": 1201,
+      "output_tokens": 34159,
+      "total_tokens": 3056899,
+      "latency_seconds": 464.6,
+      "total_cost_usd": 2.85697525,
+      "result_subtype": "success",
+      "task_score": 70.2,
+      "cache_read_tokens": 2936978,
+      "cache_write_tokens": 84561,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 73.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 78,
+          "notes": "The issue tightly scopes build_and_run.sh, identifies the five named secret blocks plus the metrics-key loop, and provides testable count, value, failure, and preservation criteria. Its largest weakness is the asserted operational consequence: source .env uses the later appended assignment, and no evidence establishes a first-assignment consumer or resulting crash-loop. The BSD sed failure and duplicate-line creation are credible from the submitted source contexts, but the proposed literal grep gate conflicts with the later implementation comment containing 'sed -i'. No independent task statement was supplied, and the linked issue and documentation claims could not be independently confirmed."
+        },
+        "lld": {
+          "completeness": 22,
+          "correctness": 16,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 78,
+          "notes": "The LLD is unusually concrete about build_and_run.sh integration points, grep exit status 1 under set -e, same-directory temporary files, and all six replacement sites. The helper is implementation-ready for the common path, and its contexts align with the submitted handle_error and generation-block hunks. Its largest correctness gap is the claim that unchanged guards protect operator values: if both NAME= and NAME=operator-value exist, the empty-line guard fires and set_env_var deletes both before writing a generated value. It also claims interrupted runs cannot leave temporary secrets despite defining no signal trap, and it does not address the permission change caused by replacing .env with a mode-0600 mktemp file."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 14,
+          "specificity": 18,
+          "risk_awareness": 15,
+          "total": 64,
+          "notes": "The review's strongest contribution is the concrete temporary-secret residue finding and its recommendation to clean up printf and mv failure paths. However, it incorrectly treats that change as resolving interruption leakage even though SIGINT between mktemp and mv bypasses those branches without a trap. It misses the mixed empty/non-empty duplicate case that can overwrite an operator value and claims secrets are not logged despite the shown metrics loop logging a token prefix with ${NEW_TOKEN:0:20}. The frontend role contributes little, while several repository-document and dependency assertions remain unsupported."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 60,
+          "notes": "The plan provides useful exact oracles for one-line replacement, non-empty values, unrelated-line preservation, nonzero failure, and temporary-file cleanup. Its primary static gate is invalid for the submitted patch because grep -n 'sed -i' matches the helper's explanatory comment, so the stated expected exit 1 cannot occur. Several tests are sketches rather than runnable checks: source_helper_and_call is undefined, the helper must be pasted manually, the operator test never executes the generation block, and the help grep does not prove all four options exist. It also omits the mixed duplicate state that exposes operator-value clobbering and does not directly exercise all six real call sites."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 16,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 71,
+          "notes": "The patch targets the correct five named generation blocks and metrics-key loop shown in build_and_run.sh, and the temporary-file helper avoids GNU-specific in-place sed while handling grep's normal status 1. Its largest defect is preservation behavior: an empty duplicate causes the unchanged guard to run, after which grep -v removes any non-empty operator assignment and replaces it with a generated secret. The added comment also violates the issue's literal no-'sed -i' grep criterion, and explicit command-failure cleanup does not support the summary's claim that interrupted runs leave no temporary secret. The asserted baseline commit and successful git apply --check could not be independently verified, so applicability beyond the matching submitted hunk contexts remains unconfirmed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-mcp-proxy-upstream-timeout",
+      "complexity": "medium",
+      "ref": "1.25.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 33,
+      "input_tokens": 5967,
+      "output_tokens": 39801,
+      "total_tokens": 3444328,
+      "latency_seconds": 511.1,
+      "total_cost_usd": 3.2584012500000004,
+      "result_subtype": "success",
+      "task_score": 68.4,
+      "cache_read_tokens": 3305645,
+      "cache_write_tokens": 92915,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.9,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 16,
+          "specificity": 22,
+          "risk_awareness": 18,
+          "total": 78,
+          "notes": "The strongest aspect is its testable scope: it identifies the settings field, proxy call site, deployment surfaces, defaults, exclusions, and compatibility behavior. Its largest technical error is describing the scalar HTTPX timeout as a total wall-clock limit; HTTPX applies it to network-operation inactivity, while disabling timeouts uses None rather than zero.  The requirement that sub-floor values clamp without crashing conflicts with Field(ge=1), because BaseSettings validates environment-derived values during construction before the reader can clamp them.  No independent task statement establishes the reported production scenario, and the local sandbox failure prevented independent verification of the cited baseline source."
+        },
+        "lld": {
+          "completeness": 23,
+          "correctness": 13,
+          "specificity": 23,
+          "risk_awareness": 17,
+          "total": 76,
+          "notes": "The design is unusually concrete about files, integration points, precedence, deployment wiring, observability, rollback, and the exact implementation shape. Its largest defect is the unresolved conflict between Pydantic ge=1 validation and the promised runtime clamp: an invalid compose or Helm environment value can fail Settings construction before _read_mcp_proxy_upstream_timeout_seconds executes.  It also repeatedly calls the HTTPX scalar value a total timeout and treats zero as disabling timeouts, neither of which matches HTTPX's documented behavior.  Claims that the admin surface supports PUT and that edits take effect without restart were not substantiated by a named route or state-update mechanism, and exact source verification was unavailable because the repository shell could not initialize."
+        },
+        "review": {
+          "completeness": 16,
+          "correctness": 8,
+          "specificity": 17,
+          "risk_awareness": 15,
+          "total": 56,
+          "notes": "The review's strongest contribution is identifying concrete operational concerns such as held-open connections, deployment-surface drift, unit labeling, and duplicated readers. Its largest failure is approving the design without catching that Field(ge=1) can reject an environment value before the proposed clamp runs, which directly defeats an acceptance criterion.  Multiple personas reinforce the incorrect assertion that timeout zero disables HTTPX timeouts, although HTTPX documents None as the disabling value.  The live-edit/no-restart conclusion is also asserted without repository evidence, making the largely approving verdict less defensible than its detail suggests."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 11,
+          "specificity": 20,
+          "risk_awareness": 13,
+          "total": 61,
+          "notes": "The plan provides specific reader branch tests, expected values, HTTP status oracles, compatibility checks, and deployment-surface coverage. Its largest gap is that the zero-environment test replaces server.settings with an attribute-less mock, bypassing the real Settings construction path where ge=1 can raise validation failure before clamping.  It lacks an automated assertion that mcp_proxy passes the resolved value to AsyncClient, while grep-based wiring checks establish textual presence rather than valid placement or rendered configuration. The proposed public proxy and config API URLs, Helm command, and full unittest-discovery command could not be verified against the baseline because local repository execution was unavailable."
+        },
+        "implementation": {
+          "completeness": 22,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 71,
+          "notes": "The submitted diff comprehensively changes the settings model, helper, AsyncClient call, admin tuple, three compose files, Terraform, Helm, documentation, and focused unit tests. Its largest defect is functional: MCP_PROXY_UPSTREAM_TIMEOUT_SECONDS=0 can be rejected while constructing Settings because of ge=1, so the helper's clamp and its mocked test do not satisfy the promised non-crashing deployment behavior.  The summary's claim of no deviations therefore overstates correctness, and the documentation also mischaracterizes HTTPX's operation-specific inactivity limits as a total request timeout.  Diff paths and contexts are internally coherent with the cited symbols, but git apply --check and exact baseline inspection could not be performed because the managed shell failed before command execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "build-docker-images-from-uv-lock",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 40,
+      "input_tokens": 1115,
+      "output_tokens": 63602,
+      "total_tokens": 5137834,
+      "latency_seconds": 866.3,
+      "total_cost_usd": 4.873059499999999,
+      "result_subtype": "success",
+      "task_score": 66.0,
+      "cache_read_tokens": 4944269,
+      "cache_write_tokens": 128848,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 73.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 14,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 73,
+          "notes": "The issue clearly identifies affected Dockerfiles, missing lockfiles, CPU-torch handling, CI enforcement, acceptance criteria, and non-goals. Its largest defect is claiming that `uv sync --frozen` rejects a stale lock; uv documents that frozen mode skips freshness checks, while `--locked` performs that validation.  It also promises unchanged behavior despite explicitly changing torch and removing torchvision, and excludes `Dockerfile.registry-cpu` from the stated image-wide objective. No independent task statement was supplied, so the candidate-defined scope cannot be fully validated."
+        },
+        "lld": {
+          "completeness": 19,
+          "correctness": 12,
+          "specificity": 22,
+          "risk_awareness": 17,
+          "total": 70,
+          "notes": "The LLD is unusually concrete about Dockerfiles, project roots, environment pruning, `--inexact`, editable installation, CI matrices, and the torch source pin. Its central failure-handling decision is wrong: `--frozen` installs from the existing lock without verifying manifest drift, invalidating repeated claims that Docker builds fail loudly on stale locks.  The design also overstates runtime equivalence while changing torch and removing torchvision, and leaves one registry image outside lock-based installation. Exact repository claims such as every project using `package = false` could not be independently verified because local repository command execution was unavailable."
+        },
+        "review": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 19,
+          "risk_awareness": 16,
+          "total": 65,
+          "notes": "The review raises concrete concerns about the torch version change, `--inexact` safety, matrix completeness, index isolation, and the `registry-cpu` deferral. Its largest deficiency is missing the design's most consequential technical error and explicitly approving the false assertion that frozen sync detects stale locks.  Several resolutions rely only on asserted grep and lock-generation results rather than evidence present in the review. The frontend persona contributes little, but the backend, SRE, and security sections otherwise provide actionable scrutiny."
+        },
+        "testing": {
+          "completeness": 19,
+          "correctness": 9,
+          "specificity": 20,
+          "risk_awareness": 14,
+          "total": 62,
+          "notes": "The plan covers lock presence, CI coverage, builds, CPU torch, CUDA absence, drift, rollback, and container smoke behavior with concrete commands and expected outcomes. The critical negative test expects `uv sync --frozen` to reject drift, contrary to uv semantics, so it cannot validate the promised build-time guard.  Its shell also fails to enforce several oracles: the drift commands can continue after unexpected success, and the server-lock test merely prints unexpected torch entries without failing. The image-size check lacks a captured baseline, while the health checks assume bare containers can become healthy without documenting required runtime configuration."
+        },
+        "implementation": {
+          "completeness": 16,
+          "correctness": 12,
+          "specificity": 19,
+          "risk_awareness": 13,
+          "total": 60,
+          "notes": "The submitted summary describes an end-to-end change across lockfiles, five Dockerfiles, root torch configuration, and a nine-project CI matrix, and the visible workflow and generated lock content are consistent with that intent. The implementation preserves the design's core defect by using `uv sync --frozen` where stale-lock rejection requires locked checking, although CI's separate `uv lock --check` partially mitigates it.  It also leaves `Dockerfile.registry-cpu` unresolved and knowingly changes the installed torch/torchvision surface without executed image or smoke validation. The supplied diff is truncated inside `auth_server/uv.lock`, so the Dockerfile and root-lock hunks and the claimed `git apply --check` result could not be independently inspected."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "derive-repo-url-from-skill-md",
+      "complexity": "medium",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 35,
+      "input_tokens": 5049,
+      "output_tokens": 40365,
+      "total_tokens": 4283867,
+      "latency_seconds": 520.6,
+      "total_cost_usd": 3.8154617499999994,
+      "result_subtype": "success",
+      "task_score": 63.6,
+      "cache_read_tokens": 4123346,
+      "cache_write_tokens": 115107,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 77.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 22,
+          "correctness": 21,
+          "specificity": 23,
+          "risk_awareness": 20,
+          "total": 86,
+          "notes": "The issue provides unusually concrete URL examples, testable acceptance criteria, and clear exclusions for network verification, non-GitHub providers, and backfilling. Its largest gap is that the semantic-search requirement does not explicitly require that search results actually populate repository_url, enabling the later implementation to add only a dormant optional field. Submitted patch context supports the named Dashboard, SkillInfo, modal, and parse-response integration points. No independent task statement was supplied, and the sandbox prevented direct source or tag verification."
+        },
+        "lld": {
+          "completeness": 16,
+          "correctness": 12,
+          "specificity": 19,
+          "risk_awareness": 13,
+          "total": 60,
+          "notes": "The LLD is concrete about files, symbols, constructors, response fields, and frontend state flow. Its largest defect is declaring the semantic-search change safe even if that path never populates repository_url, which cannot deliver the promised View Repo behavior. It also specifies data.repository_url || prev.repository_url, retaining a stale repository after parsing a non-GitHub URL, and accepts a hostname-substring heuristic that can classify non-GitHub domains as GitHub. Exact line locations and repository conventions could not be independently verified because local read commands were blocked."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 56,
+          "notes": "The review raises concrete concerns about hostname classification, link security attributes, compatibility, deployment, and the need for focused unit tests. Its largest failure is approving end-to-end completeness while overlooking the LLD's explicit admission that semantic-search results may not contain repository_url. It also fails to identify the stale-form-state behavior caused by data.repository_url || prev.repository_url, despite reviewing that expression directly. File and symbol references align with the submitted diff, but could not be checked against the local working tree."
+        },
+        "testing": {
+          "completeness": 18,
+          "correctness": 10,
+          "specificity": 17,
+          "risk_awareness": 15,
+          "total": 60,
+          "notes": "The plan covers derivation variants, API payloads, listing behavior, backward compatibility, both modals, and concrete expected values. Its primary command, uv run python -m unittest, will not collect the submitted plain pytest class and parametrized methods, allowing the new tests to run zero cases successfully. Several manual Parse scenarios use placeholder org/repo URLs that are unlikely to be fetchable, and no setup ensures semantic hits contain repository_url. It also omits the important transition test from a previously derived GitHub value to a non-GitHub parse, which would expose stale state."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 56,
+          "notes": "The patch concretely wires derivation through the parse response and listing model, updates frontend types, and replaces both modal labels with guarded links. It does not populate repository_url in the semantic-search backend, which the summary admits, so a central acceptance criterion remains unimplemented. Dashboard retains an old repository value when derivation returns null, while the helper's acknowledged substring host test can derive values for non-GitHub domains; the advertised +99/-4 total also contradicts the per-file counts in the summary. Patch applicability and exact source context could not be independently confirmed because the read-only command runner failed before executing git apply --check."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "server-side-oauth-token-storage",
+      "complexity": "high",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 41,
+      "input_tokens": 9977,
+      "output_tokens": 68756,
+      "total_tokens": 6595966,
+      "latency_seconds": 881.7,
+      "total_cost_usd": 6.061406750000001,
+      "result_subtype": "success",
+      "task_score": 55.2,
+      "cache_read_tokens": 6337406,
+      "cache_write_tokens": 179827,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 78.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 58,
+          "notes": "The issue provides unusually concrete acceptance criteria, failure behavior, compatibility expectations, and non-goals. Its central premise is materially wrong for this repository: the overflow also involves id_token and the broader OAuth session payload, which the proposed token-only scheme leaves in the cookie. Repository documentation shows the existing token-generation UI produces self-signed registry tokens, so exposing IdP access and refresh tokens is a new security-sensitive feature rather than restoration of that path. No independent task statement was supplied, which limits verification of requirements beyond the task identifier and repository behavior."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 21,
+          "risk_awareness": 13,
+          "total": 56,
+          "notes": "The LLD names real integration points such as oauth2_callback, internal_router, get_user_session_data, and the DocumentDB client, and commits to concrete schemas and failure responses. It designs around access and refresh tokens while explicitly leaving the legacy session block untouched, so it does not remove the id_token/full-session data responsible for the repository's cookie overflow. The delete-many-then-insert sequence is not last-writer-wins under concurrent logins, retrieval does not reject documents past expire_at before the TTL sweep, and stable cross-process encryption-key configuration is not established. The design also defers the frontend consumer and several deployment surfaces while claiming the user-visible flow and rollout are complete."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 19,
+          "risk_awareness": 16,
+          "total": 61,
+          "notes": "The review identifies several concrete defects, including naive MongoDB datetimes, deployment parity, key separation, server-derived ownership, and the missing frontend wiring. Its largest failure is declaring those findings resolved when the UI remains a follow-up and the acknowledged delete-then-insert race still permits multiple valid documents. It misses the repository-critical id_token/full-session cookie path, the expired-document retrieval gap, unstable key configuration, GET caching of secrets, and flaky ciphertext substring assertions. Claims that the backend is complete and that no critical findings remain are contradicted by both the proposed implementation and existing token-generation behavior."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 12,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 64,
+          "notes": "The plan spans unit, endpoint, compatibility, deployment, rollback, and live OAuth checks with concrete actions and expected statuses. It does not assert that id_token and the complete oversized session payload are absent, treats unimplemented frontend wiring as a prerequisite, and expects expired access tokens to be returned with is_expired despite the issue requiring expired stored tokens not be returned. It lacks concurrency coverage for superseding logins, TTL-index failure and expire_at enforcement, cache-control checks, and callback or logout integration tests. The proposed ciphertext test using b\"AT\" absence is probabilistically flaky because Fernet output is base64 text, while the stated uv commands and endpoint setup could not be independently executed here."
+        },
+        "implementation": {
+          "completeness": 8,
+          "correctness": 5,
+          "specificity": 17,
+          "risk_awareness": 7,
+          "total": 37,
+          "notes": "The patch is concrete and internally coherent around TokenStore, encrypted MongoDB documents, owner-scoped lookup, internal routes, and sequential store tests. It does not implement the repository's core cookie fix because it never removes id_token or the complete OAuth session payload, and the existing frontend continues calling POST /api/tokens/generate rather than the new route. The delete-before-insert race violates supersede-on-relogin, get_tokens can return documents beyond expire_at until TTL cleanup, index-creation failure is never retried, and the public GET response exposes upstream refresh tokens without explicit no-store handling. The summary consequently oversells an incomplete change; its target paths and symbols are plausible from the supplied contexts, but the claimed git apply check could not be independently verified because repository shell execution was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "macos-setup-python-version-precheck",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 29,
+      "input_tokens": 4377,
+      "output_tokens": 35517,
+      "total_tokens": 2841189,
+      "latency_seconds": 470.3,
+      "total_cost_usd": 2.7606709999999985,
+      "result_subtype": "success",
+      "task_score": 54.6,
+      "cache_read_tokens": 2722997,
+      "cache_write_tokens": 78298,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 75.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 7,
+          "specificity": 21,
+          "risk_awareness": 11,
+          "total": 57,
+          "notes": "The issue provides precise scope, non-goals, phase references, and directly testable acceptance criteria. Its central diagnosis is incorrect: the repository's post-fix skill checks `uv python find '>=3.14'` because Phase 5 uses uv-managed interpreters, so rejecting an older `python3` on PATH can block a valid setup. The original skill does contain the quoted permissive probe and existing remediation table, grounding those repository claims. No independent task statement or verified issue #1568 text establishes the proposed dynamic-metadata requirement."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 6,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 59,
+          "notes": "The LLD is concrete about the real skill file, phase ordering, marker tokens, output, fallback branches, and known parsing assumptions. Its load-bearing interface is wrong because it compares the system `python3` rather than the interpreter uv will select, contrary to the repository's post-fix implementation. The first-version regex also does not generally follow `requires-python`: patch releases, upper bounds, exclusions, and reordered constraints can be evaluated incorrectly. It discusses offline fallback and ref drift, but understates the false-failure risk and the new Phase 1 network dependency."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 7,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 53,
+          "notes": "The review raises specific concerns about equality, constraint parsing, offline degradation, ref drift, output vocabulary, and trust boundaries. However, every reviewer misses the decisive architectural question of whether PATH's `python3` is the interpreter used by `uv sync`; the repository's actual corrected approach shows it is not necessarily so. Consequently the approval verdict preserves a design that can reject setups already possessing a suitable uv-managed Python. Its claim that all findings were resolved also overstates matters because parsing and offline behavior remain acknowledged limitations."
+        },
+        "testing": {
+          "completeness": 17,
+          "correctness": 7,
+          "specificity": 19,
+          "risk_awareness": 11,
+          "total": 54,
+          "notes": "The plan supplies concrete scenarios and output oracles for below-minimum, equal, newer, absent, and unavailable-metadata cases, plus token-shape and UX checks. All primary tests stub `python3` rather than uv's selected interpreter, so they can pass while the implementation still rejects a valid uv-managed Python configuration. The absent-interpreter command is not deterministic because `/usr/bin:/bin` may contain `python3`, and the manually copied script can diverge from the skill block. It also omits remote-success, local-precedence, and meaningful PEP 440 constraint cases that would expose the parser's limitations."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 6,
+          "specificity": 20,
+          "risk_awareness": 10,
+          "total": 50,
+          "notes": "The patch targets the exact original Python probe context, stays within Phase 1, and faithfully implements the submitted LLD's local-or-remote metadata flow and output details. It does not implement the repository's actual required behavior because it gates PATH's `python3` instead of asking uv whether a compatible interpreter is available, producing false failures. Its extraction of only the first `X.Y` also fails to enforce general `requires-python` specifications, despite the summary claiming the gate automatically follows metadata changes. The textual hunk context matches the original source, but the exact commit hash and asserted `git apply --check` execution could not be independently rerun because local command execution was unavailable."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    }
+  ],
+  "run_date": "2026-09-01"
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "model": "us.anthropic.claude-opus-4-8",
+  "scores": {
+    "github_issue": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 58,
+      "notes": "The issue provides unusually concrete acceptance criteria, failure behavior, compatibility expectations, and non-goals. Its central premise is materially wrong for this repository: the overflow also involves id_token and the broader OAuth session payload, which the proposed token-only scheme leaves in the cookie. Repository documentation shows the existing token-generation UI produces self-signed registry tokens, so exposing IdP access and refresh tokens is a new security-sensitive feature rather than restoration of that path. No independent task statement was supplied, which limits verification of requirements beyond the task identifier and repository behavior."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 8,
+      "specificity": 21,
+      "risk_awareness": 13,
+      "total": 56,
+      "notes": "The LLD names real integration points such as oauth2_callback, internal_router, get_user_session_data, and the DocumentDB client, and commits to concrete schemas and failure responses. It designs around access and refresh tokens while explicitly leaving the legacy session block untouched, so it does not remove the id_token/full-session data responsible for the repository's cookie overflow. The delete-many-then-insert sequence is not last-writer-wins under concurrent logins, retrieval does not reject documents past expire_at before the TTL sweep, and stable cross-process encryption-key configuration is not established. The design also defers the frontend consumer and several deployment surfaces while claiming the user-visible flow and rollout are complete."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 11,
+      "specificity": 19,
+      "risk_awareness": 16,
+      "total": 61,
+      "notes": "The review identifies several concrete defects, including naive MongoDB datetimes, deployment parity, key separation, server-derived ownership, and the missing frontend wiring. Its largest failure is declaring those findings resolved when the UI remains a follow-up and the acknowledged delete-then-insert race still permits multiple valid documents. It misses the repository-critical id_token/full-session cookie path, the expired-document retrieval gap, unstable key configuration, GET caching of secrets, and flaky ciphertext substring assertions. Claims that the backend is complete and that no critical findings remain are contradicted by both the proposed implementation and existing token-generation behavior."
+    },
+    "testing": {
+      "completeness": 17,
+      "correctness": 12,
+      "specificity": 20,
+      "risk_awareness": 15,
+      "total": 64,
+      "notes": "The plan spans unit, endpoint, compatibility, deployment, rollback, and live OAuth checks with concrete actions and expected statuses. It does not assert that id_token and the complete oversized session payload are absent, treats unimplemented frontend wiring as a prerequisite, and expects expired access tokens to be returned with is_expired despite the issue requiring expired stored tokens not be returned. It lacks concurrency coverage for superseding logins, TTL-index failure and expire_at enforcement, cache-control checks, and callback or logout integration tests. The proposed ciphertext test using b\"AT\" absence is probabilistically flaky because Fernet output is base64 text, while the stated uv commands and endpoint setup could not be independently executed here."
+    },
+    "implementation": {
+      "completeness": 8,
+      "correctness": 5,
+      "specificity": 17,
+      "risk_awareness": 7,
+      "total": 37,
+      "notes": "The patch is concrete and internally coherent around TokenStore, encrypted MongoDB documents, owner-scoped lookup, internal routes, and sequential store tests. It does not implement the repository's core cookie fix because it never removes id_token or the complete OAuth session payload, and the existing frontend continues calling POST /api/tokens/generate rather than the new route. The delete-before-insert race violates supersede-on-relogin, get_tokens can return documents beyond expire_at until TTL cleanup, index-creation failure is never retried, and the public GET response exposes upstream refresh tokens without explicit no-store handling. The summary consequently oversells an incomplete change; its target paths and symbols are plausible from the supplied contexts, but the claimed git apply check could not be independently verified because repository shell execution was unavailable."
+    }
+  },
+  "task_score": 55.2,
+  "verdict": "The submission is polished and highly specific, but it is built around an incorrect token-only and UI-flow premise that leaves the repository's actual oversized OAuth session behavior unfixed.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-01T12:45:01.414138Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 444423,
+      "cached_input_tokens": 313492,
+      "cache_write_input_tokens": 59012,
+      "output_tokens": 13637,
+      "reasoning_output_tokens": 11640
+    },
+    "duration_ms": 223754
+  }
+}

--- a/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
+++ b/benchmarks/swe-benchmark-data/claude-opus-4-8/omp/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
@@ -1,0 +1,153 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "high",
+  "tags": [
+    "authentication",
+    "oauth",
+    "session",
+    "mongodb",
+    "encryption",
+    "auth-server",
+    "fixed-in-1.24.0"
+  ],
+  "model": "us.anthropic.claude-opus-4-8",
+  "model_slug": "claude-opus-4-8",
+  "agent": "omp",
+  "skill": "swe3",
+  "provider": "bedrock",
+  "endpoint": null,
+  "aws_region": "us-east-1",
+  "serving": {
+    "instance_type": "g6e.12xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 78.0,
+  "token_accounting_warning": null,
+  "metrics": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 9977,
+    "output_tokens": 68756,
+    "cache_read_tokens": 6337406,
+    "cache_write_tokens": 179827,
+    "total_tokens": 6595966,
+    "total_cost_usd": 6.061406750000001,
+    "latency_seconds": 881.7,
+    "num_turns": 41,
+    "generation_tokens_per_sec": 78.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "input_tokens": 9977,
+  "output_tokens": 68756,
+  "latency_seconds": 881.7,
+  "num_turns": 41,
+  "total_cost_usd": 6.061406750000001,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 6337406,
+  "cache_creation_tokens": 179827,
+  "run_started_at": "2026-09-01T09:29:14.110218Z",
+  "run_ended_at": "2026-09-01T09:43:55.870409Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics as reported by the model API (claude -p); there is no vLLM server for this provider, so no server-side cache telemetry.",
+    "input_tokens": 9977,
+    "output_tokens": 68756,
+    "cache_read_tokens": 6337406,
+    "cache_write_tokens": 179827,
+    "total_tokens": 6595966,
+    "total_cost_usd": 6.061406750000001,
+    "latency_seconds": 881.7,
+    "num_turns": 41,
+    "generation_tokens_per_sec": 78.0,
+    "sources": {
+      "input_tokens": "omp_api.usage.input",
+      "output_tokens": "omp_api.usage.output",
+      "cache_read_tokens": "omp_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "omp_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input)",
+      "total_cost_usd": "omp_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or omp_api.duration_ms)",
+      "num_turns": "omp_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds"
+    }
+  },
+  "evaluation": {
+    "task": "server-side-oauth-token-storage",
+    "model": "us.anthropic.claude-opus-4-8",
+    "scores": {
+      "github_issue": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 58,
+        "notes": "The issue provides unusually concrete acceptance criteria, failure behavior, compatibility expectations, and non-goals. Its central premise is materially wrong for this repository: the overflow also involves id_token and the broader OAuth session payload, which the proposed token-only scheme leaves in the cookie. Repository documentation shows the existing token-generation UI produces self-signed registry tokens, so exposing IdP access and refresh tokens is a new security-sensitive feature rather than restoration of that path. No independent task statement was supplied, which limits verification of requirements beyond the task identifier and repository behavior."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 8,
+        "specificity": 21,
+        "risk_awareness": 13,
+        "total": 56,
+        "notes": "The LLD names real integration points such as oauth2_callback, internal_router, get_user_session_data, and the DocumentDB client, and commits to concrete schemas and failure responses. It designs around access and refresh tokens while explicitly leaving the legacy session block untouched, so it does not remove the id_token/full-session data responsible for the repository's cookie overflow. The delete-many-then-insert sequence is not last-writer-wins under concurrent logins, retrieval does not reject documents past expire_at before the TTL sweep, and stable cross-process encryption-key configuration is not established. The design also defers the frontend consumer and several deployment surfaces while claiming the user-visible flow and rollout are complete."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 11,
+        "specificity": 19,
+        "risk_awareness": 16,
+        "total": 61,
+        "notes": "The review identifies several concrete defects, including naive MongoDB datetimes, deployment parity, key separation, server-derived ownership, and the missing frontend wiring. Its largest failure is declaring those findings resolved when the UI remains a follow-up and the acknowledged delete-then-insert race still permits multiple valid documents. It misses the repository-critical id_token/full-session cookie path, the expired-document retrieval gap, unstable key configuration, GET caching of secrets, and flaky ciphertext substring assertions. Claims that the backend is complete and that no critical findings remain are contradicted by both the proposed implementation and existing token-generation behavior."
+      },
+      "testing": {
+        "completeness": 17,
+        "correctness": 12,
+        "specificity": 20,
+        "risk_awareness": 15,
+        "total": 64,
+        "notes": "The plan spans unit, endpoint, compatibility, deployment, rollback, and live OAuth checks with concrete actions and expected statuses. It does not assert that id_token and the complete oversized session payload are absent, treats unimplemented frontend wiring as a prerequisite, and expects expired access tokens to be returned with is_expired despite the issue requiring expired stored tokens not be returned. It lacks concurrency coverage for superseding logins, TTL-index failure and expire_at enforcement, cache-control checks, and callback or logout integration tests. The proposed ciphertext test using b\"AT\" absence is probabilistically flaky because Fernet output is base64 text, while the stated uv commands and endpoint setup could not be independently executed here."
+      },
+      "implementation": {
+        "completeness": 8,
+        "correctness": 5,
+        "specificity": 17,
+        "risk_awareness": 7,
+        "total": 37,
+        "notes": "The patch is concrete and internally coherent around TokenStore, encrypted MongoDB documents, owner-scoped lookup, internal routes, and sequential store tests. It does not implement the repository's core cookie fix because it never removes id_token or the complete OAuth session payload, and the existing frontend continues calling POST /api/tokens/generate rather than the new route. The delete-before-insert race violates supersede-on-relogin, get_tokens can return documents beyond expire_at until TTL cleanup, index-creation failure is never retried, and the public GET response exposes upstream refresh tokens without explicit no-store handling. The summary consequently oversells an incomplete change; its target paths and symbols are plausible from the supplied contexts, but the claimed git apply check could not be independently verified because repository shell execution was unavailable."
+      }
+    },
+    "task_score": 55.2,
+    "verdict": "The submission is polished and highly specific, but it is built around an incorrect token-only and UI-flow premise that leaves the repository's actual oversized OAuth session behavior unfixed.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-01T12:45:01.414138Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 444423,
+        "cached_input_tokens": 313492,
+        "cache_write_input_tokens": 59012,
+        "output_tokens": 13637,
+        "reasoning_output_tokens": 11640
+      },
+      "duration_ms": 223754
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the **omp** harness results for **Opus 4.6 and Opus 4.8** on Amazon Bedrock, over the v2 dataset (`mcp-gateway-registry-v2`, 21 release-sourced tasks) under the single-agent `/swe3` skill. Data only: per-task `metrics.json` and `eval.json` plus each model's `run-summary.json`. No source, config, or script changes.

Follows #148 (Opus 5 / Sonnet 5 / Haiku 4.5 on the same path), so the omp harness now covers five Anthropic models on Bedrock alongside the four self-hosted models from #146.

## Results

| Model | Mean score | Scored | Failed | Run cost | $/task |
|---|---:|---:|---:|---:|---:|
| claude-opus-4-8 | 74.69 | 21/21 | 0 | $111.76 | $5.32 |
| claude-opus-4-6-v1 | 70.64 | 21/21 | 0 | $103.97 | $4.95 |

Zero failed tasks: every task produced all six artifacts and was scored. Total metered spend **$215.72**.

Placing them against the models already landed on this dataset and harness:

| Model | Mean | Basis |
|---|---:|---|
| claude-opus-5 | 82.83 | Bedrock (metered) |
| qwen3.8-27b | 78.48 (20 tasks) | self-hosted (hardware-derived) |
| claude-sonnet-5 | 76.97 | Bedrock (metered) |
| **claude-opus-4-8** | **74.69** | Bedrock (metered) |
| **claude-opus-4-6-v1** | **70.64** | Bedrock (metered) |
| gemma-4-31b | 59.74 | self-hosted |
| claude-haiku-4-5 | 56.18 | Bedrock (metered) |

The Opus line orders generationally here -- 4.6 (70.64) < 4.8 (74.69) < 5 (82.83). Worth noting because it differs from the v1 dataset under Claude Code, where Opus 4.8 outscored Opus 5 while costing less; the task sets and harness both differ, so the two are not in tension, but the v1 footnote should not be carried over to v2.

## Model id note

Opus 4.6 is recorded under the slug **`claude-opus-4-6-v1`**, not `claude-opus-4-6`. Its only invokable Bedrock inference profile is `us.anthropic.claude-opus-4-6-v1`; the suffix-free id is rejected with `ValidationException`. `model_to_slug` strips date-versioned suffixes (`-20251001-v1:0`) but not a bare `-v1`, so the slug retains it. The folder name is therefore accurate but reads inconsistently beside `claude-opus-4-8`. Normalizing it would mean either a `model_to_slug` change (shared function, has test coverage) or a rename plus a `model_slug` rewrite in the artifacts -- deliberately not done here, so this PR stays data-only.

## How it was run

Sequentially through `run-e2e-benchmark.sh --provider bedrock --agent omp --skill swe3`, one model at a time, which judges inline and writes its own run summary. The multi-model batch script is vLLM-only and cannot take Bedrock models, and `--judge-mode async` is counter-indicated on this path (no GPU to reclaim; agent and judge would contend for the same Bedrock quota).

The run was detached as a **systemd user unit** (`systemd-run --user --unit=omp-opus46-48`) with lingering enabled. This matters: the previous Bedrock batch was launched under `setsid nohup` and was still killed mid-judging, because `Linger=no` means systemd tears down the whole user slice cgroup when the last session ends. `loginctl enable-linger` plus a transient unit is what actually survives a disconnect. Both models ran to completion with no session attached.

The driver also re-runs its own judge when the scored count comes up short of the generated count (`--no-overwrite`, so it is cheap and idempotent) -- the failure that left Opus 5 half-scored in #148. Neither model needed it this time.

## Testing

- Both models verified complete: 21 `eval.json`, 21 `metrics.json`, and both `run-summary.{json,md}` each.
- `run-summary.json` written by `summarize_run.py` after judging; counts and means agree with the per-task `eval.json` files.
- Security gate run over the pending diff before committing: no credentials, no local paths, no request bodies. Artifacts carry counts, latencies, model ids, `provider: bedrock` and the region name only.

## Follow-ups (not in this PR)

- Published tables and charts are not regenerated; `docs/harness-omp-swe3.md` still shows only the self-hosted rows, and now lags five Bedrock models.
- A Bedrock path for `run-multi-model-benchmark.sh` would let these batches use one script with the `--judge-mode` failure handling from #147.
