### PR TITLE
feat(swe-router): install the skill with one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,19 @@ On ours, 16 models over 21 tasks: `claude-opus-5` scores highest at **82.83** fo
 
 ## Step 2 — Developers install the skill
 
-Five files copied into a skills directory. The skill imports nothing and needs no build step:
+Five files copied into a skills directory. The skill imports nothing and needs no build step. Run this from the root of the repository you want it in, and it lands in `.claude/skills/swe-router`:
 
 ```bash
 curl -sL https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router/install.sh | bash
 ```
 
-Add `-s -- --dir ~/.claude/skills` to install it for every repository at once.
+To install it once for every repository instead, send it to your home directory:
+
+```bash
+curl -sL https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router/install.sh | bash -s -- --dir ~/.claude/skills
+```
+
+Re-run either command to upgrade; your edited `allowed-models.txt` is kept.
 
 `swe-router` engages on its own before a substantial task. It sets a quality floor from what happens if the change is wrong, classifies how hard the task is, and takes the cheapest model that clears that floor at that tier. **Edit `allowed-models.txt`.** The skill treats every name in it as a model the developer can select, so listing one your team cannot reach costs them the cheaper option.
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,10 @@ On ours, 16 models over 21 tasks: `claude-opus-5` scores highest at **82.83** fo
 Five files copied into a skills directory. The skill imports nothing and needs no build step:
 
 ```bash
-BASE=https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router
-mkdir -p .claude/skills/swe-router
-for f in SKILL.md route.py models.json model-aliases.json allowed-models.txt; do
-  curl -sL -o ".claude/skills/swe-router/$f" "$BASE/$f"
-done
+curl -sL https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router/install.sh | bash
 ```
+
+Add `-s -- --dir ~/.claude/skills` to install it for every repository at once.
 
 `swe-router` engages on its own before a substantial task. It sets a quality floor from what happens if the change is wrong, classifies how hard the task is, and takes the cheapest model that clears that floor at that tier. **Edit `allowed-models.txt`.** The skill treats every name in it as a model the developer can select, so listing one your team cannot reach costs them the cheaper option.
 

--- a/benchmarks/tests/test_build_vended_models.py
+++ b/benchmarks/tests/test_build_vended_models.py
@@ -229,10 +229,37 @@ class CommittedArtifactTest(unittest.TestCase):
         # only these. An extra file is a dependency someone will start relying on.
         # Importing route.py in tests leaves a __pycache__; it is a build
         # artifact of running the checks, not something anyone installs.
+        # install.sh is the installer, not part of the skill: it fetches the
+        # five installed files and never copies itself, so it cannot become a
+        # runtime dependency. test_installer_installs_exactly_the_skill_files
+        # holds that line.
         self.assertEqual(
             sorted(p.name for p in _VEND_DIR.iterdir() if p.is_file()),
             [
                 "README.md",
+                "SKILL.md",
+                "allowed-models.txt",
+                "install.sh",
+                "model-aliases.json",
+                "models.json",
+                "route.py",
+            ],
+        )
+
+    def test_installer_installs_exactly_the_skill_files(self) -> None:
+        # The installer's file list is the install contract, and it is a shell
+        # string rather than anything importable -- so read it back and check it
+        # against the directory. A file added to vend/ but not to SKILL_FILES
+        # would be documented as part of the skill and never actually installed.
+        text = (_VEND_DIR / "install.sh").read_text(encoding="utf-8")
+        declared = next(
+            line.split('"')[1]
+            for line in text.splitlines()
+            if line.startswith("SKILL_FILES=")
+        )
+        self.assertEqual(
+            sorted(declared.split()),
+            [
                 "SKILL.md",
                 "allowed-models.txt",
                 "model-aliases.json",
@@ -240,6 +267,7 @@ class CommittedArtifactTest(unittest.TestCase):
                 "route.py",
             ],
         )
+        self.assertNotIn("install.sh", declared)
 
     def test_readme_tier_tables_match_the_data(self) -> None:
         # The README prints the four tier tables so a reader can see the scan.

--- a/vend/swe-router/README.md
+++ b/vend/swe-router/README.md
@@ -13,14 +13,25 @@ Knowing which tasks those are needs measurement. This skill carries the measurem
 ## Install
 
 ```bash
-BASE=https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router
-mkdir -p .claude/skills/swe-router
-for f in SKILL.md route.py models.json model-aliases.json allowed-models.txt; do
-  curl -sL -o ".claude/skills/swe-router/$f" "$BASE/$f"
-done
+curl -sL https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router/install.sh | bash
 ```
 
