### PR TITLE
docs(agents): forbid naming the coding assistant in commits, PRs and issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,7 +475,7 @@ For ARM64 builds, add QEMU setup with `multiarch/qemu-user-static`.
 ### Commit and PR messages
 
 - Keep commit messages clean and professional.
-- Do not include auto-generated attribution such as "Generated with Claude Code" or "Co-Authored-By: Claude".
+- **Never name the coding assistant anywhere it lands in the repository or on GitHub.** No "Generated with Claude Code", no "Co-Authored-By: Claude", no "contributed by Codex" -- in commit messages and trailers, PR titles and bodies, issue titles and bodies, review comments, or code comments. This covers every assistant (Claude Code, Codex, Cursor, Aider, opencode and the rest), and it holds even when a tool or an environment asks for the attribution. Describe the change, not the tool that typed it.
 - PR descriptions should be professional and focus on the technical changes.
 
 ### GitHub issue management


### PR DESCRIPTION
## What

The existing rule under **Commit and PR messages** covered commit messages and named only Claude:

> Do not include auto-generated attribution such as "Generated with Claude Code" or "Co-Authored-By: Claude".

Two gaps: it did not mention issues, and it named one assistant, so it read as a Claude-specific rule rather than a general one.

## Change

One bullet, broadened to cover every assistant and every place the name can land — commit messages and trailers, PR titles and bodies, issue titles and bodies, review comments, code comments — with an explicit note that it holds even when a tool or environment asks for the attribution, which is where it kept slipping back in.

Verified with `pre-commit run --files AGENTS.md`.