### PR TITLE
docs: move the explainer video below the title and embed it inline via user-attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 </p>
 
 <p align="center">
-<video src="https://github.com/aarora79/agentic-coding-harness-benchmarks/releases/download/media-assets/swe-router-explainer.mp4" controls width="820">
-Your browser cannot play this video inline. <a href="https://github.com/aarora79/agentic-coding-harness-benchmarks/releases/download/media-assets/swe-router-explainer.mp4">Download the swe-router explainer</a> or open the <a href="docs/slides/agentic-coding-benchmarks-presentation.pdf">slide deck</a>.
+<video src="https://github.com/user-attachments/assets/5c525197-0d54-4163-bfe6-54fc656dd1fe" controls width="820">
+Your browser cannot play this video inline. <a href="https://github.com/user-attachments/assets/5c525197-0d54-4163-bfe6-54fc656dd1fe">Download the swe-router explainer</a> or open the <a href="docs/slides/agentic-coding-benchmarks-presentation.pdf">slide deck</a>.
 </video>
 </p>
 

--- a/docs/slides/agentic-coding-benchmarks-exec.html
+++ b/docs/slides/agentic-coding-benchmarks-exec.html
@@ -401,20 +401,6 @@
 
     <nav class="nav-dots" id="navDots"></nav>
 
-    <!-- SLIDE 0: INTRO VIDEO -->
-    <section class="slide">
-        <div class="slide-content" style="align-items: center; justify-content: center; gap: var(--content-gap, 1.5rem); text-align: center;">
-            <h2 style="margin: 0;">swe-router in 70 seconds</h2>
-            <video controls playsinline preload="metadata"
-                   style="width: min(92vw, 1180px); max-height: 68vh; aspect-ratio: 16 / 9; border-radius: 14px; box-shadow: 0 24px 64px rgba(0,0,0,0.22); background: #000;">
-                <source src="https://github.com/aarora79/agentic-coding-harness-benchmarks/releases/download/media-assets/swe-router-explainer.mp4" type="video/mp4" />
-                Your browser does not support embedded video. Open swe-router-explainer.mp4 in this folder.
-            </video>
-            <p style="font-size: var(--small-size, 0.85rem); color: #94a3b8; margin: 0;">The right model, handed to the developer for each task. The platform team benchmarks once, and spends less.</p>
-        </div>
-        <div class="slide-number"></div>
-    </section>
-
     <!-- SLIDE 1: TITLE -->
     <section class="slide slide-title">
         <div class="slide-content">
@@ -435,6 +421,20 @@
                 </div>
                 <p class="reveal" style="margin-top: var(--content-gap); font-size: var(--small-size); color: #94a3b8;">Executive briefing</p>
             </div>
+        </div>
+        <div class="slide-number"></div>
+    </section>
+
+    <!-- INTRO VIDEO (after title) -->
+    <section class="slide">
+        <div class="slide-content" style="align-items: center; justify-content: center; gap: var(--content-gap, 1.5rem); text-align: center;">
+            <h2 style="margin: 0;">swe-router in 70 seconds</h2>
+            <video controls playsinline preload="metadata"
+                   style="width: min(92vw, 1180px); max-height: 68vh; aspect-ratio: 16 / 9; border-radius: 14px; box-shadow: 0 24px 64px rgba(0,0,0,0.22); background: #000;">
+                <source src="https://github.com/user-attachments/assets/5c525197-0d54-4163-bfe6-54fc656dd1fe" type="video/mp4" />
+                Your browser does not support embedded video.
+            </video>
+            <p style="font-size: var(--small-size, 0.85rem); color: #94a3b8; margin: 0;">The right model, handed to the developer for each task. The platform team benchmarks once, and spends less.</p>
         </div>
         <div class="slide-number"></div>
     </section>

--- a/docs/slides/agentic-coding-benchmarks-presentation.html
+++ b/docs/slides/agentic-coding-benchmarks-presentation.html
@@ -352,20 +352,6 @@
 
     <nav class="nav-dots" id="navDots"></nav>
 
-    <!-- SLIDE 0: INTRO VIDEO -->
-    <section class="slide">
-        <div class="slide-content" style="align-items: center; justify-content: center; gap: var(--content-gap, 1.5rem); text-align: center;">
-            <h2 style="margin: 0;">swe-router in 70 seconds</h2>
-            <video controls playsinline preload="metadata"
-                   style="width: min(92vw, 1180px); max-height: 68vh; aspect-ratio: 16 / 9; border-radius: 14px; box-shadow: 0 24px 64px rgba(0,0,0,0.22); background: #000;">
-                <source src="https://github.com/aarora79/agentic-coding-harness-benchmarks/releases/download/media-assets/swe-router-explainer.mp4" type="video/mp4" />
-                Your browser does not support embedded video. Open swe-router-explainer.mp4 in this folder.
-            </video>
-            <p style="font-size: var(--small-size, 0.85rem); color: #94a3b8; margin: 0;">The right model, handed to the developer for each task. The platform team benchmarks once, and spends less.</p>
-        </div>
-        <div class="slide-number"></div>
-    </section>
-
     <!-- SLIDE 1: TITLE -->
     <section class="slide slide-title">
         <div class="slide-content">
@@ -386,6 +372,20 @@
                 </div>
                 <p class="reveal" style="margin-top: var(--content-gap); font-size: var(--small-size); color: #94a3b8;">Practitioner + executive briefing</p>
             </div>
+        </div>
+        <div class="slide-number"></div>
+    </section>
+
+    <!-- INTRO VIDEO (after title) -->
+    <section class="slide">
+        <div class="slide-content" style="align-items: center; justify-content: center; gap: var(--content-gap, 1.5rem); text-align: center;">
+            <h2 style="margin: 0;">swe-router in 70 seconds</h2>
+            <video controls playsinline preload="metadata"
+                   style="width: min(92vw, 1180px); max-height: 68vh; aspect-ratio: 16 / 9; border-radius: 14px; box-shadow: 0 24px 64px rgba(0,0,0,0.22); background: #000;">
+                <source src="https://github.com/user-attachments/assets/5c525197-0d54-4163-bfe6-54fc656dd1fe" type="video/mp4" />
+                Your browser does not support embedded video.
+            </video>
+            <p style="font-size: var(--small-size, 0.85rem); color: #94a3b8; margin: 0;">The right model, handed to the developer for each task. The platform team benchmarks once, and spends less.</p>
         </div>
         <div class="slide-number"></div>
     </section>


### PR DESCRIPTION
Follow-up to #168. Two changes to how the swe-router explainer video is presented.

## 1. Video moved below the title slide

In both decks the video was the first slide, ahead of the title. It now sits on the slide immediately after the title, so the deck still opens on the title.

## 2. README now shows a real inline player

#168 embedded the video with a GitHub Release asset URL. GitHub's README sanitizer strips `<video>` tags whose source is a release-asset or raw URL, so nothing rendered (only the caption survived). This switches the README and both decks to the GitHub `user-attachments` URL for the same file, which is served as `video/mp4` and is kept by the sanitizer, so the README renders an inline player and the decks play from the same source.

The `media-assets` release is no longer referenced and can stay as an optional download fallback or be deleted.

Source video hosted via #169.