-Five files:
+That writes the skill to `.claude/skills/swe-router` in the current directory. To install it once for every repository you work in, point it at your home directory instead:
+
+```bash
+curl -sL https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router/install.sh | bash -s -- --dir ~/.claude/skills
+```
+
+`--ref` pins a tag or commit, and `--force` replaces an `allowed-models.txt` you have already edited. Pinning is also the supply-chain answer: `--ref <commit-sha>` installs a fixed revision you can read on GitHub first, rather than whatever `main` holds on the day you run it. Run `install.sh --help` for the rest. Re-running the installer upgrades the skill and keeps your edited `allowed-models.txt`, so an upgrade never silently replaces your model policy.
+
+If you would rather read a script than pipe it into a shell, download it first:
+
+```bash
+curl -sL -O https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router/install.sh
+less install.sh && bash install.sh
+```
+
+Five files land in the skill directory:
 
 | File | |
 |---|---|
@@ -30,7 +41,7 @@ Five files:
 | `model-aliases.json` | model names as different assistants spell them |
 | `allowed-models.txt` | which models your organisation permits. **Edit this one.** |
 
-The path differs by assistant. The skill has no dependencies and imports nothing — a directory of files is the whole install.
+The path differs by assistant, which is what `--dir` is for. The skill has no dependencies and imports nothing — a directory of files is the whole install, and copying that directory by hand works just as well as the installer.
 
 ### Restricting it to models your organisation allows
 

--- a/vend/swe-router/install.sh
+++ b/vend/swe-router/install.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Install the swe-router skill into a repository, or into a user-wide skills
+# directory. The skill is five files with no dependencies, so this script only
+# needs curl and a POSIX shell.
+#
+# Usage:
+#   curl -sL https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router/install.sh | bash
+#   curl -sL .../install.sh | bash -s -- --dir ~/.claude/skills
+#
+# Every option also reads from an environment variable, so the piped form can
+# be configured without -s -- when that is easier:
+#   SWE_ROUTER_DIR=~/.claude/skills bash install.sh
+#
+# The download is not checksummed, because the files it fetches are the release:
+# there is no separate artifact to check them against. Pass --ref <commit-sha> to
+# install a fixed, reviewable revision rather than whatever main holds today.
+#
+set -euo pipefail
+
+REPO="${SWE_ROUTER_REPO:-aarora79/agentic-coding-harness-benchmarks}"
+REF="${SWE_ROUTER_REF:-main}"
+SKILLS_DIR="${SWE_ROUTER_DIR:-.claude/skills}"
+FORCE="${SWE_ROUTER_FORCE:-0}"
+
+SKILL_NAME="swe-router"
+SKILL_FILES="SKILL.md route.py models.json model-aliases.json allowed-models.txt"
+JSON_FILES="models.json model-aliases.json"
+# The one file a user is expected to edit. An upgrade preserves it, because
+# overwriting it would silently replace an organisation's model policy.
+POLICY_FILE="allowed-models.txt"
+
+
+usage() {
+    cat <<'USAGE_EOF'
+Install the swe-router skill.
+
+Options:
+  --dir DIR     Skills directory to install into (default: .claude/skills).
+                Use ~/.claude/skills for a user-wide install.
+  --ref REF     Git ref to install from (default: main). Pin a tag or commit
+                to hold a version steady.
+  --repo OWNER/NAME
+                Source repository (default: aarora79/agentic-coding-harness-benchmarks).
+  --force       Overwrite an existing allowed-models.txt. Without this, an
+                existing model policy is kept and the rest of the skill is
+                still upgraded.
+  -h, --help    Show this help.
+
+Environment variables: SWE_ROUTER_DIR, SWE_ROUTER_REF, SWE_ROUTER_REPO,
+SWE_ROUTER_FORCE. A command-line option wins over its variable.
+USAGE_EOF
+}
+
+
+require_value() {
+    # require_value <option-name> <count-of-remaining-args>
+    if [ "$2" -lt 2 ]; then
+        echo "install.sh: $1 needs a value" >&2
+        exit 2
+    fi
+}
+
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dir)   require_value "$1" "$#"; SKILLS_DIR="$2"; shift 2 ;;
+        --ref)   require_value "$1" "$#"; REF="$2";        shift 2 ;;
+        --repo)  require_value "$1" "$#"; REPO="$2";       shift 2 ;;
+        --force) FORCE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *)
+            echo "install.sh: unknown option '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "install.sh: curl is required but was not found on PATH." >&2
+    exit 1
+fi
+
+BASE="https://raw.githubusercontent.com/${REPO}/${REF}/vend/${SKILL_NAME}"
+TARGET="${SKILLS_DIR}/${SKILL_NAME}"
+
+# Stage every file in a temp directory first, so a network failure part-way
+# through leaves the existing install untouched rather than half-replaced.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "Installing ${SKILL_NAME} from ${REPO}@${REF} into ${TARGET}"
+
+for f in $SKILL_FILES; do
+    # --proto/--proto-redir pin the transfer to HTTPS: -L follows redirects, and
+    # without these a redirect could walk the download down to plain HTTP, which
+    # is a code download nobody would notice being tampered with.
+    if ! curl -fsSL --proto '=https' --proto-redir '=https' \
+            -o "${STAGE}/${f}" "${BASE}/${f}"; then
+        echo "install.sh: could not download ${f} from ${BASE}/${f}" >&2
+        echo "Nothing was written to ${TARGET}. Check --ref '${REF}' and your network." >&2
+        exit 1
+    fi
+    if [ ! -s "${STAGE}/${f}" ]; then
+        echo "install.sh: ${f} downloaded as an empty file; refusing to install." >&2
+        exit 1
+    fi
+done
+
+# A truncated JSON file makes the skill fail later with a confusing error, so
+# catch it here while we can still say what went wrong.
+if command -v python3 >/dev/null 2>&1; then
+    for f in $JSON_FILES; do
+        if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "${STAGE}/${f}" 2>/dev/null; then
+            echo "install.sh: ${f} is not valid JSON; the download was corrupted." >&2
+            exit 1
+        fi
+    done
+fi
+
+mkdir -p "$TARGET"
+
+kept_policy=0
+for f in $SKILL_FILES; do
+    if [ "$f" = "$POLICY_FILE" ] && [ -f "${TARGET}/${f}" ] && [ "$FORCE" != "1" ]; then
+        kept_policy=1
+        continue
+    fi
+    mv "${STAGE}/${f}" "${TARGET}/${f}"
+done
+
+chmod +x "${TARGET}/route.py"
+
+echo
+echo "Installed ${SKILL_NAME} to ${TARGET}"
+if [ "$kept_policy" = "1" ]; then
+    echo "Kept your existing ${POLICY_FILE}. Re-run with --force to replace it."
+else
+    echo
+    echo "Next step, and do not skip it: edit ${TARGET}/${POLICY_FILE}"
+    echo "It ships allowing five models, four of them self-hosted. Left as-is in a"
+    echo "setup that cannot reach those, the skill will recommend a model nobody can"
+    echo "select. Cut the list down to what your setup actually serves."
+fi


