### PR TITLE
docs: link every setup guide from AGENTS.md and document omp on Bedrock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,8 +512,11 @@ Read the doc that covers what you are about to do rather than rediscovering it. 
 **Machine setup -- do this before any benchmark run:**
 
 - [.claude/skills/setup-machine/SKILL.md](.claude/skills/setup-machine/SKILL.md) -- the `setup-machine` skill: inspects the instance, reports every missing dependency, and installs it (adding vLLM, nvtop and nvitop only when a GPU is present). Start here on a fresh box; `setup-machine.sh --check` alone is a fast answer to "why is `uv` / `claude` / `codex` not found".
-- [benchmarks/docs/agent-cli-bedrock-setup.md](benchmarks/docs/agent-cli-bedrock-setup.md) -- wiring `codex` (the judge) and `claude` to Amazon Bedrock. **Working AWS credentials are not sufficient**: an unconfigured `codex` ignores them and 401s against `api.openai.com`, so prove it with a real call before starting a long run.
+- [benchmarks/docs/agent-cli-bedrock-setup.md](benchmarks/docs/agent-cli-bedrock-setup.md) -- wiring `codex` (the judge), `claude` and `omp` to Amazon Bedrock. **Working AWS credentials are not sufficient**: an unconfigured `codex` ignores them and 401s against `api.openai.com`, so prove it with a real call before starting a long run.
+- [docs/omp-setup.md](docs/omp-setup.md) -- installing `omp` (oh-my-pi), the harness behind the headline results, and the three ways it differs from `pi`. Read it before `--agent omp`: its config is YAML, it has no `--skill` flag, and it hangs on an inherited stdin.
 - [docs/kiro-cli-setup.md](docs/kiro-cli-setup.md) -- kiro-cli's own sign-in and its credit-based cost basis.
+- [.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md](.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md) -- the one-time driver, NVMe and CUDA-JIT fixes an 8-GPU NVSwitch node needs. `setup-machine.sh` points here when it detects one, and vLLM fails at KV-cache init without them.
+- [docs/getting-started.md](docs/getting-started.md) -- the guided tour from a fresh checkout to a first run, for anyone who wants the narrative rather than the reference pages above.
 
 **Running a benchmark:**
 

--- a/benchmarks/docs/agent-cli-bedrock-setup.md
+++ b/benchmarks/docs/agent-cli-bedrock-setup.md
@@ -50,9 +50,30 @@ codex exec --skip-git-repo-check "Reply with exactly: JUDGE OK"
 Two things that decide whether this works:
 
 - **The region must host the model.** The GPT-5.6 models are region-scoped, and asking a region that does not host one returns a 404 (`The model '...' does not exist`), not a helpful message. `openai.gpt-5.6-sol` -- the judge's default ([codex_judge.py](../scripts/codex_judge.py), overridable with `JUDGE_MODEL`) -- runs in **us-east-1 and us-east-2 only**; `openai.gpt-5.6-terra` and `openai.gpt-5.6-luna` add us-west-2.
+- **Do not trust `list-foundation-models` for this.** `aws bedrock list-foundation-models --region us-west-2` returns `openai.gpt-5.6-sol`, yet the `bedrock-mantle` endpoint in that region 404s on the same id. The two surfaces do not agree, so the listing is not evidence the judge can reach a model. The `codex exec` call below is the only check that settles it.
 - **Scope the region in `config.toml`, not `AWS_REGION`.** `model_providers.amazon-bedrock.aws.region` pins Codex to one region without disturbing the ambient environment -- which matters here, because the same box may point Claude Code at a different region and drives a local vLLM server that reads `AWS_*` for its own reasons.
 
 `--skip-git-repo-check` is only needed outside a git repo or trusted folder; the judge passes its own flags. If Codex warns that `bubblewrap` is missing it falls back to a bundled copy, which is harmless for `--sandbox read-only` judging; `sudo apt install bubblewrap` silences it.
