### PR TITLE
Add release-notes skill, versioning scheme, and 0.1.0 notes

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: release-notes
+description: "Create release notes for a new version tag of this benchmark repository. Decides the correct semver bump from the change set (new dataset or new model is a minor; a methodology change or completely new functionality is a major; everything else is a patch), gathers all commits, PRs and closed issues since the previous release, writes the release notes markdown following the project format, then opens a PR and tags the merge commit. Use when the user wants to cut a release, write release notes, decide the next version number, or tag a release."
+license: Apache-2.0
+metadata:
+  author: Amit Arora
+  version: "1.0"
+---
+
+# Release Notes Skill
+
+Use this skill when the user wants to cut a release of `agentic-coding-harness-benchmarks`. It decides the correct next version, gathers every change since the previous release, writes structured release notes in the project format, opens a PR (this repo never commits to `main` directly), and tags the merge commit after the PR is approved and merged.
+
+This repo is a benchmark harness plus its published results, docs and slides. It is **not** a deployed service, so there is no Docker Compose / Helm / Terraform upgrade path and no live smoke test. What a release captures instead is: new models benchmarked, new datasets, methodology changes, new harness functionality, and the results / frontier / doc updates that follow.
+
+## Versioning scheme (read this first)
+
+Releases follow [Semantic Versioning 2.0.0](https://semver.org): `MAJOR.MINOR.PATCH`, **bare, with no `v` prefix** (e.g. `0.2.0`, not `v0.2.0`). The one existing non-version tag, `media-assets`, hosts video/asset release attachments and is not a release: ignore it when finding the latest version.
+
+### What each bump means in this repo
+
+The "public API" of a benchmark repo is its dataset, its measured models, and its measurement methodology. Map the change set to a bump with these rules, in priority order (if a change set matches more than one, take the highest):
+
+| Bump | Trigger | Examples |
+|------|---------|----------|
+| **MAJOR** | A methodology change, or completely new functionality | The judge or scoring changes so old and new scores are no longer comparable; the cost-per-task derivation changes; the cost/quality frontier is recomputed on a new basis; a new benchmark type or hosting path is added; the config schema changes in a backward-incompatible way. |
+| **MINOR** | A new dataset, or a new model added to the frontier | A new SWE dataset (e.g. a new `sweN` task set); a new model benchmarked and folded into results, `models.json`, charts and docs; a new skill or a new backward-compatible config knob. |
+| **PATCH** | Everything else, backward compatible | Doc / slide fixes, chart or frontier regeneration for an existing model, bug fixes in a script, dependency bumps, typo and link fixes. |
+
+Because a methodology change makes previously published numbers no longer directly comparable, it is the clearest MAJOR signal: **when scores from before and after the change cannot sit in the same table, bump MAJOR.** New datasets and new models are additive, so they are MINOR even though they add a lot of data.
+
+### Choosing the first version and the 1.0.0 line
+
+There are no version tags yet, so the first release sets the convention:
+
+- In `0.y.z` the methodology and results are still settling and nothing is promised to stay comparable across releases. This is the honest place to start: **use `0.1.0` for the first release** unless the user says the harness and its published frontier are already something people depend on.
+- Go to `1.0.0` when you are ready to stand behind a stable methodology and results contract, and to bump MAJOR whenever a methodology change breaks it. `1.0.0` is a commitment, not a maturity trophy earned after `0.9.0` -- there is no rule that the first release must be `0.9.0`, and you never need to march through `0.9.0` before `1.0.0`.
+
+**Always confirm the computed version with the user** before writing anything. State the bump you chose and the one-line reason (e.g. "MINOR: adds the minimax-m3 model to the omp/swe3 frontier"), and let them override.
+
+## Input
+
+- An optional version, `{major}.{minor}.{patch}` (e.g. `0.2.0`), **no `v` prefix**. If the user gives a `v`-prefixed version, strip the `v` and confirm.
+- If no version is given, compute the recommended bump from the change set (see above) and confirm it with the user.
+
+## Output
+
+- `docs/release-notes/{version}.md` -- the release notes file (e.g. `docs/release-notes/0.2.0.md`).
+- On the first release only: `docs/release-notes/README.md` -- a small index of releases, and one new row in the root `README.md` "Documentation map" table pointing at it.
+- A git tag `{version}` on the merge commit, created **after** the release-notes PR is merged to `main`.
+
+## Workflow
+
+### Step 0: Verification gate
+
+A release must not ship code or results that fail the repo's own checks. Before writing notes, confirm the checks pass for every `uv` project touched since the base version (`benchmarks/` and/or `self-hosted/vllm/`). CI gates on the unittest suites, so those are the hard block.
+
+1. **Ask the user, using AskUserQuestion**, whether the checks have already been run and passed. Offer:
+   - "Yes, they passed" (proceed to Step 1)
+   - "No, run them now" (Recommended -- run them, see below)
+   - "Skip them" (proceed only after the warning below)
+
+2. **If the user asks you to run them**, run the AGENTS.md check line from inside each touched `uv` project. At minimum the test suites must pass:
+   ```bash
+   # From benchmarks/ (and/or self-hosted/vllm/) -- whichever owns the changed files
+   uv run ruff check --fix . && uv run ruff format .
+   uv run python -m unittest discover -s tests
+   ```
+   - **If any test FAILS, STOP.** Do not cut the release. Report which tests failed and help investigate. A release must not be cut with a failing suite.
+   - Run the fuller line (`bandit`, `mypy`) too when the change is security- or type-sensitive; treat a new failure as a blocker.
+
+3. **If the user chooses to skip**, warn once that the release is being cut without verification, then proceed only if they confirm.
+
+Only after this gate is resolved continue to Step 1.
+
+### Step 1: Determine the new version tag
+
+1. Compute the recommended bump from the change set using the [Versioning scheme](#versioning-scheme-read-this-first) rules, or take the version the user gave.
+2. Normalize to bare semver (strip any leading `v`).
+3. Verify the tag does not already exist: `git tag -l {version}`.
+4. If it exists, ask the user whether to move it or pick a different version.
+5. **Confirm the version and the one-line bump reason with the user before proceeding.**
+
+### Step 2: Determine the base version (ask the user to confirm)
+
+Release notes are incremental from the previous release.
+
+1. List existing release notes and version tags (excluding the `media-assets` asset tag):
+   ```bash
+   ls docs/release-notes/*.md 2>/dev/null
+   git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+   ```
+2. **First release (no version tags):** there is no base. Diff from the repository's first commit and summarize the harness as it stands, rather than an incremental changelog:
+   ```bash
+   FIRST_COMMIT=$(git rev-list --max-parents=0 HEAD | tail -1)
+   ```
+   Use `$FIRST_COMMIT` wherever the steps below say `{base_tag}`.
+3. **Otherwise:** take the most recent version tag as the base and **confirm it with the user** using AskUserQuestion (present it as the recommended option, with the 2-3 previous tags as alternatives). The user may want to span multiple versions.
+
+### Step 3: Gather all changes between base and HEAD
+
+Run these in parallel to gather the change data:
+
+```bash
+# All commits (including merges) between base and HEAD
+git log {base_tag}..HEAD --oneline
+
+# Non-merge commits (for detailed change analysis)
+git log {base_tag}..HEAD --oneline --no-merges
+
+# Merge commits (to extract PR numbers)
+git log {base_tag}..HEAD --oneline --grep="Merge pull request"
+
+# Contributors -- direct authors of commits on main
+# WARNING: this misses co-authors of squash-merged PRs (Step 4 #9 explains).
+git log {base_tag}..HEAD --format="%aN" | sort | uniq -c | sort -rn
+
+# Contributors -- per-PR commit authors (catches squash-merge co-authors)
+# Squash merges collapse a branch's commits into one commit on main authored by
+# the merger, so `git log` above will not show the real code authors.
+# `gh pr view --json commits` returns the original branch commits with authors intact.
+for pr in $(git log {base_tag}..HEAD --oneline --grep="Merge pull request\|(#[0-9]\+)$" | grep -oE "#[0-9]+" | tr -d '#' | sort -u); do
+  gh pr view $pr --json number,author,commits \
+    --jq '"PR #\(.number) | opener: \(.author.login) | commit_authors: \([.commits[].authors[].name] | unique | join(", "))"' 2>/dev/null
+done
+
+# Config-schema changes (this repo's analog of an env-var diff): the RunnerConfig
+# model, the example config, and the pricing table. Any change here is a config
+# change users may need to act on; a backward-incompatible one is a MAJOR signal.
+git diff {base_tag}..HEAD --stat -- \
+  benchmarks/scripts/runner_config.py \
+  benchmarks/config/runner.example.yaml \
+  self-hosted/vllm/pricing.json
+
+# New models benchmarked (per-model serving guides and the frontier data)
+git diff {base_tag}..HEAD --stat -- self-hosted/vllm/models/ docs/metrics/
+
+# New or changed skills
+git diff {base_tag}..HEAD --stat -- .claude/skills/
+
+# Dataset changes (new sweN task sets)
+git diff {base_tag}..HEAD --stat -- benchmarks/dataset/
+
+# Closed issues since the base tag was cut (floor by the base tag's commit date)
+BASE_TAG_DATE=$(git log -1 --format=%cI {base_tag})
+gh issue list --state closed --limit 200 --json number,title,closedAt,labels \
+  --jq ".[] | select(.closedAt >= \"$BASE_TAG_DATE\") | \"\(.number) | \(.title) | \(.closedAt)\""
+
+# Closed issues referenced by merged PRs (most reliable mapping)
+for pr in $(git log {base_tag}..HEAD --oneline --grep="Merge pull request" | grep -oE "#[0-9]+" | tr -d '#' | sort -u); do
+  gh pr view $pr --json number,title,closingIssuesReferences \
+    --jq '"\(.number) | \(.title) | closes: \(.closingIssuesReferences | map("#\(.number)") | join(","))"' 2>/dev/null
+done
+```
+
+### Step 4: Categorize changes
+
+Analyze the commits and PRs and sort them. The bump you chose in Step 1 should be justified by what lands in the first few categories.
+
+1. **New models benchmarked** (MINOR): a model added to the frontier -- new `models.json` / `docs/metrics/` frontier entries, a new per-model guide under `self-hosted/vllm/models/`, new charts and results docs. Name the model, the harness/skill and dataset it was run on, and the headline number.
+2. **New datasets** (MINOR): a new `sweN` task set or a new set of tasks under `benchmarks/dataset/`. Say how many tasks and how it differs from existing datasets (never merge scores across datasets).
+3. **Methodology changes** (MAJOR): anything that changes what a number means -- the judge, scoring, cost-per-task derivation, frontier basis, or a backward-incompatible config-schema change. Spell out why old and new numbers are no longer comparable.
+4. **New functionality** (MAJOR): a new benchmark type, hosting path, or major harness capability.
+5. **Skills** (MINOR for a new skill; PATCH for a fix): new or changed entries under `.claude/skills/`.
+6. **Results and frontier updates** (PATCH when just regenerated for existing models): recomputed charts, frontier JSON, decks.
+7. **Config changes**: new or changed `RunnerConfig` knobs, `runner.example.yaml`, `pricing.json` (from the diff above).
+8. **Bug fixes** (PATCH): `fix:`-prefixed commits or PRs labeled `bug`.
+9. **Documentation / slides** (PATCH): `docs:` commits, changes under `docs/`, deck HTML/PDF regen.
+10. **Dependency updates**: `pyproject.toml` / lockfile bumps in either `uv` project.
+11. **Closed issues**: build from the `closingIssuesReferences` of every merged PR (GitHub auto-closes `Closes #N` / `Fixes #N`), supplemented by manually-closed issues whose `closedAt` falls between the base-tag commit date and HEAD. De-duplicate by issue number.
+12. **Contributors**: build the union of TWO sources, because neither alone is complete:
+    - **Direct authors on main**: `git log {base_tag}..HEAD --format="%aN"`.
+    - **Per-PR commit authors**: for every merged PR, `gh pr view <num> --json commits --jq '[.commits[].authors[].name] | unique'`, unioned. This catches co-authors of squash-merged PRs whose branch commits collapse into one commit authored by the merger. Without it, every contributor on a squash-merged branch except the merger is silently dropped.
+
+    Resolve each unique name to a GitHub login from a real PR: `.author.login` if they opened one, or `.commits[].authors[].login` if they were a co-author only. Verify uncertain guesses with `gh api users/<candidate>` (404 means wrong). **Never synthesize a username from a display name** -- "Amit Arora" is `aarora79`, not `amitarora`.
+
+### Step 5: Write the release notes
+
+Write `docs/release-notes/{version}.md` following this structure. Keep every prose section to the writing skill ([.claude/skills/writing/SKILL.md](../writing/SKILL.md)): plain words, no em-dashes, no emojis, and every number cited to the file it came from.
+
+```markdown
+# Release {version} - {short title summarizing the headline change}
+
+**{Month} {Year}**
+
+Version bump: **{MAJOR|MINOR|PATCH}** -- {one-line reason, e.g. "adds the minimax-m3 model to the omp/swe3 frontier"}.
+
+---
+
+## Upgrading from {base_version}
+
+This repo is cloned and run, not deployed, so upgrading is a pull plus a dependency sync.
+
+```bash
+git pull origin main
+git checkout {version}
+
+# Sync the uv project(s) you run. If dependencies changed, sync both:
+cd benchmarks && uv sync && cd ..
+cd self-hosted/vllm && uv sync && cd ../..
+```
+
+### Methodology changes
+
+{For a MAJOR release, state exactly what changed in how a number is produced and
+why results from {base_version} and {version} must not be compared or merged in
+the same table. For MINOR / PATCH, write: "None. Numbers remain comparable with
+{base_version}."}
+
+### Config changes
+
+| File | Change | Action needed |
+|------|--------|---------------|
+| {runner_config.py / runner.example.yaml / pricing.json} | {what changed} | {what a user must update, or "none -- has a default"} |
+
+{If no config changed, write: "No configuration changes in this release."}
+
+---
+
+## New models
+
+### {Model name} on {harness} / {dataset}
+
+{What it scored and where it sits on the frontier, cited to the frontier JSON /
+results doc. Link the per-model serving guide.}
+
+{Repeat per model. Omit the whole section if no model was added.}
+
+---
+
+## New datasets
+
+- **{dataset name}** -- {N tasks, how it was sourced, how it differs from existing sets, and the reminder that its scores never merge into another dataset's table}.
+
+{Omit if no dataset was added.}
+
+---
+
+## New functionality
+
+### {Feature name}
+
+{What it does and why it matters. Link the PR.}
+
+[PR #{number}](https://github.com/aarora79/agentic-coding-harness-benchmarks/pull/{number})
+
+{Omit if none.}
+
+---
+
+## What's changed
+
+{Group remaining changes by category. Only include categories that have changes.}
+
+### Skills
+- {change} (#{pr})
+
+### Results and frontier
+- {change} (#{pr})
+
+### Documentation and slides
+- {change} (#{pr})
+
+---
+
+## Bug fixes
+
+- {fix} (#{pr})
+
+{Omit if none.}
+
+---
+
+## Closed issues
+
+| Issue | Title | Closed by |
+|-------|-------|-----------|
+| #{n} | {title} | {PR #{pr} or "manual"} |
+
+{Sorted by issue number descending. If none: "No issues were closed in this release window."}
+
+---
+
+## Pull requests included
+
+| PR | Title |
+|----|-------|
+| #{n} | {title} |
+
+{All merged PRs between base and HEAD, sorted by PR number descending.}
+
+---
+
+## Dependency updates
+
+| Package | Previous | Updated | Project |
+|---------|----------|---------|---------|
+| {package} | {old} | {new} | {benchmarks / self-hosted/vllm} |
+
+{Omit if none.}
+
+---
+
+## Contributors
+
+Thank you to everyone who contributed to this release:
+
+- **{Full Name}** ([@{login}](https://github.com/{login}))
+
+{Union of direct authors and per-PR commit authors (Step 4 #12). Every login
+resolved from a real PR. Sorted by commit count descending.}
+
+---
+
+**Full Changelog:** [{base_version}...{version}](https://github.com/aarora79/agentic-coding-harness-benchmarks/compare/{base_version}...{version})
+```
+
+For the **first release** there is no `{base_version}` to diff against: drop the "Upgrading from" section's diff framing, describe the harness and its published frontier as it stands at this version, and omit the "Full Changelog" compare link (or point it at the first commit).
+
+### Step 6: Present the draft for review
+
+After writing the file:
+
+1. Tell the user the file is at `docs/release-notes/{version}.md`.
+2. Summarize: the chosen bump and why, new models, new datasets, methodology changes, PR count, bug-fix count, closed-issue count, contributor count.
+3. Ask the user to review and confirm, or request changes.
+
+### Step 7: Security gate, PR, and tag
+
+This repo **never commits or merges directly to `main`.** Cut the release through a PR, and tag only after it merges.
+
+1. **Run the `security-check` skill** over the pending diff (mandatory gate before any commit or PR). Resolve every blocker before continuing; do not commit while the verdict is NEEDS REVISION.
+
+2. **On the first release only**, also create `docs/release-notes/README.md` as a short index (a table of `| Version | Date | Highlights |` rows, newest first) and add one row to the root `README.md` "Documentation map" table pointing at it. On later releases, prepend a row to that index instead.
+
+3. **Commit on the feature branch** (you should already be on one; if on `main`, create `release/{version}` first):
+   ```bash
+   git add docs/release-notes/{version}.md
+   # first release also:
+   git add docs/release-notes/README.md README.md
+   git commit -m "docs: add {version} release notes"
+   git push -u origin HEAD
+   ```
+
+4. **Open a PR** with a professional description that summarizes the release (no assistant attribution anywhere):
+   ```bash
+   gh pr create --title "Release {version}" --body-file <(printf '...') --base main
+   ```
+
+5. **After the PR is approved and merged to `main`**, tag the merge commit and push the tag:
+   ```bash
+   git checkout main && git pull origin main
+   git tag {version}          # bare semver, no v prefix
+   git push origin {version}
+   ```
+
+6. **Optionally publish a GitHub Release** from the tag using the notes file:
+   ```bash
+   gh release create {version} --title "Release {version}" --notes-file docs/release-notes/{version}.md
+   ```
+
+7. **Verify:**
+   ```bash
+   git tag -l {version} --format="%(refname:short) -> %(objectname:short)"
+   ```
+   Tell the user the notes are merged and the tag is created and pushed.
+
+## Important rules
+
+- **Pick the bump by the repo's rules, not by feel:** new dataset or new model is a MINOR; a methodology change or completely new functionality is a MAJOR; everything else is a PATCH. A methodology change is the clearest MAJOR because it breaks comparability of published numbers. Always confirm the computed version with the user.
+- **Bare semver, no `v` prefix.** Ignore the `media-assets` tag when finding the latest version.
+- **Never commit or merge to `main` directly.** Cut every release through a feature branch and a PR; tag the merge commit only after it lands.
+- **Always run the `security-check` gate** before committing and before opening the PR.
+- **Run the Step 0 verification gate first.** If any test suite fails, STOP and do not cut the release. Only the user's explicit skip may bypass it, warned once.
+- **Never skip the base-version confirmation** in Step 2; the user may span multiple versions.
+- **Never include emojis** in the release notes or commits, and run the [writing skill](../writing/SKILL.md) revision pass over the prose before committing.
+- **Never name the coding assistant** anywhere -- not in the notes, commit messages, PR title or body.
+- **Check every number against its source** (a `performance-summary.json`, a frontier JSON, a results doc) and cite it, per AGENTS.md.
+- **Always credit squash-merge co-authors** via `gh pr view <num> --json commits`, and **never synthesize a GitHub username from a display name** ("Amit Arora" is `aarora79`).
+
+## Example usage
+
+```
+User: /release-notes
+Assistant: (computes the bump from the change set, e.g. "MINOR -- adds the
+minimax-m3 model to the omp/swe3 frontier", confirms 0.2.0 with the user,
+runs the verification gate, gathers changes since the base tag, writes
+docs/release-notes/0.2.0.md, runs security-check, opens a PR, and tags after merge)
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,8 @@ When a task is unscoped, the source worth reading lives under `benchmarks/` and 
 │       ├── pricing.json          # instance pricing for cost derivation
 │       └── tests/                # unittest suite
 ├── docs/                         # cross-cutting docs: results, comparisons, methodology, slides
-├── .claude/skills/               # repo skills (setup-machine, benchmark, swe/swe2/swe3, throughput, vllm-setup, security-check, swe-router)
+│   └── release-notes/            # release notes per version (newest first) + the versioning scheme
+├── .claude/skills/               # repo skills (setup-machine, benchmark, swe/swe2/swe3, throughput, vllm-setup, security-check, swe-router, release-notes)
 └── .github/                      # CI workflows and repo metadata
 ```
 
@@ -484,6 +485,12 @@ For ARM64 builds, add QEMU setup with `multiarch/qemu-user-static`.
 
 - Check available labels first with `gh label list`, and apply only labels that already exist.
 - If a new label would help, suggest it in the issue description or a comment rather than trying to create it during issue creation.
+
+### Releases and versioning
+
+- Releases follow [Semantic Versioning](https://semver.org), bare with no `v` prefix (`0.1.0`, `0.2.0`, ...). Bump rules for this benchmark repo: a **new dataset** or a **new benchmarked model** is a MINOR; a **methodology change** (anything that makes previously published numbers no longer comparable) or **completely new functionality** is a MAJOR; everything else (doc and slide fixes, chart or frontier regeneration, bug fixes, dependency bumps) is a PATCH.
+- Release notes live in [docs/release-notes/](docs/release-notes/), one file per version (`docs/release-notes/{version}.md`) plus a [docs/release-notes/README.md](docs/release-notes/README.md) index, newest first. The `media-assets` tag hosts asset attachments and is not a release: ignore it when finding the latest version.
+- Cut a release with the **`release-notes` skill** ([.claude/skills/release-notes/SKILL.md](.claude/skills/release-notes/SKILL.md)): it computes the bump from the change set, gathers commits, PRs and closed issues since the base version, writes the notes, runs the `security-check` gate, opens a PR (never commits to `main`), and tags the merge commit after the PR is merged.
 
 ## Scratchpad for planning and design
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Where to read more, by topic:
 | [docs/gpu-selection-h200-vs-l40s.md](docs/gpu-selection-h200-vs-l40s.md) | Which GPU to serve on: one H200 slice of a p5en vs a whole g6e.4xlarge (1x L40S), same model and config. Why the H200 slice is 41% cheaper per unit of work despite costing 2.6x per hour, and what it costs to serve N developers. Public on-demand prices, no discounts. |
 | [docs/cost-per-task-methodology.md](docs/cost-per-task-methodology.md) | How the cost numbers are derived: the two cost lenses, prompt-caching accounting (API vs self-hosted), and why agentic coding is prefill-bound. |
 | [docs/serving-optimization-notes.md](docs/serving-optimization-notes.md) | Portable vLLM serving defaults and why we do not tune the prefill knobs per model. |
+| [docs/release-notes/](docs/release-notes/) | Release notes per version, newest first, and the versioning scheme: new dataset or model is a minor, a methodology change or new functionality is a major. |
 | [CONTRIBUTING.md](CONTRIBUTING.md) / [SECURITY.md](SECURITY.md) / [SUPPORT.md](SUPPORT.md) | How to contribute, report a vulnerability, and get help. |
 
 ## See also

--- a/docs/model-selection-by-complexity.md
+++ b/docs/model-selection-by-complexity.md
@@ -1,6 +1,6 @@
 # Which model for which task? Reading the v2 results as a buying decision
 
-> **Not the headline result.** The reported run is the **[oh-my-pi](omp-setup.md)** (`omp`) harness with `/swe3` on the **v2** dataset -- 16 models, 21 tasks -- in [harness-omp-swe3.md](harness-omp-swe3.md). This page covers the complexity read of the v2 dataset from the 3-model pi run. Different task sets and harnesses, so the scores here do not compare with it.
+> **Not the headline result.** The reported run is the **[oh-my-pi](omp-setup.md)** (`omp`) harness with `/swe3` on the **v2** dataset -- 18 models, 21 tasks -- in [harness-omp-swe3.md](harness-omp-swe3.md). This page covers the complexity read of the v2 dataset from the 3-model pi run. Different task sets and harnesses, so the scores here do not compare with it.
 
 The [v2 dataset](../benchmarks/dataset/mcp-gateway-registry-v2.yaml) was built to answer a question a single leaderboard number cannot: **does the right model change with the difficulty of the work?**
 

--- a/docs/release-notes/0.1.0.md
+++ b/docs/release-notes/0.1.0.md
@@ -1,0 +1,112 @@
+# Release 0.1.0 - First tagged release
+
+**September 2026**
+
+Version bump: **first release.** This tag establishes the versioning convention for the repository. From here, a new dataset or a new benchmarked model is a MINOR release, a change in methodology or completely new functionality is a MAJOR release, and everything else is a PATCH. See [What each release will mean](#what-each-release-will-mean) below.
+
+---
+
+## What this repository is
+
+This repository measures how well a language model does real agentic coding work, and what that work costs. It does not test a model in the abstract: it drives a model through a **coding harness** (the CLI agent that plans, edits files, and runs commands) over a **dataset** of real coding tasks, on one of three **hosting paths**, and scores the result with an independent judge.
+
+So a result is always a triple: **harness x model x dataset.** Two benchmark types sit on top of that triple: a **quality** benchmark (can the model take a task from issue to a working patch, scored 0-100) and a **throughput and cost** benchmark (how much agentic load a self-hosted model sustains on a given GPU, and therefore what a task really costs).
+
+## Coding harnesses
+
+A model is only as good as the harness driving it, so we benchmark several and keep every run.
+
+**We have settled on `omp` (oh-my-pi) as the headline harness.** It drives the single-agent `/swe3` skill, and the reported results are omp on the `mcp-gateway-registry-v2` dataset. That is a deliberate choice, not the only one we support. The harness is a swappable part of the triple, and we run more than one on purpose so that a model's score can be read against the agent that produced it.
+
+Harnesses with published runs in this release:
+
+- **omp (oh-my-pi)** -- the headline harness, single-agent `/swe3` on the v2 dataset. Setup and the three ways it differs from `pi` are in [docs/omp-setup.md](../omp-setup.md).
+- **Claude Code** -- runs on both the single-agent `/swe3` and the multi-agent `/swe2` skills.
+- **pi** -- runs on `/swe3` and `/swe2`.
+- **kiro-cli** -- landed as a third harness ([#73](https://github.com/aarora79/agentic-coding-harness-benchmarks/issues/73)), `/swe3`, 5 models, driving Kiro's managed Bedrock-backed models on a distinct Kiro-credit cost basis. See [docs/kiro-cli-setup.md](../kiro-cli-setup.md).
+
+**We will keep adding harnesses as they come up.** [opencode](https://opencode.ai) is next ([#72](https://github.com/aarora79/agentic-coding-harness-benchmarks/issues/72)). The benchmark is built so a new harness slots into the same triple without disturbing existing results, because scores are held per (harness, skill, dataset) and never merged across them.
+
+## Models
+
+The headline omp / `/swe3` run measures **18 models** across the 21 tasks of the `mcp-gateway-registry-v2` dataset. Every score and cost below is from [docs/metrics/pareto-frontier-omp-swe3.json](../metrics/pareto-frontier-omp-swe3.json); the framing is from [docs/results-index.md](../results-index.md). Score is the mean judge score (0-100); cost is mean cost per task. The two cost bases do not compare as raw dollars -- a metered Bedrock bill against a hardware-derived self-hosted figure -- so read the models within each basis, per [docs/cost-per-task-methodology.md](../cost-per-task-methodology.md).
+
+### On Amazon Bedrock (Anthropic family)
+
+| Model | Score | Cost/task |
+|-------|-------|-----------|
+| claude-opus-5 | 82.83 | $11.95 |
+| claude-sonnet-5 | 76.97 | $4.67 |
+| claude-opus-4-7 | 75.60 | $7.35 |
+| claude-opus-4-8 | 74.69 | $5.32 |
+| claude-opus-4-6-v1 | 70.64 | $4.95 |
+| claude-opus-4-5 | 66.32 | $4.18 |
+| claude-haiku-4-5 | 56.18 | $0.76 |
+
+### Self-hosted open-weight (vLLM)
+
+| Model | Score | Cost/task |
+|-------|-------|-----------|
+| glm-5.3 | 80.11 | $7.04 |
+| kimi-k3 | 79.17 | $4.33 |
+| qwen3.8-27b | 78.48 | $1.47 |
+| kimi-k2.7-code | 69.13 | $2.47 |
+| deepseek-v3.2 | 61.66 | $2.15 |
+| minimax-m3 | 60.51 | $3.51 |
+| gemma-4-31b | 59.74 | $0.87 |
+| qwen3.6-35b | 59.24 | $0.26 |
+| minimax-m2.5 | 55.94 | $0.48 |
+| devstral-2-123b | 51.15 | $0.79 |
+| qwen3-coder-30b | 42.58 | $0.47 |
+
+The headline finding: **claude-opus-5 tops quality at 82.83 for $11.95 a task**, but the cheapest route into the high 70s is the open-weight **qwen3.8-27b at 78.48 for $1.47 a task** -- a 27B self-hosted model that outscores claude-sonnet-5 (76.97, $4.67) at under a third of the cost. At the low end, **qwen3.6-35b scores 59.24 for 26 cents a task.** Per-model serving guides (HF repo, context window, tensor-parallel size, tool-call parser, hardware fit) live in [self-hosted/vllm/models/](../../self-hosted/vllm/models/).
+
+## Datasets
+
+Four datasets ship in [benchmarks/dataset/](../../benchmarks/dataset/). Scores from different task sets never merge, because the tasks, refs, and difficulty mixes differ.
+
+- **`mcp-gateway-registry-v2`** -- the headline dataset: 21 tasks across four complexity tiers. Each task is a closed issue from [agentic-community/mcp-gateway-registry](https://github.com/agentic-community/mcp-gateway-registry), pinned to the release *before* the fix shipped, so the defect is present in the tree the agent clones.
+- **`mcp-gateway-registry`** (v1) -- the earlier 5-task set, kept as background.
+- **`hello-world`** -- a smoke-test task for verifying a harness and hosting path work end to end.
+- **`multi-repo-throughput`** -- the task set the throughput-and-cost sweep drives.
+
+## Hosting paths
+
+A model can run in three places, all measurable by the same harness:
+
+- **Path 1** -- Anthropic models on Amazon Bedrock (published).
+- **Path 2** -- open-weight models on Amazon Bedrock through the LiteLLM proxy ([works](../../benchmarks/docs/path-open-weight-on-bedrock-litellm.md), not yet run).
+- **Path 3** -- self-hosted open-weight models on a vLLM server on EC2 (published).
+
+## What each release will mean
+
+The "public interface" of this repository is its datasets, its measured models, and its measurement methodology. Versions follow [Semantic Versioning](https://semver.org), bare, with no `v` prefix:
+
+- **MAJOR** -- a methodology change, or completely new functionality. A methodology change makes previously published numbers no longer comparable, which is the clearest reason to bump MAJOR.
+- **MINOR** -- a new dataset, or a new model added to the frontier.
+- **PATCH** -- everything else, backward compatible: doc and slide fixes, chart or frontier regeneration for an existing model, bug fixes, dependency bumps.
+
+Releases are cut with the [release-notes skill](../../.claude/skills/release-notes/SKILL.md), which computes the bump from the change set, gathers the changes, writes the notes, and tags the merge commit through a PR.
+
+## Getting started
+
+This repository is cloned and run, not deployed. There is nothing to upgrade from at `0.1.0`:
+
+```bash
+git clone https://github.com/aarora79/agentic-coding-harness-benchmarks
+cd agentic-coding-harness-benchmarks
+git checkout 0.1.0
+
+# Sync whichever uv project you run:
+cd benchmarks && uv sync && cd ..
+cd self-hosted/vllm && uv sync && cd ../..
+```
+
+On a fresh box, run the `setup-machine` skill first: it inspects the instance, names every missing dependency, and installs it. The guided tour from a checkout to a first run is [docs/getting-started.md](../getting-started.md).
+
+## Contributors
+
+Thank you to everyone who contributed to this release:
+
+- **Amit Arora** ([@aarora79](https://github.com/aarora79))
+- **Prateek Sinha** ([@shekharprateek](https://github.com/shekharprateek))

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -1,0 +1,11 @@
+# Release notes
+
+Every tagged release, newest first. Versions follow [Semantic Versioning](https://semver.org), bare with no `v` prefix. A new dataset or a new benchmarked model is a MINOR release; a methodology change or completely new functionality is a MAJOR release; everything else is a PATCH. Releases are cut with the [release-notes skill](../../.claude/skills/release-notes/SKILL.md).
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| [0.1.0](0.1.0.md) | September 2026 | First tagged release: the harness x model x dataset benchmark, 18 models on the omp / `/swe3` headline run, four datasets, three hosting paths. |
+
+---
+
+[< Back to the README](../../README.md)

--- a/docs/results-index.md
+++ b/docs/results-index.md
@@ -3,7 +3,7 @@
 The headline run, and every earlier run kept as background. Results are held per (harness, skill, dataset), and scores from different task sets do not merge.
 
 
-The headline run is the **omp** harness driving the single-agent `/swe3` skill over the **`mcp-gateway-registry-v2`** dataset: 21 tasks, 16 models, every task scored 0-100 by an independent judge. Each task comes from a closed issue in [agentic-community/mcp-gateway-registry](https://github.com/agentic-community/mcp-gateway-registry), pinned to the release *before* the fix shipped, so the defect is present in the tree the agent clones. The tasks span four complexity tiers, so the results split by how hard the work is.
+The headline run is the **omp** harness driving the single-agent `/swe3` skill over the **`mcp-gateway-registry-v2`** dataset: 21 tasks, 18 models, every task scored 0-100 by an independent judge. Each task comes from a closed issue in [agentic-community/mcp-gateway-registry](https://github.com/agentic-community/mcp-gateway-registry), pinned to the release *before* the fix shipped, so the defect is present in the tree the agent clones. The tasks span four complexity tiers, so the results split by how hard the work is.
 
 This repo also holds earlier runs on other harnesses, skills and datasets -- Claude Code and pi on the 5-task v1 dataset, kiro-cli, and the multi-agent `/swe2` skill. Those stay published as background. They use different task sets, so their scores do not line up with the table below and must not be merged into it.
 
@@ -11,11 +11,11 @@ This repo also holds earlier runs on other harnesses, skills and datasets -- Cla
 
 > **What is a Pareto frontier, and what does it mean here?** The frontier is the set of models where **no other model is both higher-scoring _and_ cheaper**. Those are the only models worth considering; everything else is *dominated*, so there is never a reason to pick it. From this chart: **`qwen3.8-27b` (78.48, $1.47/task) dominates `claude-sonnet-5` (76.97, $4.67/task)** -- a 27B open-weight model outscores a frontier API model at under a third of the cost. Read it in two steps: pick the quality you need on the y-axis, then take the cheapest model on the frontier at that level. Costs come in two bases that do not compare as raw dollars -- metered Bedrock bills against hardware-derived self-hosted figures -- so the results docs also draw the frontier within each basis.
 
-**claude-opus-5 tops quality at 82.83 for $11.95 a task.** `glm-5.3` comes within 1.6 points at 81.27 for $8.09. The cheapest way to reach the high 70s is `qwen3.8-27b`: 78.48 for **$1.47 a task**. At the other end, `qwen3.6-35b` scores 59.24 for **26 cents**. Every self-hosted figure is priced on one basis -- the p5en.48xlarge sweep -- so the fleet compares like for like even where a model was served on a smaller box; a figure is the cost of that model's work on p5en, not a quote for the box it ran on.
+**claude-opus-5 tops quality at 82.83 for $11.95 a task.** `glm-5.3` comes within 2.7 points at 80.11 for $7.04. The cheapest way to reach the high 70s is `qwen3.8-27b`: 78.48 for **$1.47 a task**. At the other end, `qwen3.6-35b` scores 59.24 for **26 cents**. Every self-hosted figure is priced on one basis -- the p5en.48xlarge sweep -- so the fleet compares like for like even where a model was served on a smaller box; a figure is the cost of that model's work on p5en, not a quote for the box it ran on.
 
 Within the metered Bedrock rows alone the frontier is `claude-haiku-4-5` ($0.76, 56.18), `claude-opus-4-5` ($4.18, 66.32), `claude-sonnet-5` ($4.67, 76.97) and `claude-opus-5` ($11.95, 82.83). Three Opus builds fall off it: Sonnet 5 beats `claude-opus-4-7` (75.60, $7.35), `claude-opus-4-8` (74.69, $5.32) and `claude-opus-4-6-v1` (70.64, $4.95) on score and on price.
 
-- **[omp harness, /swe3, v2 dataset](harness-omp-swe3.md)** -- the headline table above, 16 models, with the quality radar and the cost-accuracy view.
+- **[omp harness, /swe3, v2 dataset](harness-omp-swe3.md)** -- the headline table above, 18 models, with the quality radar and the cost-accuracy view.
 - **[Which model for which task?](model-selection-by-complexity.md)** -- what a model upgrade buys you at each difficulty tier.
 - **[Cost per task, and why the two bases differ](cost-per-task-methodology.md)** -- how a fixed instance price becomes a cost per token and per task.
 

--- a/docs/results-swe3-v2.md
+++ b/docs/results-swe3-v2.md
@@ -1,6 +1,6 @@
 # Results -- `/swe3` on the v2 dataset (release-sourced, complexity-balanced)
 
-> **Not the headline result.** The reported run is the **[oh-my-pi](omp-setup.md)** (`omp`) harness with `/swe3` on the **v2** dataset -- 16 models, 21 tasks -- in [harness-omp-swe3.md](harness-omp-swe3.md). This page covers the same v2 dataset under the **pi** harness, 3 models. Different task sets and harnesses, so the scores here do not compare with it.
+> **Not the headline result.** The reported run is the **[oh-my-pi](omp-setup.md)** (`omp`) harness with `/swe3` on the **v2** dataset -- 18 models, 21 tasks -- in [harness-omp-swe3.md](harness-omp-swe3.md). This page covers the same v2 dataset under the **pi** harness, 3 models. Different task sets and harnesses, so the scores here do not compare with it.
 
 Three models, 21 tasks each, on the **pi** harness with the single-agent [`/swe3`](../.claude/skills/swe3/SKILL.md) skill, scored by the codex judge (`openai.gpt-5.6-sol`, high effort).
 

--- a/docs/results-swe3.md
+++ b/docs/results-swe3.md
@@ -1,6 +1,6 @@
 # Results -- /swe3 (single-agent skill)
 
-> **Not the headline result.** The reported run is the **[oh-my-pi](omp-setup.md)** (`omp`) harness with `/swe3` on the **v2** dataset -- 16 models, 21 tasks -- in [harness-omp-swe3.md](harness-omp-swe3.md). This page covers the v1 dataset (5 tasks) under the pi harness. Different task sets and harnesses, so the scores here do not compare with it.
+> **Not the headline result.** The reported run is the **[oh-my-pi](omp-setup.md)** (`omp`) harness with `/swe3` on the **v2** dataset -- 18 models, 21 tasks -- in [harness-omp-swe3.md](harness-omp-swe3.md). This page covers the v1 dataset (5 tasks) under the pi harness. Different task sets and harnesses, so the scores here do not compare with it.
 
 Full benchmark results for the **`/swe3`** skill (the single-agent variant -- one agent loop, no sub-agent fan-out) on [agentic-community/mcp-gateway-registry](https://github.com/agentic-community/mcp-gateway-registry) at tag `1.24.4`: **5 tasks**, each scored 0-100 by an independent LLM judge (`codex exec`, `gpt-5.6-sol`, high reasoning effort). The multi-agent `/swe2` numbers live in [results-swe2.md](results-swe2.md).
 

--- a/vend/swe-router/models.json
+++ b/vend/swe-router/models.json
@@ -2,9 +2,9 @@
   "schema_version": "1.0",
   "generated_by": "benchmarks/scripts/build_vended_models.py",
   "provenance": {
-    "measured_on": "2026-09-08",
+    "measured_on": "2026-09-09",
     "source_file": "docs/metrics/pareto-frontier-omp-swe3.json",
-    "source_commit": "25a080d",
+    "source_commit": "14540cf",
     "harness": "omp",
     "skill": "swe3",
     "dataset": "mcp-gateway-registry-v2",


### PR DESCRIPTION
## What this does

Adds a `release-notes` skill and the repository's first release notes, and establishes the versioning scheme.

### Release-notes skill
A new `.claude/skills/release-notes/SKILL.md` that cuts a release end to end. It computes the correct semver bump from the change set, gathers commits, PRs and closed issues since the base version, writes the notes in the project format, runs the `security-check` gate, opens a PR (this repo never commits to `main` directly), and tags the merge commit after the PR is merged. It is adapted to this repo, not a copy of the gateway version: no Docker/Helm/Terraform upgrade path, the test-suite verification gate replaces a live smoke test, and the config-diff surface is `runner_config.py` / `runner.example.yaml` / `pricing.json`.

### Versioning scheme
Bare semver, no `v` prefix. Bump rules for this benchmark repo:

- **MAJOR**: a methodology change (previously published numbers stop being comparable) or completely new functionality.
- **MINOR**: a new dataset or a new benchmarked model.
- **PATCH**: everything else, backward compatible (doc and slide fixes, chart or frontier regeneration, bug fixes, dependency bumps).

Documented in a new `docs/release-notes/README.md` index, wired into the root README documentation map, and captured in a new "Releases and versioning" section of `AGENTS.md`.

### First release notes (0.1.0)
`docs/release-notes/0.1.0.md` covers the harness x model x dataset benchmark: the `omp` (oh-my-pi) headline harness alongside the other supported harnesses (Claude Code, pi, kiro-cli, with opencode next), the 18 models on the omp/swe3 frontier, the four datasets, and the three hosting paths. Every number is cited to its source (`docs/metrics/pareto-frontier-omp-swe3.json`, `docs/results-index.md`).

### Stale count corrections
The minimax-m3 merge (#179) bumped the frontier JSON and decks to 18 models but left the prose at 16. This corrects the omp/swe3 headline model count (16 to 18) in `results-index.md`, `results-swe3.md`, `results-swe3-v2.md` and `model-selection-by-complexity.md`, and refreshes the glm-5.3 headline figure to match the current frontier JSON. The v1/pi "16 models" reference and the combined-chart count in `best-harness-selection.md` are different counts and left unchanged.

## Notes
- No code, config, or dependency changes; documentation only. The `security-check` gate passed with an APPROVED verdict.
- No git tag is created by this PR. Per the skill, `0.1.0` is tagged on the merge commit after this PR merges.