### PR TITLE
docs: embed the swe-router explainer video in the README and both decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@
 <a href="docs/cost-per-task-methodology.md">Cost Methodology</a>
 </p>
 
+<p align="center">
+<video src="https://github.com/aarora79/agentic-coding-harness-benchmarks/releases/download/media-assets/swe-router-explainer.mp4" controls width="820">
+Your browser cannot play this video inline. <a href="https://github.com/aarora79/agentic-coding-harness-benchmarks/releases/download/media-assets/swe-router-explainer.mp4">Download the swe-router explainer</a> or open the <a href="docs/slides/agentic-coding-benchmarks-presentation.pdf">slide deck</a>.
+</video>
+</p>
+
+<p align="center"><em>swe-router in about 70 seconds: the right model, handed to the developer for each task, while the platform team benchmarks once and spends less.</em></p>
+
 > **This is sample code intended for demonstration and learning purposes only.**
 > It is not meant for production use. Review and harden all scripts, configurations,
 > and IAM permissions before using in any production or sensitive environment.

--- a/docs/slides/agentic-coding-benchmarks-exec.html
+++ b/docs/slides/agentic-coding-benchmarks-exec.html
@@ -401,6 +401,20 @@
 
     <nav class="nav-dots" id="navDots"></nav>
 
+    <!-- SLIDE 0: INTRO VIDEO -->
+    <section class="slide">
+        <div class="slide-content" style="align-items: center; justify-content: center; gap: var(--content-gap, 1.5rem); text-align: center;">
+            <h2 style="margin: 0;">swe-router in 70 seconds</h2>
+            <video controls playsinline preload="metadata"
+                   style="width: min(92vw, 1180px); max-height: 68vh; aspect-ratio: 16 / 9; border-radius: 14px; box-shadow: 0 24px 64px rgba(0,0,0,0.22); background: #000;">
+                <source src="https://github.com/aarora79/agentic-coding-harness-benchmarks/releases/download/media-assets/swe-router-explainer.mp4" type="video/mp4" />
+                Your browser does not support embedded video. Open swe-router-explainer.mp4 in this folder.
+            </video>
+            <p style="font-size: var(--small-size, 0.85rem); color: #94a3b8; margin: 0;">The right model, handed to the developer for each task. The platform team benchmarks once, and spends less.</p>
+        </div>
+        <div class="slide-number"></div>
+    </section>
+
     <!-- SLIDE 1: TITLE -->
     <section class="slide slide-title">
         <div class="slide-content">

--- a/docs/slides/agentic-coding-benchmarks-presentation.html
+++ b/docs/slides/agentic-coding-benchmarks-presentation.html
@@ -352,6 +352,20 @@
 
     <nav class="nav-dots" id="navDots"></nav>
 
+    <!-- SLIDE 0: INTRO VIDEO -->
+    <section class="slide">
+        <div class="slide-content" style="align-items: center; justify-content: center; gap: var(--content-gap, 1.5rem); text-align: center;">
+            <h2 style="margin: 0;">swe-router in 70 seconds</h2>
+            <video controls playsinline preload="metadata"
+                   style="width: min(92vw, 1180px); max-height: 68vh; aspect-ratio: 16 / 9; border-radius: 14px; box-shadow: 0 24px 64px rgba(0,0,0,0.22); background: #000;">
+                <source src="https://github.com/aarora79/agentic-coding-harness-benchmarks/releases/download/media-assets/swe-router-explainer.mp4" type="video/mp4" />
+                Your browser does not support embedded video. Open swe-router-explainer.mp4 in this folder.
+            </video>
+            <p style="font-size: var(--small-size, 0.85rem); color: #94a3b8; margin: 0;">The right model, handed to the developer for each task. The platform team benchmarks once, and spends less.</p>
+        </div>
+        <div class="slide-number"></div>
+    </section>
+
     <!-- SLIDE 1: TITLE -->
     <section class="slide slide-title">
         <div class="slide-content">


### PR DESCRIPTION
Embeds the 70-second swe-router explainer video in the two slide decks and the README.

## What changed

- **Both decks get the video as the opening slide.** A new first `section.slide` in `agentic-coding-benchmarks-presentation.html` and `agentic-coding-benchmarks-exec.html` holds an HTML5 `<video controls>` (click to play, with sound), ahead of the title slide. Slide numbering and nav dots are generated at runtime, so no renumbering was needed.
- **README embed.** A `<video>` near the top of the README, under the header links.

## Where the video is hosted

The MP4 is 5.8 MB, over the repo's deliberate 1.5 MB `check-added-large-files` guard, so it is not committed. It is uploaded as an asset on a dedicated `media-assets` GitHub Release (marked not-latest) and referenced by URL from both the decks and the README. This keeps the guard intact and adds no binary to git history.

## Playback caveat

GitHub serves release assets as `application/octet-stream` with `content-disposition: attachment`. Browsers generally still play that in a `<video>` element (media elements decode by container), so the decks should play when opened in a browser or via Pages. GitHub's README renderer may instead show the fallback download link rather than an inline player. If it does, the guaranteed-inline fix is a `user-attachments` URL (drag-drop the file into a PR/issue comment on github.com); that URL can be swapped into the README and decks with no other change.

## Notes

- The PDF exports of the decks are unchanged and cannot carry a video; this only affects the HTML decks.
- The source composition and script live under `.scratchpad/` (not committed) for future edits.