+
+## omp (the agent, on the Bedrock path)
+
+`omp` needs no config file for Bedrock. It ships an `amazon-bedrock` provider, addresses models as `amazon-bedrock/<wire model id>`, and resolves credentials from the standard chain, an EC2 instance role included. All it needs from you is a region:
+
+```bash
+export AWS_REGION=us-west-2    # or wherever your Anthropic inference profiles live
+omp -p --mode json --no-session \
+    --model amazon-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 \
+    -- "Reply with exactly: OMP OK" </dev/null
+```
+
+A working call reports `"provider":"amazon-bedrock"` and `"api":"bedrock-converse-stream"` in its `message_end` event. Redirect stdin from `/dev/null`: omp reads an inherited stdin as a piped prompt and blocks on EOF, ignoring the positional one ([omp-setup.md](../../docs/omp-setup.md)).
+
+Two traps when you persist that export:
+
+- **`~/.bashrc` returns early for non-interactive shells.** Ubuntu's stock `~/.bashrc` opens with a `case $- in *i*) ;; *) return;; esac` guard, so an export appended to the end reaches interactive shells only. Put it in `~/.profile` as well, or a script and a `systemd --user` unit both start without it.
+- **The harness sets the region itself.** `run-swe-headless.py` pins `AWS_REGION` per run from `aws_region` in the runner config, so `--provider bedrock` runs do not depend on your shell at all. The export matters for driving `omp` by hand.
+
+Unlike `codex`, `omp` cannot pin its region in a config file, so this one is ambient. Check what `AWS_REGION` holds before blaming a model id.
 
 ## Claude Code (the agent, on the Bedrock path)
 


### PR DESCRIPTION
## Why

AGENTS.md tells agents to "read the doc that covers what you are about to do rather than rediscovering it", but its **Setup and reference docs** section listed only two of the five setup guides in the repo. The other three were reachable through a script reference or not at all. This came up while wiring `codex` and `omp` to Amazon Bedrock on a fresh p5en.48xlarge: `docs/omp-setup.md` had to be found through a string constant in `gen_agent_report.py`.

## What changed

**AGENTS.md** -- three guides added to the Machine setup list:

- `docs/omp-setup.md`, the harness behind the headline results, and the three ways it differs from pi.
- `.claude/skills/vllm-setup/p5en-h200-cuda-fixes.md`, which `setup-machine.sh` already points at when it detects an 8-GPU NVSwitch node. Without those fixes vLLM dies at KV-cache init.
- `docs/getting-started.md`, the narrative path from a fresh checkout to a first run.

The `agent-cli-bedrock-setup.md` entry now names `omp` alongside `codex` and `claude`, matching what that doc covers.

**benchmarks/docs/agent-cli-bedrock-setup.md** -- adds the omp section the doc's own intro already promised:

- omp needs no config file for Bedrock. It ships an `amazon-bedrock` provider and resolves the credential chain itself, an EC2 instance role included, so a region is all it needs.
- The stdin redirect a manual invocation needs, cross-referencing `omp-setup.md`.
- Ubuntu's stock `~/.bashrc` returns early for non-interactive shells, so an appended `export` reaches interactive shells only. `~/.profile` needs it too, or a script and a `systemd --user` unit both start without it.
- The harness pins `AWS_REGION` per run from the runner config, so `--provider bedrock` runs never depend on the developer's shell.

It also records a gotcha found during that setup: `aws bedrock list-foundation-models --region us-west-2` reports `openai.gpt-5.6-sol`, while the `bedrock-mantle` endpoint in the same region returns 404 for that id. The two surfaces disagree, so the listing cannot be used as evidence the judge can reach a model. Only the `codex exec` check settles it. This follows the section's own closing instruction to write down a setup problem that was not already documented.

## Verification

Both CLIs were wired and confirmed with real calls on a p5en.48xlarge before the docs were written:

- `codex exec --skip-git-repo-check` returned `JUDGE OK` from `us-east-2` (us-west-2 produced the 404 described above).
- `omp -p --mode json` returned `OMP OK` from `us-west-2`, reporting `"provider":"amazon-bedrock"` and `"api":"bedrock-converse-stream"`.

Documentation only; no code paths change. Every added link target was checked to resolve from its containing file.