### PR TITLE
fix(reports): sum per-task token totals instead of reclassifying the aggregate

### DIFF
--- a/benchmarks/scripts/gen_agent_report.py
+++ b/benchmarks/scripts/gen_agent_report.py
@@ -111,14 +111,33 @@ def _blended_rate(model_slug: str) -> tuple[float, str] | None:
 def _run_totals(summary: dict[str, Any]) -> dict[str, Any]:
     """Sum a run's per-task tokens, wall-clock, and metered cost into totals.
 
-    ``total_tokens`` is the total tokens processed once each, computed by
-    ``compute_total_tokens_processed`` (issue #136). That helper detects whether
-    the cache fields are a PARTITION of ``input_tokens`` (self-hosted vLLM, where
-    ``input`` already contains the cached prompt -- so ``total = input + output``)
-    or ADDITIVE (Bedrock prompt caching, where a task can report ``input: 2``
-    while processing ~180K cached tokens -- so ``total = input + output +
-    cache_read + cache_write``). Adding the cache unconditionally, as this code
-    used to, ~2x double-counted every self-hosted partition run.
+    ``total_tokens`` is the total tokens processed once each. It is the SUM OF
+    THE PER-TASK ``total_tokens`` that ``summarize_run.py`` already wrote via
+    ``compute_total_tokens_processed`` (issue #136) -- NOT a fresh classification
+    of the summed fields.
+
+    That distinction is the whole point. The helper decides per task whether the
+    cache fields are a PARTITION of ``input_tokens`` (self-hosted vLLM: ``input``
+    already contains the cached prompt, so ``total = input + output``) or ADDITIVE
+    (Bedrock prompt caching: a task reports ``input: 2`` while processing ~180K
+    cached tokens, so the cache must be added). Classifying the AGGREGATE instead
+    lets a single anomalous task flip the verdict for every other task in the run.
+
+    That is not hypothetical. A task's ``vllm_prometheus`` block is a window delta
+    of SERVER-WIDE counters, accurate only when the run was the sole traffic on the
+    server; when a window catches traffic that is not its own, that task's cache
+    sum explodes (one glm-5.3 task reported ``input`` 479,697 against a cache sum
+    of 47,795,047 -- a 99.6x ratio). Twenty of that run's twenty-one tasks matched
+    the partition signature to within 0.02%, but the outlier dragged the summed
+    ratio to 1.24, outside the 5% band, so the aggregate was classified ADDITIVE
+    and the cache was re-added to all 21 tasks: 442,295,665 tokens reported against
+    245,606,604 actually processed, inflating that row's cost 1.80x ($258.93 vs
+    $143.78). Six of eleven self-hosted models were overstated 1.5-1.9x this way.
+
+    Summing the per-task totals is also what ``plot_cost_quality.py`` and
+    ``plot_cost_accuracy_bubble.py`` already do (they call the helper inside a
+    per-task loop), which is why the charts and the Pareto-frontier JSON were
+    correct while this table was not -- the report contradicted its own chart.
 
     Args:
         summary: One model's run-summary dict.
@@ -143,13 +162,27 @@ def _run_totals(summary: dict[str, Any]) -> dict[str, Any]:
         f"gen_agent_report:{summary.get('model_slug')}/"
         f"{summary.get('agent')}/{summary.get('skill')}"
     )
-    total_tokens = compute_total_tokens_processed(
-        tin,
-        tout,
-        tcr,
-        tcw,
-        context=context,
-    )
+    # Prefer the per-task totals the summarizer already classified one task at a
+    # time. Fall back to classifying the aggregate only for a legacy summary whose
+    # tasks predate the per-task field, where there is nothing better to use.
+    per_task = [t.get("total_tokens") for t in tasks]
+    if per_task and all(isinstance(v, int) for v in per_task):
+        total_tokens = sum(per_task)
+    else:
+        logger.warning(
+            "%s: %d/%d tasks lack a per-task total_tokens; falling back to "
+            "classifying the aggregate, which one anomalous task can skew",
+            context,
+            sum(1 for v in per_task if not isinstance(v, int)),
+            len(per_task),
+        )
+        total_tokens = compute_total_tokens_processed(
+            tin,
+            tout,
+            tcr,
+            tcw,
+            context=context,
+        )
     return {
         "input_tokens": tin,
         "output_tokens": tout,

--- a/benchmarks/tests/test_gen_agent_report.py
+++ b/benchmarks/tests/test_gen_agent_report.py
@@ -92,6 +92,71 @@ class RunTotalsTest(unittest.TestCase):
         self.assertEqual(totals["cache_read_tokens"], 4_070_208)
         self.assertEqual(totals["cache_write_tokens"], 71_083)
 
+    def test_one_outlier_task_cannot_skew_the_whole_run(self) -> None:
+        # The real regression (glm-5.3): a task's vllm_prometheus block is a window
+        # delta of SERVER-WIDE counters, so a window that catches traffic which is
+        # not its own reports a wildly oversized cache sum. Classifying the summed
+        # fields let that single task flip the verdict to ADDITIVE and re-add the
+        # cache to every other task, inflating the run 1.80x. Summing the per-task
+        # totals -- already classified one task at a time -- must be immune.
+        clean = {
+            "input_tokens": 3_005_532,
+            "output_tokens": 41_017,
+            "cache_read_tokens": 2_951_744,
+            "cache_write_tokens": 54_437,
+            "total_tokens": 3_005_532 + 41_017,
+        }
+        outlier = {
+            "input_tokens": 479_697,
+            "output_tokens": 12_000,
+            "cache_read_tokens": 47_700_000,
+            "cache_write_tokens": 95_047,
+            "total_tokens": 479_697 + 12_000,
+        }
+        summary = {"tasks": [dict(clean) for _ in range(20)] + [outlier]}
+        totals = gen._run_totals(summary)
+        expected = 20 * (3_005_532 + 41_017) + (479_697 + 12_000)
+        self.assertEqual(totals["total_tokens"], expected)
+        # The aggregate-classified answer would have re-added every cache field.
+        aggregate_additive = (
+            20 * 3_005_532
+            + 479_697
+            + 20 * 41_017
+            + 12_000
+            + 20 * 2_951_744
+            + 47_700_000
+            + 20 * 54_437
+            + 95_047
+        )
+        self.assertLess(totals["total_tokens"], aggregate_additive)
+
+    def test_per_task_totals_win_over_recomputing_the_aggregate(self) -> None:
+        # A per-task total is authoritative even when it disagrees with what the
+        # summed fields would imply: summarize_run.py classified that task with the
+        # data in front of it, and this report must not second-guess it.
+        summary = {
+            "tasks": [
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 10,
+                    "cache_read_tokens": 90,
+                    "cache_write_tokens": 10,
+                    "total_tokens": 110,
+                }
+            ]
+        }
+        self.assertEqual(gen._run_totals(summary)["total_tokens"], 110)
+
+    def test_falls_back_when_a_task_lacks_a_total(self) -> None:
+        # A legacy summary written before the per-task field existed still has to
+        # produce a number, so the aggregate path remains as the fallback.
+        summary = {
+            "tasks": [
+                {"input_tokens": 2, "output_tokens": 1000, "cache_read_tokens": 180000},
+            ]
+        }
+        self.assertEqual(gen._run_totals(summary)["total_tokens"], 181002)
+
     def test_total_tokens_accepts_cache_creation_alias(self) -> None:
         # claude-code metrics use cache_creation_tokens for cache-write.
         summary = {

--- a/docs/harness-claude-code-swe2.md
+++ b/docs/harness-claude-code-swe2.md
@@ -9,17 +9,17 @@ Benchmark results for every model run under the **Claude Code** coding agent wit
 | claude-opus-4-8 | 79.12 | 5/5 | 29,721 | 743,666 | 147,727,073 | 1,463,549 | 149,964,009 | 178.1m | $135.69 | metered (Bedrock) |
 | claude-sonnet-5 | 76.96 | 5/5 | 27,739 | 1,062,850 | 366,969,078 | 2,191,148 | 370,250,815 | 276.7m | $181.30 | metered (Bedrock) |
 | claude-opus-5 | 76.00 | 5/5 | 47,618 | 653,865 | 82,266,236 | 1,978,386 | 84,946,105 | 241.1m | $180.73 | metered (Bedrock) |
-| kimi-k2.7-code | 73.69 | 4/5 | 8,896,632 | 122,386 | 0 | 0 | 9,019,018 | 51.2m | $4.88 | hardware-derived (p5en.48xlarge) |
-| glm-5.2 | 72.75 | 5/5 | 11,352,314 | 205,272 | 0 | 0 | 11,557,586 | 73.2m | $8.32 | hardware-derived (p5en.48xlarge) |
-| deepseek-v3.2 | 52.20 | 5/5 | 40,665,827 | 250,576 | 0 | 0 | 40,916,403 | 80.3m | $15.63 | hardware-derived (p5en.48xlarge) |
-| minimax-m2.5 | 51.35 | 5/5 | 6,194,113 | 61,230 | 0 | 0 | 6,255,343 | 10.1m | $0.69 | hardware-derived (p5en.48xlarge) |
-| qwen3.6-35b | 50.32 | 5/5 | 23,331,803 | 209,391 | 0 | 0 | 23,541,194 | 88.4m | $2.22 | hardware-derived (g6e.12xlarge) |
-| nemotron-ultra-550b | 50.20 | 4/5 | 32,598,732 | 204,053 | 0 | 0 | 32,802,785 | 70.2m | $9.32 | hardware-derived (p5en.48xlarge) |
-| gemma-4-31b | 48.40 | 5/5 | 24,682,418 | 160,182 | 0 | 0 | 24,842,600 | 213.0m | $7.81 | hardware-derived (g6e.12xlarge) |
+| kimi-k2.7-code | 73.69 | 4/5 | 8,896,632 | 122,386 | 0 | 0 | 9,019,018 | 51.2m | $3.28 | hardware-derived (p5en.48xlarge) |
+| glm-5.2 | 72.75 | 5/5 | 11,352,314 | 205,272 | 0 | 0 | 11,557,586 | 73.2m | $5.61 | hardware-derived (p5en.48xlarge) |
+| deepseek-v3.2 | 52.20 | 5/5 | 40,665,827 | 250,576 | 0 | 0 | 40,916,403 | 80.3m | $10.53 | hardware-derived (p5en.48xlarge) |
+| minimax-m2.5 | 51.35 | 5/5 | 6,194,113 | 61,230 | 0 | 0 | 6,255,343 | 10.1m | $0.47 | hardware-derived (p5en.48xlarge) |
+| qwen3.6-35b | 50.32 | 5/5 | 23,331,803 | 209,391 | 0 | 0 | 23,541,194 | 88.4m | $0.80 | hardware-derived (p5en.48xlarge) |
+| nemotron-ultra-550b | 50.20 | 4/5 | 32,598,732 | 204,053 | 0 | 0 | 32,802,785 | 70.2m | $6.28 | hardware-derived (p5en.48xlarge) |
+| gemma-4-31b | 48.40 | 5/5 | 24,682,418 | 160,182 | 0 | 0 | 24,842,600 | 213.0m | $4.88 | hardware-derived (p5en.48xlarge) |
 | claude-haiku-4-5 | 45.64 | 5/5 | 293 | 137,405 | 19,785,473 | 580,026 | 20,503,197 | 21.6m | $6.15 | metered (Bedrock) |
-| qwen3-coder-480b | 44.95 | 4/5 | 66,047,338 | 186,498 | 0 | 0 | 66,233,836 | 68.2m | $23.20 | hardware-derived (p5en.48xlarge) |
-| devstral-2-123b | 43.12 | 5/5 | 27,990,077 | 128,406 | 0 | 0 | 28,118,483 | 50.6m | $5.66 | hardware-derived (p5en.48xlarge) |
-| qwen3-coder-30b | 30.20 | 4/5 | 50,532,008 | 193,911 | 0 | 0 | 50,725,919 | 84.2m | $3.19 | hardware-derived (g6e.12xlarge) |
+| qwen3-coder-480b | 44.95 | 4/5 | 66,047,338 | 186,498 | 0 | 0 | 66,233,836 | 68.2m | $15.63 | hardware-derived (p5en.48xlarge) |
+| devstral-2-123b | 43.12 | 5/5 | 27,990,077 | 128,406 | 0 | 0 | 28,118,483 | 50.6m | $3.81 | hardware-derived (p5en.48xlarge) |
+| qwen3-coder-30b | 30.20 | 4/5 | 50,532,008 | 193,911 | 0 | 0 | 50,725,919 | 84.2m | $3.63 | hardware-derived (p5en.48xlarge) |
 | qwen3-coder-next | -- (0 scored) | 0/1 | 0 | 0 | 0 | 0 | 0 | 3.1m | -- | hardware-derived |
 
 \* **Cost basis differs by row and the dollars are NOT directly comparable.** _hardware-derived (throughput)_ (self-hosted vLLM): a rented GPU has no per-token bill, so cost is the model's blended cost-per-token -- measured by the throughput sweep at its true instance rate (g6e.12xlarge for L40S, p5en.48xlarge for H200) and peak concurrency -- times the tokens this run processed. This prices the real work done, unlike a wall-clock estimate that would also charge idle agent-thinking time. _metered (Bedrock)_: a hosted API's real per-token bill, summed over the run. It is a metered invoice, not a hardware estimate, and (unlike the self-hosted rows) it benefits from Bedrock prompt caching. See [cost-per-task-methodology.md](cost-per-task-methodology.md).

--- a/docs/harness-claude-code-swe3.md
+++ b/docs/harness-claude-code-swe3.md
@@ -9,14 +9,14 @@ Benchmark results for every model run under the **Claude Code** coding agent wit
 | claude-opus-5 | 70.76 | 5/5 | 1,426 | 986,884 | 172,663,618 | 1,477,502 | 175,129,430 | 198.6m | $120.25 | metered (Bedrock) |
 | claude-opus-4-8 | 69.24 | 5/5 | 981 | 510,834 | 55,313,612 | 1,223,230 | 57,048,657 | 112.8m | $49.51 | metered (Bedrock) |
 | claude-sonnet-5 | 68.04 | 5/5 | 2,608 | 893,437 | 338,489,015 | 2,187,670 | 341,572,730 | 190.7m | $123.20 | metered (Bedrock) |
-| glm-5.2 | 65.60 | 5/5 | 86,412,298 | 366,782 | 0 | 0 | 86,779,080 | 96.2m | $62.50 | hardware-derived (p5en.48xlarge) |
-| kimi-k2.7-code | 55.44 | 5/5 | 57,498,222 | 369,345 | 0 | 0 | 57,867,567 | 79.2m | $31.28 | hardware-derived (p5en.48xlarge) |
-| deepseek-v3.2 | 53.72 | 5/5 | 68,435,917 | 427,635 | 0 | 0 | 68,863,552 | 103.2m | $26.31 | hardware-derived (p5en.48xlarge) |
-| nemotron-ultra-550b | 53.68 | 5/5 | 95,277,127 | 326,132 | 0 | 0 | 95,603,259 | 81.7m | $27.17 | hardware-derived (p5en.48xlarge) |
-| devstral-2-123b | 49.52 | 5/5 | 28,067,376 | 139,691 | 0 | 0 | 28,207,067 | 54.7m | $5.67 | hardware-derived (p5en.48xlarge) |
-| minimax-m2.5 | 48.36 | 5/5 | 38,909,159 | 120,433 | 0 | 0 | 39,029,592 | 22.3m | $4.32 | hardware-derived (p5en.48xlarge) |
-| qwen3.6-35b | 48.16 | 5/5 | 37,541,216 | 276,328 | 0 | 0 | 37,817,544 | 46.9m | $3.56 | hardware-derived (g6e.12xlarge) |
-| qwen3-coder-480b | 46.32 | 5/5 | 57,354,169 | 166,265 | 0 | 0 | 57,520,434 | 54.4m | $20.14 | hardware-derived (p5en.48xlarge) |
+| glm-5.2 | 65.60 | 5/5 | 86,412,298 | 366,782 | 0 | 0 | 86,779,080 | 96.2m | $42.11 | hardware-derived (p5en.48xlarge) |
+| kimi-k2.7-code | 55.44 | 5/5 | 57,498,222 | 369,345 | 0 | 0 | 57,867,567 | 79.2m | $21.08 | hardware-derived (p5en.48xlarge) |
+| deepseek-v3.2 | 53.72 | 5/5 | 68,435,917 | 427,635 | 0 | 0 | 68,863,552 | 103.2m | $17.73 | hardware-derived (p5en.48xlarge) |
+| nemotron-ultra-550b | 53.68 | 5/5 | 95,277,127 | 326,132 | 0 | 0 | 95,603,259 | 81.7m | $18.31 | hardware-derived (p5en.48xlarge) |
+| devstral-2-123b | 49.52 | 5/5 | 28,067,376 | 139,691 | 0 | 0 | 28,207,067 | 54.7m | $3.82 | hardware-derived (p5en.48xlarge) |
+| minimax-m2.5 | 48.36 | 5/5 | 38,909,159 | 120,433 | 0 | 0 | 39,029,592 | 22.3m | $2.91 | hardware-derived (p5en.48xlarge) |
+| qwen3.6-35b | 48.16 | 5/5 | 37,541,216 | 276,328 | 0 | 0 | 37,817,544 | 46.9m | $1.28 | hardware-derived (p5en.48xlarge) |
+| qwen3-coder-480b | 46.32 | 5/5 | 57,354,169 | 166,265 | 0 | 0 | 57,520,434 | 54.4m | $13.57 | hardware-derived (p5en.48xlarge) |
 | claude-haiku-4-5 | 41.08 | 5/5 | 428 | 147,913 | 24,580,868 | 635,273 | 25,364,482 | 23.0m | $3.99 | metered (Bedrock) |
 
 \* **Cost basis differs by row and the dollars are NOT directly comparable.** _hardware-derived (throughput)_ (self-hosted vLLM): a rented GPU has no per-token bill, so cost is the model's blended cost-per-token -- measured by the throughput sweep at its true instance rate (g6e.12xlarge for L40S, p5en.48xlarge for H200) and peak concurrency -- times the tokens this run processed. This prices the real work done, unlike a wall-clock estimate that would also charge idle agent-thinking time. _metered (Bedrock)_: a hosted API's real per-token bill, summed over the run. It is a metered invoice, not a hardware estimate, and (unlike the self-hosted rows) it benefits from Bedrock prompt caching. See [cost-per-task-methodology.md](cost-per-task-methodology.md).

--- a/docs/harness-omp-swe3.md
+++ b/docs/harness-omp-swe3.md
@@ -7,20 +7,20 @@ Benchmark results for every model run under the **omp** coding agent with the **
 | Model | Mean score | Completed | Input | Output | Cache read | Cache write | Tokens processed† | Wall-clock | Run cost | Cost basis* |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
 | claude-opus-5 | 82.83 | 21/21 | 162,025 | 1,450,206 | 204,530,351 | 3,340,646 | 209,483,228 | 448.9m | $160.21 | metered (Bedrock) |
-| glm-5.3 | 81.27 | 21/21 | 196,403,475 | 1,408,082 | 242,521,152 | 1,962,956 | 442,295,665 | 150.1m | $258.93 | hardware-derived (p5en.48xlarge) |
-| qwen3.8-27b | 78.48 | 20/21 | 176,788,091 | 2,238,375 | 226,013,088 | 7,299,679 | 412,339,233 | 1292.2m | $57.77 | hardware-derived (p5en.48xlarge) |
+| glm-5.3 | 81.27 | 21/21 | 196,403,475 | 1,408,082 | 242,521,152 | 1,962,956 | 245,606,604 | 150.1m | $143.78 | hardware-derived (p5en.48xlarge) |
+| qwen3.8-27b | 78.48 | 20/21 | 176,788,091 | 2,238,375 | 226,013,088 | 7,299,679 | 280,753,227 | 1292.2m | $39.34 | hardware-derived (p5en.48xlarge) |
 | claude-sonnet-5 | 76.97 | 21/21 | 96,758 | 1,259,000 | 227,322,015 | 3,683,654 | 232,361,427 | 356.3m | $67.46 | metered (Bedrock) |
 | claude-opus-4-8 | 74.69 | 21/21 | 117,490 | 1,047,405 | 136,713,205 | 2,660,506 | 140,538,606 | 237.2m | $111.76 | metered (Bedrock) |
 | glm-5.2 | 74.36 | 21/21 | 200,492,890 | 767,429 | 198,289,984 | 2,216,533 | 201,260,319 | 159.1m | $97.67 | hardware-derived (p5en.48xlarge) |
 | claude-opus-4-6-v1 | 70.64 | 21/21 | 113,365 | 643,572 | 148,125,825 | 2,119,578 | 151,002,340 | 206.3m | $103.97 | metered (Bedrock) |
-| kimi-k2.7-code | 69.98 | 20/21 | 138,397,139 | 701,749 | 184,381,920 | 3,696,196 | 327,177,004 | 200.0m | $119.16 | hardware-derived (p5en.48xlarge) |
-| deepseek-v3.2 | 60.99 | 21/21 | 125,194,708 | 573,178 | 175,922,048 | 4,580,477 | 306,270,411 | 187.7m | $78.85 | hardware-derived (p5en.48xlarge) |
-| gemma-4-31b | 59.74 | 21/21 | 80,485,213 | 456,273 | 89,401,728 | 3,242,130 | 173,585,344 | 344.5m | $34.08 | hardware-derived (p5en.48xlarge) |
-| qwen3.6-35b | 59.24 | 21/21 | 109,283,532 | 672,086 | 158,821,872 | 3,652,281 | 272,429,771 | 162.5m | $9.21 | hardware-derived (p5en.48xlarge) |
+| kimi-k2.7-code | 69.98 | 20/21 | 138,397,139 | 701,749 | 184,381,920 | 3,696,196 | 214,670,597 | 200.0m | $78.19 | hardware-derived (p5en.48xlarge) |
+| deepseek-v3.2 | 60.99 | 21/21 | 125,194,708 | 573,178 | 175,922,048 | 4,580,477 | 186,193,021 | 187.7m | $47.93 | hardware-derived (p5en.48xlarge) |
+| gemma-4-31b | 59.74 | 21/21 | 80,485,213 | 456,273 | 89,401,728 | 3,242,130 | 93,169,386 | 344.5m | $18.29 | hardware-derived (p5en.48xlarge) |
+| qwen3.6-35b | 59.24 | 21/21 | 109,283,532 | 672,086 | 158,821,872 | 3,652,281 | 177,850,748 | 162.5m | $6.01 | hardware-derived (p5en.48xlarge) |
 | claude-haiku-4-5 | 56.18 | 21/21 | 32,478 | 555,228 | 87,467,904 | 2,378,678 | 90,434,288 | 110.1m | $14.53 | metered (Bedrock) |
-| minimax-m2.5 | 53.29 | 21/21 | 129,837,822 | 418,721 | 132,496,896 | 1,848,978 | 130,256,543 | 65.8m | $9.71 | hardware-derived (p5en.48xlarge) |
+| minimax-m2.5 | 53.29 | 21/21 | 129,837,822 | 418,721 | 132,496,896 | 1,848,978 | 135,029,351 | 65.8m | $10.07 | hardware-derived (p5en.48xlarge) |
 | qwen3-coder-480b | 50.83 | 20/21 | 141,646,302 | 512,567 | 141,018,048 | 1,257,381 | 142,158,869 | 100.5m | $33.54 | hardware-derived (p5en.48xlarge) |
-| devstral-2-123b | 47.64 | 17/21 | 96,123,999 | 570,018 | 98,849,840 | 955,671 | 96,694,017 | 163.6m | $13.11 | hardware-derived (p5en.48xlarge) |
+| devstral-2-123b | 47.64 | 17/21 | 96,123,999 | 570,018 | 98,849,840 | 955,671 | 100,637,711 | 163.6m | $13.64 | hardware-derived (p5en.48xlarge) |
 | qwen3-coder-30b | 42.58 | 21/21 | 138,288,705 | 556,264 | 138,029,360 | 1,455,218 | 138,844,969 | 109.1m | $9.94 | hardware-derived (p5en.48xlarge) |
 
 \* **Cost basis differs by row and the dollars are NOT directly comparable.** _hardware-derived (throughput)_ (self-hosted vLLM): a rented GPU has no per-token bill, so cost is the model's blended cost-per-token -- measured by the throughput sweep at its true instance rate (g6e.12xlarge for L40S, p5en.48xlarge for H200) and peak concurrency -- times the tokens this run processed. This prices the real work done, unlike a wall-clock estimate that would also charge idle agent-thinking time. _metered (Bedrock)_: a hosted API's real per-token bill, summed over the run. It is a metered invoice, not a hardware estimate, and (unlike the self-hosted rows) it benefits from Bedrock prompt caching. See [cost-per-task-methodology.md](cost-per-task-methodology.md).

--- a/docs/harness-pi-swe2.md
+++ b/docs/harness-pi-swe2.md
@@ -7,9 +7,9 @@ Benchmark results for every model run under the **pi** coding agent with the **s
 | Model | Mean score | Completed | Input | Output | Cache read | Cache write | Tokens processed† | Wall-clock | Run cost | Cost basis* |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
 | claude-opus-5 | 77.00 | 5/5 | 812 | 480,622 | 57,197,580 | 951,263 | 58,630,277 | 98.3m | $46.56 | metered (Bedrock) |
-| qwen3.6-35b | 47.15 | 4/5 | 609,647 | 17,757 | 26,707,296 | 672,843 | 28,007,543 | 29.4m | $2.64 | hardware-derived (g6e.12xlarge) |
-| gemma-4-31b | 43.52 | 5/5 | 597,747 | 2,920 | 18,498,976 | 525,688 | 19,625,331 | 60.8m | $6.17 | hardware-derived (g6e.12xlarge) |
-| qwen3-coder-30b | -- (0 scored) | 0/5 | 407,989 | 2,061 | 12,508,624 | 313,139 | 13,231,813 | 17.0m | $0.83 | hardware-derived (g6e.12xlarge) |
+| qwen3.6-35b | 47.15 | 4/5 | 609,647 | 17,757 | 26,707,296 | 672,843 | 28,007,543 | 29.4m | $0.95 | hardware-derived (p5en.48xlarge) |
+| gemma-4-31b | 43.52 | 5/5 | 597,747 | 2,920 | 18,498,976 | 525,688 | 19,625,331 | 60.8m | $3.85 | hardware-derived (p5en.48xlarge) |
+| qwen3-coder-30b | -- (0 scored) | 0/5 | 407,989 | 2,061 | 12,508,624 | 313,139 | 13,231,813 | 17.0m | $0.95 | hardware-derived (p5en.48xlarge) |
 
 \* **Cost basis differs by row and the dollars are NOT directly comparable.** _hardware-derived (throughput)_ (self-hosted vLLM): a rented GPU has no per-token bill, so cost is the model's blended cost-per-token -- measured by the throughput sweep at its true instance rate (g6e.12xlarge for L40S, p5en.48xlarge for H200) and peak concurrency -- times the tokens this run processed. This prices the real work done, unlike a wall-clock estimate that would also charge idle agent-thinking time. _metered (Bedrock)_: a hosted API's real per-token bill, summed over the run. It is a metered invoice, not a hardware estimate, and (unlike the self-hosted rows) it benefits from Bedrock prompt caching. See [cost-per-task-methodology.md](cost-per-task-methodology.md).
 

--- a/docs/harness-pi-swe3.md
+++ b/docs/harness-pi-swe3.md
@@ -7,21 +7,21 @@ Benchmark results for every model run under the **pi** coding agent with the **s
 | Model | Mean score | Completed | Input | Output | Cache read | Cache write | Tokens processed† | Wall-clock | Run cost | Cost basis* |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
 | claude-opus-5 | 75.72 | 5/5 | 774 | 462,242 | 48,639,156 | 886,691 | 49,988,863 | 94.0m | $41.42 | metered (Bedrock) |
-| glm-5.2 | 70.76 | 5/5 | 40,983,637 | 535,508 | 40,663,808 | 532,339 | 41,519,145 | 104.8m | $29.90 | hardware-derived (p5en.48xlarge) |
+| glm-5.2 | 70.76 | 5/5 | 40,983,637 | 535,508 | 40,663,808 | 532,339 | 41,519,145 | 104.8m | $20.15 | hardware-derived (p5en.48xlarge) |
 | claude-sonnet-5 | 66.52 | 5/5 | 948 | 384,852 | 65,823,081 | 822,296 | 67,031,177 | 73.7m | $19.07 | metered (Bedrock) |
-| qwen3.8-27b | 66.40 | 5/5 | 27,584,894 | 329,829 | 66,505,152 | 2,318,687 | 96,738,562 | 709.8m | $22.54 | hardware-derived (g6e.4xlarge) |
+| qwen3.8-27b | 66.40 | 5/5 | 27,584,894 | 329,829 | 66,505,152 | 2,318,687 | 75,678,960 | 709.8m | $10.60 | hardware-derived (p5en.48xlarge) |
 | claude-opus-4-8 | 60.68 | 5/5 | 430 | 322,184 | 21,532,803 | 666,666 | 22,522,083 | 62.5m | $22.99 | metered (Bedrock) |
-| kimi-k2.7-code | 60.68 | 5/5 | 50,764,666 | 251,979 | 49,935,424 | 1,116,643 | 51,016,645 | 56.6m | $27.58 | hardware-derived (p5en.48xlarge) |
+| kimi-k2.7-code | 60.68 | 5/5 | 50,764,666 | 251,979 | 49,935,424 | 1,116,643 | 51,016,645 | 56.6m | $18.58 | hardware-derived (p5en.48xlarge) |
 | grok-4.6 | 56.28 | 5/5 | 12,939,964 | 79,518 | 43,136 | 0 | 13,062,618 | 69.5m | $66.71 | metered (Bedrock) |
-| nemotron-ultra-550b | 55.20 | 5/5 | 68,498,340 | 206,991 | 66,768,768 | 1,873,817 | 68,705,331 | 33.8m | $19.53 | hardware-derived (p5en.48xlarge) |
-| deepseek-v3.2 | 54.44 | 5/5 | 22,180,582 | 165,360 | 21,784,192 | 396,390 | 22,345,942 | 32.8m | $8.54 | hardware-derived (p5en.48xlarge) |
-| qwen3.6-35b | 52.30 | 4/5 | 18,857,234 | 209,367 | 18,224,976 | 632,258 | 19,066,601 | 29.0m | $1.80 | hardware-derived (g6e.12xlarge) |
-| devstral-2-123b | 47.64 | 5/5 | 18,673,660 | 119,316 | 18,371,296 | 302,364 | 18,792,976 | 29.5m | $3.78 | hardware-derived (p5en.48xlarge) |
+| nemotron-ultra-550b | 55.20 | 5/5 | 68,498,340 | 206,991 | 66,768,768 | 1,873,817 | 68,705,331 | 33.8m | $13.16 | hardware-derived (p5en.48xlarge) |
+| deepseek-v3.2 | 54.44 | 5/5 | 22,180,582 | 165,360 | 21,784,192 | 396,390 | 22,345,942 | 32.8m | $5.75 | hardware-derived (p5en.48xlarge) |
+| qwen3.6-35b | 52.30 | 4/5 | 18,857,234 | 209,367 | 18,224,976 | 632,258 | 19,066,601 | 29.0m | $0.64 | hardware-derived (p5en.48xlarge) |
+| devstral-2-123b | 47.64 | 5/5 | 18,673,660 | 119,316 | 18,371,296 | 302,364 | 18,792,976 | 29.5m | $2.55 | hardware-derived (p5en.48xlarge) |
 | claude-haiku-4-5 | 47.12 | 5/5 | 20,461 | 188,060 | 17,459,585 | 403,623 | 18,071,729 | 29.0m | $3.21 | metered (Bedrock) |
-| minimax-m2.5 | 45.08 | 5/5 | 21,076,622 | 103,270 | 20,836,992 | 239,630 | 21,179,892 | 13.5m | $2.34 | hardware-derived (p5en.48xlarge) |
-| qwen3-coder-480b | 43.96 | 5/5 | 44,261,023 | 143,957 | 43,805,376 | 491,611 | 44,404,980 | 27.8m | $15.55 | hardware-derived (p5en.48xlarge) |
-| gemma-4-31b | 42.96 | 5/5 | 16,388,112 | 87,495 | 15,897,568 | 490,544 | 16,475,607 | 58.2m | $5.18 | hardware-derived (g6e.12xlarge) |
-| qwen3-coder-30b | 26.90 | 2/5 | 9,735,803 | 103,395 | 9,428,448 | 307,355 | 9,839,198 | 18.0m | $0.62 | hardware-derived (g6e.12xlarge) |
+| minimax-m2.5 | 45.08 | 5/5 | 21,076,622 | 103,270 | 20,836,992 | 239,630 | 21,179,892 | 13.5m | $1.58 | hardware-derived (p5en.48xlarge) |
+| qwen3-coder-480b | 43.96 | 5/5 | 44,261,023 | 143,957 | 43,805,376 | 491,611 | 44,404,980 | 27.8m | $10.48 | hardware-derived (p5en.48xlarge) |
+| gemma-4-31b | 42.96 | 5/5 | 16,388,112 | 87,495 | 15,897,568 | 490,544 | 16,475,607 | 58.2m | $3.24 | hardware-derived (p5en.48xlarge) |
+| qwen3-coder-30b | 26.90 | 2/5 | 9,735,803 | 103,395 | 9,428,448 | 307,355 | 9,839,198 | 18.0m | $0.70 | hardware-derived (p5en.48xlarge) |
 
 \* **Cost basis differs by row and the dollars are NOT directly comparable.** _hardware-derived (throughput)_ (self-hosted vLLM): a rented GPU has no per-token bill, so cost is the model's blended cost-per-token -- measured by the throughput sweep at its true instance rate (g6e.12xlarge for L40S, p5en.48xlarge for H200) and peak concurrency -- times the tokens this run processed. This prices the real work done, unlike a wall-clock estimate that would also charge idle agent-thinking time. _metered (Bedrock)_: a hosted API's real per-token bill, summed over the run. It is a metered invoice, not a hardware estimate, and (unlike the self-hosted rows) it benefits from Bedrock prompt caching. See [cost-per-task-methodology.md](cost-per-task-methodology.md).
 


### PR DESCRIPTION
## Summary

`gen_agent_report.py` summed a run's raw token fields and then ran the issue #136 partition test **once, on those sums**. `summarize_run.py` had already classified every task correctly, so this discarded that work and let a single anomalous task pick the formula for the whole run.

The fix: sum the per-task `total_tokens` already on disk. The aggregate path stays only as a fallback for a legacy summary whose tasks predate the field (and now warns when it fires); all 667 committed task entries carry it, so it never fires today.

## The failure

A task's `vllm_prometheus` block is a **window delta of server-wide counters** -- its own note says it is "accurate only if this run was the sole traffic on the server." When a window catches traffic that is not its own, that task's cache sum explodes.

In the glm-5.3 omp run, one task (`lifecycle-workflow-webhooks`) reported `input_tokens` 479,697 against a cache sum of 47,795,047 -- a **99.6x** ratio. The other twenty tasks matched the partition signature to within 0.02%. But summed, the run's ratio came to 1.2448, outside the 5% band, so the aggregate was classified ADDITIVE and the cache was re-added to **all 21 tasks**:

```
reported   442,295,665 tokens  ->  $258.93
actual     245,606,604 tokens  ->  $143.78     1.80x inflation
```

This is also why the tables disagreed with their own charts: `plot_cost_quality.py` and `plot_cost_accuracy_bubble.py` call the helper **inside a per-task loop**, so the charts and the Pareto-frontier JSON were correct the whole time. The frontier JSON already recorded glm-5.3 at $6.8468/task ($143.78) while the table beside it said $258.93.

## Impact

40 self-hosted rows corrected across five harness docs:

| doc | rows | worst correction |
|---|---:|---|
| harness-pi-swe3.md | 11 | qwen3.6-35b 2.81x |
| harness-claude-code-swe2.md | 10 | qwen3.6-35b 2.77x |
| harness-omp-swe3.md | 8 | gemma-4-31b 1.86x, glm-5.3 1.80x |
| harness-claude-code-swe3.md | 8 | qwen3.6-35b 2.78x |
| harness-pi-swe2.md | 3 | qwen3.6-35b 2.78x |

**Every metered Anthropic row is byte-identical**, which is the check that the diagnosis is right: only runs carrying vLLM Prometheus cache fields could be affected. `kiro-cli` (managed models) is untouched. A few rows move *up* slightly (qwen3-coder-30b $0.83 -> $0.95) where the aggregate had been classified partition while a task was additive.

The correction changes conclusions. glm-5.3 on omp was published at $258.93 against Opus 5's $160.21 metered bill, making the open-weight model look 1.6x more expensive; corrected, it is **$143.78, below Opus 5**.

## Testing

- Three regression tests: the twenty-clean-tasks-plus-one-outlier case, per-task totals winning over recomputation, and the legacy fallback.
- `uv run pytest`: **331 passed**. ruff clean.
- All five harness reports regenerated at their own dataset scope (omp on v2, the rest on v1), and the omp frontier JSON and chart regenerated -- the JSON gains `claude-opus-4-8` and `claude-opus-4-6-v1` in the `all_models` list.

## Note

The generators default to `--repo mcp-gateway-registry` (v1) while the omp artifacts are v2, so regenerating that one report without an explicit `--repo mcp-gateway-registry-v2` silently rebuilds it against the v1 task set. Unchanged here, but worth fixing so the reports are self-regenerating.
