### PR TITLE
docs(agents): point batch runs at run-multi-model-benchmark.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,9 @@ When a task is unscoped, the source worth reading lives under `benchmarks/` and 
 │   │   └── litellm-mantle.yaml   # LiteLLM proxy config for open-weight Bedrock models
 │   ├── dataset/                  # the coding-task dataset the harness runs over
 │   ├── scripts/                  # the harness itself: runners, judge, config, plots
-│   │   ├── run-e2e-benchmark.sh  # top-level end-to-end entry point
+│   │   ├── run-multi-model-benchmark.sh # MANY models back to back (start here for a batch)
+│   │   ├── run-e2e-benchmark.sh  # ONE model, end to end
+│   │   ├── run-benchmark-batch.sh # simple sequential loop; judges inline, serves nothing
 │   │   ├── run-swe-headless.py   # drives Claude Code over the dataset
 │   │   ├── runner_config.py      # RunnerConfig Pydantic model (config source of truth)
 │   │   ├── codex_judge.py        # scores artifacts (the judge)
@@ -520,6 +522,7 @@ Read the doc that covers what you are about to do rather than rediscovering it. 
 
 **Running a benchmark:**
 
+- **More than one model? Use [benchmarks/scripts/run-multi-model-benchmark.sh](benchmarks/scripts/run-multi-model-benchmark.sh), and do not hand-roll a loop around `run-e2e-benchmark.sh`.** It already does the four things a batch needs: it serves each model from its own registry (stopping the previous one, with the tensor-parallel size and parser each one requires), self-detaches with `setsid` so a session teardown cannot kill a multi-day run, commits each `run-summary` to the current branch, and with `--judge-mode async` scores the finished model in the background while the next one generates. The judge is a Bedrock call that uses no GPU, so async overlaps it for free; inline leaves the GPU idle for roughly 50 minutes per 21-task model, and `skip` leaves a serial tail after the batch. `run-benchmark-batch.sh` is the simpler sibling: it judges inline and serves nothing, so it suits a Bedrock batch, not a self-hosted one.
 - [benchmarks/docs/end-to-end-self-hosted-run.md](benchmarks/docs/end-to-end-self-hosted-run.md) -- the full manual run-book for a self-hosted run.
 - [benchmarks/docs/harness-reference.md](benchmarks/docs/harness-reference.md) -- the dataset format, the artifacts, and what the judge does.
 - [benchmarks/docs/path-anthropic-on-bedrock.md](benchmarks/docs/path-anthropic-on-bedrock.md), [path-open-weight-on-bedrock-litellm.md](benchmarks/docs/path-open-weight-on-bedrock-litellm.md), [path-self-hosted-vllm.md](benchmarks/docs/path-self-hosted-vllm.md) -- the three hosting paths.


### PR DESCRIPTION
## Why

The repository map in AGENTS.md labelled `run-e2e-benchmark.sh` the "top-level end-to-end entry point" and never mentioned `run-multi-model-benchmark.sh`. An agent asked to benchmark several models therefore finds the one-model script, and either wraps it in a hand-rolled loop or lands on `run-benchmark-batch.sh`, which judges inline and serves nothing. That is the wrong tool for a self-hosted batch, and the mistake costs GPU-idle hours rather than failing loudly.

This happened while setting up the issue #157 re-run: two scripts were read before the right one, even though `.claude/skills/benchmark/SKILL.md` already says "do not hand-write a scoring watcher". That guidance only reaches someone who has opened the skill.

## What changed

**Repository map** -- all three runners are now listed with what each is for:

```
run-multi-model-benchmark.sh # MANY models back to back (start here for a batch)
run-e2e-benchmark.sh         # ONE model, end to end
run-benchmark-batch.sh       # simple sequential loop; judges inline, serves nothing
```

**Running a benchmark** -- a new first entry states the rule before the reading list, and records what the multi-model script already handles, since each is something an agent would otherwise rebuild:

- serves each model from its own registry, stopping the previous one, with the tensor-parallel size and parsers that model requires
- self-detaches with `setsid`, so a session teardown cannot kill a multi-day run
- commits each `run-summary` to the current branch
- `--judge-mode async` scores the finished model while the next one generates

It also explains why the judge mode matters: the judge is a Bedrock call that uses no GPU, so `async` overlaps it for free, `inline` leaves the GPU idle for roughly 50 minutes per 21-task model, and `skip` leaves a serial tail after the batch. The `run-benchmark-batch.sh` line says what that script is for rather than leaving it unexplained.

Documentation only. No code paths change, and every path named was checked to exist.