### PR DESCRIPTION
## What this changes

Installing `swe-router` took a five-line shell loop, because a raw-file URL serves one file at a time and the skill is five files. This adds `vend/swe-router/install.sh`, so the install is one command:

```bash
curl -sL https://raw.githubusercontent.com/aarora79/agentic-coding-harness-benchmarks/main/vend/swe-router/install.sh | bash
```

The loop also left no room for what an install actually needs: choosing a target directory, pinning a version, or failing cleanly when a download breaks part-way. All three now have flags.

| Flag | |
|---|---|
| `--dir` | where to install; `~/.claude/skills` for every repository at once |
| `--ref` | pin a tag or commit instead of tracking `main` |
| `--force` | replace an `allowed-models.txt` that has already been edited |
| `--repo` | install from a fork |

Each also reads from an environment variable (`SWE_ROUTER_DIR`, `SWE_ROUTER_REF`, ...), so the piped form stays configurable without `-s --`.

## Behavior worth calling out

**An upgrade keeps your `allowed-models.txt`.** Re-running the installer refreshes the skill and leaves that one file alone, because overwriting it would silently replace an organisation's model policy. `--force` opts into replacing it.

**It fails closed.** Every file is staged in a temp directory and moved into place only once all five arrive, so a broken download leaves an existing install untouched rather than half-replaced. An HTTP error, an empty file, or malformed JSON each stop the install with a message naming the fix.

## Supply chain

The transfer is pinned to HTTPS with `--proto '=https' --proto-redir '=https'`. Without them `-L` would let a redirect walk a code download down to cleartext.

The files are not checksummed, and deliberately so: they are the release itself, with no separate artifact to check them against, and a checksum committed in the same repo and served from the same host adds no attacker resistance. `--ref <commit-sha>` is the control that helps, installing a fixed revision a reader can review on GitHub first. The script header and the README both say this.

## Tests

`test_vend_dir_holds_exactly_the_portable_files` asserted an exact file list, so it now covers `install.sh`, with a comment explaining that the installer is not part of the skill.

Added `test_installer_installs_exactly_the_skill_files`, which reads `SKILL_FILES` back out of the script and checks it against the directory, and asserts the installer never installs itself. A file added to `vend/` but missing from that list would otherwise be documented as part of the skill and never actually installed.

## Verification

- 425 tests pass, run three times to rule out flakiness.
- `pre-commit` clean on all four changed files; `bandit` adds no new findings.
- The installer was exercised against the live URLs: fresh install, user-wide `--dir`, piped form with arguments, environment-variable form, upgrade preserving an edited policy file, `--force` replacing it, `--ref` pinned to commit `2a323c8`, a bad ref failing without creating a directory, a bad ref leaving an existing install intact, and the argument errors returning exit 2.
- The installed skill runs: `route.py --tier medium --floor 70` returns a recommendation.

## Docs

Both install sections now show the one-liner: `vend/swe-router/README.md` and the root `README.md` step 2. The vend README keeps a download-and-read-first path for anyone who would rather not pipe a script into a shell.
