### PR TITLE
fix(pricing): price Qwen on Bedrock, and stop a cacheless model costing zero

### DIFF
--- a/benchmarks/scripts/bedrock_pricing.py
+++ b/benchmarks/scripts/bedrock_pricing.py
@@ -4,12 +4,21 @@ Used by the codex agent path to derive total_cost_usd from token counts,
 since codex exec does not report a billed cost itself.
 
 Provenance of the rates:
-- Rates were read directly from https://aws.amazon.com/bedrock/pricing/ on 2026-08-31.
-- Tier: Global CRIS (cross-region inference, global profile) — the tier used
-  by codex exec routing through bedrock-mantle.
-- Context window tier: Long Context Window (1M) — confirmed from actual run
-  token counts (all tasks exceeded 272K input tokens).
+- Rates were read directly from https://aws.amazon.com/bedrock/pricing/ on the
+  date in ``PRICES_AS_OF``.
+- Tier: Standard (on-demand). For the openai.* rows this is the Global CRIS
+  (cross-region inference, global profile) Long Context Window (1M) table, the
+  tier codex exec uses when it routes through bedrock-mantle; the run token
+  counts confirmed it (all tasks exceeded 272K input tokens).
 - Cache write is the 30-minute TTL rate.
+
+Not every model on Bedrock supports prompt caching. Qwen does not: a Converse
+call carrying a ``cachePoint`` block is rejected with ``AccessDeniedException:
+You invoked an unsupported model or your request did not allow prompt
+caching``, and the pricing page publishes only input and output columns for
+those models. Such a row omits ``cache_read`` / ``cache_write`` entirely, and
+``cost_usd`` returns None if a caller ever reports cached tokens against it,
+rather than pricing them at zero and understating the bill.
 
 All prices are per 1M tokens in USD.
 
@@ -20,7 +29,9 @@ Public API:
 
 from __future__ import annotations
 
-PRICES_AS_OF = "2026-08-31"
+import re
+
+PRICES_AS_OF = "2026-09-11"
 
 # USD per 1M tokens — Global CRIS, Long Context Window (1M), Standard tier.
 # Sourced from https://aws.amazon.com/bedrock/pricing/ on PRICES_AS_OF.
@@ -39,24 +50,57 @@ PRICES: dict[str, dict[str, float]] = {
         "cache_read": 0.04,
         "output": 1.80,
     },
+    # Qwen3 Coder 30B A3B — Standard tier. No cache keys: Bedrock refuses a
+    # cachePoint for this family, so a cached-token count here is a bug, not a
+    # discount. Flex and Batch are both $0.0773 / $0.3090, Priority is
+    # $0.2704 / $1.0815, if a run ever uses another tier.
+    "qwen.qwen3-coder-30b-a3b": {
+        "input": 0.1545,
+        "output": 0.6180,
+    },
 }
 
 _PER_1M = 1_000_000.0
 
 
-def _rates(model: str) -> dict[str, float] | None:
-    """Return the price row for a model id, or None if unknown.
+def _normalize(model: str) -> str:
+    """Return a model id reduced to its price-table key.
 
-    Matching strips any 'us.' or 'global.' inference-profile prefix so both
-    'openai.gpt-5.6-terra' and 'us.openai.gpt-5.6-terra' resolve correctly.
+    Three spellings of one model reach this module, and all must price the
+    same: the inference-profile form (``us.openai.gpt-5.6-terra``), the raw
+    Bedrock id with its version suffix (``qwen.qwen3-coder-30b-a3b-v1:0``), and
+    the LiteLLM alias the harness records as ``--model``
+    (``qwen.qwen3-coder-30b-a3b-instruct``). Without the last two a priced
+    model still yields a null cost, which reads as a free run.
+
+    Args:
+        model: The model id in any of those spellings.
+
+    Returns:
+        The bare key: prefix, version suffix and ``-instruct`` removed.
     """
-    # Strip common inference-profile prefixes
     clean = model
     for prefix in ("us.", "global.", "eu.", "ap."):
         if clean.startswith(prefix):
             clean = clean[len(prefix) :]
             break
-    return PRICES.get(clean) or PRICES.get(model)
+    # Bedrock version suffixes: '-v1:0', ':0', '-v2:1'.
+    clean = re.sub(r"(-v\d+)?:\d+$", "", clean)
+    if clean.endswith("-instruct"):
+        clean = clean[: -len("-instruct")]
+    return clean
+
+
+def _rates(model: str) -> dict[str, float] | None:
+    """Return the price row for a model id, or None if unknown.
+
+    Args:
+        model: The model id, in any spelling ``_normalize`` accepts.
+
+    Returns:
+        The rate row, or None when the model is not in the table.
+    """
+    return PRICES.get(_normalize(model)) or PRICES.get(model)
 
 
 def cost_usd(
@@ -79,15 +123,24 @@ def cost_usd(
         cache_write_tokens: Tokens written to cache (cache write).
 
     Returns:
-        Total cost in USD, or None if the model is not priced.
+        Total cost in USD, or None if the model is not priced, or if cached
+        tokens are reported against a model whose row carries no cache rate
+        (a caching-incapable model such as Qwen: pricing those at zero would
+        understate the bill and cannot be told apart from a real free run).
     """
     rates = _rates(model)
     if rates is None:
         return None
+    for tokens, key in (
+        (cache_read_tokens, "cache_read"),
+        (cache_write_tokens, "cache_write"),
+    ):
+        if tokens and key not in rates:
+            return None
     total = (
         input_tokens * rates["input"] / _PER_1M
         + output_tokens * rates["output"] / _PER_1M
-        + cache_read_tokens * rates["cache_read"] / _PER_1M
-        + cache_write_tokens * rates["cache_write"] / _PER_1M
+        + cache_read_tokens * rates.get("cache_read", 0.0) / _PER_1M
+        + cache_write_tokens * rates.get("cache_write", 0.0) / _PER_1M
     )
     return round(total, 6)

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 13,
+      "specificity": 17,
+      "risk_awareness": 11,
+      "total": 58,
+      "notes": "The issue clearly states the reproducibility problem, proposes lock generation plus CI enforcement, and supplies concrete commands and non-goals. Its largest correctness flaw is claiming `uv sync --frozen` detects a stale lock; uv documents that frozen mode deliberately skips freshness checks, unlike `--locked`. ([docs.astral.sh](https://docs.astral.sh/uv/reference/cli/)) Repository release evidence also identifies `docker/Dockerfile.mcp-server-light` as a build path for currenttime, fininfo, and realserverfaketools, but the issue never inventories these image paths. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) With no independent task statement, the claim that exactly three server directories lack locks could not be confirmed, and “run exactly as before” is not a precise acceptance oracle."
+    },
+    "lld": {
+      "completeness": 9,
+      "correctness": 7,
+      "specificity": 10,
+      "risk_awareness": 6,
+      "total": 32,
+      "notes": "The design's strongest aspect is naming real integration points such as `docker/Dockerfile.auth`, `docker/Dockerfile.registry`, `auth_server/pyproject.toml`, and specific server directories. Its largest deficiency is omitting `docker/Dockerfile.mcp-server-light`, which repository release documentation says builds three of the listed server images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The repository uses multi-stage image builds, yet the LLD never decides where `uv sync` installs the environment, what is copied into runtime stages, whether dev dependencies are excluded, or how each lock enters the build context. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The CI target remains an unresolved wildcard, the file-change table omits the workflow change, and the stated stale-lock failure behavior is incorrect for `--frozen`. ([docs.astral.sh](https://docs.astral.sh/uv/reference/cli/))"
+    },
+    "review": {
+      "completeness": 9,
+      "correctness": 9,
+      "specificity": 8,
+      "risk_awareness": 10,
+      "total": 36,
+      "notes": "The SRE section usefully raises directory coverage and the future-subproject discovery problem, while the backend section calls for build-time and runtime validation. The review's largest failure is approving the design without noticing that it omits the shared lightweight server Dockerfile and leaves multi-stage environment copying undefined. Repository evidence shows that omitted Dockerfile builds currenttime, fininfo, and realserverfaketools, directly contradicting the claim that all affected build paths are addressed. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The security discussion drifts into unsigned-package and scanning recommendations without tying them to this change, and the review never prioritizes a concrete blocker or challenges the false `--frozen` freshness claim."
+    },
+    "testing": {
+      "completeness": 8,
+      "correctness": 4,
+      "specificity": 8,
+      "risk_awareness": 7,
+      "total": 27,
+      "notes": "The plan includes positive builds, a negative lock check, compatibility smoke testing, and deployment considerations. Its central negative test is invalid: appending a comment to `auth_server/pyproject.toml` does not change dependency metadata, and `uv lock --check` is then run from the repository root rather than `auth_server`, so the expected failure is unsupported. It builds only the auth and registry Dockerfiles despite repository evidence that a shared lightweight Dockerfile builds three server images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The two-build reproducibility assertion has no digest or dependency oracle, while `docker ps` provides no service-health, endpoint, or runtime-import validation."
+    },
+    "implementation": {
+      "completeness": 4,
+      "correctness": 1,
+      "specificity": 5,
+      "risk_awareness": 2,
+      "total": 12,
+      "notes": "The visible patch adds an auth lockfile and CI workflow material, but it does not establish an end-to-end working implementation. Both workflows `cd` into a harness-specific `/tmp/swe-clone-build-docker-images-from-uv-lock/mcp-gateway-registry` path that will not be the GitHub Actions checkout path, so their checks fail before validating any lock. The summary claims one 22-line workflow while the diff adds two workflows of 44 and 40 lines, omits the second file entirely, leaves “How to Apply” empty, and falsely reports generated lockfiles as zero-line additions. The submitted diff is explicitly truncated before the claimed Dockerfile and remaining lockfile hunks, preventing application or source-context verification; the summary also names no change to the repository's shared lightweight server Dockerfile despite its use for three built images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases))"
+    }
+  },
+  "task_score": 33.0,
+  "verdict": "The submission identifies the correct reproducibility goal, but the design misses real shared image-build paths and the submitted implementation contains nonfunctional CI and cannot be verified end to end.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T17:51:56.917789Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 624983,
+      "cached_input_tokens": 456935,
+      "cache_write_input_tokens": 116840,
+      "output_tokens": 11731,
+      "reasoning_output_tokens": 9698
+    },
+    "duration_ms": 172611
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/build-docker-images-from-uv-lock/metrics.json
@@ -1,0 +1,177 @@
+{
+  "task": "build-docker-images-from-uv-lock",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "docker",
+    "build",
+    "uv",
+    "dependencies",
+    "reproducibility",
+    "ci",
+    "fixed-in-1.24.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 137.7,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1963348,
+    "output_tokens": 13940,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1977288,
+    "total_cost_usd": 0.311952,
+    "latency_seconds": 101.2,
+    "num_turns": 96,
+    "generation_tokens_per_sec": 137.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 1963348,
+  "output_tokens": 13940,
+  "latency_seconds": 101.2,
+  "num_turns": 96,
+  "total_cost_usd": 0.311952,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:30:32.159575Z",
+  "run_ended_at": "2026-09-11T16:32:13.313759Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1963348,
+    "output_tokens": 13940,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1977288,
+    "total_cost_usd": 0.311952,
+    "latency_seconds": 101.2,
+    "num_turns": 96,
+    "generation_tokens_per_sec": 137.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "build-docker-images-from-uv-lock",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 13,
+        "specificity": 17,
+        "risk_awareness": 11,
+        "total": 58,
+        "notes": "The issue clearly states the reproducibility problem, proposes lock generation plus CI enforcement, and supplies concrete commands and non-goals. Its largest correctness flaw is claiming `uv sync --frozen` detects a stale lock; uv documents that frozen mode deliberately skips freshness checks, unlike `--locked`. ([docs.astral.sh](https://docs.astral.sh/uv/reference/cli/)) Repository release evidence also identifies `docker/Dockerfile.mcp-server-light` as a build path for currenttime, fininfo, and realserverfaketools, but the issue never inventories these image paths. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) With no independent task statement, the claim that exactly three server directories lack locks could not be confirmed, and “run exactly as before” is not a precise acceptance oracle."
+      },
+      "lld": {
+        "completeness": 9,
+        "correctness": 7,
+        "specificity": 10,
+        "risk_awareness": 6,
+        "total": 32,
+        "notes": "The design's strongest aspect is naming real integration points such as `docker/Dockerfile.auth`, `docker/Dockerfile.registry`, `auth_server/pyproject.toml`, and specific server directories. Its largest deficiency is omitting `docker/Dockerfile.mcp-server-light`, which repository release documentation says builds three of the listed server images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The repository uses multi-stage image builds, yet the LLD never decides where `uv sync` installs the environment, what is copied into runtime stages, whether dev dependencies are excluded, or how each lock enters the build context. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The CI target remains an unresolved wildcard, the file-change table omits the workflow change, and the stated stale-lock failure behavior is incorrect for `--frozen`. ([docs.astral.sh](https://docs.astral.sh/uv/reference/cli/))"
+      },
+      "review": {
+        "completeness": 9,
+        "correctness": 9,
+        "specificity": 8,
+        "risk_awareness": 10,
+        "total": 36,
+        "notes": "The SRE section usefully raises directory coverage and the future-subproject discovery problem, while the backend section calls for build-time and runtime validation. The review's largest failure is approving the design without noticing that it omits the shared lightweight server Dockerfile and leaves multi-stage environment copying undefined. Repository evidence shows that omitted Dockerfile builds currenttime, fininfo, and realserverfaketools, directly contradicting the claim that all affected build paths are addressed. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The security discussion drifts into unsigned-package and scanning recommendations without tying them to this change, and the review never prioritizes a concrete blocker or challenges the false `--frozen` freshness claim."
+      },
+      "testing": {
+        "completeness": 8,
+        "correctness": 4,
+        "specificity": 8,
+        "risk_awareness": 7,
+        "total": 27,
+        "notes": "The plan includes positive builds, a negative lock check, compatibility smoke testing, and deployment considerations. Its central negative test is invalid: appending a comment to `auth_server/pyproject.toml` does not change dependency metadata, and `uv lock --check` is then run from the repository root rather than `auth_server`, so the expected failure is unsupported. It builds only the auth and registry Dockerfiles despite repository evidence that a shared lightweight Dockerfile builds three server images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The two-build reproducibility assertion has no digest or dependency oracle, while `docker ps` provides no service-health, endpoint, or runtime-import validation."
+      },
+      "implementation": {
+        "completeness": 4,
+        "correctness": 1,
+        "specificity": 5,
+        "risk_awareness": 2,
+        "total": 12,
+        "notes": "The visible patch adds an auth lockfile and CI workflow material, but it does not establish an end-to-end working implementation. Both workflows `cd` into a harness-specific `/tmp/swe-clone-build-docker-images-from-uv-lock/mcp-gateway-registry` path that will not be the GitHub Actions checkout path, so their checks fail before validating any lock. The summary claims one 22-line workflow while the diff adds two workflows of 44 and 40 lines, omits the second file entirely, leaves “How to Apply” empty, and falsely reports generated lockfiles as zero-line additions. The submitted diff is explicitly truncated before the claimed Dockerfile and remaining lockfile hunks, preventing application or source-context verification; the summary also names no change to the repository's shared lightweight server Dockerfile despite its use for three built images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases))"
+      }
+    },
+    "task_score": 33.0,
+    "verdict": "The submission identifies the correct reproducibility goal, but the design misses real shared image-build paths and the submitted implementation contains nonfunctional CI and cannot be verified end to end.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T17:51:56.917789Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 624983,
+        "cached_input_tokens": 456935,
+        "cache_write_input_tokens": 116840,
+        "output_tokens": 11731,
+        "reasoning_output_tokens": 9698
+      },
+      "duration_ms": 172611
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/eval.json
@@ -1,0 +1,60 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    },
+    "lld": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    },
+    "review": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    },
+    "testing": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    }
+  },
+  "task_score": 0.0,
+  "verdict": "MODEL FAILURE: the candidate run did not produce the required artifact(s): github-issue.md, lld.md, review.md, testing.md. Scored 0.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": false,
+    "scored_zero_missing_artifacts": [
+      "github-issue.md",
+      "lld.md",
+      "review.md",
+      "testing.md"
+    ],
+    "evaluated_at": "2026-09-11T17:51:56.927339Z"
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/cli-custom-egress-oauth-provider-flags/metrics.json
@@ -1,0 +1,175 @@
+{
+  "task": "cli-custom-egress-oauth-provider-flags",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "cli",
+    "python",
+    "egress-auth",
+    "oauth",
+    "api-parity",
+    "fixed-in-1.29.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 0,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 38.2,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3519965,
+    "output_tokens": 15275,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 3535240,
+    "total_cost_usd": 0.553275,
+    "latency_seconds": 213.5,
+    "num_turns": 187,
+    "generation_tokens_per_sec": 38.2,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 3519965,
+  "output_tokens": 15275,
+  "latency_seconds": 213.5,
+  "num_turns": 187,
+  "total_cost_usd": 0.553275,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:40:21.632142Z",
+  "run_ended_at": "2026-09-11T16:41:26.353321Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3519965,
+    "output_tokens": 15275,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 3535240,
+    "total_cost_usd": 0.553275,
+    "latency_seconds": 213.5,
+    "num_turns": 187,
+    "generation_tokens_per_sec": 38.2,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "agent_invocations": 2,
+  "topped_up_artifacts": [],
+  "evaluation": {
+    "task": "cli-custom-egress-oauth-provider-flags",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      },
+      "lld": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      },
+      "review": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      },
+      "testing": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      }
+    },
+    "task_score": 0.0,
+    "verdict": "MODEL FAILURE: the candidate run did not produce the required artifact(s): github-issue.md, lld.md, review.md, testing.md. Scored 0.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": false,
+      "scored_zero_missing_artifacts": [
+        "github-issue.md",
+        "lld.md",
+        "review.md",
+        "testing.md"
+      ],
+      "evaluated_at": "2026-09-11T17:51:56.927339Z"
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 19,
+      "specificity": 20,
+      "risk_awareness": 16,
+      "total": 75,
+      "notes": "The issue clearly states the hardcoded 30-second problem and provides testable criteria for the default, override, minimum, UI exposure, documentation, and tests. The supplied patch context corroborates the `httpx.AsyncClient(timeout=30.0)` baseline in `auth_server/server.py`. Its main gap is limited operational risk treatment: it does not discuss unbounded timeout values or resource occupancy from long-running requests. With no independent task statement, related issue `#1320` and the full required deployment surface remain unverifiable."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 10,
+      "specificity": 14,
+      "risk_awareness": 10,
+      "total": 48,
+      "notes": "The LLD identifies concrete integration points in `auth_server/server.py`, `registry/core/config.py`, and `registry/api/config_routes.py`, all of which appear in the submitted baseline diff context. Its largest technical flaw is inconsistent validation: the typed `BaseSettings` field has no `ge=1` constraint, so an invalid environment value may fail settings construction before the proposed runtime fallback executes. Terraform, Helm, and Compose work is left as a generic checklist without verified paths or schemas, while metrics and info logging are proposed but absent from the file-change plan. The minimum remains an open question, and the claimed deployment surfaces could not be verified from the available repository access."
+    },
+    "review": {
+      "completeness": 11,
+      "correctness": 10,
+      "specificity": 10,
+      "risk_awareness": 10,
+      "total": 41,
+      "notes": "The review usefully calls out deployment wiring, UI units, and minimum-value test coverage. It nevertheless mostly approves the design and misses its central validation inconsistency, lack of a maximum, placeholder deployment paths, and unsupported observability commitments. The security section asks whether sub-one values are rejected even though the LLD explicitly clamps them, and the SRE section declares a blocker without resolving exact Terraform or Helm changes. Claims that the approach completely preserves compatibility and matches repository deployment practices remain insufficiently verified."
+    },
+    "testing": {
+      "completeness": 10,
+      "correctness": 5,
+      "specificity": 8,
+      "risk_awareness": 9,
+      "total": 32,
+      "notes": "The plan spans defaults, overrides, minimum handling, compatibility, UI, deployment, timeout failure, and rollback. Its primary functional override command sets `MCP_PROXY_UPSTREAM_TIMEOUT` only for the `curl` process, not the already-running gateway, so it cannot test server configuration. It provides no controlled delayed upstream or precise elapsed-time and response oracle, and the promised unit tests are only a checklist item. The exact `/mcp-proxy` invocation, token-file path, and invented `mcpProxy.upstreamTimeout` Helm key were not established by the submitted repository evidence."
+    },
+    "implementation": {
+      "completeness": 4,
+      "correctness": 0,
+      "specificity": 7,
+      "risk_awareness": 3,
+      "total": 14,
+      "notes": "The patch attempts the central setting, helper, client wiring, admin exposure, and `.env.example` update. However, `server.py` inserts a top-level function immediately after `if not group_mappings:` without an indented suite, while `config.py` inserts a field declaration inside the unfinished `mcp_proxy_max_body_bytes = Field(` call; both are parser-level syntax errors. The application therefore cannot import, and tests plus the LLD's deployment updates are absent. The summary's claim of exact implementation and successful examination is contradicted by the diff, while exact `git apply --check` verification was unavailable because repository shell access failed."
+    }
+  },
+  "task_score": 42.0,
+  "verdict": "The design establishes a useful direction, but the submitted implementation is unusable because its two core Python edits are syntactically invalid.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T17:53:48.530205Z",
+    "repo_ref": "1.25.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 172471,
+      "cached_input_tokens": 80420,
+      "cache_write_input_tokens": 24163,
+      "output_tokens": 8101,
+      "reasoning_output_tokens": 5875
+    },
+    "duration_ms": 111591
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/configurable-mcp-proxy-upstream-timeout/metrics.json
@@ -1,0 +1,177 @@
+{
+  "task": "configurable-mcp-proxy-upstream-timeout",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.25.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "config",
+    "auth-server",
+    "httpx",
+    "proxy",
+    "timeouts",
+    "fixed-in-1.26.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 132.1,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2459068,
+    "output_tokens": 12907,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2471975,
+    "total_cost_usd": 0.387903,
+    "latency_seconds": 97.7,
+    "num_turns": 118,
+    "generation_tokens_per_sec": 132.1,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2459068,
+  "output_tokens": 12907,
+  "latency_seconds": 97.7,
+  "num_turns": 118,
+  "total_cost_usd": 0.387903,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:48:58.155065Z",
+  "run_ended_at": "2026-09-11T16:50:35.852744Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2459068,
+    "output_tokens": 12907,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2471975,
+    "total_cost_usd": 0.387903,
+    "latency_seconds": 97.7,
+    "num_turns": 118,
+    "generation_tokens_per_sec": 132.1,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "configurable-mcp-proxy-upstream-timeout",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 19,
+        "specificity": 20,
+        "risk_awareness": 16,
+        "total": 75,
+        "notes": "The issue clearly states the hardcoded 30-second problem and provides testable criteria for the default, override, minimum, UI exposure, documentation, and tests. The supplied patch context corroborates the `httpx.AsyncClient(timeout=30.0)` baseline in `auth_server/server.py`. Its main gap is limited operational risk treatment: it does not discuss unbounded timeout values or resource occupancy from long-running requests. With no independent task statement, related issue `#1320` and the full required deployment surface remain unverifiable."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 10,
+        "specificity": 14,
+        "risk_awareness": 10,
+        "total": 48,
+        "notes": "The LLD identifies concrete integration points in `auth_server/server.py`, `registry/core/config.py`, and `registry/api/config_routes.py`, all of which appear in the submitted baseline diff context. Its largest technical flaw is inconsistent validation: the typed `BaseSettings` field has no `ge=1` constraint, so an invalid environment value may fail settings construction before the proposed runtime fallback executes. Terraform, Helm, and Compose work is left as a generic checklist without verified paths or schemas, while metrics and info logging are proposed but absent from the file-change plan. The minimum remains an open question, and the claimed deployment surfaces could not be verified from the available repository access."
+      },
+      "review": {
+        "completeness": 11,
+        "correctness": 10,
+        "specificity": 10,
+        "risk_awareness": 10,
+        "total": 41,
+        "notes": "The review usefully calls out deployment wiring, UI units, and minimum-value test coverage. It nevertheless mostly approves the design and misses its central validation inconsistency, lack of a maximum, placeholder deployment paths, and unsupported observability commitments. The security section asks whether sub-one values are rejected even though the LLD explicitly clamps them, and the SRE section declares a blocker without resolving exact Terraform or Helm changes. Claims that the approach completely preserves compatibility and matches repository deployment practices remain insufficiently verified."
+      },
+      "testing": {
+        "completeness": 10,
+        "correctness": 5,
+        "specificity": 8,
+        "risk_awareness": 9,
+        "total": 32,
+        "notes": "The plan spans defaults, overrides, minimum handling, compatibility, UI, deployment, timeout failure, and rollback. Its primary functional override command sets `MCP_PROXY_UPSTREAM_TIMEOUT` only for the `curl` process, not the already-running gateway, so it cannot test server configuration. It provides no controlled delayed upstream or precise elapsed-time and response oracle, and the promised unit tests are only a checklist item. The exact `/mcp-proxy` invocation, token-file path, and invented `mcpProxy.upstreamTimeout` Helm key were not established by the submitted repository evidence."
+      },
+      "implementation": {
+        "completeness": 4,
+        "correctness": 0,
+        "specificity": 7,
+        "risk_awareness": 3,
+        "total": 14,
+        "notes": "The patch attempts the central setting, helper, client wiring, admin exposure, and `.env.example` update. However, `server.py` inserts a top-level function immediately after `if not group_mappings:` without an indented suite, while `config.py` inserts a field declaration inside the unfinished `mcp_proxy_max_body_bytes = Field(` call; both are parser-level syntax errors. The application therefore cannot import, and tests plus the LLD's deployment updates are absent. The summary's claim of exact implementation and successful examination is contradicted by the diff, while exact `git apply --check` verification was unavailable because repository shell access failed."
+      }
+    },
+    "task_score": 42.0,
+    "verdict": "The design establishes a useful direction, but the submitted implementation is unusable because its two core Python edits are syntactically invalid.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T17:53:48.530205Z",
+      "repo_ref": "1.25.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 172471,
+        "cached_input_tokens": 80420,
+        "cache_write_input_tokens": 24163,
+        "output_tokens": 8101,
+        "reasoning_output_tokens": 5875
+      },
+      "duration_ms": 111591
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/configurable-ui-title/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "configurable-ui-title",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 19,
+      "specificity": 21,
+      "risk_awareness": 14,
+      "total": 75,
+      "notes": "The issue clearly defines UI_TITLE precedence, exact mode-dependent defaults, affected API and admin surfaces, and explicit non-goals. The submitted diff context corroborates hardcoded titles in Layout.tsx, Login.tsx, and Logout.tsx and an existing CONFIG_GROUPS structure in config_routes.py. Its largest gap is edge behavior: empty or whitespace values, configuration-fetch failure, and precise display locations are unspecified. No independent task statement was supplied, so the broader requirement and related issue #984 could not be verified."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 8,
+      "specificity": 14,
+      "risk_awareness": 11,
+      "total": 48,
+      "notes": "The LLD identifies concrete backend, frontend, Docker, Terraform, and Helm integration points and specifies the intended title precedence. Its core design is internally inconsistent: ui_title defaults to None while the sample API returns a derived title, and the browser title is declared out of scope but receives an unresolved implementation plan. The Layout.tsx example redundantly imports hooks already present in the submitted baseline context, and it never defines a reusable mechanism for Login.tsx and Logout.tsx to obtain uiTitle. Exact Terraform and Helm wiring was not specified sufficiently to verify variable names or templates."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 12,
+      "specificity": 14,
+      "risk_awareness": 15,
+      "total": 54,
+      "notes": "The review usefully identifies asynchronous fallback, initial-render flicker, malformed configuration, static-title consistency, and input-validation concerns. It does not catch the LLD's contradictory API semantics, duplicated React imports, missing shared title state, or conflict between the browser-title non-goal and implementation plan. Several reviewers repeat the same static HTML concern while proposing incompatible client-side, build-time, and server-side remedies without selecting one. Its approvals of deployment completeness and backward compatibility are unsupported by concrete Terraform, Helm, or route-authentication evidence."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 6,
+      "specificity": 11,
+      "risk_awareness": 10,
+      "total": 40,
+      "notes": "The plan spans default, custom, rollback, deployment, API, UI, and failure scenarios and names several expected titles. The commands `UI_TITLE=\"Test Registry\" curl ...` only set the variable for curl, not the running registry process, so the central custom-title tests cannot establish their expected result. The static HTML test has no meaningful oracle, error handling lacks a concrete fault injection and assertion, and the Terraform and Helm commands assume unverified paths and variable names. The final pytest checklist names broad directories but provides no concrete unit setup or assertions for the React components or title derivation."
+    },
+    "implementation": {
+      "completeness": 5,
+      "correctness": 2,
+      "specificity": 6,
+      "risk_awareness": 2,
+      "total": 15,
+      "notes": "The patch adds a plausible Pydantic field, CONFIG_GROUPS entry, Docker environment pass-through, and example documentation, but it does not implement a working frontend data flow. Layout.tsx imports useEffect and useState twice, while Layout.tsx, Login.tsx, and Logout.tsx reference an undefined uiTitle; the quoted alt value is also literal rather than JSX interpolation. The index.html replacement is malformed, places executable content before the doctype, nests title tags, and directly edits a one-line artifact referencing hashed build assets. The summary falsely claims Terraform and Helm coverage despite no such diff entries, and exact git applicability could not be independently checked because the read-only repository shell failed before executing commands."
+    }
+  },
+  "task_score": 46.4,
+  "verdict": "The design establishes a useful requirement foundation, but the submitted implementation is incomplete and frontend-breaking, with invalid React references, malformed HTML, and falsely claimed deployment coverage.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T17:55:39.496497Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 134335,
+      "cached_input_tokens": 91908,
+      "cache_write_input_tokens": 27864,
+      "output_tokens": 8894,
+      "reasoning_output_tokens": 7141
+    },
+    "duration_ms": 110954
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/configurable-ui-title/metrics.json
@@ -1,0 +1,179 @@
+{
+  "task": "configurable-ui-title",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "ui",
+    "react",
+    "config",
+    "branding",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.24.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 117.5,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4423389,
+    "output_tokens": 18191,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4441580,
+    "total_cost_usd": 0.694656,
+    "latency_seconds": 154.8,
+    "num_turns": 166,
+    "generation_tokens_per_sec": 117.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4423389,
+  "output_tokens": 18191,
+  "latency_seconds": 154.8,
+  "num_turns": 166,
+  "total_cost_usd": 0.694656,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:46:21.350129Z",
+  "run_ended_at": "2026-09-11T16:48:56.185360Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4423389,
+    "output_tokens": 18191,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4441580,
+    "total_cost_usd": 0.694656,
+    "latency_seconds": 154.8,
+    "num_turns": 166,
+    "generation_tokens_per_sec": 117.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "configurable-ui-title",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 19,
+        "specificity": 21,
+        "risk_awareness": 14,
+        "total": 75,
+        "notes": "The issue clearly defines UI_TITLE precedence, exact mode-dependent defaults, affected API and admin surfaces, and explicit non-goals. The submitted diff context corroborates hardcoded titles in Layout.tsx, Login.tsx, and Logout.tsx and an existing CONFIG_GROUPS structure in config_routes.py. Its largest gap is edge behavior: empty or whitespace values, configuration-fetch failure, and precise display locations are unspecified. No independent task statement was supplied, so the broader requirement and related issue #984 could not be verified."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 8,
+        "specificity": 14,
+        "risk_awareness": 11,
+        "total": 48,
+        "notes": "The LLD identifies concrete backend, frontend, Docker, Terraform, and Helm integration points and specifies the intended title precedence. Its core design is internally inconsistent: ui_title defaults to None while the sample API returns a derived title, and the browser title is declared out of scope but receives an unresolved implementation plan. The Layout.tsx example redundantly imports hooks already present in the submitted baseline context, and it never defines a reusable mechanism for Login.tsx and Logout.tsx to obtain uiTitle. Exact Terraform and Helm wiring was not specified sufficiently to verify variable names or templates."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 12,
+        "specificity": 14,
+        "risk_awareness": 15,
+        "total": 54,
+        "notes": "The review usefully identifies asynchronous fallback, initial-render flicker, malformed configuration, static-title consistency, and input-validation concerns. It does not catch the LLD's contradictory API semantics, duplicated React imports, missing shared title state, or conflict between the browser-title non-goal and implementation plan. Several reviewers repeat the same static HTML concern while proposing incompatible client-side, build-time, and server-side remedies without selecting one. Its approvals of deployment completeness and backward compatibility are unsupported by concrete Terraform, Helm, or route-authentication evidence."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 6,
+        "specificity": 11,
+        "risk_awareness": 10,
+        "total": 40,
+        "notes": "The plan spans default, custom, rollback, deployment, API, UI, and failure scenarios and names several expected titles. The commands `UI_TITLE=\"Test Registry\" curl ...` only set the variable for curl, not the running registry process, so the central custom-title tests cannot establish their expected result. The static HTML test has no meaningful oracle, error handling lacks a concrete fault injection and assertion, and the Terraform and Helm commands assume unverified paths and variable names. The final pytest checklist names broad directories but provides no concrete unit setup or assertions for the React components or title derivation."
+      },
+      "implementation": {
+        "completeness": 5,
+        "correctness": 2,
+        "specificity": 6,
+        "risk_awareness": 2,
+        "total": 15,
+        "notes": "The patch adds a plausible Pydantic field, CONFIG_GROUPS entry, Docker environment pass-through, and example documentation, but it does not implement a working frontend data flow. Layout.tsx imports useEffect and useState twice, while Layout.tsx, Login.tsx, and Logout.tsx reference an undefined uiTitle; the quoted alt value is also literal rather than JSX interpolation. The index.html replacement is malformed, places executable content before the doctype, nests title tags, and directly edits a one-line artifact referencing hashed build assets. The summary falsely claims Terraform and Helm coverage despite no such diff entries, and exact git applicability could not be independently checked because the read-only repository shell failed before executing commands."
+      }
+    },
+    "task_score": 46.4,
+    "verdict": "The design establishes a useful requirement foundation, but the submitted implementation is incomplete and frontend-breaking, with invalid React references, malformed HTML, and falsely claimed deployment coverage.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T17:55:39.496497Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 134335,
+        "cached_input_tokens": 91908,
+        "cache_write_input_tokens": 27864,
+        "output_tokens": 8894,
+        "reasoning_output_tokens": 7141
+      },
+      "duration_ms": 110954
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 11,
+      "correctness": 6,
+      "specificity": 9,
+      "risk_awareness": 8,
+      "total": 34,
+      "notes": "The issue clearly identifies the real user-visible symptom: CSRF validation blocks bearer-authenticated agent and skill toggles. However, the repository's v1.0.21 notes identify the fix as skipping CSRF for Bearer clients on toggle endpoints, while this issue instead centers the solution on adding CSRF to virtual-server toggles. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) The acceptance criteria never specify when CSRF must be enforced or bypassed, authentication precedence, or concrete expected responses. The assertion that virtual-server coverage is the cause of the agent/skill failure is unsupported, although the documented virtual-server toggle route itself exists."
+    },
+    "lld": {
+      "completeness": 7,
+      "correctness": 3,
+      "specificity": 10,
+      "risk_awareness": 4,
+      "total": 24,
+      "notes": "The design is concrete about `registry/api/virtual_server_routes.py`, the toggle signature, and the proposed dependency, and the repository documentation confirms that route and endpoint exist. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/design/virtual-mcp-server.md)) Its sole implementation step adds CSRF validation to the virtual-server endpoint, but the established fix required Bearer clients to skip CSRF and specifically addressed blocked agent/skill toggles. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) The M2M sequence still performs CSRF validation despite acknowledging that these clients lack the required cookie and token, leaving the load-bearing bypass and authentication decision undefined. The claimed line numbers, helper behavior, session handling, and compatibility were not substantiated, and rollout, error handling, and testing are largely dismissed."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 7,
+      "specificity": 9,
+      "risk_awareness": 10,
+      "total": 36,
+      "notes": "The backend and security sections correctly raise the central question of whether `verify_csrf_token_flexible` blocks M2M clients without session cookies. The review nevertheless approves the design, declares no blocking findings, and even contradicts its own summary table, which records one security blocker. Repository release evidence shows that Bearer-token bypass was the essential fix, so leaving that question unanswered should have blocked approval. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) Frontend token behavior and the asserted absence of operational impact are recommendations or assumptions rather than repository-grounded findings."
+    },
+    "testing": {
+      "completeness": 9,
+      "correctness": 4,
+      "specificity": 9,
+      "risk_awareness": 7,
+      "total": 29,
+      "notes": "The plan provides concrete HTTP examples and includes missing-token and invalid-token negative cases. Its virtual-server curls provide only an `enabled` query parameter even though the LLD's own route signature requires a `ToggleVirtualServerRequest` body, so the expected 200 response is not supported. More importantly, it never concretely tests the required Bearer-only request without session cookie or CSRF token; instead, the examples mix Bearer and session authentication and even expect that combination to fail without CSRF. The repository identifies programmatic agent/skill toggles as the regression, while those flows receive only checklist assertions, and the token file path and test-directory conventions were not verified. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md))"
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "No unified diff was included in the submitted implementation artifact; only a summary referencing `./patch.diff` was supplied, so there is no code change to validate or apply. The described change adds CSRF to the virtual-server toggle, whereas the repository records the required fix as skipping CSRF for Bearer clients on toggle endpoints to unblock agent and skill operations. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) Consequently, the described implementation does not address the established failure and could extend CSRF blocking to another M2M path. Claims about the baseline commit, `+2 / -1` change, exact LLD compliance, and preserved M2M compatibility are unverifiable and oversell the absent patch."
+    }
+  },
+  "task_score": 24.6,
+  "verdict": "The submission recognizes the M2M/CSRF conflict but designs the wrong remedy, fails to specify or test the required Bearer-token bypass, and supplies no verifiable implementation diff.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:00:32.617842Z",
+    "repo_ref": "v1.0.20",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 129444,
+      "cached_input_tokens": 79239,
+      "cache_write_input_tokens": 20534,
+      "output_tokens": 9508,
+      "reasoning_output_tokens": 7571
+    },
+    "duration_ms": 293108
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/consistent-csrf-across-toggle-endpoints/metrics.json
@@ -1,0 +1,177 @@
+{
+  "task": "consistent-csrf-across-toggle-endpoints",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.20",
+  "complexity": "medium",
+  "tags": [
+    "security",
+    "csrf",
+    "authentication",
+    "api",
+    "fastapi",
+    "m2m",
+    "fixed-in-1.0.21"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 129.3,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1984803,
+    "output_tokens": 10836,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1995639,
+    "total_cost_usd": 0.313349,
+    "latency_seconds": 83.8,
+    "num_turns": 104,
+    "generation_tokens_per_sec": 129.3,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 1984803,
+  "output_tokens": 10836,
+  "latency_seconds": 83.8,
+  "num_turns": 104,
+  "total_cost_usd": 0.313349,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:44:55.805161Z",
+  "run_ended_at": "2026-09-11T16:46:19.594215Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1984803,
+    "output_tokens": 10836,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1995639,
+    "total_cost_usd": 0.313349,
+    "latency_seconds": 83.8,
+    "num_turns": 104,
+    "generation_tokens_per_sec": 129.3,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "consistent-csrf-across-toggle-endpoints",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 11,
+        "correctness": 6,
+        "specificity": 9,
+        "risk_awareness": 8,
+        "total": 34,
+        "notes": "The issue clearly identifies the real user-visible symptom: CSRF validation blocks bearer-authenticated agent and skill toggles. However, the repository's v1.0.21 notes identify the fix as skipping CSRF for Bearer clients on toggle endpoints, while this issue instead centers the solution on adding CSRF to virtual-server toggles. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) The acceptance criteria never specify when CSRF must be enforced or bypassed, authentication precedence, or concrete expected responses. The assertion that virtual-server coverage is the cause of the agent/skill failure is unsupported, although the documented virtual-server toggle route itself exists."
+      },
+      "lld": {
+        "completeness": 7,
+        "correctness": 3,
+        "specificity": 10,
+        "risk_awareness": 4,
+        "total": 24,
+        "notes": "The design is concrete about `registry/api/virtual_server_routes.py`, the toggle signature, and the proposed dependency, and the repository documentation confirms that route and endpoint exist. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/design/virtual-mcp-server.md)) Its sole implementation step adds CSRF validation to the virtual-server endpoint, but the established fix required Bearer clients to skip CSRF and specifically addressed blocked agent/skill toggles. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) The M2M sequence still performs CSRF validation despite acknowledging that these clients lack the required cookie and token, leaving the load-bearing bypass and authentication decision undefined. The claimed line numbers, helper behavior, session handling, and compatibility were not substantiated, and rollout, error handling, and testing are largely dismissed."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 7,
+        "specificity": 9,
+        "risk_awareness": 10,
+        "total": 36,
+        "notes": "The backend and security sections correctly raise the central question of whether `verify_csrf_token_flexible` blocks M2M clients without session cookies. The review nevertheless approves the design, declares no blocking findings, and even contradicts its own summary table, which records one security blocker. Repository release evidence shows that Bearer-token bypass was the essential fix, so leaving that question unanswered should have blocked approval. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) Frontend token behavior and the asserted absence of operational impact are recommendations or assumptions rather than repository-grounded findings."
+      },
+      "testing": {
+        "completeness": 9,
+        "correctness": 4,
+        "specificity": 9,
+        "risk_awareness": 7,
+        "total": 29,
+        "notes": "The plan provides concrete HTTP examples and includes missing-token and invalid-token negative cases. Its virtual-server curls provide only an `enabled` query parameter even though the LLD's own route signature requires a `ToggleVirtualServerRequest` body, so the expected 200 response is not supported. More importantly, it never concretely tests the required Bearer-only request without session cookie or CSRF token; instead, the examples mix Bearer and session authentication and even expect that combination to fail without CSRF. The repository identifies programmatic agent/skill toggles as the regression, while those flows receive only checklist assertions, and the token file path and test-directory conventions were not verified. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md))"
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "No unified diff was included in the submitted implementation artifact; only a summary referencing `./patch.diff` was supplied, so there is no code change to validate or apply. The described change adds CSRF to the virtual-server toggle, whereas the repository records the required fix as skipping CSRF for Bearer clients on toggle endpoints to unblock agent and skill operations. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) Consequently, the described implementation does not address the established failure and could extend CSRF blocking to another M2M path. Claims about the baseline commit, `+2 / -1` change, exact LLD compliance, and preserved M2M compatibility are unverifiable and oversell the absent patch."
+      }
+    },
+    "task_score": 24.6,
+    "verdict": "The submission recognizes the M2M/CSRF conflict but designs the wrong remedy, fails to specify or test the required Bearer-token bypass, and supplies no verifiable implementation diff.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:00:32.617842Z",
+      "repo_ref": "v1.0.20",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 129444,
+        "cached_input_tokens": 79239,
+        "cache_write_input_tokens": 20534,
+        "output_tokens": 9508,
+        "reasoning_output_tokens": 7571
+      },
+      "duration_ms": 293108
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 21,
+      "risk_awareness": 20,
+      "total": 82,
+      "notes": "The issue clearly defines the unsafe default, preserves explicit opt-in behavior, and identifies accidental IdP mutation and insufficient-write-scope failures. Its initial-unchecked and user-toggle acceptance criteria are directly testable, and the backend default is explicitly excluded. The editing criterion is less precise because it does not define whether editing should preserve stored state or merely initialize unchecked, while the requested frontend test covers only initial creation state. No independent task statement was supplied, and the asserted relationship to issue #916 could not be independently verified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 72,
+      "notes": "The strongest portion is the concrete two-site plan in `frontend/src/components/IAMGroups.tsx`, naming `resetForm()` and the edit path exactly as shown in the submitted diff. It correctly avoids unnecessary API, model, configuration, and dependency changes for a boolean UI default. However, it estimates zero test lines while simultaneously requiring a frontend unit test, and it does not explain why hard-resetting the edit checkbox is preferable to reflecting existing group state. Claims about `useIAM.hooks.ts` and the backend default at `registry/api/management_routes.py` could not be independently confirmed because repository shell access was unavailable."
+    },
+    "review": {
+      "completeness": 12,
+      "correctness": 14,
+      "specificity": 10,
+      "risk_awareness": 8,
+      "total": 44,
+      "notes": "The review recognizes the change as a narrow frontend default adjustment and correctly notes that explicit IdP creation remains available. Its largest weakness is that the persona sections mostly approve the design without testing its assumptions or identifying a concrete required correction. It misses the LLD's contradiction between requiring a regression test and estimating no tests, and it does not challenge the ambiguous edit-state behavior or frontend/backend default split. Browser, accessibility, documentation, and tooltip recommendations are generic, while statements that the implementation already resolves concerns are unsupported in a review of a draft LLD."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 11,
+      "specificity": 12,
+      "risk_awareness": 12,
+      "total": 50,
+      "notes": "The plan covers unchecked creation, explicit opt-in, editing, browser behavior, and both local-only and IdP-backed flows. The edit test navigates from editing back to creation, so it does not actually verify the edit handler changed by the patch. The API test involving omitted `scope_config` is disconnected from the `create_in_idp` UI state, and assertions such as handling errors gracefully lack failure setup and a concrete oracle. The proposed `frontend/src/components/__tests__/IAMGroups.test.tsx` location and `yarn test` command were not grounded in verifiable repository test configuration."
+    },
+    "implementation": {
+      "completeness": 16,
+      "correctness": 20,
+      "specificity": 20,
+      "risk_awareness": 15,
+      "total": 71,
+      "notes": "The patch implements the designed behavior at both submitted `setCreateInIdp(true)` call sites, changing only the reset and edit defaults without unrelated churn. The boolean replacements are internally coherent and preserve the existing opt-in control because no interaction handler is removed. The required frontend regression test is absent, yet the summary says nothing remains unimplemented; its `+0 / -2` accounting is also inaccurate for two replacements, which are two additions and two deletions. The target path and context align with the LLD, but the baseline commit and clean application could not be independently confirmed because local repository commands were blocked by the execution sandbox."
+    }
+  },
+  "task_score": 63.8,
+  "verdict": "The submission proposes a plausible, tightly scoped fix, but its shallow review, weak test oracles, and omission of the explicitly required automated regression test materially limit confidence.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:02:40.091890Z",
+    "repo_ref": "v1.0.21",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 104806,
+      "cached_input_tokens": 53697,
+      "cache_write_input_tokens": 20718,
+      "output_tokens": 9598,
+      "reasoning_output_tokens": 7623
+    },
+    "duration_ms": 127462
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/default-create-in-idp-checkbox-unchecked/metrics.json
@@ -1,0 +1,176 @@
+{
+  "task": "default-create-in-idp-checkbox-unchecked",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.21",
+  "complexity": "low",
+  "tags": [
+    "ui",
+    "react",
+    "iam",
+    "groups",
+    "ux",
+    "fixed-in-1.0.22"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 126.5,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 15207933,
+    "output_tokens": 63469,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 15271402,
+    "total_cost_usd": 2.388849,
+    "latency_seconds": 501.6,
+    "num_turns": 408,
+    "generation_tokens_per_sec": 126.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 15207933,
+  "output_tokens": 63469,
+  "latency_seconds": 501.6,
+  "num_turns": 408,
+  "total_cost_usd": 2.388849,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:22:08.765233Z",
+  "run_ended_at": "2026-09-11T16:30:30.352235Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 15207933,
+    "output_tokens": 63469,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 15271402,
+    "total_cost_usd": 2.388849,
+    "latency_seconds": 501.6,
+    "num_turns": 408,
+    "generation_tokens_per_sec": 126.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "default-create-in-idp-checkbox-unchecked",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 21,
+        "risk_awareness": 20,
+        "total": 82,
+        "notes": "The issue clearly defines the unsafe default, preserves explicit opt-in behavior, and identifies accidental IdP mutation and insufficient-write-scope failures. Its initial-unchecked and user-toggle acceptance criteria are directly testable, and the backend default is explicitly excluded. The editing criterion is less precise because it does not define whether editing should preserve stored state or merely initialize unchecked, while the requested frontend test covers only initial creation state. No independent task statement was supplied, and the asserted relationship to issue #916 could not be independently verified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 72,
+        "notes": "The strongest portion is the concrete two-site plan in `frontend/src/components/IAMGroups.tsx`, naming `resetForm()` and the edit path exactly as shown in the submitted diff. It correctly avoids unnecessary API, model, configuration, and dependency changes for a boolean UI default. However, it estimates zero test lines while simultaneously requiring a frontend unit test, and it does not explain why hard-resetting the edit checkbox is preferable to reflecting existing group state. Claims about `useIAM.hooks.ts` and the backend default at `registry/api/management_routes.py` could not be independently confirmed because repository shell access was unavailable."
+      },
+      "review": {
+        "completeness": 12,
+        "correctness": 14,
+        "specificity": 10,
+        "risk_awareness": 8,
+        "total": 44,
+        "notes": "The review recognizes the change as a narrow frontend default adjustment and correctly notes that explicit IdP creation remains available. Its largest weakness is that the persona sections mostly approve the design without testing its assumptions or identifying a concrete required correction. It misses the LLD's contradiction between requiring a regression test and estimating no tests, and it does not challenge the ambiguous edit-state behavior or frontend/backend default split. Browser, accessibility, documentation, and tooltip recommendations are generic, while statements that the implementation already resolves concerns are unsupported in a review of a draft LLD."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 11,
+        "specificity": 12,
+        "risk_awareness": 12,
+        "total": 50,
+        "notes": "The plan covers unchecked creation, explicit opt-in, editing, browser behavior, and both local-only and IdP-backed flows. The edit test navigates from editing back to creation, so it does not actually verify the edit handler changed by the patch. The API test involving omitted `scope_config` is disconnected from the `create_in_idp` UI state, and assertions such as handling errors gracefully lack failure setup and a concrete oracle. The proposed `frontend/src/components/__tests__/IAMGroups.test.tsx` location and `yarn test` command were not grounded in verifiable repository test configuration."
+      },
+      "implementation": {
+        "completeness": 16,
+        "correctness": 20,
+        "specificity": 20,
+        "risk_awareness": 15,
+        "total": 71,
+        "notes": "The patch implements the designed behavior at both submitted `setCreateInIdp(true)` call sites, changing only the reset and edit defaults without unrelated churn. The boolean replacements are internally coherent and preserve the existing opt-in control because no interaction handler is removed. The required frontend regression test is absent, yet the summary says nothing remains unimplemented; its `+0 / -2` accounting is also inaccurate for two replacements, which are two additions and two deletions. The target path and context align with the LLD, but the baseline commit and clean application could not be independently confirmed because local repository commands were blocked by the execution sandbox."
+      }
+    },
+    "task_score": 63.8,
+    "verdict": "The submission proposes a plausible, tightly scoped fix, but its shallow review, weak test oracles, and omission of the explicitly required automated regression test materially limit confidence.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:02:40.091890Z",
+      "repo_ref": "v1.0.21",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 104806,
+        "cached_input_tokens": 53697,
+        "cache_write_input_tokens": 20718,
+        "output_tokens": 9598,
+        "reasoning_output_tokens": 7623
+      },
+      "duration_ms": 127462
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 78,
+      "notes": "The issue clearly defines both registration and modal behavior, including public, raw-content, enterprise, and non-GitHub URL cases. Its largest omission is precedence and recovery behavior for an existing or manually entered repository URL when parsing succeeds or fails. The acceptance criteria name concrete URL patterns, link labels, and both ordinary and semantic-search modals. No independent task statement was supplied, and the claimed relationship to issue #846 and absence of dependencies could not be verified."
+    },
+    "lld": {
+      "completeness": 12,
+      "correctness": 6,
+      "specificity": 13,
+      "risk_awareness": 9,
+      "total": 40,
+      "notes": "The design identifies concrete backend and frontend files and discusses preserving explicitly supplied repository URLs. Its central implementation choice performs derivation during backend registration rather than when the user clicks Parse, and its sample returns github.com for enterprise URLs instead of preserving the enterprise host. It also says non-GitHub input is a 400 error despite requiring a blank repository URL, omits the declared frontend type change from its file plan, and lists the existing url_utils.py as a new file. Claims about authentication, validation patterns, helper behavior, logging, and CLI invocation are asserted without sufficient repository evidence."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 7,
+      "specificity": 10,
+      "risk_awareness": 11,
+      "total": 38,
+      "notes": "The review usefully requests URL-parser unit tests, integration coverage, accessibility labels, and better handling of silent failures. It misses the design's enterprise-host bug, frontend type omission, contradictory non-GitHub behavior, and mismatch between Parse-time UX and registration-time derivation. Recommendations for HEAD validation and retrying URL fetches contradict the issue's repository-verification non-goal and introduce unnecessary network and SSRF concerns. Assertions that existing SSRF protection applies and that a feature flag or atomicity change is needed are not grounded in cited repository behavior."
+    },
+    "testing": {
+      "completeness": 13,
+      "correctness": 7,
+      "specificity": 14,
+      "risk_awareness": 9,
+      "total": 43,
+      "notes": "The plan provides concrete request payloads and expected repository_url values for public GitHub, enterprise, non-GitHub, and explicit-override cases. It entirely omits the required raw.githubusercontent.com pattern and lacks focused unit cases for malformed paths, unsupported patterns, and parsing failures. The root-level registry_management.py command, token JSON shape, response status, and response schema are presented without repository-backed confirmation, while the UI checks use vague oracles such as confirming links work. The compatibility assertion names no preserved fields, deployment sections are generic, and there is no frontend build or type-check step that would catch the submitted TSX breakage."
+    },
+    "implementation": {
+      "completeness": 1,
+      "correctness": 0,
+      "specificity": 3,
+      "risk_awareness": 2,
+      "total": 6,
+      "notes": "The patch does not implement the design end to end: SemanticSearchResults.tsx is absent, and skill_service.py imports the extractor without invoking it. The SkillCard.tsx hunk deletes the anchor closure, conditional boundary, fragment, and button opening, leaving a stray `}}`, while the service hunk deletes core SkillCard constructor arguments including repository_url. The extractor also hardcodes github.com for enterprise inputs and uses the incorrect annotation `str or None`; the implementation summary's touched-file counts and completion claims therefore do not match the diff. A repository dry-run could not be completed because command execution was unavailable, but the submitted hunks are independently sufficient to demonstrate syntax errors and missing functionality."
+    }
+  },
+  "task_score": 41.0,
+  "verdict": "The issue is strong, but the design and review preserve major contradictions and the implementation is incomplete, internally broken, and inconsistent with its own summary.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:05:08.841288Z",
+    "repo_ref": "v1.0.19",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 165761,
+      "cached_input_tokens": 91463,
+      "cache_write_input_tokens": 25146,
+      "output_tokens": 10778,
+      "reasoning_output_tokens": 9475
+    },
+    "duration_ms": 148736
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/derive-repo-url-from-skill-md/metrics.json
@@ -1,0 +1,177 @@
+{
+  "task": "derive-repo-url-from-skill-md",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "medium",
+  "tags": [
+    "enhancement",
+    "skills",
+    "ui",
+    "react",
+    "api",
+    "ux",
+    "fixed-in-1.0.20"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 90.7,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4620213,
+    "output_tokens": 18684,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4638897,
+    "total_cost_usd": 0.72537,
+    "latency_seconds": 205.9,
+    "num_turns": 147,
+    "generation_tokens_per_sec": 90.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4620213,
+  "output_tokens": 18684,
+  "latency_seconds": 205.9,
+  "num_turns": 147,
+  "total_cost_usd": 0.72537,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:41:28.171518Z",
+  "run_ended_at": "2026-09-11T16:44:54.062650Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4620213,
+    "output_tokens": 18684,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4638897,
+    "total_cost_usd": 0.72537,
+    "latency_seconds": 205.9,
+    "num_turns": 147,
+    "generation_tokens_per_sec": 90.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "derive-repo-url-from-skill-md",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 78,
+        "notes": "The issue clearly defines both registration and modal behavior, including public, raw-content, enterprise, and non-GitHub URL cases. Its largest omission is precedence and recovery behavior for an existing or manually entered repository URL when parsing succeeds or fails. The acceptance criteria name concrete URL patterns, link labels, and both ordinary and semantic-search modals. No independent task statement was supplied, and the claimed relationship to issue #846 and absence of dependencies could not be verified."
+      },
+      "lld": {
+        "completeness": 12,
+        "correctness": 6,
+        "specificity": 13,
+        "risk_awareness": 9,
+        "total": 40,
+        "notes": "The design identifies concrete backend and frontend files and discusses preserving explicitly supplied repository URLs. Its central implementation choice performs derivation during backend registration rather than when the user clicks Parse, and its sample returns github.com for enterprise URLs instead of preserving the enterprise host. It also says non-GitHub input is a 400 error despite requiring a blank repository URL, omits the declared frontend type change from its file plan, and lists the existing url_utils.py as a new file. Claims about authentication, validation patterns, helper behavior, logging, and CLI invocation are asserted without sufficient repository evidence."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 7,
+        "specificity": 10,
+        "risk_awareness": 11,
+        "total": 38,
+        "notes": "The review usefully requests URL-parser unit tests, integration coverage, accessibility labels, and better handling of silent failures. It misses the design's enterprise-host bug, frontend type omission, contradictory non-GitHub behavior, and mismatch between Parse-time UX and registration-time derivation. Recommendations for HEAD validation and retrying URL fetches contradict the issue's repository-verification non-goal and introduce unnecessary network and SSRF concerns. Assertions that existing SSRF protection applies and that a feature flag or atomicity change is needed are not grounded in cited repository behavior."
+      },
+      "testing": {
+        "completeness": 13,
+        "correctness": 7,
+        "specificity": 14,
+        "risk_awareness": 9,
+        "total": 43,
+        "notes": "The plan provides concrete request payloads and expected repository_url values for public GitHub, enterprise, non-GitHub, and explicit-override cases. It entirely omits the required raw.githubusercontent.com pattern and lacks focused unit cases for malformed paths, unsupported patterns, and parsing failures. The root-level registry_management.py command, token JSON shape, response status, and response schema are presented without repository-backed confirmation, while the UI checks use vague oracles such as confirming links work. The compatibility assertion names no preserved fields, deployment sections are generic, and there is no frontend build or type-check step that would catch the submitted TSX breakage."
+      },
+      "implementation": {
+        "completeness": 1,
+        "correctness": 0,
+        "specificity": 3,
+        "risk_awareness": 2,
+        "total": 6,
+        "notes": "The patch does not implement the design end to end: SemanticSearchResults.tsx is absent, and skill_service.py imports the extractor without invoking it. The SkillCard.tsx hunk deletes the anchor closure, conditional boundary, fragment, and button opening, leaving a stray `}}`, while the service hunk deletes core SkillCard constructor arguments including repository_url. The extractor also hardcodes github.com for enterprise inputs and uses the incorrect annotation `str or None`; the implementation summary's touched-file counts and completion claims therefore do not match the diff. A repository dry-run could not be completed because command execution was unavailable, but the submitted hunks are independently sufficient to demonstrate syntax errors and missing functionality."
+      }
+    },
+    "task_score": 41.0,
+    "verdict": "The issue is strong, but the design and review preserve major contradictions and the implementation is incomplete, internally broken, and inconsistent with its own summary.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:05:08.841288Z",
+      "repo_ref": "v1.0.19",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 165761,
+        "cached_input_tokens": 91463,
+        "cache_write_input_tokens": 25146,
+        "output_tokens": 10778,
+        "reasoning_output_tokens": 9475
+      },
+      "duration_ms": 148736
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 21,
+      "correctness": 20,
+      "specificity": 21,
+      "risk_awareness": 17,
+      "total": 79,
+      "notes": "The issue clearly identifies the affected script, `verify_setup()`, Bash's special `GROUPS` variable, the erroneous exit status, and concrete acceptance criteria. Repository documentation confirms `keycloak/setup/setup-agent-service-account.sh` and its `--agent-id` and `--group` interface. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/complete-setup-guide.md)) The largest gap is that the reserved-variable sweep is not bounded by a specific command or exhaustive definition, while the claim about checking only one group is imprecisely explained. No independent task statement exists, and the related issue number, macos-setup skill dependency, and exact Keycloak 26.x requirement could not be verified."
+    },
+    "lld": {
+      "completeness": 17,
+      "correctness": 16,
+      "specificity": 18,
+      "risk_awareness": 12,
+      "total": 63,
+      "notes": "The design names both target scripts, the `verify_setup()` integration point, and the intended `GROUPS` to `SERVICE_ACCOUNT_GROUPS` replacement; repository documentation confirms that both service-account scripts exist. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/configuration.md)) Its largest deficiency is that it never shows the existing membership expression, commits to an exact matching method, or reports concrete results from the promised audit of all `keycloak/setup/*.sh` files. It also promises stderr diagnostics while estimating only variable-reference renames, and its stated lowercase naming convention conflicts with the proposed uppercase name. Claims that the M2M code is identical, federation needs no change, every reviewed script uses `set -e`, and Jenkins consumes these exits remain unverified."
+    },
+    "review": {
+      "completeness": 12,
+      "correctness": 10,
+      "specificity": 11,
+      "risk_awareness": 11,
+      "total": 44,
+      "notes": "The review consistently identifies the load-bearing `GROUPS` conflict and recommends applying the rename in both named service-account scripts. Its largest weakness is repetitive persona role-play rather than scrutiny of the LLD's exact matching semantics, audit coverage, error-message promise, or rollout details. It repeatedly calls the defect critical but concludes that all findings are non-critical and that no blocker exists, producing an internally inconsistent verdict. The alleged shell-injection or exploitation vector from assigning `GROUPS` is unsupported, while the potentially relevant race and special-character concerns are raised without evidence or actionable mitigation."
+    },
+    "testing": {
+      "completeness": 10,
+      "correctness": 9,
+      "specificity": 13,
+      "risk_awareness": 8,
+      "total": 40,
+      "notes": "The plan provides concrete commands and useful oracles for the primary agent-script exit status, missing credentials, missing groups, and success output; the documented long-form `--agent-id` and `--group` invocation is repository-consistent. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/complete-setup-guide.md)) It entirely omits execution coverage for `setup-m2m-service-account.sh`, the required ShellCheck SC2178/SC2128 checks, and the promised reserved-variable sweep. The short flags and `--client` option are not substantiated, and several grep pipelines test text rather than preserving the script's exit status. The simulated end-to-end section executes no test, and the plan lacks multi-group/exact-match cases, repeat-run cleanup, and a real Bash 3.2 compatibility check."
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "No implementation was actually submitted: the purported `patch.diff` contains only prose comments and has no `diff --git`, file headers, or hunks. It therefore cannot apply or modify either named script, and no source-level rename can be checked against the repository. The summary falsely reports `+4 / -4` changes, no deviations, and complete implementation despite supplying no code. There are also no implementation tests or evidence supporting the claimed ShellCheck resolution, so every implementation criterion is zero."
+    }
+  },
+  "task_score": 45.2,
+  "verdict": "The design artifacts capture the core Bash defect reasonably well, but weak verification and testing are overshadowed by the complete absence of an actual code patch.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:07:31.896456Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 186678,
+      "cached_input_tokens": 97746,
+      "cache_write_input_tokens": 21966,
+      "output_tokens": 9951,
+      "reasoning_output_tokens": 8546
+    },
+    "duration_ms": 143043
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/fix-reserved-groups-var-in-service-account-script/metrics.json
@@ -1,0 +1,177 @@
+{
+  "task": "fix-reserved-groups-var-in-service-account-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "bash",
+    "keycloak",
+    "setup-scripts",
+    "shellcheck",
+    "fixed-in-1.28.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 129.7,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5217029,
+    "output_tokens": 26325,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5243354,
+    "total_cost_usd": 0.8223,
+    "latency_seconds": 206.1,
+    "num_turns": 230,
+    "generation_tokens_per_sec": 129.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5217029,
+  "output_tokens": 26325,
+  "latency_seconds": 206.1,
+  "num_turns": 230,
+  "total_cost_usd": 0.8223,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:35:42.292375Z",
+  "run_ended_at": "2026-09-11T16:37:48.321215Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5217029,
+    "output_tokens": 26325,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5243354,
+    "total_cost_usd": 0.8223,
+    "latency_seconds": 206.1,
+    "num_turns": 230,
+    "generation_tokens_per_sec": 129.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "agent_invocations": 2,
+  "evaluation": {
+    "task": "fix-reserved-groups-var-in-service-account-script",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 21,
+        "correctness": 20,
+        "specificity": 21,
+        "risk_awareness": 17,
+        "total": 79,
+        "notes": "The issue clearly identifies the affected script, `verify_setup()`, Bash's special `GROUPS` variable, the erroneous exit status, and concrete acceptance criteria. Repository documentation confirms `keycloak/setup/setup-agent-service-account.sh` and its `--agent-id` and `--group` interface. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/complete-setup-guide.md)) The largest gap is that the reserved-variable sweep is not bounded by a specific command or exhaustive definition, while the claim about checking only one group is imprecisely explained. No independent task statement exists, and the related issue number, macos-setup skill dependency, and exact Keycloak 26.x requirement could not be verified."
+      },
+      "lld": {
+        "completeness": 17,
+        "correctness": 16,
+        "specificity": 18,
+        "risk_awareness": 12,
+        "total": 63,
+        "notes": "The design names both target scripts, the `verify_setup()` integration point, and the intended `GROUPS` to `SERVICE_ACCOUNT_GROUPS` replacement; repository documentation confirms that both service-account scripts exist. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/configuration.md)) Its largest deficiency is that it never shows the existing membership expression, commits to an exact matching method, or reports concrete results from the promised audit of all `keycloak/setup/*.sh` files. It also promises stderr diagnostics while estimating only variable-reference renames, and its stated lowercase naming convention conflicts with the proposed uppercase name. Claims that the M2M code is identical, federation needs no change, every reviewed script uses `set -e`, and Jenkins consumes these exits remain unverified."
+      },
+      "review": {
+        "completeness": 12,
+        "correctness": 10,
+        "specificity": 11,
+        "risk_awareness": 11,
+        "total": 44,
+        "notes": "The review consistently identifies the load-bearing `GROUPS` conflict and recommends applying the rename in both named service-account scripts. Its largest weakness is repetitive persona role-play rather than scrutiny of the LLD's exact matching semantics, audit coverage, error-message promise, or rollout details. It repeatedly calls the defect critical but concludes that all findings are non-critical and that no blocker exists, producing an internally inconsistent verdict. The alleged shell-injection or exploitation vector from assigning `GROUPS` is unsupported, while the potentially relevant race and special-character concerns are raised without evidence or actionable mitigation."
+      },
+      "testing": {
+        "completeness": 10,
+        "correctness": 9,
+        "specificity": 13,
+        "risk_awareness": 8,
+        "total": 40,
+        "notes": "The plan provides concrete commands and useful oracles for the primary agent-script exit status, missing credentials, missing groups, and success output; the documented long-form `--agent-id` and `--group` invocation is repository-consistent. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/complete-setup-guide.md)) It entirely omits execution coverage for `setup-m2m-service-account.sh`, the required ShellCheck SC2178/SC2128 checks, and the promised reserved-variable sweep. The short flags and `--client` option are not substantiated, and several grep pipelines test text rather than preserving the script's exit status. The simulated end-to-end section executes no test, and the plan lacks multi-group/exact-match cases, repeat-run cleanup, and a real Bash 3.2 compatibility check."
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "No implementation was actually submitted: the purported `patch.diff` contains only prose comments and has no `diff --git`, file headers, or hunks. It therefore cannot apply or modify either named script, and no source-level rename can be checked against the repository. The summary falsely reports `+4 / -4` changes, no deviations, and complete implementation despite supplying no code. There are also no implementation tests or evidence supporting the claimed ShellCheck resolution, so every implementation criterion is zero."
+      }
+    },
+    "task_score": 45.2,
+    "verdict": "The design artifacts capture the core Bash defect reasonably well, but weak verification and testing are overshadowed by the complete absence of an actual code patch.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:07:31.896456Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 186678,
+        "cached_input_tokens": 97746,
+        "cache_write_input_tokens": 21966,
+        "output_tokens": 9951,
+        "reasoning_output_tokens": 8546
+      },
+      "duration_ms": 143043
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 23,
+      "correctness": 22,
+      "specificity": 23,
+      "risk_awareness": 19,
+      "total": 87,
+      "notes": "The issue clearly defines the duplicate-action problem, five testable visibility outcomes, and useful non-goals. Its requested behavior aligns directly with the submitted task identifier. The main gap is that it does not address other possible dashboard views, permission-dependent rendering, or accessibility regressions. The claimed relationship to issue #793 and precise existing navigation behavior could not be independently verified because repository shell access was unavailable."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 11,
+      "specificity": 15,
+      "risk_awareness": 9,
+      "total": 49,
+      "notes": "The design identifies Dashboard.tsx, viewFilter, and the relevant view values, giving an implementer a plausible integration point. Its allowlist of discover, servers, and agents conflicts with its own diagram containing an External tab and with the implementation's denylist approach. The cited locations are inconsistent—approximately 1456, 2310, and later 2408—and it never specifies how the condition composes with existing permission checks. The unresolved question about whether Register differs by tab is a load-bearing behavior question, while compatibility and testing guidance remain generic."
+    },
+    "review": {
+      "completeness": 7,
+      "correctness": 5,
+      "specificity": 5,
+      "risk_awareness": 6,
+      "total": 23,
+      "notes": "The review at least recommends checking visibility, tab transitions, registration behavior, and accessibility. Its largest deficiency is that every role effectively approves the design without identifying a concrete defect or resolving the LLD's open behavior question. It misses the allowlist-versus-External-tab ambiguity and calls the implementation clean and well-executed without supporting evidence. Assertions of no security, performance, backend, or monitoring impact are plausible for this small UI change but are not grounded in inspected conditions or tests."
+    },
+    "testing": {
+      "completeness": 15,
+      "correctness": 11,
+      "specificity": 13,
+      "risk_awareness": 12,
+      "total": 51,
+      "notes": "The strongest section provides explicit visible/hidden expectations for all five named tabs and verifies that Register returns after navigating away from Skills. Most actions are prose rather than executable tests, and the broad registration-flow checks lack concrete setup and success-state oracles. The exported URL and token are unused, while the plan dismisses unit and integration tests as inapplicable to a rendering change and offers unverified alternative commands such as npm run test or yarn test. It also omits permission variants, configuration-hidden tabs, the LLD's External view, and a concrete accessibility-checking method."
+    },
+    "implementation": {
+      "completeness": 1,
+      "correctness": 0,
+      "specificity": 3,
+      "risk_awareness": 1,
+      "total": 5,
+      "notes": "The patch does not implement the design: it retains the original unconditional Register button and adds a second conditional copy, leaving Register visible on Virtual and Skills while duplicating it elsewhere. The unified-diff hunk is structurally invalid because its header declares 10 old and 14 new lines, while the body contains 10 old and 20 new lines. The summary also incorrectly reports +7/-0, claims exact LLD conformance despite the denylist/allowlist deviation, and declares completion without tests. Exact source context could not be independently checked because repository shell execution was unavailable, but the patch's intrinsic syntax and behavior defects are independently decisive."
+    }
+  },
+  "task_score": 43.0,
+  "verdict": "The issue is strong and testable, but the implementation is malformed and behaviorally inverted, while the design review and testing artifacts fail to catch that critical defect.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:09:22.319281Z",
+    "repo_ref": "v1.0.18",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 142671,
+      "cached_input_tokens": 71100,
+      "cache_write_input_tokens": 20045,
+      "output_tokens": 8575,
+      "reasoning_output_tokens": 6938
+    },
+    "duration_ms": 110410
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/hide-register-button-on-virtual-and-skills-tabs/metrics.json
@@ -1,0 +1,175 @@
+{
+  "task": "hide-register-button-on-virtual-and-skills-tabs",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.18",
+  "complexity": "trivial",
+  "tags": [
+    "ui",
+    "react",
+    "dashboard",
+    "ux",
+    "fixed-in-v1.0.19"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 107.5,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4668818,
+    "output_tokens": 15313,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4684131,
+    "total_cost_usd": 0.730796,
+    "latency_seconds": 142.5,
+    "num_turns": 160,
+    "generation_tokens_per_sec": 107.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4668818,
+  "output_tokens": 15313,
+  "latency_seconds": 142.5,
+  "num_turns": 160,
+  "total_cost_usd": 0.730796,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:39:46.788378Z",
+  "run_ended_at": "2026-09-11T17:42:09.327173Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4668818,
+    "output_tokens": 15313,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4684131,
+    "total_cost_usd": 0.730796,
+    "latency_seconds": 142.5,
+    "num_turns": 160,
+    "generation_tokens_per_sec": 107.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "hide-register-button-on-virtual-and-skills-tabs",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 23,
+        "correctness": 22,
+        "specificity": 23,
+        "risk_awareness": 19,
+        "total": 87,
+        "notes": "The issue clearly defines the duplicate-action problem, five testable visibility outcomes, and useful non-goals. Its requested behavior aligns directly with the submitted task identifier. The main gap is that it does not address other possible dashboard views, permission-dependent rendering, or accessibility regressions. The claimed relationship to issue #793 and precise existing navigation behavior could not be independently verified because repository shell access was unavailable."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 11,
+        "specificity": 15,
+        "risk_awareness": 9,
+        "total": 49,
+        "notes": "The design identifies Dashboard.tsx, viewFilter, and the relevant view values, giving an implementer a plausible integration point. Its allowlist of discover, servers, and agents conflicts with its own diagram containing an External tab and with the implementation's denylist approach. The cited locations are inconsistent—approximately 1456, 2310, and later 2408—and it never specifies how the condition composes with existing permission checks. The unresolved question about whether Register differs by tab is a load-bearing behavior question, while compatibility and testing guidance remain generic."
+      },
+      "review": {
+        "completeness": 7,
+        "correctness": 5,
+        "specificity": 5,
+        "risk_awareness": 6,
+        "total": 23,
+        "notes": "The review at least recommends checking visibility, tab transitions, registration behavior, and accessibility. Its largest deficiency is that every role effectively approves the design without identifying a concrete defect or resolving the LLD's open behavior question. It misses the allowlist-versus-External-tab ambiguity and calls the implementation clean and well-executed without supporting evidence. Assertions of no security, performance, backend, or monitoring impact are plausible for this small UI change but are not grounded in inspected conditions or tests."
+      },
+      "testing": {
+        "completeness": 15,
+        "correctness": 11,
+        "specificity": 13,
+        "risk_awareness": 12,
+        "total": 51,
+        "notes": "The strongest section provides explicit visible/hidden expectations for all five named tabs and verifies that Register returns after navigating away from Skills. Most actions are prose rather than executable tests, and the broad registration-flow checks lack concrete setup and success-state oracles. The exported URL and token are unused, while the plan dismisses unit and integration tests as inapplicable to a rendering change and offers unverified alternative commands such as npm run test or yarn test. It also omits permission variants, configuration-hidden tabs, the LLD's External view, and a concrete accessibility-checking method."
+      },
+      "implementation": {
+        "completeness": 1,
+        "correctness": 0,
+        "specificity": 3,
+        "risk_awareness": 1,
+        "total": 5,
+        "notes": "The patch does not implement the design: it retains the original unconditional Register button and adds a second conditional copy, leaving Register visible on Virtual and Skills while duplicating it elsewhere. The unified-diff hunk is structurally invalid because its header declares 10 old and 14 new lines, while the body contains 10 old and 20 new lines. The summary also incorrectly reports +7/-0, claims exact LLD conformance despite the denylist/allowlist deviation, and declares completion without tests. Exact source context could not be independently checked because repository shell execution was unavailable, but the patch's intrinsic syntax and behavior defects are independently decisive."
+      }
+    },
+    "task_score": 43.0,
+    "verdict": "The issue is strong and testable, but the implementation is malformed and behaviorally inverted, while the design review and testing artifacts fail to catch that critical defect.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:09:22.319281Z",
+      "repo_ref": "v1.0.18",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 142671,
+        "cached_input_tokens": 71100,
+        "cache_write_input_tokens": 20045,
+        "output_tokens": 8575,
+        "reasoning_output_tokens": 6938
+      },
+      "duration_ms": 110410
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 19,
+      "specificity": 20,
+      "risk_awareness": 15,
+      "total": 74,
+      "notes": "The issue clearly identifies the override mismatch, allowed MCP_CLOUD_PROVIDER values, fallback requirement, and narrow non-goals. Its acceptance criteria are mostly testable, but telemetry alignment and compatibility for “all existing configurations” lack exact oracles, especially for invalid values. The concrete claims reference AWS_REGION, the raw detection cascade, and method=explicit, though no independent task statement was supplied. Baseline repository inspection could not be completed because the local command sandbox failed, so claims about .env.example and issue #1306 remain unverified."
+    },
+    "lld": {
+      "completeness": 18,
+      "correctness": 18,
+      "specificity": 21,
+      "risk_awareness": 15,
+      "total": 72,
+      "notes": "The LLD commits to a precise change in registry/api/system_routes.py from _detect_cloud_provider_with_method() to _resolve_cloud() and describes the API data flow. Its largest deficiencies are zero planned regression tests and leaving the route docstring inconsistent with on_premises, other, and the explicit method. It also incorrectly presents MCP_CLOUD_PROVIDER as new while saying it already exists, and its claim that an additive stats field necessarily breaks compatibility is unsupported. Exact baseline symbols and caching behavior could not be independently verified because repository command execution was unavailable."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 16,
+      "specificity": 13,
+      "risk_awareness": 8,
+      "total": 50,
+      "notes": "The review correctly recommends endpoint regression coverage and recognizes reuse of _resolve_cloud() as the central design decision. It is largely a rubber-stamp persona exercise and fails to catch the LLD’s stale API docstring, contradictory environment-variable treatment, absent tests, or invalid-override behavior. Concrete discussion is limited to the resolver, endpoint, authentication dependency, and documentation concern, while most approvals assert compatibility, caching, and no security impact without evidence. Repository-level validation of those assertions was not possible in the available sandbox."
+    },
+    "testing": {
+      "completeness": 16,
+      "correctness": 7,
+      "specificity": 14,
+      "risk_awareness": 11,
+      "total": 48,
+      "notes": "The plan covers explicit overrides, fallback behavior, response shape, UI display, deployment surfaces, rollback, and concrete expected JSON values. Its critical flaw is that env MCP_CLOUD_PROVIDER=... uv run curl changes only the curl client environment, not the already-running registry process, so the principal functional tests cannot exercise the override. It also treats an empty value as unset, omits a nonempty invalid-value case, and lists unit and integration tests without specifying files, fixtures, or executable assertions. The token path and deployment commands could not be verified against the baseline repository because local inspection failed."
+    },
+    "implementation": {
+      "completeness": 20,
+      "correctness": 20,
+      "specificity": 22,
+      "risk_awareness": 15,
+      "total": 77,
+      "notes": "The patch is internally consistent with the design: it replaces both the local import and invocation in get_telemetry_detection_info() while preserving the response schema. Reusing _resolve_cloud() is a focused end-to-end backend fix if that existing function returns the asserted resolved cloud and method tuple. The largest gaps are no regression test and no update to the route docstring, which still omits override-specific cloud values and the explicit method; the summary’s claim that nothing remains therefore oversells completeness. I could not run git apply --check or inspect the actual baseline source because every local command failed in the sandbox, so patch applicability and resolver semantics remain unverified."
+    }
+  },
+  "task_score": 64.2,
+  "verdict": "The submission presents a plausible, focused fix with a strong core design decision, but its testing commands do not configure the server under test and several repository-specific claims could not be independently validated.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:10:37.900458Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 103769,
+      "cached_input_tokens": 54865,
+      "cache_write_input_tokens": 18800,
+      "output_tokens": 5575,
+      "reasoning_output_tokens": 4157
+    },
+    "duration_ms": 75569
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/honor-cloud-provider-override-in-ui/metrics.json
@@ -1,0 +1,176 @@
+{
+  "task": "honor-cloud-provider-override-in-ui",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "low",
+  "tags": [
+    "bug",
+    "telemetry",
+    "api",
+    "ui",
+    "deployment",
+    "fixed-in-1.25.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 123.7,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3249316,
+    "output_tokens": 15202,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 3264518,
+    "total_cost_usd": 0.511414,
+    "latency_seconds": 122.9,
+    "num_turns": 142,
+    "generation_tokens_per_sec": 123.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 3249316,
+  "output_tokens": 15202,
+  "latency_seconds": 122.9,
+  "num_turns": 142,
+  "total_cost_usd": 0.511414,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:32:15.304534Z",
+  "run_ended_at": "2026-09-11T16:34:18.250199Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 3249316,
+    "output_tokens": 15202,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 3264518,
+    "total_cost_usd": 0.511414,
+    "latency_seconds": 122.9,
+    "num_turns": 142,
+    "generation_tokens_per_sec": 123.7,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "honor-cloud-provider-override-in-ui",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 19,
+        "specificity": 20,
+        "risk_awareness": 15,
+        "total": 74,
+        "notes": "The issue clearly identifies the override mismatch, allowed MCP_CLOUD_PROVIDER values, fallback requirement, and narrow non-goals. Its acceptance criteria are mostly testable, but telemetry alignment and compatibility for “all existing configurations” lack exact oracles, especially for invalid values. The concrete claims reference AWS_REGION, the raw detection cascade, and method=explicit, though no independent task statement was supplied. Baseline repository inspection could not be completed because the local command sandbox failed, so claims about .env.example and issue #1306 remain unverified."
+      },
+      "lld": {
+        "completeness": 18,
+        "correctness": 18,
+        "specificity": 21,
+        "risk_awareness": 15,
+        "total": 72,
+        "notes": "The LLD commits to a precise change in registry/api/system_routes.py from _detect_cloud_provider_with_method() to _resolve_cloud() and describes the API data flow. Its largest deficiencies are zero planned regression tests and leaving the route docstring inconsistent with on_premises, other, and the explicit method. It also incorrectly presents MCP_CLOUD_PROVIDER as new while saying it already exists, and its claim that an additive stats field necessarily breaks compatibility is unsupported. Exact baseline symbols and caching behavior could not be independently verified because repository command execution was unavailable."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 16,
+        "specificity": 13,
+        "risk_awareness": 8,
+        "total": 50,
+        "notes": "The review correctly recommends endpoint regression coverage and recognizes reuse of _resolve_cloud() as the central design decision. It is largely a rubber-stamp persona exercise and fails to catch the LLD’s stale API docstring, contradictory environment-variable treatment, absent tests, or invalid-override behavior. Concrete discussion is limited to the resolver, endpoint, authentication dependency, and documentation concern, while most approvals assert compatibility, caching, and no security impact without evidence. Repository-level validation of those assertions was not possible in the available sandbox."
+      },
+      "testing": {
+        "completeness": 16,
+        "correctness": 7,
+        "specificity": 14,
+        "risk_awareness": 11,
+        "total": 48,
+        "notes": "The plan covers explicit overrides, fallback behavior, response shape, UI display, deployment surfaces, rollback, and concrete expected JSON values. Its critical flaw is that env MCP_CLOUD_PROVIDER=... uv run curl changes only the curl client environment, not the already-running registry process, so the principal functional tests cannot exercise the override. It also treats an empty value as unset, omits a nonempty invalid-value case, and lists unit and integration tests without specifying files, fixtures, or executable assertions. The token path and deployment commands could not be verified against the baseline repository because local inspection failed."
+      },
+      "implementation": {
+        "completeness": 20,
+        "correctness": 20,
+        "specificity": 22,
+        "risk_awareness": 15,
+        "total": 77,
+        "notes": "The patch is internally consistent with the design: it replaces both the local import and invocation in get_telemetry_detection_info() while preserving the response schema. Reusing _resolve_cloud() is a focused end-to-end backend fix if that existing function returns the asserted resolved cloud and method tuple. The largest gaps are no regression test and no update to the route docstring, which still omits override-specific cloud values and the explicit method; the summary’s claim that nothing remains therefore oversells completeness. I could not run git apply --check or inspect the actual baseline source because every local command failed in the sandbox, so patch applicability and resolver semantics remain unverified."
+      }
+    },
+    "task_score": 64.2,
+    "verdict": "The submission presents a plausible, focused fix with a strong core design decision, but its testing commands do not configure the server under test and several repository-specific claims could not be independently validated.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:10:37.900458Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 103769,
+        "cached_input_tokens": 54865,
+        "cache_write_input_tokens": 18800,
+        "output_tokens": 5575,
+        "reasoning_output_tokens": 4157
+      },
+      "duration_ms": 75569
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 17,
+      "risk_awareness": 16,
+      "total": 67,
+      "notes": "The issue clearly defines the short-lived-token failure, preserves static-key behavior, and excludes other OAuth flows. Its largest weakness is that criteria such as proper error handling and secure credential handling lack observable outcomes. It specifically identifies EMBEDDINGS_API_KEY, LiteLLM, refresh buffering, deployment surfaces, and the re-index caveat. With no independent task statement, related issue #1415 and the exact deployment requirements remain unverified."
+    },
+    "lld": {
+      "completeness": 12,
+      "correctness": 3,
+      "specificity": 14,
+      "risk_awareness": 9,
+      "total": 38,
+      "notes": "The design names concrete configuration fields, files, and a token-manager integration path. Its core pseudocode is nonfunctional: it uses async with on threading.Lock and sends the literal value [REDACTED] instead of the client secret to the token endpoint. It also permits HTTP despite later claims of HTTPS enforcement, omits complete settings-to-factory wiring, and leaves refresh-failure behavior unresolved. The claimed existing symbols and patterns in registry/embeddings/client.py and credentials-provider/token_refresher.py could not be verified from the supplied artifact evidence."
+    },
+    "review": {
+      "completeness": 5,
+      "correctness": 1,
+      "specificity": 4,
+      "risk_awareness": 2,
+      "total": 12,
+      "notes": "The review at least calls for compatibility, documentation, concurrency, and timeout testing. Its largest defect is declaring security and thread-safety resolved while missing the LLD's invalid lock usage and redacted credential request. It also claims HTTPS enforcement, retry handling, and deployment integration that the LLD does not provide. The reviewer-role sections are largely generic approvals and do not identify or prioritize the design's critical-path failures."
+    },
+    "testing": {
+      "completeness": 8,
+      "correctness": 3,
+      "specificity": 7,
+      "risk_awareness": 6,
+      "total": 24,
+      "notes": "The plan spans baseline, configuration, deployment, rollback, and nominal end-to-end scenarios. The curl tests use an unsupported /api/embeddings endpoint and do not observe the upstream Authorization header, so they cannot prove token injection or refresh. Test 4 claims to validate missing configuration but merely constructs a client with idp_token_manager=None and treats default acceptance as success. There are no concrete tests for expiry boundaries, concurrent single-flight refresh, malformed token responses, transient failures, or secret redaction."
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "No unified patch.diff content was submitted, so there is no actual implementation to apply or inspect. The summary names three intended files and admits that required configuration validation was omitted, but a summary cannot establish code correctness. It also reports no deployment, documentation, or test changes despite those being acceptance criteria. Target context, symbols, API compatibility, and runtime behavior therefore cannot be verified."
+    }
+  },
+  "task_score": 28.2,
+  "verdict": "The issue is useful, but the submission is not implementation-ready because the LLD's token path is nonfunctional, the review and tests miss those defects, and no code patch was supplied.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:12:36.576962Z",
+    "repo_ref": "1.28.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 163868,
+      "cached_input_tokens": 110920,
+      "cache_write_input_tokens": 24695,
+      "output_tokens": 8636,
+      "reasoning_output_tokens": 7320
+    },
+    "duration_ms": 118663
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/idp-authenticated-embedding-endpoint/metrics.json
@@ -1,0 +1,179 @@
+{
+  "task": "idp-authenticated-embedding-endpoint",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.28.0",
+  "complexity": "high",
+  "tags": [
+    "semantic-search",
+    "embeddings",
+    "oauth",
+    "authentication",
+    "litellm",
+    "docker",
+    "terraform",
+    "helm",
+    "fixed-in-1.29.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 134.5,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4240354,
+    "output_tokens": 27380,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4267734,
+    "total_cost_usd": 0.672056,
+    "latency_seconds": 203.5,
+    "num_turns": 142,
+    "generation_tokens_per_sec": 134.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 4240354,
+  "output_tokens": 27380,
+  "latency_seconds": 203.5,
+  "num_turns": 142,
+  "total_cost_usd": 0.672056,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:35:01.952279Z",
+  "run_ended_at": "2026-09-11T17:38:25.484905Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 4240354,
+    "output_tokens": 27380,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 4267734,
+    "total_cost_usd": 0.672056,
+    "latency_seconds": 203.5,
+    "num_turns": 142,
+    "generation_tokens_per_sec": 134.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "idp-authenticated-embedding-endpoint",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 17,
+        "risk_awareness": 16,
+        "total": 67,
+        "notes": "The issue clearly defines the short-lived-token failure, preserves static-key behavior, and excludes other OAuth flows. Its largest weakness is that criteria such as proper error handling and secure credential handling lack observable outcomes. It specifically identifies EMBEDDINGS_API_KEY, LiteLLM, refresh buffering, deployment surfaces, and the re-index caveat. With no independent task statement, related issue #1415 and the exact deployment requirements remain unverified."
+      },
+      "lld": {
+        "completeness": 12,
+        "correctness": 3,
+        "specificity": 14,
+        "risk_awareness": 9,
+        "total": 38,
+        "notes": "The design names concrete configuration fields, files, and a token-manager integration path. Its core pseudocode is nonfunctional: it uses async with on threading.Lock and sends the literal value [REDACTED] instead of the client secret to the token endpoint. It also permits HTTP despite later claims of HTTPS enforcement, omits complete settings-to-factory wiring, and leaves refresh-failure behavior unresolved. The claimed existing symbols and patterns in registry/embeddings/client.py and credentials-provider/token_refresher.py could not be verified from the supplied artifact evidence."
+      },
+      "review": {
+        "completeness": 5,
+        "correctness": 1,
+        "specificity": 4,
+        "risk_awareness": 2,
+        "total": 12,
+        "notes": "The review at least calls for compatibility, documentation, concurrency, and timeout testing. Its largest defect is declaring security and thread-safety resolved while missing the LLD's invalid lock usage and redacted credential request. It also claims HTTPS enforcement, retry handling, and deployment integration that the LLD does not provide. The reviewer-role sections are largely generic approvals and do not identify or prioritize the design's critical-path failures."
+      },
+      "testing": {
+        "completeness": 8,
+        "correctness": 3,
+        "specificity": 7,
+        "risk_awareness": 6,
+        "total": 24,
+        "notes": "The plan spans baseline, configuration, deployment, rollback, and nominal end-to-end scenarios. The curl tests use an unsupported /api/embeddings endpoint and do not observe the upstream Authorization header, so they cannot prove token injection or refresh. Test 4 claims to validate missing configuration but merely constructs a client with idp_token_manager=None and treats default acceptance as success. There are no concrete tests for expiry boundaries, concurrent single-flight refresh, malformed token responses, transient failures, or secret redaction."
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "No unified patch.diff content was submitted, so there is no actual implementation to apply or inspect. The summary names three intended files and admits that required configuration validation was omitted, but a summary cannot establish code correctness. It also reports no deployment, documentation, or test changes despite those being acceptance criteria. Target context, symbols, API compatibility, and runtime behavior therefore cannot be verified."
+      }
+    },
+    "task_score": 28.2,
+    "verdict": "The issue is useful, but the submission is not implementation-ready because the LLD's token path is nonfunctional, the review and tests miss those defects, and no code patch was supplied.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:12:36.576962Z",
+      "repo_ref": "1.28.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 163868,
+        "cached_input_tokens": 110920,
+        "cache_write_input_tokens": 24695,
+        "output_tokens": 8636,
+        "reasoning_output_tokens": 7320
+      },
+      "duration_ms": 118663
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 17,
+      "specificity": 18,
+      "risk_awareness": 14,
+      "total": 69,
+      "notes": "The issue clearly defines the discoverability problem, documentation-only scope, target files, and explicit non-goals. Its largest deficiency is that “all demo videos,” “logically,” and “prominent” lack a concrete inventory or objective oracle. The repository has the asserted top-level README demo row and a docs directory, but the claimed dozen source files, duplicate references, and related issue #1190 are not substantiated by named evidence. The absent independent task statement also prevents confirming requirements beyond the identifier and internally consistent artifacts."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 12,
+      "specificity": 12,
+      "risk_awareness": 8,
+      "total": 46,
+      "notes": "The LLD correctly centers the change on README.md and a new docs/demo-videos.md without inventing runtime code or dependencies. Its core design decision remains unresolved: categorization is simultaneously a non-goal and a goal, the architecture prescribes a flat list, and the final organization is left as an open question. It names docs/index.md as a demo hub and GitHub Pages as an integration dependency without demonstrating either claim from the relevant baseline. It also provides no enumerated source-link inventory, duplicate policy, maintenance rule, or concrete method for detecting omissions and dead external links."
+    },
+    "review": {
+      "completeness": 14,
+      "correctness": 15,
+      "specificity": 14,
+      "risk_awareness": 12,
+      "total": 55,
+      "notes": "The review identifies two real weaknesses: the missing categorization decision and the manual-maintenance risk as new videos are added. Its largest deficiency is that the repetitive reviewer roles do not catch the LLD's direct flat-list/category contradiction, unsupported docs/index.md claim, or absent source inventory. The backend and overall reviews still approve while acknowledging that organization—the central acceptance requirement—has not been decided. Assertions that the design follows existing conventions and preserves every link are not backed by a checked file or link list."
+    },
+    "testing": {
+      "completeness": 10,
+      "correctness": 6,
+      "specificity": 10,
+      "risk_awareness": 7,
+      "total": 33,
+      "notes": "The README grep and file-existence checks provide a small amount of concrete smoke coverage. The central completeness requirement is never tested by extracting baseline video URLs and comparing them with docs/demo-videos.md, while several proposed oracles are subjective or merely prove that text exists. The backward-compatibility test expects eight URLs to remain in README.md even though the patch intentionally removes the inline video links, and the UX command searches for “## Demo Videos” while the implementation uses “# Demo Videos Index.” The unused REPO_PATH, arbitrary head limits, and checklist requirements for unit, integration, and pytest tests also conflict with the documented documentation-only scope."
+    },
+    "implementation": {
+      "completeness": 18,
+      "correctness": 16,
+      "specificity": 18,
+      "risk_awareness": 11,
+      "total": 63,
+      "notes": "The patch implements the main behavior end to end by replacing the README video row with a docs/demo-videos.md link and adding a categorized 58-line index containing concrete external URLs. Its largest unresolved risk is completeness: no baseline-wide inventory proves every video was captured, and the Agent Skills URL is listed twice under different headings. The summary materially misreports the diff as +2320 lines and README +1/-199 when the submitted patch is +58 and +1/-1, then claims links were verified despite saying verification was not executed. The category-based deviation is disclosed and reasonable, but external URL accessibility and the asserted baseline commit could not be independently established from the artifact."
+    }
+  },
+  "task_score": 53.2,
+  "verdict": "The submission has a clear issue and a plausible functional patch, but its design and tests do not prove complete video coverage, and the implementation summary materially misstates and overclaims the change.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:14:32.868109Z",
+    "repo_ref": "1.24.3",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 193551,
+      "cached_input_tokens": 124836,
+      "cache_write_input_tokens": 22627,
+      "output_tokens": 8988,
+      "reasoning_output_tokens": 7332
+    },
+    "duration_ms": 116279
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/index-demo-videos-in-one-page/metrics.json
@@ -1,0 +1,175 @@
+{
+  "task": "index-demo-videos-in-one-page",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.3",
+  "complexity": "trivial",
+  "tags": [
+    "docs",
+    "markdown",
+    "readme",
+    "discoverability",
+    "fixed-in-1.24.4"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 139.4,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1618005,
+    "output_tokens": 10844,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1628849,
+    "total_cost_usd": 0.256683,
+    "latency_seconds": 77.8,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 139.4,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 1618005,
+  "output_tokens": 10844,
+  "latency_seconds": 77.8,
+  "num_turns": 80,
+  "total_cost_usd": 0.256683,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:38:27.441176Z",
+  "run_ended_at": "2026-09-11T17:39:45.224773Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1618005,
+    "output_tokens": 10844,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1628849,
+    "total_cost_usd": 0.256683,
+    "latency_seconds": 77.8,
+    "num_turns": 80,
+    "generation_tokens_per_sec": 139.4,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "index-demo-videos-in-one-page",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 17,
+        "specificity": 18,
+        "risk_awareness": 14,
+        "total": 69,
+        "notes": "The issue clearly defines the discoverability problem, documentation-only scope, target files, and explicit non-goals. Its largest deficiency is that “all demo videos,” “logically,” and “prominent” lack a concrete inventory or objective oracle. The repository has the asserted top-level README demo row and a docs directory, but the claimed dozen source files, duplicate references, and related issue #1190 are not substantiated by named evidence. The absent independent task statement also prevents confirming requirements beyond the identifier and internally consistent artifacts."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 12,
+        "specificity": 12,
+        "risk_awareness": 8,
+        "total": 46,
+        "notes": "The LLD correctly centers the change on README.md and a new docs/demo-videos.md without inventing runtime code or dependencies. Its core design decision remains unresolved: categorization is simultaneously a non-goal and a goal, the architecture prescribes a flat list, and the final organization is left as an open question. It names docs/index.md as a demo hub and GitHub Pages as an integration dependency without demonstrating either claim from the relevant baseline. It also provides no enumerated source-link inventory, duplicate policy, maintenance rule, or concrete method for detecting omissions and dead external links."
+      },
+      "review": {
+        "completeness": 14,
+        "correctness": 15,
+        "specificity": 14,
+        "risk_awareness": 12,
+        "total": 55,
+        "notes": "The review identifies two real weaknesses: the missing categorization decision and the manual-maintenance risk as new videos are added. Its largest deficiency is that the repetitive reviewer roles do not catch the LLD's direct flat-list/category contradiction, unsupported docs/index.md claim, or absent source inventory. The backend and overall reviews still approve while acknowledging that organization—the central acceptance requirement—has not been decided. Assertions that the design follows existing conventions and preserves every link are not backed by a checked file or link list."
+      },
+      "testing": {
+        "completeness": 10,
+        "correctness": 6,
+        "specificity": 10,
+        "risk_awareness": 7,
+        "total": 33,
+        "notes": "The README grep and file-existence checks provide a small amount of concrete smoke coverage. The central completeness requirement is never tested by extracting baseline video URLs and comparing them with docs/demo-videos.md, while several proposed oracles are subjective or merely prove that text exists. The backward-compatibility test expects eight URLs to remain in README.md even though the patch intentionally removes the inline video links, and the UX command searches for “## Demo Videos” while the implementation uses “# Demo Videos Index.” The unused REPO_PATH, arbitrary head limits, and checklist requirements for unit, integration, and pytest tests also conflict with the documented documentation-only scope."
+      },
+      "implementation": {
+        "completeness": 18,
+        "correctness": 16,
+        "specificity": 18,
+        "risk_awareness": 11,
+        "total": 63,
+        "notes": "The patch implements the main behavior end to end by replacing the README video row with a docs/demo-videos.md link and adding a categorized 58-line index containing concrete external URLs. Its largest unresolved risk is completeness: no baseline-wide inventory proves every video was captured, and the Agent Skills URL is listed twice under different headings. The summary materially misreports the diff as +2320 lines and README +1/-199 when the submitted patch is +58 and +1/-1, then claims links were verified despite saying verification was not executed. The category-based deviation is disclosed and reasonable, but external URL accessibility and the asserted baseline commit could not be independently established from the artifact."
+      }
+    },
+    "task_score": 53.2,
+    "verdict": "The submission has a clear issue and a plausible functional patch, but its design and tests do not prove complete video coverage, and the implementation summary materially misstates and overclaims the change.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:14:32.868109Z",
+      "repo_ref": "1.24.3",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 193551,
+        "cached_input_tokens": 124836,
+        "cache_write_input_tokens": 22627,
+        "output_tokens": 8988,
+        "reasoning_output_tokens": 7332
+      },
+      "duration_ms": 116279
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 17,
+      "specificity": 16,
+      "risk_awareness": 10,
+      "total": 61,
+      "notes": "The issue clearly identifies five related behaviors, names the existing security-scan endpoint, and explicitly scopes servers, agents, and skills. Its largest deficiency is ambiguity around mandatory initial status semantics, unsigned-webhook behavior, permission migration, and the exact webhook contract. No independent task statement was supplied, so the asserted current behavior and cross-asset scan requirement could not be fully verified."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 10,
+      "specificity": 13,
+      "risk_awareness": 11,
+      "total": 48,
+      "notes": "The strongest aspect is its identification of concrete files and symbols such as registry/services/webhook_service.py, Settings, and _perform_security_scan_on_registration. Load-bearing decisions remain unresolved: exact transmitted-byte signing, permission-to-role integration, migration behavior, scan-result propagation, and mandatory-status semantics. The dependency section contradicts itself by proposing cryptography while also relying on standard-library HMAC, and the rollout plan provides no real fallback. Claimed line ranges and deployment paths could not be independently checked because repository shell commands failed before execution."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 13,
+      "specificity": 14,
+      "risk_awareness": 18,
+      "total": 60,
+      "notes": "The review usefully identifies concrete risks including asset deletion during scanning, pagination interaction, replay attacks, secret rotation, and permission migration. Its largest weakness is the unsupported conclusion that all feedback was addressed, while the LLD still uses an example permission name and leaves status validation and HMAC security as open questions. It also praises retry handling that the LLD never specifies and repeatedly approves the design without resolving its critical interface decisions."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 9,
+      "specificity": 10,
+      "risk_awareness": 10,
+      "total": 40,
+      "notes": "The plan provides concrete HTTP examples, names X-Hub-Signature-256, checks invalid-status responses, and includes compatibility and rollback sections. It lacks deterministic setup and oracles: no mixed-status fixtures, exact captured-body signature computation, bounded asynchronous wait, or scan-failure trigger is defined. Mandatory-status behavior and permission allow/deny cases receive no executable tests, while agents and skills are almost entirely omitted despite the issue's scope. Deployment checks are mostly assertions without commands or expected rendered values, and the asserted registration route could not be source-verified."
+    },
+    "implementation": {
+      "completeness": 1,
+      "correctness": 0,
+      "specificity": 1,
+      "risk_awareness": 0,
+      "total": 2,
+      "notes": "The patch does not implement the design in usable form: agent_routes.py and skill_routes.py contain duplicate parameters and stray statements, config.py has malformed Field expressions, and server_routes.py contains invalid nested-quote f-strings. It also self-imports send_registration_webhook, references server_info before assignment, and introduces continue statements outside valid loop structure. Even ignoring syntax, signing uses a separate canonical serialization without ensuring those exact bytes are transmitted, scan events omit the designed result fields, permission enforcement is incorrectly conditional on the status-mandate flag, and multiple required asset paths are absent. The summary's claim of complete implementation is contradicted by the diff; git apply verification was unavailable because the read-only shell sandbox failed before command execution."
+    }
+  },
+  "task_score": 42.2,
+  "verdict": "The design artifacts provide a useful but unresolved foundation, while the submitted implementation is structurally invalid, incomplete, and cannot deliver the claimed feature set.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:16:35.365752Z",
+    "repo_ref": "1.24.7",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 237795,
+      "cached_input_tokens": 173433,
+      "cache_write_input_tokens": 41755,
+      "output_tokens": 10071,
+      "reasoning_output_tokens": 8542
+    },
+    "duration_ms": 122486
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/lifecycle-workflow-webhooks/metrics.json
@@ -1,0 +1,178 @@
+{
+  "task": "lifecycle-workflow-webhooks",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.24.7",
+  "complexity": "high",
+  "tags": [
+    "architecture",
+    "security",
+    "api",
+    "webhooks",
+    "hmac",
+    "lifecycle",
+    "permissions",
+    "fixed-in-1.25.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 110.4,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 8758762,
+    "output_tokens": 28078,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 8786840,
+    "total_cost_usd": 1.370581,
+    "latency_seconds": 254.3,
+    "num_turns": 294,
+    "generation_tokens_per_sec": 110.4,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 8758762,
+  "output_tokens": 28078,
+  "latency_seconds": 254.3,
+  "num_turns": 294,
+  "total_cost_usd": 1.370581,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:27:07.969971Z",
+  "run_ended_at": "2026-09-11T17:31:22.275542Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 8758762,
+    "output_tokens": 28078,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 8786840,
+    "total_cost_usd": 1.370581,
+    "latency_seconds": 254.3,
+    "num_turns": 294,
+    "generation_tokens_per_sec": 110.4,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "lifecycle-workflow-webhooks",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 17,
+        "specificity": 16,
+        "risk_awareness": 10,
+        "total": 61,
+        "notes": "The issue clearly identifies five related behaviors, names the existing security-scan endpoint, and explicitly scopes servers, agents, and skills. Its largest deficiency is ambiguity around mandatory initial status semantics, unsigned-webhook behavior, permission migration, and the exact webhook contract. No independent task statement was supplied, so the asserted current behavior and cross-asset scan requirement could not be fully verified."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 10,
+        "specificity": 13,
+        "risk_awareness": 11,
+        "total": 48,
+        "notes": "The strongest aspect is its identification of concrete files and symbols such as registry/services/webhook_service.py, Settings, and _perform_security_scan_on_registration. Load-bearing decisions remain unresolved: exact transmitted-byte signing, permission-to-role integration, migration behavior, scan-result propagation, and mandatory-status semantics. The dependency section contradicts itself by proposing cryptography while also relying on standard-library HMAC, and the rollout plan provides no real fallback. Claimed line ranges and deployment paths could not be independently checked because repository shell commands failed before execution."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 13,
+        "specificity": 14,
+        "risk_awareness": 18,
+        "total": 60,
+        "notes": "The review usefully identifies concrete risks including asset deletion during scanning, pagination interaction, replay attacks, secret rotation, and permission migration. Its largest weakness is the unsupported conclusion that all feedback was addressed, while the LLD still uses an example permission name and leaves status validation and HMAC security as open questions. It also praises retry handling that the LLD never specifies and repeatedly approves the design without resolving its critical interface decisions."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 9,
+        "specificity": 10,
+        "risk_awareness": 10,
+        "total": 40,
+        "notes": "The plan provides concrete HTTP examples, names X-Hub-Signature-256, checks invalid-status responses, and includes compatibility and rollback sections. It lacks deterministic setup and oracles: no mixed-status fixtures, exact captured-body signature computation, bounded asynchronous wait, or scan-failure trigger is defined. Mandatory-status behavior and permission allow/deny cases receive no executable tests, while agents and skills are almost entirely omitted despite the issue's scope. Deployment checks are mostly assertions without commands or expected rendered values, and the asserted registration route could not be source-verified."
+      },
+      "implementation": {
+        "completeness": 1,
+        "correctness": 0,
+        "specificity": 1,
+        "risk_awareness": 0,
+        "total": 2,
+        "notes": "The patch does not implement the design in usable form: agent_routes.py and skill_routes.py contain duplicate parameters and stray statements, config.py has malformed Field expressions, and server_routes.py contains invalid nested-quote f-strings. It also self-imports send_registration_webhook, references server_info before assignment, and introduces continue statements outside valid loop structure. Even ignoring syntax, signing uses a separate canonical serialization without ensuring those exact bytes are transmitted, scan events omit the designed result fields, permission enforcement is incorrectly conditional on the status-mandate flag, and multiple required asset paths are absent. The summary's claim of complete implementation is contradicted by the diff; git apply verification was unavailable because the read-only shell sandbox failed before command execution."
+      }
+    },
+    "task_score": 42.2,
+    "verdict": "The design artifacts provide a useful but unresolved foundation, while the submitted implementation is structurally invalid, incomplete, and cannot deliver the claimed feature set.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:16:35.365752Z",
+      "repo_ref": "1.24.7",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 237795,
+        "cached_input_tokens": 173433,
+        "cache_write_input_tokens": 41755,
+        "output_tokens": 10071,
+        "reasoning_output_tokens": 8542
+      },
+      "duration_ms": 122486
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 17,
+      "specificity": 14,
+      "risk_awareness": 16,
+      "total": 64,
+      "notes": "The issue clearly identifies URL token exposure, WAF failures, intended logout behavior, and useful non-goals. Its largest deficiency is that “backward compatibility” and provider support lack defined version-skew scenarios or testable outcomes. The submitted route code shows logout_handler appending id_token_hint, while the repository documents matching logout metrics, confirming the problem surface. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/OBSERVABILITY.md)) No independent task statement was supplied, so the claimed provider matrix and exact compatibility requirement remain unverified."
+    },
+    "lld": {
+      "completeness": 8,
+      "correctness": 6,
+      "specificity": 7,
+      "risk_awareness": 7,
+      "total": 28,
+      "notes": "The strongest aspect is naming real integration areas such as registry/auth/routes.py, auth_server/server.py, the session store, and existing logout metrics. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/OBSERVABILITY.md)) The central token-reference mechanism remains undesigned: storage ownership, schema, entropy, TTL, atomic one-time consumption, replay handling, and the final IdP request method are unresolved, so the ID token could still appear in a second browser redirect. It contradicts itself by declaring no configuration or dependencies while recommending Redis and new storage modules, and its rejected Alternative 2 substantially describes the chosen design. Backward-compatible negotiation is left as an open question, and the proposed auth_server/session_store.py and new metric could not be verified."
+    },
+    "review": {
+      "completeness": 13,
+      "correctness": 11,
+      "specificity": 13,
+      "risk_awareness": 17,
+      "total": 54,
+      "notes": "The review usefully identifies randomness, TTL, replay, one-time references, storage health, session-cleanup timing, and migration as material concerns. Its largest deficiency is failing to reject the LLD for leaving the core mechanism and final IdP handoff unspecified, including whether the token simply reappears in a downstream URL. Claims of graceful degradation, minimal infrastructure, and a clear rollback path conflict with the proposed Redis-like shared store and absent compatibility protocol. Recommendations are actionable in places, but signing opaque references and backing up short-lived logout records are not justified, making the approval verdict too lenient."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 9,
+      "specificity": 9,
+      "risk_awareness": 8,
+      "total": 37,
+      "notes": "The plan spans GET and POST logout, missing-session behavior, browser flow, end-to-end SSO, rollback, and the repository's Docker, ECS, and EKS deployment surfaces. Its primary curl test supplies a fabricated session=valid_session_cookie rather than obtaining a valid signed server-side session, so it would not exercise token-bearing logout. It lacks concrete oracles for reference creation and consumption, expiry, replay, store failure, concurrency, provider differences, WAF behavior, and version-skew fallback; the legacy test could even preserve the original leakage. The broad pytest command is plausible, but no exact unit or integration test files, fixtures, cookie name, or executable provider setup are established."
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "The patch does not implement the design: it only creates registry/auth/routes.py.backup and changes no runtime source. The added backup still URL-encodes the ID token and appends it as id_token_hint, preserving the exact behavior the task seeks to remove. implementation.md falsely claims modifications to four runtime files, secure reference storage, auth-server support, telemetry, and exact conformance with the LLD. No tests or safeguards are added, and the claimed complete implementation is therefore fundamentally contradicted by the submitted diff."
+    }
+  },
+  "task_score": 36.6,
+  "verdict": "The issue is a useful problem statement and the review surfaces several real risks, but the core design is unresolved and the submitted patch makes no functional change at all.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:19:25.467346Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 213575,
+      "cached_input_tokens": 94247,
+      "cache_write_input_tokens": 29070,
+      "output_tokens": 10971,
+      "reasoning_output_tokens": 9055
+    },
+    "duration_ms": 170089
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/logout-id-token-hint-out-of-browser-url/metrics.json
@@ -1,0 +1,176 @@
+{
+  "task": "logout-id-token-hint-out-of-browser-url",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "low",
+  "tags": [
+    "auth",
+    "oidc",
+    "logout",
+    "security",
+    "waf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 147.4,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1386628,
+    "output_tokens": 11869,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1398497,
+    "total_cost_usd": 0.221569,
+    "latency_seconds": 80.5,
+    "num_turns": 74,
+    "generation_tokens_per_sec": 147.4,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 1386628,
+  "output_tokens": 11869,
+  "latency_seconds": 80.5,
+  "num_turns": 74,
+  "total_cost_usd": 0.221569,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:47:43.292869Z",
+  "run_ended_at": "2026-09-11T17:49:03.765902Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1386628,
+    "output_tokens": 11869,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1398497,
+    "total_cost_usd": 0.221569,
+    "latency_seconds": 80.5,
+    "num_turns": 74,
+    "generation_tokens_per_sec": 147.4,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "logout-id-token-hint-out-of-browser-url",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 17,
+        "specificity": 14,
+        "risk_awareness": 16,
+        "total": 64,
+        "notes": "The issue clearly identifies URL token exposure, WAF failures, intended logout behavior, and useful non-goals. Its largest deficiency is that “backward compatibility” and provider support lack defined version-skew scenarios or testable outcomes. The submitted route code shows logout_handler appending id_token_hint, while the repository documents matching logout metrics, confirming the problem surface. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/OBSERVABILITY.md)) No independent task statement was supplied, so the claimed provider matrix and exact compatibility requirement remain unverified."
+      },
+      "lld": {
+        "completeness": 8,
+        "correctness": 6,
+        "specificity": 7,
+        "risk_awareness": 7,
+        "total": 28,
+        "notes": "The strongest aspect is naming real integration areas such as registry/auth/routes.py, auth_server/server.py, the session store, and existing logout metrics. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/OBSERVABILITY.md)) The central token-reference mechanism remains undesigned: storage ownership, schema, entropy, TTL, atomic one-time consumption, replay handling, and the final IdP request method are unresolved, so the ID token could still appear in a second browser redirect. It contradicts itself by declaring no configuration or dependencies while recommending Redis and new storage modules, and its rejected Alternative 2 substantially describes the chosen design. Backward-compatible negotiation is left as an open question, and the proposed auth_server/session_store.py and new metric could not be verified."
+      },
+      "review": {
+        "completeness": 13,
+        "correctness": 11,
+        "specificity": 13,
+        "risk_awareness": 17,
+        "total": 54,
+        "notes": "The review usefully identifies randomness, TTL, replay, one-time references, storage health, session-cleanup timing, and migration as material concerns. Its largest deficiency is failing to reject the LLD for leaving the core mechanism and final IdP handoff unspecified, including whether the token simply reappears in a downstream URL. Claims of graceful degradation, minimal infrastructure, and a clear rollback path conflict with the proposed Redis-like shared store and absent compatibility protocol. Recommendations are actionable in places, but signing opaque references and backing up short-lived logout records are not justified, making the approval verdict too lenient."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 9,
+        "specificity": 9,
+        "risk_awareness": 8,
+        "total": 37,
+        "notes": "The plan spans GET and POST logout, missing-session behavior, browser flow, end-to-end SSO, rollback, and the repository's Docker, ECS, and EKS deployment surfaces. Its primary curl test supplies a fabricated session=valid_session_cookie rather than obtaining a valid signed server-side session, so it would not exercise token-bearing logout. It lacks concrete oracles for reference creation and consumption, expiry, replay, store failure, concurrency, provider differences, WAF behavior, and version-skew fallback; the legacy test could even preserve the original leakage. The broad pytest command is plausible, but no exact unit or integration test files, fixtures, cookie name, or executable provider setup are established."
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "The patch does not implement the design: it only creates registry/auth/routes.py.backup and changes no runtime source. The added backup still URL-encodes the ID token and appends it as id_token_hint, preserving the exact behavior the task seeks to remove. implementation.md falsely claims modifications to four runtime files, secure reference storage, auth-server support, telemetry, and exact conformance with the LLD. No tests or safeguards are added, and the claimed complete implementation is therefore fundamentally contradicted by the submitted diff."
+      }
+    },
+    "task_score": 36.6,
+    "verdict": "The issue is a useful problem statement and the review surfaces several real risks, but the core design is unresolved and the submitted patch makes no functional change at all.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:19:25.467346Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 213575,
+        "cached_input_tokens": 94247,
+        "cache_write_input_tokens": 29070,
+        "output_tokens": 10971,
+        "reasoning_output_tokens": 9055
+      },
+      "duration_ms": 170089
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 19,
+      "correctness": 19,
+      "specificity": 19,
+      "risk_awareness": 14,
+      "total": 71,
+      "notes": "The issue clearly scopes Phase 1 rejection of Python below 3.14, preserves the exact Homebrew remediation, and excludes metadata and dependency-sync changes. The repository guide independently documents Python 3.14+ and `brew install python@3.14`. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md)) Its largest gap is ambiguity between dynamically reading project metadata and acceptance criteria fixed to 3.14, with no behavior specified when metadata is unavailable. No independent task statement was supplied, and the claimed later sync failure and issue #1568 could not be verified."
+    },
+    "lld": {
+      "completeness": 12,
+      "correctness": 5,
+      "specificity": 15,
+      "risk_awareness": 8,
+      "total": 40,
+      "notes": "The design names the real `.claude/skills/macos-setup/SKILL.md` integration point and provides a concrete replacement for the existing `PYTHON_OK` check. Its proposed regex accepts Python 3.10 through 3.13, despite claiming to enforce 3.14, and excludes future major versions such as Python 4. It also rejects hard-coding in its alternatives while never reading `pyproject.toml`, leaves dynamic extraction as an open question, and incorrectly describes a `400 / nonzero exit` that its marker-based snippet does not produce. Version-format risk is acknowledged, but the robust `sys.version_info` approach is dismissed without resolving the central correctness problem."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 7,
+      "specificity": 11,
+      "risk_awareness": 8,
+      "total": 36,
+      "notes": "The strongest observation is the backend review's concrete `sys.version_info >= (3,14)` alternative and recognition that version-string parsing has edge cases. The review nevertheless approves the flawed regex without noticing that it matches 3.10-3.13 or that the LLD promises metadata-driven requirements while hard-coding behavior. Most security and SRE commentary is generic, including unsupported shell-injection and deployment-vulnerability claims, while the actual compatibility failure is not prioritized. The repeated approvals therefore provide limited design pressure despite identifying the area that required correction."
+    },
+    "testing": {
+      "completeness": 9,
+      "correctness": 4,
+      "specificity": 12,
+      "risk_awareness": 5,
+      "total": 30,
+      "notes": "The plan supplies concrete commands and expected markers for several version strings, which is more actionable than a purely narrative plan. Its critical Python 3.10 oracle is wrong because the proposed basic regex matches any two-or-more-digit minor version beginning with 1-9, including 3.10. It omits the decisive 3.13 boundary, missing `python3`, Python 4, prerelease output, remediation text, and proof that Phase 1 stops; marking UX testing inapplicable also contradicts the error-message acceptance criterion. The generic `tests/unit`, `tests/integration`, and broad pytest checklist does not explain how those tests would execute or assert behavior embedded in this Markdown skill."
+    },
+    "implementation": {
+      "completeness": 3,
+      "correctness": 0,
+      "specificity": 7,
+      "risk_awareness": 2,
+      "total": 12,
+      "notes": "The patch targets the intended skill and attempts to preserve the existing failure marker, but it does not produce a usable implementation. The unified-diff hunk declares 10 old and 15 new lines while its body contains only four old-side and twelve new-side lines, and the added `grep` command has an unterminated double quote, so the patch is structurally corrupt and the shell code is invalid. Even after repairing those syntax defects, its regex accepts Python 3.10-3.13, does not read `pyproject.toml`, duplicates the Python heading, and adds no clearer requirement message. The summary materially oversells the change as exact and complete with no follow-ups; exact baseline applicability could not be independently checked because the local read-only shell failed to initialize."
+    }
+  },
+  "task_score": 37.8,
+  "verdict": "The issue is reasonably strong, but the design's invalid version comparison propagates through a permissive review and false test oracle into a malformed, non-applicable implementation.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:20:56.034204Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 98778,
+      "cached_input_tokens": 53477,
+      "cache_write_input_tokens": 20384,
+      "output_tokens": 7469,
+      "reasoning_output_tokens": 5883
+    },
+    "duration_ms": 90555
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/macos-setup-python-version-precheck/metrics.json
@@ -1,0 +1,175 @@
+{
+  "task": "macos-setup-python-version-precheck",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "setup",
+    "skill",
+    "developer-experience",
+    "fixed-in-1.28.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 148.2,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2135828,
+    "output_tokens": 14466,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2150294,
+    "total_cost_usd": 0.338925,
+    "latency_seconds": 97.6,
+    "num_turns": 108,
+    "generation_tokens_per_sec": 148.2,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2135828,
+  "output_tokens": 14466,
+  "latency_seconds": 97.6,
+  "num_turns": 108,
+  "total_cost_usd": 0.338925,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:43:38.939671Z",
+  "run_ended_at": "2026-09-11T17:45:16.584283Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2135828,
+    "output_tokens": 14466,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2150294,
+    "total_cost_usd": 0.338925,
+    "latency_seconds": 97.6,
+    "num_turns": 108,
+    "generation_tokens_per_sec": 148.2,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "macos-setup-python-version-precheck",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 19,
+        "correctness": 19,
+        "specificity": 19,
+        "risk_awareness": 14,
+        "total": 71,
+        "notes": "The issue clearly scopes Phase 1 rejection of Python below 3.14, preserves the exact Homebrew remediation, and excludes metadata and dependency-sync changes. The repository guide independently documents Python 3.14+ and `brew install python@3.14`. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md)) Its largest gap is ambiguity between dynamically reading project metadata and acceptance criteria fixed to 3.14, with no behavior specified when metadata is unavailable. No independent task statement was supplied, and the claimed later sync failure and issue #1568 could not be verified."
+      },
+      "lld": {
+        "completeness": 12,
+        "correctness": 5,
+        "specificity": 15,
+        "risk_awareness": 8,
+        "total": 40,
+        "notes": "The design names the real `.claude/skills/macos-setup/SKILL.md` integration point and provides a concrete replacement for the existing `PYTHON_OK` check. Its proposed regex accepts Python 3.10 through 3.13, despite claiming to enforce 3.14, and excludes future major versions such as Python 4. It also rejects hard-coding in its alternatives while never reading `pyproject.toml`, leaves dynamic extraction as an open question, and incorrectly describes a `400 / nonzero exit` that its marker-based snippet does not produce. Version-format risk is acknowledged, but the robust `sys.version_info` approach is dismissed without resolving the central correctness problem."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 7,
+        "specificity": 11,
+        "risk_awareness": 8,
+        "total": 36,
+        "notes": "The strongest observation is the backend review's concrete `sys.version_info >= (3,14)` alternative and recognition that version-string parsing has edge cases. The review nevertheless approves the flawed regex without noticing that it matches 3.10-3.13 or that the LLD promises metadata-driven requirements while hard-coding behavior. Most security and SRE commentary is generic, including unsupported shell-injection and deployment-vulnerability claims, while the actual compatibility failure is not prioritized. The repeated approvals therefore provide limited design pressure despite identifying the area that required correction."
+      },
+      "testing": {
+        "completeness": 9,
+        "correctness": 4,
+        "specificity": 12,
+        "risk_awareness": 5,
+        "total": 30,
+        "notes": "The plan supplies concrete commands and expected markers for several version strings, which is more actionable than a purely narrative plan. Its critical Python 3.10 oracle is wrong because the proposed basic regex matches any two-or-more-digit minor version beginning with 1-9, including 3.10. It omits the decisive 3.13 boundary, missing `python3`, Python 4, prerelease output, remediation text, and proof that Phase 1 stops; marking UX testing inapplicable also contradicts the error-message acceptance criterion. The generic `tests/unit`, `tests/integration`, and broad pytest checklist does not explain how those tests would execute or assert behavior embedded in this Markdown skill."
+      },
+      "implementation": {
+        "completeness": 3,
+        "correctness": 0,
+        "specificity": 7,
+        "risk_awareness": 2,
+        "total": 12,
+        "notes": "The patch targets the intended skill and attempts to preserve the existing failure marker, but it does not produce a usable implementation. The unified-diff hunk declares 10 old and 15 new lines while its body contains only four old-side and twelve new-side lines, and the added `grep` command has an unterminated double quote, so the patch is structurally corrupt and the shell code is invalid. Even after repairing those syntax defects, its regex accepts Python 3.10-3.13, does not read `pyproject.toml`, duplicates the Python heading, and adds no clearer requirement message. The summary materially oversells the change as exact and complete with no follow-ups; exact baseline applicability could not be independently checked because the local read-only shell failed to initialize."
+      }
+    },
+    "task_score": 37.8,
+    "verdict": "The issue is reasonably strong, but the design's invalid version comparison propagates through a permissive review and false test oracle into a malformed, non-applicable implementation.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:20:56.034204Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 98778,
+        "cached_input_tokens": 53477,
+        "cache_write_input_tokens": 20384,
+        "output_tokens": 7469,
+        "reasoning_output_tokens": 5883
+      },
+      "duration_ms": 90555
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 17,
+      "correctness": 17,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 65,
+      "notes": "The issue clearly identifies nginx prefix matching, the concrete `_create_location_block` integration point, and expected preservation of `/name/mcp` and `/name/sse`. The submitted baseline source confirms that `registry/core/nginx_service.py` currently assigns `location_path = path`. Its largest deficiency is asserting no deployment breakage and compatibility with already-written configurations without addressing bare `/name` requests or how persisted configurations are regenerated. No independent task statement was supplied, and the claimed security impact beyond route interception and authentication interference cannot be verified."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 11,
+      "specificity": 16,
+      "risk_awareness": 8,
+      "total": 49,
+      "notes": "The design names the real file, method, formatting expression, and a concrete conditional normalization algorithm. However, its claim that virtual-server locations already handle trailing slashes is contradicted by `_generate_virtual_server_blocks`, which emits `safe_vs_path` without normalization. It also incorrectly says there is no runtime behavior change, leaves leading-slash normalization open, proposes no new tests, and does not decide how exact `/a` requests should behave. The rollout merely declares backward compatibility and provides no regeneration, validation, fallback, or rollback procedure for existing generated configurations."
+    },
+    "review": {
+      "completeness": 11,
+      "correctness": 9,
+      "specificity": 11,
+      "risk_awareness": 11,
+      "total": 42,
+      "notes": "The strongest recommendation is concrete collision coverage for `/a` versus `/api`, plus already-slashed and empty-path cases. Most persona sections repeat generic approval and do not challenge the LLD's unsupported compatibility, virtual-server, or no-runtime-change assertions. The security review upgrades an observed route/authentication interference bug into access bypass, path traversal, and prefix attacks without repository evidence. It also contradicts the proposed conditional normalization by saying duplicate slashes are acceptable rather than requiring a resolved design."
+    },
+    "testing": {
+      "completeness": 8,
+      "correctness": 6,
+      "specificity": 10,
+      "risk_awareness": 6,
+      "total": 30,
+      "notes": "The plan names the real singleton and generation method and gives the useful concrete oracle `location {{ROOT_PATH}}/a/ {`. Its scripts mostly print GOOD or BAD without assertions or nonzero failure, so they can pass while the feature is broken. The backward-compatibility script calls nonexistent Python method `line.trim()`, and the registration endpoint and payload are not established by the supplied repository evidence. The promised end-to-end route test is only prose and never proves with nginx that `/a/mcp` matches while `/api/`, `/auth`, and bare `/a` behave correctly."
+    },
+    "implementation": {
+      "completeness": 16,
+      "correctness": 18,
+      "specificity": 14,
+      "risk_awareness": 10,
+      "total": 58,
+      "notes": "The core hunk implements the intended behavior: `path.rstrip(\"/\") + \"/\"` converts `/a` to `/a/` while avoiding duplicate trailing separators, and its target symbol and surrounding context match the submitted baseline source. The largest defect is the unrelated addition of a 2,497-line `registry/core/nginx_service.py.backup`, which duplicates the entire original module and should not be committed. The summary falsely reports only one touched file and `+3/-3`, claims no deviation despite using broader `rstrip` normalization than the LLD's conditional append, and adds no regression test. An independent `git apply --check` could not be executed because the provided command sandbox failed before process launch, so clean application against the local checkout remains unverified."
+    }
+  },
+  "task_score": 48.8,
+  "verdict": "The submission identifies and implements the core one-line routing fix, but weak compatibility analysis, largely non-asserting tests, unsupported security claims, and an undisclosed full-source backup file make it unsuitable to merge as submitted.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:22:23.309115Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 214542,
+      "cached_input_tokens": 146801,
+      "cache_write_input_tokens": 51659,
+      "output_tokens": 7191,
+      "reasoning_output_tokens": 5308
+    },
+    "duration_ms": 87261
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/nginx-location-trailing-slash-route-hijack/metrics.json
@@ -1,0 +1,177 @@
+{
+  "task": "nginx-location-trailing-slash-route-hijack",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "medium",
+  "tags": [
+    "bug",
+    "security",
+    "nginx",
+    "routing",
+    "auth",
+    "python",
+    "fixed-in-1.28.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 128.2,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2803098,
+    "output_tokens": 16460,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2819558,
+    "total_cost_usd": 0.443251,
+    "latency_seconds": 128.4,
+    "num_turns": 117,
+    "generation_tokens_per_sec": 128.2,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2803098,
+  "output_tokens": 16460,
+  "latency_seconds": 128.4,
+  "num_turns": 117,
+  "total_cost_usd": 0.443251,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:50:37.864216Z",
+  "run_ended_at": "2026-09-11T16:52:46.238496Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2803098,
+    "output_tokens": 16460,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2819558,
+    "total_cost_usd": 0.443251,
+    "latency_seconds": 128.4,
+    "num_turns": 117,
+    "generation_tokens_per_sec": 128.2,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "nginx-location-trailing-slash-route-hijack",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 17,
+        "correctness": 17,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 65,
+        "notes": "The issue clearly identifies nginx prefix matching, the concrete `_create_location_block` integration point, and expected preservation of `/name/mcp` and `/name/sse`. The submitted baseline source confirms that `registry/core/nginx_service.py` currently assigns `location_path = path`. Its largest deficiency is asserting no deployment breakage and compatibility with already-written configurations without addressing bare `/name` requests or how persisted configurations are regenerated. No independent task statement was supplied, and the claimed security impact beyond route interception and authentication interference cannot be verified."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 11,
+        "specificity": 16,
+        "risk_awareness": 8,
+        "total": 49,
+        "notes": "The design names the real file, method, formatting expression, and a concrete conditional normalization algorithm. However, its claim that virtual-server locations already handle trailing slashes is contradicted by `_generate_virtual_server_blocks`, which emits `safe_vs_path` without normalization. It also incorrectly says there is no runtime behavior change, leaves leading-slash normalization open, proposes no new tests, and does not decide how exact `/a` requests should behave. The rollout merely declares backward compatibility and provides no regeneration, validation, fallback, or rollback procedure for existing generated configurations."
+      },
+      "review": {
+        "completeness": 11,
+        "correctness": 9,
+        "specificity": 11,
+        "risk_awareness": 11,
+        "total": 42,
+        "notes": "The strongest recommendation is concrete collision coverage for `/a` versus `/api`, plus already-slashed and empty-path cases. Most persona sections repeat generic approval and do not challenge the LLD's unsupported compatibility, virtual-server, or no-runtime-change assertions. The security review upgrades an observed route/authentication interference bug into access bypass, path traversal, and prefix attacks without repository evidence. It also contradicts the proposed conditional normalization by saying duplicate slashes are acceptable rather than requiring a resolved design."
+      },
+      "testing": {
+        "completeness": 8,
+        "correctness": 6,
+        "specificity": 10,
+        "risk_awareness": 6,
+        "total": 30,
+        "notes": "The plan names the real singleton and generation method and gives the useful concrete oracle `location {{ROOT_PATH}}/a/ {`. Its scripts mostly print GOOD or BAD without assertions or nonzero failure, so they can pass while the feature is broken. The backward-compatibility script calls nonexistent Python method `line.trim()`, and the registration endpoint and payload are not established by the supplied repository evidence. The promised end-to-end route test is only prose and never proves with nginx that `/a/mcp` matches while `/api/`, `/auth`, and bare `/a` behave correctly."
+      },
+      "implementation": {
+        "completeness": 16,
+        "correctness": 18,
+        "specificity": 14,
+        "risk_awareness": 10,
+        "total": 58,
+        "notes": "The core hunk implements the intended behavior: `path.rstrip(\"/\") + \"/\"` converts `/a` to `/a/` while avoiding duplicate trailing separators, and its target symbol and surrounding context match the submitted baseline source. The largest defect is the unrelated addition of a 2,497-line `registry/core/nginx_service.py.backup`, which duplicates the entire original module and should not be committed. The summary falsely reports only one touched file and `+3/-3`, claims no deviation despite using broader `rstrip` normalization than the LLD's conditional append, and adds no regression test. An independent `git apply --check` could not be executed because the provided command sandbox failed before process launch, so clean application against the local checkout remains unverified."
+      }
+    },
+    "task_score": 48.8,
+    "verdict": "The submission identifies and implements the core one-line routing fix, but weak compatibility analysis, largely non-asserting tests, unsupported security claims, and an undisclosed full-source backup file make it unsuitable to merge as submitted.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:22:23.309115Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 214542,
+        "cached_input_tokens": 146801,
+        "cache_write_input_tokens": 51659,
+        "output_tokens": 7191,
+        "reasoning_output_tokens": 5308
+      },
+      "duration_ms": 87261
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 20,
+      "correctness": 18,
+      "specificity": 19,
+      "risk_awareness": 12,
+      "total": 69,
+      "notes": "The issue clearly names both variables, the affected registry service, testable acceptance criteria, and a non-compose exclusion. The supplied baseline copies support their absence from the podman and prebuilt registry environments, but not the broader claim about every compose surface. The largest gap is that “all compose files” is not enumerated and default-empty compatibility and allowlist misuse are not acceptance criteria. No independent task statement exists, and the .env.example, runtime-reader, and issue #1513 claims could not be independently verified because local shell execution failed before accessing the tree."
+    },
+    "lld": {
+      "completeness": 14,
+      "correctness": 11,
+      "specificity": 14,
+      "risk_awareness": 8,
+      "total": 47,
+      "notes": "The LLD identifies concrete compose files, the registry environment list, the ${VAR:-} convention, and the intended configuration data flow. Its largest defect is unresolved scope: docker-compose.dhi.yml is variously “possibly missing,” “if applicable,” and mandatory, while the implementation changes only podman and prebuilt files. The stated two modified lines also contradict the six proposed assignments, and the claim that relying on .env.example would require runtime logic misunderstands Compose interpolation. It does not address least-privilege configuration or verification of security behavior, and the DHI, .env.example, and runtime-reader claims could not be independently checked."
+    },
+    "review": {
+      "completeness": 8,
+      "correctness": 7,
+      "specificity": 7,
+      "risk_awareness": 5,
+      "total": 27,
+      "notes": "The review consistently calls for exact variable names and alignment across compose variants. It is predominantly repetitive role-play and misses the LLD’s unresolved DHI scope, inconsistent file and line counts, and weak rollout and validation decisions. The security concern about preferring empty defaults over an explicit dash is technically confused because the dash in ${VAR:-} is interpolation syntax, not a literal value. Unsupported assertions that the change has no breakage risk replace analysis of rendered configuration, permissive allowlists, or backward-compatible empty defaults."
+    },
+    "testing": {
+      "completeness": 11,
+      "correctness": 8,
+      "specificity": 11,
+      "risk_awareness": 6,
+      "total": 36,
+      "notes": "The plan provides concrete commands for default values, custom values, compose validation, and startup. Its grep checks do not prove the values belong to the registry service, custom-value coverage is limited to podman, and startup logs neither inspect the container environment nor exercise SSRF allowlisting. The hard-coded clone path is not portable, DHI is omitted despite the LLD, and the validation loops report “Invalid” but still normally exit successfully because the final echo succeeds. “All existing functionality preserved” has no oracle, while the checklist claims unit and integration tests that the implementation does not add."
+    },
+    "implementation": {
+      "completeness": 7,
+      "correctness": 9,
+      "specificity": 6,
+      "risk_awareness": 2,
+      "total": 24,
+      "notes": "The two functional hunks use valid Compose interpolation and place both variables in the podman and prebuilt registry environment lists. However, the patch also adds two complete .backup files and two temporary file fragments totaling thousands of unrelated lines, while implementation.md falsely reports only two touched files and no deviations. It omits the DHI change required by its own LLD, misplaces explanatory comments beneath unrelated ARD and RUM comments, and asserts an unverified cloud-metadata security guarantee. Independent git apply --check was unavailable because the read-only shell wrapper failed before command execution, although the hunk context matches the baseline copies embedded in the submission."
+    }
+  },
+  "task_score": 40.6,
+  "verdict": "The core configuration fix is identified and partially implemented, but the implementation is not review-ready because it includes massive backup and temporary-file churn and a materially inaccurate summary, while the design, review, and tests leave compose scope unresolved.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:23:52.473891Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 250365,
+      "cached_input_tokens": 173280,
+      "cache_write_input_tokens": 60519,
+      "output_tokens": 7708,
+      "reasoning_output_tokens": 5891
+    },
+    "duration_ms": 89151
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/pass-ssrf-allowlist-env-to-registry-container/metrics.json
@@ -1,0 +1,175 @@
+{
+  "task": "pass-ssrf-allowlist-env-to-registry-container",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "docker",
+    "compose",
+    "configuration",
+    "ssrf",
+    "fixed-in-1.28.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 144.8,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1839122,
+    "output_tokens": 12408,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1851530,
+    "total_cost_usd": 0.291812,
+    "latency_seconds": 85.7,
+    "num_turns": 98,
+    "generation_tokens_per_sec": 144.8,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 1839122,
+  "output_tokens": 12408,
+  "latency_seconds": 85.7,
+  "num_turns": 98,
+  "total_cost_usd": 0.291812,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:42:11.273455Z",
+  "run_ended_at": "2026-09-11T17:43:36.944438Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 1839122,
+    "output_tokens": 12408,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 1851530,
+    "total_cost_usd": 0.291812,
+    "latency_seconds": 85.7,
+    "num_turns": 98,
+    "generation_tokens_per_sec": 144.8,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "pass-ssrf-allowlist-env-to-registry-container",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 20,
+        "correctness": 18,
+        "specificity": 19,
+        "risk_awareness": 12,
+        "total": 69,
+        "notes": "The issue clearly names both variables, the affected registry service, testable acceptance criteria, and a non-compose exclusion. The supplied baseline copies support their absence from the podman and prebuilt registry environments, but not the broader claim about every compose surface. The largest gap is that “all compose files” is not enumerated and default-empty compatibility and allowlist misuse are not acceptance criteria. No independent task statement exists, and the .env.example, runtime-reader, and issue #1513 claims could not be independently verified because local shell execution failed before accessing the tree."
+      },
+      "lld": {
+        "completeness": 14,
+        "correctness": 11,
+        "specificity": 14,
+        "risk_awareness": 8,
+        "total": 47,
+        "notes": "The LLD identifies concrete compose files, the registry environment list, the ${VAR:-} convention, and the intended configuration data flow. Its largest defect is unresolved scope: docker-compose.dhi.yml is variously “possibly missing,” “if applicable,” and mandatory, while the implementation changes only podman and prebuilt files. The stated two modified lines also contradict the six proposed assignments, and the claim that relying on .env.example would require runtime logic misunderstands Compose interpolation. It does not address least-privilege configuration or verification of security behavior, and the DHI, .env.example, and runtime-reader claims could not be independently checked."
+      },
+      "review": {
+        "completeness": 8,
+        "correctness": 7,
+        "specificity": 7,
+        "risk_awareness": 5,
+        "total": 27,
+        "notes": "The review consistently calls for exact variable names and alignment across compose variants. It is predominantly repetitive role-play and misses the LLD’s unresolved DHI scope, inconsistent file and line counts, and weak rollout and validation decisions. The security concern about preferring empty defaults over an explicit dash is technically confused because the dash in ${VAR:-} is interpolation syntax, not a literal value. Unsupported assertions that the change has no breakage risk replace analysis of rendered configuration, permissive allowlists, or backward-compatible empty defaults."
+      },
+      "testing": {
+        "completeness": 11,
+        "correctness": 8,
+        "specificity": 11,
+        "risk_awareness": 6,
+        "total": 36,
+        "notes": "The plan provides concrete commands for default values, custom values, compose validation, and startup. Its grep checks do not prove the values belong to the registry service, custom-value coverage is limited to podman, and startup logs neither inspect the container environment nor exercise SSRF allowlisting. The hard-coded clone path is not portable, DHI is omitted despite the LLD, and the validation loops report “Invalid” but still normally exit successfully because the final echo succeeds. “All existing functionality preserved” has no oracle, while the checklist claims unit and integration tests that the implementation does not add."
+      },
+      "implementation": {
+        "completeness": 7,
+        "correctness": 9,
+        "specificity": 6,
+        "risk_awareness": 2,
+        "total": 24,
+        "notes": "The two functional hunks use valid Compose interpolation and place both variables in the podman and prebuilt registry environment lists. However, the patch also adds two complete .backup files and two temporary file fragments totaling thousands of unrelated lines, while implementation.md falsely reports only two touched files and no deviations. It omits the DHI change required by its own LLD, misplaces explanatory comments beneath unrelated ARD and RUM comments, and asserts an unverified cloud-metadata security guarantee. Independent git apply --check was unavailable because the read-only shell wrapper failed before command execution, although the hunk context matches the baseline copies embedded in the submission."
+      }
+    },
+    "task_score": 40.6,
+    "verdict": "The core configuration fix is identified and partially implemented, but the implementation is not review-ready because it includes massive backup and temporary-file churn and a materially inaccurate summary, while the design, review, and tests leave compose scope unresolved.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:23:52.473891Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 250365,
+        "cached_input_tokens": 173280,
+        "cache_write_input_tokens": 60519,
+        "output_tokens": 7708,
+        "reasoning_output_tokens": 5891
+      },
+      "duration_ms": 89151
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 16,
+      "correctness": 18,
+      "specificity": 13,
+      "risk_awareness": 9,
+      "total": 56,
+      "notes": "The strongest aspect is its clear statement of noisy-neighbor behavior, independent caller-target quotas, early quarantine, backward compatibility, and API/CLI/UI scope. The repository README confirms the broad feature shape: caller_target limits, auto-seeded reserved-group quarantine, plain 403 denial, and runtime administration. ([github.com](https://github.com/agentic-community/mcp-gateway-registry)) The largest deficiency is that the acceptance criteria are not directly testable and omit identity types, unclassified targets, response semantics, administrative authorization, protected admin users, and the off-by-default requirement. No independent task statement was supplied, so finer requirement coverage beyond the identifier and repository documentation remains unverifiable."
+    },
+    "lld": {
+      "completeness": 10,
+      "correctness": 7,
+      "specificity": 11,
+      "risk_awareness": 8,
+      "total": 36,
+      "notes": "The strongest aspect is identifying the auth-server validation point, three enforcement axes, early quarantine, and reuse of existing storage. The largest deficiency is unresolved and contradictory core design: it alternates between adding CallerTargetRateLimitDefinition and extending RateLimitDefinition, invents list_caller_target_limits and is_quarantined interfaces, and leaves startup seeding and response semantics open. The repository describes quarantine as reserved-group membership for users, agents, and MCP servers, admin-only and admin-protected fail-closed, whereas this design creates quarantined_* subject types, defaults a new flag on, and returns dummy throttle fields. ([github.com](https://github.com/agentic-community/mcp-gateway-registry)) The proposed route-module CLI and several paths or symbols could not be verified, and the design promises UI support without identifying frontend changes."
+    },
+    "review": {
+      "completeness": 15,
+      "correctness": 14,
+      "specificity": 15,
+      "risk_awareness": 17,
+      "total": 61,
+      "notes": "The strongest aspect is its identification of raw composite-key ambiguity, missing target classification, counter cardinality, authorization and audit requirements, and quarantine lifecycle risks. The largest deficiency is that it misses the LLD's central contradictions around reserved groups, auto-seeding, default enablement, invented repository APIs, and absent frontend work. It repeats unsupported claims of full backward compatibility and clear observability, while most recommendations remain questions rather than concrete design corrections. Given that the repository documents admin protection, fail-closed safeguards, plain 403 semantics, and an off-by-default rollout, the overall review should have required revision rather than mostly approving with changes. ([github.com](https://github.com/agentic-community/mcp-gateway-registry))"
+    },
+    "testing": {
+      "completeness": 9,
+      "correctness": 6,
+      "specificity": 9,
+      "risk_awareness": 7,
+      "total": 31,
+      "notes": "The strongest aspect is an end-to-end narrative with a concrete 51st-request 429 oracle and quarantine expecting an immediate 403 without Retry-After. The largest defect is invalid identity setup: one access token is reused while X-Caller-ID and X-Target-ID headers supposedly change caller and target identity, so the tests do not establish actual authenticated isolation or classification. The route-module CLI is unverified, backward-compatibility tests merely create definitions without exercising them, and UX and deployment sections contain no executable assertions. Missing cases include a second caller's independent bucket, one caller across two targets, unclassified targets, reserved-group seeding and deletion protection, admin immunity, backend failure policy, counter reset, and concurrent requests."
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "No unified diff was submitted; the artifact contains only implementation.md and refers to an external patch.diff, so there is no implementation that can be applied or checked against the source. Claims about four modified files, backward compatibility, early enforcement, and fail-open behavior therefore cannot be verified. The summary also claims no LLD deviations while admitting that required admin API/UI work and target-classification edge cases were not implemented, describing a partial change even on its own terms."
+    }
+  },
+  "task_score": 36.8,
+  "verdict": "The submission identifies the intended feature and several real risks, but the design and tests rely on unverified interfaces and unresolved security semantics, and no actual implementation diff was provided.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:26:24.538338Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 134598,
+      "cached_input_tokens": 68621,
+      "cache_write_input_tokens": 25949,
+      "output_tokens": 9581,
+      "reasoning_output_tokens": 7785
+    },
+    "duration_ms": 152051
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/per-caller-per-target-rate-limits-and-quarantine/metrics.json
@@ -1,0 +1,176 @@
+{
+  "task": "per-caller-per-target-rate-limits-and-quarantine",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "high",
+  "tags": [
+    "rate-limiting",
+    "security",
+    "auth-server",
+    "api",
+    "operations",
+    "fixed-in-1.28.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 136.2,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2889686,
+    "output_tokens": 29353,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2919039,
+    "total_cost_usd": 0.464597,
+    "latency_seconds": 215.5,
+    "num_turns": 102,
+    "generation_tokens_per_sec": 136.2,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2889686,
+  "output_tokens": 29353,
+  "latency_seconds": 215.5,
+  "num_turns": 102,
+  "total_cost_usd": 0.464597,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:31:24.214976Z",
+  "run_ended_at": "2026-09-11T17:34:59.715169Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2889686,
+    "output_tokens": 29353,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2919039,
+    "total_cost_usd": 0.464597,
+    "latency_seconds": 215.5,
+    "num_turns": 102,
+    "generation_tokens_per_sec": 136.2,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "per-caller-per-target-rate-limits-and-quarantine",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 16,
+        "correctness": 18,
+        "specificity": 13,
+        "risk_awareness": 9,
+        "total": 56,
+        "notes": "The strongest aspect is its clear statement of noisy-neighbor behavior, independent caller-target quotas, early quarantine, backward compatibility, and API/CLI/UI scope. The repository README confirms the broad feature shape: caller_target limits, auto-seeded reserved-group quarantine, plain 403 denial, and runtime administration. ([github.com](https://github.com/agentic-community/mcp-gateway-registry)) The largest deficiency is that the acceptance criteria are not directly testable and omit identity types, unclassified targets, response semantics, administrative authorization, protected admin users, and the off-by-default requirement. No independent task statement was supplied, so finer requirement coverage beyond the identifier and repository documentation remains unverifiable."
+      },
+      "lld": {
+        "completeness": 10,
+        "correctness": 7,
+        "specificity": 11,
+        "risk_awareness": 8,
+        "total": 36,
+        "notes": "The strongest aspect is identifying the auth-server validation point, three enforcement axes, early quarantine, and reuse of existing storage. The largest deficiency is unresolved and contradictory core design: it alternates between adding CallerTargetRateLimitDefinition and extending RateLimitDefinition, invents list_caller_target_limits and is_quarantined interfaces, and leaves startup seeding and response semantics open. The repository describes quarantine as reserved-group membership for users, agents, and MCP servers, admin-only and admin-protected fail-closed, whereas this design creates quarantined_* subject types, defaults a new flag on, and returns dummy throttle fields. ([github.com](https://github.com/agentic-community/mcp-gateway-registry)) The proposed route-module CLI and several paths or symbols could not be verified, and the design promises UI support without identifying frontend changes."
+      },
+      "review": {
+        "completeness": 15,
+        "correctness": 14,
+        "specificity": 15,
+        "risk_awareness": 17,
+        "total": 61,
+        "notes": "The strongest aspect is its identification of raw composite-key ambiguity, missing target classification, counter cardinality, authorization and audit requirements, and quarantine lifecycle risks. The largest deficiency is that it misses the LLD's central contradictions around reserved groups, auto-seeding, default enablement, invented repository APIs, and absent frontend work. It repeats unsupported claims of full backward compatibility and clear observability, while most recommendations remain questions rather than concrete design corrections. Given that the repository documents admin protection, fail-closed safeguards, plain 403 semantics, and an off-by-default rollout, the overall review should have required revision rather than mostly approving with changes. ([github.com](https://github.com/agentic-community/mcp-gateway-registry))"
+      },
+      "testing": {
+        "completeness": 9,
+        "correctness": 6,
+        "specificity": 9,
+        "risk_awareness": 7,
+        "total": 31,
+        "notes": "The strongest aspect is an end-to-end narrative with a concrete 51st-request 429 oracle and quarantine expecting an immediate 403 without Retry-After. The largest defect is invalid identity setup: one access token is reused while X-Caller-ID and X-Target-ID headers supposedly change caller and target identity, so the tests do not establish actual authenticated isolation or classification. The route-module CLI is unverified, backward-compatibility tests merely create definitions without exercising them, and UX and deployment sections contain no executable assertions. Missing cases include a second caller's independent bucket, one caller across two targets, unclassified targets, reserved-group seeding and deletion protection, admin immunity, backend failure policy, counter reset, and concurrent requests."
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "No unified diff was submitted; the artifact contains only implementation.md and refers to an external patch.diff, so there is no implementation that can be applied or checked against the source. Claims about four modified files, backward compatibility, early enforcement, and fail-open behavior therefore cannot be verified. The summary also claims no LLD deviations while admitting that required admin API/UI work and target-classification edge cases were not implemented, describing a partial change even on its own terms."
+      }
+    },
+    "task_score": 36.8,
+    "verdict": "The submission identifies the intended feature and several real risks, but the design and tests rely on unverified interfaces and unresolved security semantics, and no actual implementation diff was provided.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:26:24.538338Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 134598,
+        "cached_input_tokens": 68621,
+        "cache_write_input_tokens": 25949,
+        "output_tokens": 9581,
+        "reasoning_output_tokens": 7785
+      },
+      "duration_ms": 152051
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 18,
+      "correctness": 15,
+      "specificity": 18,
+      "risk_awareness": 13,
+      "total": 64,
+      "notes": "The issue clearly identifies build_and_run.sh, .env, the GNU/BSD sed -i incompatibility, and useful scope exclusions. Its largest weakness is an overstated causal claim: the shown flow appends the generated value after sed, so failure demonstrably leaves empty or duplicate entries rather than necessarily discarding the secret. The replacement and cross-platform criteria are testable, but preserving error handling and preventing silent failures lack precise observable outcomes. No independent task statement was supplied, and the related issue #1577 could not be verified."
+    },
+    "lld": {
+      "completeness": 15,
+      "correctness": 10,
+      "specificity": 17,
+      "risk_awareness": 10,
+      "total": 52,
+      "notes": "The LLD's strongest aspect is its concrete identification of build_and_run.sh and the eleven affected sed expressions reflected in the patch. The chosen helper is not safely designed: mktemp may place the file on another filesystem, undermining the atomic-move claim, while failure checks, cleanup, and metadata preservation are unspecified. One proposed redirection alternative would concatenate two independently filtered copies of .env, and load-bearing questions about error reporting and BSD testing remain unresolved. Exact baseline line counts could not be independently checked because the local command sandbox failed before execution."
+    },
+    "review": {
+      "completeness": 10,
+      "correctness": 8,
+      "specificity": 10,
+      "risk_awareness": 11,
+      "total": 39,
+      "notes": "The review's strongest observation is that temporary-file cleanup, permissions, and silent failures require attention. Its largest deficiency is approving the design as atomic and backward-compatible without analyzing the helper's actual failure semantics. It misses both the malformed quoted dynamic sed expression and the possibility that a suppressed sed failure leads to an empty file replacing .env, so its no-blocker verdict is not defensible. Claims about preserved logging, error handling, and complete command coverage were not independently verified against the baseline repository."
+    },
+    "testing": {
+      "completeness": 7,
+      "correctness": 4,
+      "specificity": 4,
+      "risk_awareness": 4,
+      "total": 19,
+      "notes": "The plan at least identifies Linux/macOS compatibility, backward behavior, logging, and deployment surfaces. Its only concrete setup writes to /tmp/test.env even though the submitted script operations target .env, and it invokes neither the helper nor the script. It incorrectly says both SECRET_KEY lines should be removed, which would delete the valid non-empty value, while most other sections provide no actions or exact oracles. The dynamic ENV_VAR_NAME path, sed/mktemp/mv failures, duplicate entries, file permissions, and cleanup are untested, and the asserted logging strings and test-directory conventions could not be verified."
+    },
+    "implementation": {
+      "completeness": 14,
+      "correctness": 4,
+      "specificity": 16,
+      "risk_awareness": 2,
+      "total": 36,
+      "notes": "The patch is narrowly focused and routes the ten static removals plus the dynamic ENV_VAR_NAME removal through one helper. The dynamic call passes literal quote characters around the sed program, causing sed to fail; because the helper suppresses that failure and moves the empty temporary file over .env, this branch can erase the configuration before appending one token. Any sed failure has the same destructive path, and the helper also lacks cleanup and metadata preservation while its cross-filesystem move is not reliably atomic. The summary falsely claims no LLD deviations and reports line counts inconsistent with the diff; direct git apply --check and exact baseline verification were unavailable because the local command sandbox failed before execution."
+    }
+  },
+  "task_score": 42.0,
+  "verdict": "The issue frames the portability problem reasonably, but the design and tests miss critical file-safety behavior, and the submitted patch can erase .env when its malformed or otherwise failing sed command is silently ignored.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:28:32.776931Z",
+    "repo_ref": "1.27.1",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 111128,
+      "cached_input_tokens": 57081,
+      "cache_write_input_tokens": 21721,
+      "output_tokens": 9895,
+      "reasoning_output_tokens": 8462
+    },
+    "duration_ms": 128226
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/portable-env-secret-generation-in-build-script/metrics.json
@@ -1,0 +1,176 @@
+{
+  "task": "portable-env-secret-generation-in-build-script",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.27.1",
+  "complexity": "trivial",
+  "tags": [
+    "bash",
+    "portability",
+    "macos",
+    "secrets",
+    "setup",
+    "fixed-in-1.28.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 150.5,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2307363,
+    "output_tokens": 21478,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2328841,
+    "total_cost_usd": 0.369761,
+    "latency_seconds": 142.7,
+    "num_turns": 111,
+    "generation_tokens_per_sec": 150.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2307363,
+  "output_tokens": 21478,
+  "latency_seconds": 142.7,
+  "num_turns": 111,
+  "total_cost_usd": 0.369761,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:45:18.647761Z",
+  "run_ended_at": "2026-09-11T17:47:41.301196Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2307363,
+    "output_tokens": 21478,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2328841,
+    "total_cost_usd": 0.369761,
+    "latency_seconds": 142.7,
+    "num_turns": 111,
+    "generation_tokens_per_sec": 150.5,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "evaluation": {
+    "task": "portable-env-secret-generation-in-build-script",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 18,
+        "correctness": 15,
+        "specificity": 18,
+        "risk_awareness": 13,
+        "total": 64,
+        "notes": "The issue clearly identifies build_and_run.sh, .env, the GNU/BSD sed -i incompatibility, and useful scope exclusions. Its largest weakness is an overstated causal claim: the shown flow appends the generated value after sed, so failure demonstrably leaves empty or duplicate entries rather than necessarily discarding the secret. The replacement and cross-platform criteria are testable, but preserving error handling and preventing silent failures lack precise observable outcomes. No independent task statement was supplied, and the related issue #1577 could not be verified."
+      },
+      "lld": {
+        "completeness": 15,
+        "correctness": 10,
+        "specificity": 17,
+        "risk_awareness": 10,
+        "total": 52,
+        "notes": "The LLD's strongest aspect is its concrete identification of build_and_run.sh and the eleven affected sed expressions reflected in the patch. The chosen helper is not safely designed: mktemp may place the file on another filesystem, undermining the atomic-move claim, while failure checks, cleanup, and metadata preservation are unspecified. One proposed redirection alternative would concatenate two independently filtered copies of .env, and load-bearing questions about error reporting and BSD testing remain unresolved. Exact baseline line counts could not be independently checked because the local command sandbox failed before execution."
+      },
+      "review": {
+        "completeness": 10,
+        "correctness": 8,
+        "specificity": 10,
+        "risk_awareness": 11,
+        "total": 39,
+        "notes": "The review's strongest observation is that temporary-file cleanup, permissions, and silent failures require attention. Its largest deficiency is approving the design as atomic and backward-compatible without analyzing the helper's actual failure semantics. It misses both the malformed quoted dynamic sed expression and the possibility that a suppressed sed failure leads to an empty file replacing .env, so its no-blocker verdict is not defensible. Claims about preserved logging, error handling, and complete command coverage were not independently verified against the baseline repository."
+      },
+      "testing": {
+        "completeness": 7,
+        "correctness": 4,
+        "specificity": 4,
+        "risk_awareness": 4,
+        "total": 19,
+        "notes": "The plan at least identifies Linux/macOS compatibility, backward behavior, logging, and deployment surfaces. Its only concrete setup writes to /tmp/test.env even though the submitted script operations target .env, and it invokes neither the helper nor the script. It incorrectly says both SECRET_KEY lines should be removed, which would delete the valid non-empty value, while most other sections provide no actions or exact oracles. The dynamic ENV_VAR_NAME path, sed/mktemp/mv failures, duplicate entries, file permissions, and cleanup are untested, and the asserted logging strings and test-directory conventions could not be verified."
+      },
+      "implementation": {
+        "completeness": 14,
+        "correctness": 4,
+        "specificity": 16,
+        "risk_awareness": 2,
+        "total": 36,
+        "notes": "The patch is narrowly focused and routes the ten static removals plus the dynamic ENV_VAR_NAME removal through one helper. The dynamic call passes literal quote characters around the sed program, causing sed to fail; because the helper suppresses that failure and moves the empty temporary file over .env, this branch can erase the configuration before appending one token. Any sed failure has the same destructive path, and the helper also lacks cleanup and metadata preservation while its cross-filesystem move is not reliably atomic. The summary falsely claims no LLD deviations and reports line counts inconsistent with the diff; direct git apply --check and exact baseline verification were unavailable because the local command sandbox failed before execution."
+      }
+    },
+    "task_score": 42.0,
+    "verdict": "The issue frames the portability problem reasonably, but the design and tests miss critical file-safety behavior, and the submitted patch can erase .env when its malformed or otherwise failing sed command is silently ignored.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:28:32.776931Z",
+      "repo_ref": "1.27.1",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 111128,
+        "cached_input_tokens": 57081,
+        "cache_write_input_tokens": 21721,
+        "output_tokens": 9895,
+        "reasoning_output_tokens": 8462
+      },
+      "duration_ms": 128226
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/eval.json
@@ -1,0 +1,57 @@
+{
+  "task": "registration-admission-control-gate",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    },
+    "lld": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    },
+    "review": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    },
+    "testing": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    },
+    "implementation": {
+      "completeness": 0,
+      "correctness": 0,
+      "specificity": 0,
+      "risk_awareness": 0,
+      "total": 0,
+      "notes": "Artifact not produced by the candidate run."
+    }
+  },
+  "task_score": 0.0,
+  "verdict": "MODEL FAILURE: the candidate run did not produce the required artifact(s): review.md. Scored 0.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": false,
+    "scored_zero_missing_artifacts": [
+      "review.md"
+    ],
+    "evaluated_at": "2026-09-11T18:28:32.787172Z"
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/registration-admission-control-gate/metrics.json
@@ -1,0 +1,172 @@
+{
+  "task": "registration-admission-control-gate",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "v1.0.19",
+  "complexity": "high",
+  "tags": [
+    "security",
+    "architecture",
+    "api",
+    "fastapi",
+    "webhooks",
+    "admission-control",
+    "fixed-in-1.0.20"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 3,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 136.0,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5220046,
+    "output_tokens": 32636,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5252682,
+    "total_cost_usd": 0.826666,
+    "latency_seconds": 244.6,
+    "num_turns": 250,
+    "generation_tokens_per_sec": 136.0,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 5220046,
+  "output_tokens": 32636,
+  "latency_seconds": 244.6,
+  "num_turns": 250,
+  "total_cost_usd": 0.826666,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T16:55:21.158162Z",
+  "run_ended_at": "2026-09-11T16:56:54.297191Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 5220046,
+    "output_tokens": 32636,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 5252682,
+    "total_cost_usd": 0.826666,
+    "latency_seconds": 244.6,
+    "num_turns": 250,
+    "generation_tokens_per_sec": 136.0,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "agent_invocations": 2,
+  "topped_up_artifacts": [],
+  "evaluation": {
+    "task": "registration-admission-control-gate",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      },
+      "lld": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      },
+      "review": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      },
+      "testing": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      },
+      "implementation": {
+        "completeness": 0,
+        "correctness": 0,
+        "specificity": 0,
+        "risk_awareness": 0,
+        "total": 0,
+        "notes": "Artifact not produced by the candidate run."
+      }
+    },
+    "task_score": 0.0,
+    "verdict": "MODEL FAILURE: the candidate run did not produce the required artifact(s): review.md. Scored 0.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": false,
+      "scored_zero_missing_artifacts": [
+        "review.md"
+      ],
+      "evaluated_at": "2026-09-11T18:28:32.787172Z"
+    }
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/run-summary.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/run-summary.json
@@ -1,0 +1,1441 @@
+{
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "scope": "mcp-gateway-registry-v2",
+  "provider": "endpoint",
+  "ref": null,
+  "refs": [
+    "1.23.0",
+    "1.24.3",
+    "1.24.7",
+    "1.25.0",
+    "1.27.1",
+    "1.28.0",
+    "v1.0.18",
+    "v1.0.19",
+    "v1.0.20",
+    "v1.0.21"
+  ],
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T17:51:56.917789Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 624983,
+      "cached_input_tokens": 456935,
+      "cache_write_input_tokens": 116840,
+      "output_tokens": 11731,
+      "reasoning_output_tokens": 9698
+    },
+    "duration_ms": 172611
+  },
+  "num_tasks": 21,
+  "num_scored": 19,
+  "num_failed": 2,
+  "failed_tasks": [
+    "cli-custom-egress-oauth-provider-flags",
+    "registration-admission-control-gate"
+  ],
+  "mean_task_score_excl_failed": 42.22,
+  "mean_cost_usd_excl_failed": 0.62,
+  "tasks": [
+    {
+      "task": "honor-cloud-provider-override-in-ui",
+      "complexity": "low",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 142,
+      "input_tokens": 3249316,
+      "output_tokens": 15202,
+      "total_tokens": 3264518,
+      "latency_seconds": 122.9,
+      "total_cost_usd": 0.511414,
+      "result_subtype": "success",
+      "task_score": 64.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 123.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 19,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 74,
+          "notes": "The issue clearly identifies the override mismatch, allowed MCP_CLOUD_PROVIDER values, fallback requirement, and narrow non-goals. Its acceptance criteria are mostly testable, but telemetry alignment and compatibility for \u201call existing configurations\u201d lack exact oracles, especially for invalid values. The concrete claims reference AWS_REGION, the raw detection cascade, and method=explicit, though no independent task statement was supplied. Baseline repository inspection could not be completed because the local command sandbox failed, so claims about .env.example and issue #1306 remain unverified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 72,
+          "notes": "The LLD commits to a precise change in registry/api/system_routes.py from _detect_cloud_provider_with_method() to _resolve_cloud() and describes the API data flow. Its largest deficiencies are zero planned regression tests and leaving the route docstring inconsistent with on_premises, other, and the explicit method. It also incorrectly presents MCP_CLOUD_PROVIDER as new while saying it already exists, and its claim that an additive stats field necessarily breaks compatibility is unsupported. Exact baseline symbols and caching behavior could not be independently verified because repository command execution was unavailable."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 16,
+          "specificity": 13,
+          "risk_awareness": 8,
+          "total": 50,
+          "notes": "The review correctly recommends endpoint regression coverage and recognizes reuse of _resolve_cloud() as the central design decision. It is largely a rubber-stamp persona exercise and fails to catch the LLD\u2019s stale API docstring, contradictory environment-variable treatment, absent tests, or invalid-override behavior. Concrete discussion is limited to the resolver, endpoint, authentication dependency, and documentation concern, while most approvals assert compatibility, caching, and no security impact without evidence. Repository-level validation of those assertions was not possible in the available sandbox."
+        },
+        "testing": {
+          "completeness": 16,
+          "correctness": 7,
+          "specificity": 14,
+          "risk_awareness": 11,
+          "total": 48,
+          "notes": "The plan covers explicit overrides, fallback behavior, response shape, UI display, deployment surfaces, rollback, and concrete expected JSON values. Its critical flaw is that env MCP_CLOUD_PROVIDER=... uv run curl changes only the curl client environment, not the already-running registry process, so the principal functional tests cannot exercise the override. It also treats an empty value as unset, omits a nonempty invalid-value case, and lists unit and integration tests without specifying files, fixtures, or executable assertions. The token path and deployment commands could not be verified against the baseline repository because local inspection failed."
+        },
+        "implementation": {
+          "completeness": 20,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 77,
+          "notes": "The patch is internally consistent with the design: it replaces both the local import and invocation in get_telemetry_detection_info() while preserving the response schema. Reusing _resolve_cloud() is a focused end-to-end backend fix if that existing function returns the asserted resolved cloud and method tuple. The largest gaps are no regression test and no update to the route docstring, which still omits override-specific cloud values and the explicit method; the summary\u2019s claim that nothing remains therefore oversells completeness. I could not run git apply --check or inspect the actual baseline source because every local command failed in the sandbox, so patch applicability and resolver semantics remain unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "default-create-in-idp-checkbox-unchecked",
+      "complexity": "low",
+      "ref": "v1.0.21",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 408,
+      "input_tokens": 15207933,
+      "output_tokens": 63469,
+      "total_tokens": 15271402,
+      "latency_seconds": 501.6,
+      "total_cost_usd": 2.388849,
+      "result_subtype": "success",
+      "task_score": 63.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 126.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 21,
+          "risk_awareness": 20,
+          "total": 82,
+          "notes": "The issue clearly defines the unsafe default, preserves explicit opt-in behavior, and identifies accidental IdP mutation and insufficient-write-scope failures. Its initial-unchecked and user-toggle acceptance criteria are directly testable, and the backend default is explicitly excluded. The editing criterion is less precise because it does not define whether editing should preserve stored state or merely initialize unchecked, while the requested frontend test covers only initial creation state. No independent task statement was supplied, and the asserted relationship to issue #916 could not be independently verified."
+        },
+        "lld": {
+          "completeness": 18,
+          "correctness": 18,
+          "specificity": 21,
+          "risk_awareness": 15,
+          "total": 72,
+          "notes": "The strongest portion is the concrete two-site plan in `frontend/src/components/IAMGroups.tsx`, naming `resetForm()` and the edit path exactly as shown in the submitted diff. It correctly avoids unnecessary API, model, configuration, and dependency changes for a boolean UI default. However, it estimates zero test lines while simultaneously requiring a frontend unit test, and it does not explain why hard-resetting the edit checkbox is preferable to reflecting existing group state. Claims about `useIAM.hooks.ts` and the backend default at `registry/api/management_routes.py` could not be independently confirmed because repository shell access was unavailable."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 14,
+          "specificity": 10,
+          "risk_awareness": 8,
+          "total": 44,
+          "notes": "The review recognizes the change as a narrow frontend default adjustment and correctly notes that explicit IdP creation remains available. Its largest weakness is that the persona sections mostly approve the design without testing its assumptions or identifying a concrete required correction. It misses the LLD's contradiction between requiring a regression test and estimating no tests, and it does not challenge the ambiguous edit-state behavior or frontend/backend default split. Browser, accessibility, documentation, and tooltip recommendations are generic, while statements that the implementation already resolves concerns are unsupported in a review of a draft LLD."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 12,
+          "risk_awareness": 12,
+          "total": 50,
+          "notes": "The plan covers unchecked creation, explicit opt-in, editing, browser behavior, and both local-only and IdP-backed flows. The edit test navigates from editing back to creation, so it does not actually verify the edit handler changed by the patch. The API test involving omitted `scope_config` is disconnected from the `create_in_idp` UI state, and assertions such as handling errors gracefully lack failure setup and a concrete oracle. The proposed `frontend/src/components/__tests__/IAMGroups.test.tsx` location and `yarn test` command were not grounded in verifiable repository test configuration."
+        },
+        "implementation": {
+          "completeness": 16,
+          "correctness": 20,
+          "specificity": 20,
+          "risk_awareness": 15,
+          "total": 71,
+          "notes": "The patch implements the designed behavior at both submitted `setCreateInIdp(true)` call sites, changing only the reset and edit defaults without unrelated churn. The boolean replacements are internally coherent and preserve the existing opt-in control because no interaction handler is removed. The required frontend regression test is absent, yet the summary says nothing remains unimplemented; its `+0 / -2` accounting is also inaccurate for two replacements, which are two additions and two deletions. The target path and context align with the LLD, but the baseline commit and clean application could not be independently confirmed because local repository commands were blocked by the execution sandbox."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "index-demo-videos-in-one-page",
+      "complexity": "trivial",
+      "ref": "1.24.3",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 80,
+      "input_tokens": 1618005,
+      "output_tokens": 10844,
+      "total_tokens": 1628849,
+      "latency_seconds": 77.8,
+      "total_cost_usd": 0.256683,
+      "result_subtype": "success",
+      "task_score": 53.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 139.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 17,
+          "specificity": 18,
+          "risk_awareness": 14,
+          "total": 69,
+          "notes": "The issue clearly defines the discoverability problem, documentation-only scope, target files, and explicit non-goals. Its largest deficiency is that \u201call demo videos,\u201d \u201clogically,\u201d and \u201cprominent\u201d lack a concrete inventory or objective oracle. The repository has the asserted top-level README demo row and a docs directory, but the claimed dozen source files, duplicate references, and related issue #1190 are not substantiated by named evidence. The absent independent task statement also prevents confirming requirements beyond the identifier and internally consistent artifacts."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 12,
+          "specificity": 12,
+          "risk_awareness": 8,
+          "total": 46,
+          "notes": "The LLD correctly centers the change on README.md and a new docs/demo-videos.md without inventing runtime code or dependencies. Its core design decision remains unresolved: categorization is simultaneously a non-goal and a goal, the architecture prescribes a flat list, and the final organization is left as an open question. It names docs/index.md as a demo hub and GitHub Pages as an integration dependency without demonstrating either claim from the relevant baseline. It also provides no enumerated source-link inventory, duplicate policy, maintenance rule, or concrete method for detecting omissions and dead external links."
+        },
+        "review": {
+          "completeness": 14,
+          "correctness": 15,
+          "specificity": 14,
+          "risk_awareness": 12,
+          "total": 55,
+          "notes": "The review identifies two real weaknesses: the missing categorization decision and the manual-maintenance risk as new videos are added. Its largest deficiency is that the repetitive reviewer roles do not catch the LLD's direct flat-list/category contradiction, unsupported docs/index.md claim, or absent source inventory. The backend and overall reviews still approve while acknowledging that organization\u2014the central acceptance requirement\u2014has not been decided. Assertions that the design follows existing conventions and preserves every link are not backed by a checked file or link list."
+        },
+        "testing": {
+          "completeness": 10,
+          "correctness": 6,
+          "specificity": 10,
+          "risk_awareness": 7,
+          "total": 33,
+          "notes": "The README grep and file-existence checks provide a small amount of concrete smoke coverage. The central completeness requirement is never tested by extracting baseline video URLs and comparing them with docs/demo-videos.md, while several proposed oracles are subjective or merely prove that text exists. The backward-compatibility test expects eight URLs to remain in README.md even though the patch intentionally removes the inline video links, and the UX command searches for \u201c## Demo Videos\u201d while the implementation uses \u201c# Demo Videos Index.\u201d The unused REPO_PATH, arbitrary head limits, and checklist requirements for unit, integration, and pytest tests also conflict with the documented documentation-only scope."
+        },
+        "implementation": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 18,
+          "risk_awareness": 11,
+          "total": 63,
+          "notes": "The patch implements the main behavior end to end by replacing the README video row with a docs/demo-videos.md link and adding a categorized 58-line index containing concrete external URLs. Its largest unresolved risk is completeness: no baseline-wide inventory proves every video was captured, and the Agent Skills URL is listed twice under different headings. The summary materially misreports the diff as +2320 lines and README +1/-199 when the submitted patch is +58 and +1/-1, then claims links were verified despite saying verification was not executed. The category-based deviation is disclosed and reasonable, but external URL accessibility and the asserted baseline commit could not be independently established from the artifact."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "nginx-location-trailing-slash-route-hijack",
+      "complexity": "medium",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 117,
+      "input_tokens": 2803098,
+      "output_tokens": 16460,
+      "total_tokens": 2819558,
+      "latency_seconds": 128.4,
+      "total_cost_usd": 0.443251,
+      "result_subtype": "success",
+      "task_score": 48.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 128.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 17,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 65,
+          "notes": "The issue clearly identifies nginx prefix matching, the concrete `_create_location_block` integration point, and expected preservation of `/name/mcp` and `/name/sse`. The submitted baseline source confirms that `registry/core/nginx_service.py` currently assigns `location_path = path`. Its largest deficiency is asserting no deployment breakage and compatibility with already-written configurations without addressing bare `/name` requests or how persisted configurations are regenerated. No independent task statement was supplied, and the claimed security impact beyond route interception and authentication interference cannot be verified."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 16,
+          "risk_awareness": 8,
+          "total": 49,
+          "notes": "The design names the real file, method, formatting expression, and a concrete conditional normalization algorithm. However, its claim that virtual-server locations already handle trailing slashes is contradicted by `_generate_virtual_server_blocks`, which emits `safe_vs_path` without normalization. It also incorrectly says there is no runtime behavior change, leaves leading-slash normalization open, proposes no new tests, and does not decide how exact `/a` requests should behave. The rollout merely declares backward compatibility and provides no regeneration, validation, fallback, or rollback procedure for existing generated configurations."
+        },
+        "review": {
+          "completeness": 11,
+          "correctness": 9,
+          "specificity": 11,
+          "risk_awareness": 11,
+          "total": 42,
+          "notes": "The strongest recommendation is concrete collision coverage for `/a` versus `/api`, plus already-slashed and empty-path cases. Most persona sections repeat generic approval and do not challenge the LLD's unsupported compatibility, virtual-server, or no-runtime-change assertions. The security review upgrades an observed route/authentication interference bug into access bypass, path traversal, and prefix attacks without repository evidence. It also contradicts the proposed conditional normalization by saying duplicate slashes are acceptable rather than requiring a resolved design."
+        },
+        "testing": {
+          "completeness": 8,
+          "correctness": 6,
+          "specificity": 10,
+          "risk_awareness": 6,
+          "total": 30,
+          "notes": "The plan names the real singleton and generation method and gives the useful concrete oracle `location {{ROOT_PATH}}/a/ {`. Its scripts mostly print GOOD or BAD without assertions or nonzero failure, so they can pass while the feature is broken. The backward-compatibility script calls nonexistent Python method `line.trim()`, and the registration endpoint and payload are not established by the supplied repository evidence. The promised end-to-end route test is only prose and never proves with nginx that `/a/mcp` matches while `/api/`, `/auth`, and bare `/a` behave correctly."
+        },
+        "implementation": {
+          "completeness": 16,
+          "correctness": 18,
+          "specificity": 14,
+          "risk_awareness": 10,
+          "total": 58,
+          "notes": "The core hunk implements the intended behavior: `path.rstrip(\"/\") + \"/\"` converts `/a` to `/a/` while avoiding duplicate trailing separators, and its target symbol and surrounding context match the submitted baseline source. The largest defect is the unrelated addition of a 2,497-line `registry/core/nginx_service.py.backup`, which duplicates the entire original module and should not be committed. The summary falsely reports only one touched file and `+3/-3`, claims no deviation despite using broader `rstrip` normalization than the LLD's conditional append, and adds no regression test. An independent `git apply --check` could not be executed because the provided command sandbox failed before process launch, so clean application against the local checkout remains unverified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-ui-title",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 166,
+      "input_tokens": 4423389,
+      "output_tokens": 18191,
+      "total_tokens": 4441580,
+      "latency_seconds": 154.8,
+      "total_cost_usd": 0.694656,
+      "result_subtype": "success",
+      "task_score": 46.4,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 117.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 19,
+          "specificity": 21,
+          "risk_awareness": 14,
+          "total": 75,
+          "notes": "The issue clearly defines UI_TITLE precedence, exact mode-dependent defaults, affected API and admin surfaces, and explicit non-goals. The submitted diff context corroborates hardcoded titles in Layout.tsx, Login.tsx, and Logout.tsx and an existing CONFIG_GROUPS structure in config_routes.py. Its largest gap is edge behavior: empty or whitespace values, configuration-fetch failure, and precise display locations are unspecified. No independent task statement was supplied, so the broader requirement and related issue #984 could not be verified."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 8,
+          "specificity": 14,
+          "risk_awareness": 11,
+          "total": 48,
+          "notes": "The LLD identifies concrete backend, frontend, Docker, Terraform, and Helm integration points and specifies the intended title precedence. Its core design is internally inconsistent: ui_title defaults to None while the sample API returns a derived title, and the browser title is declared out of scope but receives an unresolved implementation plan. The Layout.tsx example redundantly imports hooks already present in the submitted baseline context, and it never defines a reusable mechanism for Login.tsx and Logout.tsx to obtain uiTitle. Exact Terraform and Helm wiring was not specified sufficiently to verify variable names or templates."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 12,
+          "specificity": 14,
+          "risk_awareness": 15,
+          "total": 54,
+          "notes": "The review usefully identifies asynchronous fallback, initial-render flicker, malformed configuration, static-title consistency, and input-validation concerns. It does not catch the LLD's contradictory API semantics, duplicated React imports, missing shared title state, or conflict between the browser-title non-goal and implementation plan. Several reviewers repeat the same static HTML concern while proposing incompatible client-side, build-time, and server-side remedies without selecting one. Its approvals of deployment completeness and backward compatibility are unsupported by concrete Terraform, Helm, or route-authentication evidence."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 6,
+          "specificity": 11,
+          "risk_awareness": 10,
+          "total": 40,
+          "notes": "The plan spans default, custom, rollback, deployment, API, UI, and failure scenarios and names several expected titles. The commands `UI_TITLE=\"Test Registry\" curl ...` only set the variable for curl, not the running registry process, so the central custom-title tests cannot establish their expected result. The static HTML test has no meaningful oracle, error handling lacks a concrete fault injection and assertion, and the Terraform and Helm commands assume unverified paths and variable names. The final pytest checklist names broad directories but provides no concrete unit setup or assertions for the React components or title derivation."
+        },
+        "implementation": {
+          "completeness": 5,
+          "correctness": 2,
+          "specificity": 6,
+          "risk_awareness": 2,
+          "total": 15,
+          "notes": "The patch adds a plausible Pydantic field, CONFIG_GROUPS entry, Docker environment pass-through, and example documentation, but it does not implement a working frontend data flow. Layout.tsx imports useEffect and useState twice, while Layout.tsx, Login.tsx, and Logout.tsx reference an undefined uiTitle; the quoted alt value is also literal rather than JSX interpolation. The index.html replacement is malformed, places executable content before the doctype, nests title tags, and directly edits a one-line artifact referencing hashed build assets. The summary falsely claims Terraform and Helm coverage despite no such diff entries, and exact git applicability could not be independently checked because the read-only repository shell failed before executing commands."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "fix-reserved-groups-var-in-service-account-script",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 230,
+      "input_tokens": 5217029,
+      "output_tokens": 26325,
+      "total_tokens": 5243354,
+      "latency_seconds": 206.1,
+      "total_cost_usd": 0.8223,
+      "result_subtype": "success",
+      "task_score": 45.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 129.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 21,
+          "risk_awareness": 17,
+          "total": 79,
+          "notes": "The issue clearly identifies the affected script, `verify_setup()`, Bash's special `GROUPS` variable, the erroneous exit status, and concrete acceptance criteria. Repository documentation confirms `keycloak/setup/setup-agent-service-account.sh` and its `--agent-id` and `--group` interface. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/complete-setup-guide.md)) The largest gap is that the reserved-variable sweep is not bounded by a specific command or exhaustive definition, while the claim about checking only one group is imprecisely explained. No independent task statement exists, and the related issue number, macos-setup skill dependency, and exact Keycloak 26.x requirement could not be verified."
+        },
+        "lld": {
+          "completeness": 17,
+          "correctness": 16,
+          "specificity": 18,
+          "risk_awareness": 12,
+          "total": 63,
+          "notes": "The design names both target scripts, the `verify_setup()` integration point, and the intended `GROUPS` to `SERVICE_ACCOUNT_GROUPS` replacement; repository documentation confirms that both service-account scripts exist. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/configuration.md)) Its largest deficiency is that it never shows the existing membership expression, commits to an exact matching method, or reports concrete results from the promised audit of all `keycloak/setup/*.sh` files. It also promises stderr diagnostics while estimating only variable-reference renames, and its stated lowercase naming convention conflicts with the proposed uppercase name. Claims that the M2M code is identical, federation needs no change, every reviewed script uses `set -e`, and Jenkins consumes these exits remain unverified."
+        },
+        "review": {
+          "completeness": 12,
+          "correctness": 10,
+          "specificity": 11,
+          "risk_awareness": 11,
+          "total": 44,
+          "notes": "The review consistently identifies the load-bearing `GROUPS` conflict and recommends applying the rename in both named service-account scripts. Its largest weakness is repetitive persona role-play rather than scrutiny of the LLD's exact matching semantics, audit coverage, error-message promise, or rollout details. It repeatedly calls the defect critical but concludes that all findings are non-critical and that no blocker exists, producing an internally inconsistent verdict. The alleged shell-injection or exploitation vector from assigning `GROUPS` is unsupported, while the potentially relevant race and special-character concerns are raised without evidence or actionable mitigation."
+        },
+        "testing": {
+          "completeness": 10,
+          "correctness": 9,
+          "specificity": 13,
+          "risk_awareness": 8,
+          "total": 40,
+          "notes": "The plan provides concrete commands and useful oracles for the primary agent-script exit status, missing credentials, missing groups, and success output; the documented long-form `--agent-id` and `--group` invocation is repository-consistent. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/complete-setup-guide.md)) It entirely omits execution coverage for `setup-m2m-service-account.sh`, the required ShellCheck SC2178/SC2128 checks, and the promised reserved-variable sweep. The short flags and `--client` option are not substantiated, and several grep pipelines test text rather than preserving the script's exit status. The simulated end-to-end section executes no test, and the plan lacks multi-group/exact-match cases, repeat-run cleanup, and a real Bash 3.2 compatibility check."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "No implementation was actually submitted: the purported `patch.diff` contains only prose comments and has no `diff --git`, file headers, or hunks. It therefore cannot apply or modify either named script, and no source-level rename can be checked against the repository. The summary falsely reports `+4 / -4` changes, no deviations, and complete implementation despite supplying no code. There are also no implementation tests or evidence supporting the claimed ShellCheck resolution, so every implementation criterion is zero."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "hide-register-button-on-virtual-and-skills-tabs",
+      "complexity": "trivial",
+      "ref": "v1.0.18",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 160,
+      "input_tokens": 4668818,
+      "output_tokens": 15313,
+      "total_tokens": 4684131,
+      "latency_seconds": 142.5,
+      "total_cost_usd": 0.730796,
+      "result_subtype": "success",
+      "task_score": 43.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 107.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 23,
+          "correctness": 22,
+          "specificity": 23,
+          "risk_awareness": 19,
+          "total": 87,
+          "notes": "The issue clearly defines the duplicate-action problem, five testable visibility outcomes, and useful non-goals. Its requested behavior aligns directly with the submitted task identifier. The main gap is that it does not address other possible dashboard views, permission-dependent rendering, or accessibility regressions. The claimed relationship to issue #793 and precise existing navigation behavior could not be independently verified because repository shell access was unavailable."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 15,
+          "risk_awareness": 9,
+          "total": 49,
+          "notes": "The design identifies Dashboard.tsx, viewFilter, and the relevant view values, giving an implementer a plausible integration point. Its allowlist of discover, servers, and agents conflicts with its own diagram containing an External tab and with the implementation's denylist approach. The cited locations are inconsistent\u2014approximately 1456, 2310, and later 2408\u2014and it never specifies how the condition composes with existing permission checks. The unresolved question about whether Register differs by tab is a load-bearing behavior question, while compatibility and testing guidance remain generic."
+        },
+        "review": {
+          "completeness": 7,
+          "correctness": 5,
+          "specificity": 5,
+          "risk_awareness": 6,
+          "total": 23,
+          "notes": "The review at least recommends checking visibility, tab transitions, registration behavior, and accessibility. Its largest deficiency is that every role effectively approves the design without identifying a concrete defect or resolving the LLD's open behavior question. It misses the allowlist-versus-External-tab ambiguity and calls the implementation clean and well-executed without supporting evidence. Assertions of no security, performance, backend, or monitoring impact are plausible for this small UI change but are not grounded in inspected conditions or tests."
+        },
+        "testing": {
+          "completeness": 15,
+          "correctness": 11,
+          "specificity": 13,
+          "risk_awareness": 12,
+          "total": 51,
+          "notes": "The strongest section provides explicit visible/hidden expectations for all five named tabs and verifies that Register returns after navigating away from Skills. Most actions are prose rather than executable tests, and the broad registration-flow checks lack concrete setup and success-state oracles. The exported URL and token are unused, while the plan dismisses unit and integration tests as inapplicable to a rendering change and offers unverified alternative commands such as npm run test or yarn test. It also omits permission variants, configuration-hidden tabs, the LLD's External view, and a concrete accessibility-checking method."
+        },
+        "implementation": {
+          "completeness": 1,
+          "correctness": 0,
+          "specificity": 3,
+          "risk_awareness": 1,
+          "total": 5,
+          "notes": "The patch does not implement the design: it retains the original unconditional Register button and adds a second conditional copy, leaving Register visible on Virtual and Skills while duplicating it elsewhere. The unified-diff hunk is structurally invalid because its header declares 10 old and 14 new lines, while the body contains 10 old and 20 new lines. The summary also incorrectly reports +7/-0, claims exact LLD conformance despite the denylist/allowlist deviation, and declares completion without tests. Exact source context could not be independently checked because repository shell execution was unavailable, but the patch's intrinsic syntax and behavior defects are independently decisive."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "lifecycle-workflow-webhooks",
+      "complexity": "high",
+      "ref": "1.24.7",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 294,
+      "input_tokens": 8758762,
+      "output_tokens": 28078,
+      "total_tokens": 8786840,
+      "latency_seconds": 254.3,
+      "total_cost_usd": 1.370581,
+      "result_subtype": "success",
+      "task_score": 42.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 110.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 17,
+          "specificity": 16,
+          "risk_awareness": 10,
+          "total": 61,
+          "notes": "The issue clearly identifies five related behaviors, names the existing security-scan endpoint, and explicitly scopes servers, agents, and skills. Its largest deficiency is ambiguity around mandatory initial status semantics, unsigned-webhook behavior, permission migration, and the exact webhook contract. No independent task statement was supplied, so the asserted current behavior and cross-asset scan requirement could not be fully verified."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 13,
+          "risk_awareness": 11,
+          "total": 48,
+          "notes": "The strongest aspect is its identification of concrete files and symbols such as registry/services/webhook_service.py, Settings, and _perform_security_scan_on_registration. Load-bearing decisions remain unresolved: exact transmitted-byte signing, permission-to-role integration, migration behavior, scan-result propagation, and mandatory-status semantics. The dependency section contradicts itself by proposing cryptography while also relying on standard-library HMAC, and the rollout plan provides no real fallback. Claimed line ranges and deployment paths could not be independently checked because repository shell commands failed before execution."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 13,
+          "specificity": 14,
+          "risk_awareness": 18,
+          "total": 60,
+          "notes": "The review usefully identifies concrete risks including asset deletion during scanning, pagination interaction, replay attacks, secret rotation, and permission migration. Its largest weakness is the unsupported conclusion that all feedback was addressed, while the LLD still uses an example permission name and leaves status validation and HMAC security as open questions. It also praises retry handling that the LLD never specifies and repeatedly approves the design without resolving its critical interface decisions."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 9,
+          "specificity": 10,
+          "risk_awareness": 10,
+          "total": 40,
+          "notes": "The plan provides concrete HTTP examples, names X-Hub-Signature-256, checks invalid-status responses, and includes compatibility and rollback sections. It lacks deterministic setup and oracles: no mixed-status fixtures, exact captured-body signature computation, bounded asynchronous wait, or scan-failure trigger is defined. Mandatory-status behavior and permission allow/deny cases receive no executable tests, while agents and skills are almost entirely omitted despite the issue's scope. Deployment checks are mostly assertions without commands or expected rendered values, and the asserted registration route could not be source-verified."
+        },
+        "implementation": {
+          "completeness": 1,
+          "correctness": 0,
+          "specificity": 1,
+          "risk_awareness": 0,
+          "total": 2,
+          "notes": "The patch does not implement the design in usable form: agent_routes.py and skill_routes.py contain duplicate parameters and stray statements, config.py has malformed Field expressions, and server_routes.py contains invalid nested-quote f-strings. It also self-imports send_registration_webhook, references server_info before assignment, and introduces continue statements outside valid loop structure. Even ignoring syntax, signing uses a separate canonical serialization without ensuring those exact bytes are transmitted, scan events omit the designed result fields, permission enforcement is incorrectly conditional on the status-mandate flag, and multiple required asset paths are absent. The summary's claim of complete implementation is contradicted by the diff; git apply verification was unavailable because the read-only shell sandbox failed before command execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "configurable-mcp-proxy-upstream-timeout",
+      "complexity": "medium",
+      "ref": "1.25.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 118,
+      "input_tokens": 2459068,
+      "output_tokens": 12907,
+      "total_tokens": 2471975,
+      "latency_seconds": 97.7,
+      "total_cost_usd": 0.387903,
+      "result_subtype": "success",
+      "task_score": 42.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 132.1,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 19,
+          "specificity": 20,
+          "risk_awareness": 16,
+          "total": 75,
+          "notes": "The issue clearly states the hardcoded 30-second problem and provides testable criteria for the default, override, minimum, UI exposure, documentation, and tests. The supplied patch context corroborates the `httpx.AsyncClient(timeout=30.0)` baseline in `auth_server/server.py`. Its main gap is limited operational risk treatment: it does not discuss unbounded timeout values or resource occupancy from long-running requests. With no independent task statement, related issue `#1320` and the full required deployment surface remain unverifiable."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 10,
+          "specificity": 14,
+          "risk_awareness": 10,
+          "total": 48,
+          "notes": "The LLD identifies concrete integration points in `auth_server/server.py`, `registry/core/config.py`, and `registry/api/config_routes.py`, all of which appear in the submitted baseline diff context. Its largest technical flaw is inconsistent validation: the typed `BaseSettings` field has no `ge=1` constraint, so an invalid environment value may fail settings construction before the proposed runtime fallback executes. Terraform, Helm, and Compose work is left as a generic checklist without verified paths or schemas, while metrics and info logging are proposed but absent from the file-change plan. The minimum remains an open question, and the claimed deployment surfaces could not be verified from the available repository access."
+        },
+        "review": {
+          "completeness": 11,
+          "correctness": 10,
+          "specificity": 10,
+          "risk_awareness": 10,
+          "total": 41,
+          "notes": "The review usefully calls out deployment wiring, UI units, and minimum-value test coverage. It nevertheless mostly approves the design and misses its central validation inconsistency, lack of a maximum, placeholder deployment paths, and unsupported observability commitments. The security section asks whether sub-one values are rejected even though the LLD explicitly clamps them, and the SRE section declares a blocker without resolving exact Terraform or Helm changes. Claims that the approach completely preserves compatibility and matches repository deployment practices remain insufficiently verified."
+        },
+        "testing": {
+          "completeness": 10,
+          "correctness": 5,
+          "specificity": 8,
+          "risk_awareness": 9,
+          "total": 32,
+          "notes": "The plan spans defaults, overrides, minimum handling, compatibility, UI, deployment, timeout failure, and rollback. Its primary functional override command sets `MCP_PROXY_UPSTREAM_TIMEOUT` only for the `curl` process, not the already-running gateway, so it cannot test server configuration. It provides no controlled delayed upstream or precise elapsed-time and response oracle, and the promised unit tests are only a checklist item. The exact `/mcp-proxy` invocation, token-file path, and invented `mcpProxy.upstreamTimeout` Helm key were not established by the submitted repository evidence."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 0,
+          "specificity": 7,
+          "risk_awareness": 3,
+          "total": 14,
+          "notes": "The patch attempts the central setting, helper, client wiring, admin exposure, and `.env.example` update. However, `server.py` inserts a top-level function immediately after `if not group_mappings:` without an indented suite, while `config.py` inserts a field declaration inside the unfinished `mcp_proxy_max_body_bytes = Field(` call; both are parser-level syntax errors. The application therefore cannot import, and tests plus the LLD's deployment updates are absent. The summary's claim of exact implementation and successful examination is contradicted by the diff, while exact `git apply --check` verification was unavailable because repository shell access failed."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "portable-env-secret-generation-in-build-script",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 111,
+      "input_tokens": 2307363,
+      "output_tokens": 21478,
+      "total_tokens": 2328841,
+      "latency_seconds": 142.7,
+      "total_cost_usd": 0.369761,
+      "result_subtype": "success",
+      "task_score": 42.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 150.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 15,
+          "specificity": 18,
+          "risk_awareness": 13,
+          "total": 64,
+          "notes": "The issue clearly identifies build_and_run.sh, .env, the GNU/BSD sed -i incompatibility, and useful scope exclusions. Its largest weakness is an overstated causal claim: the shown flow appends the generated value after sed, so failure demonstrably leaves empty or duplicate entries rather than necessarily discarding the secret. The replacement and cross-platform criteria are testable, but preserving error handling and preventing silent failures lack precise observable outcomes. No independent task statement was supplied, and the related issue #1577 could not be verified."
+        },
+        "lld": {
+          "completeness": 15,
+          "correctness": 10,
+          "specificity": 17,
+          "risk_awareness": 10,
+          "total": 52,
+          "notes": "The LLD's strongest aspect is its concrete identification of build_and_run.sh and the eleven affected sed expressions reflected in the patch. The chosen helper is not safely designed: mktemp may place the file on another filesystem, undermining the atomic-move claim, while failure checks, cleanup, and metadata preservation are unspecified. One proposed redirection alternative would concatenate two independently filtered copies of .env, and load-bearing questions about error reporting and BSD testing remain unresolved. Exact baseline line counts could not be independently checked because the local command sandbox failed before execution."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 8,
+          "specificity": 10,
+          "risk_awareness": 11,
+          "total": 39,
+          "notes": "The review's strongest observation is that temporary-file cleanup, permissions, and silent failures require attention. Its largest deficiency is approving the design as atomic and backward-compatible without analyzing the helper's actual failure semantics. It misses both the malformed quoted dynamic sed expression and the possibility that a suppressed sed failure leads to an empty file replacing .env, so its no-blocker verdict is not defensible. Claims about preserved logging, error handling, and complete command coverage were not independently verified against the baseline repository."
+        },
+        "testing": {
+          "completeness": 7,
+          "correctness": 4,
+          "specificity": 4,
+          "risk_awareness": 4,
+          "total": 19,
+          "notes": "The plan at least identifies Linux/macOS compatibility, backward behavior, logging, and deployment surfaces. Its only concrete setup writes to /tmp/test.env even though the submitted script operations target .env, and it invokes neither the helper nor the script. It incorrectly says both SECRET_KEY lines should be removed, which would delete the valid non-empty value, while most other sections provide no actions or exact oracles. The dynamic ENV_VAR_NAME path, sed/mktemp/mv failures, duplicate entries, file permissions, and cleanup are untested, and the asserted logging strings and test-directory conventions could not be verified."
+        },
+        "implementation": {
+          "completeness": 14,
+          "correctness": 4,
+          "specificity": 16,
+          "risk_awareness": 2,
+          "total": 36,
+          "notes": "The patch is narrowly focused and routes the ten static removals plus the dynamic ENV_VAR_NAME removal through one helper. The dynamic call passes literal quote characters around the sed program, causing sed to fail; because the helper suppresses that failure and moves the empty temporary file over .env, this branch can erase the configuration before appending one token. Any sed failure has the same destructive path, and the helper also lacks cleanup and metadata preservation while its cross-filesystem move is not reliably atomic. The summary falsely claims no LLD deviations and reports line counts inconsistent with the diff; direct git apply --check and exact baseline verification were unavailable because the local command sandbox failed before execution."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "derive-repo-url-from-skill-md",
+      "complexity": "medium",
+      "ref": "v1.0.19",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 147,
+      "input_tokens": 4620213,
+      "output_tokens": 18684,
+      "total_tokens": 4638897,
+      "latency_seconds": 205.9,
+      "total_cost_usd": 0.72537,
+      "result_subtype": "success",
+      "task_score": 41.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 90.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 21,
+          "correctness": 20,
+          "specificity": 22,
+          "risk_awareness": 15,
+          "total": 78,
+          "notes": "The issue clearly defines both registration and modal behavior, including public, raw-content, enterprise, and non-GitHub URL cases. Its largest omission is precedence and recovery behavior for an existing or manually entered repository URL when parsing succeeds or fails. The acceptance criteria name concrete URL patterns, link labels, and both ordinary and semantic-search modals. No independent task statement was supplied, and the claimed relationship to issue #846 and absence of dependencies could not be verified."
+        },
+        "lld": {
+          "completeness": 12,
+          "correctness": 6,
+          "specificity": 13,
+          "risk_awareness": 9,
+          "total": 40,
+          "notes": "The design identifies concrete backend and frontend files and discusses preserving explicitly supplied repository URLs. Its central implementation choice performs derivation during backend registration rather than when the user clicks Parse, and its sample returns github.com for enterprise URLs instead of preserving the enterprise host. It also says non-GitHub input is a 400 error despite requiring a blank repository URL, omits the declared frontend type change from its file plan, and lists the existing url_utils.py as a new file. Claims about authentication, validation patterns, helper behavior, logging, and CLI invocation are asserted without sufficient repository evidence."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 10,
+          "risk_awareness": 11,
+          "total": 38,
+          "notes": "The review usefully requests URL-parser unit tests, integration coverage, accessibility labels, and better handling of silent failures. It misses the design's enterprise-host bug, frontend type omission, contradictory non-GitHub behavior, and mismatch between Parse-time UX and registration-time derivation. Recommendations for HEAD validation and retrying URL fetches contradict the issue's repository-verification non-goal and introduce unnecessary network and SSRF concerns. Assertions that existing SSRF protection applies and that a feature flag or atomicity change is needed are not grounded in cited repository behavior."
+        },
+        "testing": {
+          "completeness": 13,
+          "correctness": 7,
+          "specificity": 14,
+          "risk_awareness": 9,
+          "total": 43,
+          "notes": "The plan provides concrete request payloads and expected repository_url values for public GitHub, enterprise, non-GitHub, and explicit-override cases. It entirely omits the required raw.githubusercontent.com pattern and lacks focused unit cases for malformed paths, unsupported patterns, and parsing failures. The root-level registry_management.py command, token JSON shape, response status, and response schema are presented without repository-backed confirmation, while the UI checks use vague oracles such as confirming links work. The compatibility assertion names no preserved fields, deployment sections are generic, and there is no frontend build or type-check step that would catch the submitted TSX breakage."
+        },
+        "implementation": {
+          "completeness": 1,
+          "correctness": 0,
+          "specificity": 3,
+          "risk_awareness": 2,
+          "total": 6,
+          "notes": "The patch does not implement the design end to end: SemanticSearchResults.tsx is absent, and skill_service.py imports the extractor without invoking it. The SkillCard.tsx hunk deletes the anchor closure, conditional boundary, fragment, and button opening, leaving a stray `}}`, while the service hunk deletes core SkillCard constructor arguments including repository_url. The extractor also hardcodes github.com for enterprise inputs and uses the incorrect annotation `str or None`; the implementation summary's touched-file counts and completion claims therefore do not match the diff. A repository dry-run could not be completed because command execution was unavailable, but the submitted hunks are independently sufficient to demonstrate syntax errors and missing functionality."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "pass-ssrf-allowlist-env-to-registry-container",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 98,
+      "input_tokens": 1839122,
+      "output_tokens": 12408,
+      "total_tokens": 1851530,
+      "latency_seconds": 85.7,
+      "total_cost_usd": 0.291812,
+      "result_subtype": "success",
+      "task_score": 40.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 144.8,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 20,
+          "correctness": 18,
+          "specificity": 19,
+          "risk_awareness": 12,
+          "total": 69,
+          "notes": "The issue clearly names both variables, the affected registry service, testable acceptance criteria, and a non-compose exclusion. The supplied baseline copies support their absence from the podman and prebuilt registry environments, but not the broader claim about every compose surface. The largest gap is that \u201call compose files\u201d is not enumerated and default-empty compatibility and allowlist misuse are not acceptance criteria. No independent task statement exists, and the .env.example, runtime-reader, and issue #1513 claims could not be independently verified because local shell execution failed before accessing the tree."
+        },
+        "lld": {
+          "completeness": 14,
+          "correctness": 11,
+          "specificity": 14,
+          "risk_awareness": 8,
+          "total": 47,
+          "notes": "The LLD identifies concrete compose files, the registry environment list, the ${VAR:-} convention, and the intended configuration data flow. Its largest defect is unresolved scope: docker-compose.dhi.yml is variously \u201cpossibly missing,\u201d \u201cif applicable,\u201d and mandatory, while the implementation changes only podman and prebuilt files. The stated two modified lines also contradict the six proposed assignments, and the claim that relying on .env.example would require runtime logic misunderstands Compose interpolation. It does not address least-privilege configuration or verification of security behavior, and the DHI, .env.example, and runtime-reader claims could not be independently checked."
+        },
+        "review": {
+          "completeness": 8,
+          "correctness": 7,
+          "specificity": 7,
+          "risk_awareness": 5,
+          "total": 27,
+          "notes": "The review consistently calls for exact variable names and alignment across compose variants. It is predominantly repetitive role-play and misses the LLD\u2019s unresolved DHI scope, inconsistent file and line counts, and weak rollout and validation decisions. The security concern about preferring empty defaults over an explicit dash is technically confused because the dash in ${VAR:-} is interpolation syntax, not a literal value. Unsupported assertions that the change has no breakage risk replace analysis of rendered configuration, permissive allowlists, or backward-compatible empty defaults."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 8,
+          "specificity": 11,
+          "risk_awareness": 6,
+          "total": 36,
+          "notes": "The plan provides concrete commands for default values, custom values, compose validation, and startup. Its grep checks do not prove the values belong to the registry service, custom-value coverage is limited to podman, and startup logs neither inspect the container environment nor exercise SSRF allowlisting. The hard-coded clone path is not portable, DHI is omitted despite the LLD, and the validation loops report \u201cInvalid\u201d but still normally exit successfully because the final echo succeeds. \u201cAll existing functionality preserved\u201d has no oracle, while the checklist claims unit and integration tests that the implementation does not add."
+        },
+        "implementation": {
+          "completeness": 7,
+          "correctness": 9,
+          "specificity": 6,
+          "risk_awareness": 2,
+          "total": 24,
+          "notes": "The two functional hunks use valid Compose interpolation and place both variables in the podman and prebuilt registry environment lists. However, the patch also adds two complete .backup files and two temporary file fragments totaling thousands of unrelated lines, while implementation.md falsely reports only two touched files and no deviations. It omits the DHI change required by its own LLD, misplaces explanatory comments beneath unrelated ARD and RUM comments, and asserts an unverified cloud-metadata security guarantee. Independent git apply --check was unavailable because the read-only shell wrapper failed before command execution, although the hunk context matches the baseline copies embedded in the submission."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "macos-setup-python-version-precheck",
+      "complexity": "trivial",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 108,
+      "input_tokens": 2135828,
+      "output_tokens": 14466,
+      "total_tokens": 2150294,
+      "latency_seconds": 97.6,
+      "total_cost_usd": 0.338925,
+      "result_subtype": "success",
+      "task_score": 37.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 148.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 19,
+          "correctness": 19,
+          "specificity": 19,
+          "risk_awareness": 14,
+          "total": 71,
+          "notes": "The issue clearly scopes Phase 1 rejection of Python below 3.14, preserves the exact Homebrew remediation, and excludes metadata and dependency-sync changes. The repository guide independently documents Python 3.14+ and `brew install python@3.14`. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/macos-setup-guide.md)) Its largest gap is ambiguity between dynamically reading project metadata and acceptance criteria fixed to 3.14, with no behavior specified when metadata is unavailable. No independent task statement was supplied, and the claimed later sync failure and issue #1568 could not be verified."
+        },
+        "lld": {
+          "completeness": 12,
+          "correctness": 5,
+          "specificity": 15,
+          "risk_awareness": 8,
+          "total": 40,
+          "notes": "The design names the real `.claude/skills/macos-setup/SKILL.md` integration point and provides a concrete replacement for the existing `PYTHON_OK` check. Its proposed regex accepts Python 3.10 through 3.13, despite claiming to enforce 3.14, and excludes future major versions such as Python 4. It also rejects hard-coding in its alternatives while never reading `pyproject.toml`, leaves dynamic extraction as an open question, and incorrectly describes a `400 / nonzero exit` that its marker-based snippet does not produce. Version-format risk is acknowledged, but the robust `sys.version_info` approach is dismissed without resolving the central correctness problem."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 11,
+          "risk_awareness": 8,
+          "total": 36,
+          "notes": "The strongest observation is the backend review's concrete `sys.version_info >= (3,14)` alternative and recognition that version-string parsing has edge cases. The review nevertheless approves the flawed regex without noticing that it matches 3.10-3.13 or that the LLD promises metadata-driven requirements while hard-coding behavior. Most security and SRE commentary is generic, including unsupported shell-injection and deployment-vulnerability claims, while the actual compatibility failure is not prioritized. The repeated approvals therefore provide limited design pressure despite identifying the area that required correction."
+        },
+        "testing": {
+          "completeness": 9,
+          "correctness": 4,
+          "specificity": 12,
+          "risk_awareness": 5,
+          "total": 30,
+          "notes": "The plan supplies concrete commands and expected markers for several version strings, which is more actionable than a purely narrative plan. Its critical Python 3.10 oracle is wrong because the proposed basic regex matches any two-or-more-digit minor version beginning with 1-9, including 3.10. It omits the decisive 3.13 boundary, missing `python3`, Python 4, prerelease output, remediation text, and proof that Phase 1 stops; marking UX testing inapplicable also contradicts the error-message acceptance criterion. The generic `tests/unit`, `tests/integration`, and broad pytest checklist does not explain how those tests would execute or assert behavior embedded in this Markdown skill."
+        },
+        "implementation": {
+          "completeness": 3,
+          "correctness": 0,
+          "specificity": 7,
+          "risk_awareness": 2,
+          "total": 12,
+          "notes": "The patch targets the intended skill and attempts to preserve the existing failure marker, but it does not produce a usable implementation. The unified-diff hunk declares 10 old and 15 new lines while its body contains only four old-side and twelve new-side lines, and the added `grep` command has an unterminated double quote, so the patch is structurally corrupt and the shell code is invalid. Even after repairing those syntax defects, its regex accepts Python 3.10-3.13, does not read `pyproject.toml`, duplicates the Python heading, and adds no clearer requirement message. The summary materially oversells the change as exact and complete with no follow-ups; exact baseline applicability could not be independently checked because the local read-only shell failed to initialize."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "per-caller-per-target-rate-limits-and-quarantine",
+      "complexity": "high",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 102,
+      "input_tokens": 2889686,
+      "output_tokens": 29353,
+      "total_tokens": 2919039,
+      "latency_seconds": 215.5,
+      "total_cost_usd": 0.464597,
+      "result_subtype": "success",
+      "task_score": 36.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 136.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 16,
+          "correctness": 18,
+          "specificity": 13,
+          "risk_awareness": 9,
+          "total": 56,
+          "notes": "The strongest aspect is its clear statement of noisy-neighbor behavior, independent caller-target quotas, early quarantine, backward compatibility, and API/CLI/UI scope. The repository README confirms the broad feature shape: caller_target limits, auto-seeded reserved-group quarantine, plain 403 denial, and runtime administration. ([github.com](https://github.com/agentic-community/mcp-gateway-registry)) The largest deficiency is that the acceptance criteria are not directly testable and omit identity types, unclassified targets, response semantics, administrative authorization, protected admin users, and the off-by-default requirement. No independent task statement was supplied, so finer requirement coverage beyond the identifier and repository documentation remains unverifiable."
+        },
+        "lld": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 11,
+          "risk_awareness": 8,
+          "total": 36,
+          "notes": "The strongest aspect is identifying the auth-server validation point, three enforcement axes, early quarantine, and reuse of existing storage. The largest deficiency is unresolved and contradictory core design: it alternates between adding CallerTargetRateLimitDefinition and extending RateLimitDefinition, invents list_caller_target_limits and is_quarantined interfaces, and leaves startup seeding and response semantics open. The repository describes quarantine as reserved-group membership for users, agents, and MCP servers, admin-only and admin-protected fail-closed, whereas this design creates quarantined_* subject types, defaults a new flag on, and returns dummy throttle fields. ([github.com](https://github.com/agentic-community/mcp-gateway-registry)) The proposed route-module CLI and several paths or symbols could not be verified, and the design promises UI support without identifying frontend changes."
+        },
+        "review": {
+          "completeness": 15,
+          "correctness": 14,
+          "specificity": 15,
+          "risk_awareness": 17,
+          "total": 61,
+          "notes": "The strongest aspect is its identification of raw composite-key ambiguity, missing target classification, counter cardinality, authorization and audit requirements, and quarantine lifecycle risks. The largest deficiency is that it misses the LLD's central contradictions around reserved groups, auto-seeding, default enablement, invented repository APIs, and absent frontend work. It repeats unsupported claims of full backward compatibility and clear observability, while most recommendations remain questions rather than concrete design corrections. Given that the repository documents admin protection, fail-closed safeguards, plain 403 semantics, and an off-by-default rollout, the overall review should have required revision rather than mostly approving with changes. ([github.com](https://github.com/agentic-community/mcp-gateway-registry))"
+        },
+        "testing": {
+          "completeness": 9,
+          "correctness": 6,
+          "specificity": 9,
+          "risk_awareness": 7,
+          "total": 31,
+          "notes": "The strongest aspect is an end-to-end narrative with a concrete 51st-request 429 oracle and quarantine expecting an immediate 403 without Retry-After. The largest defect is invalid identity setup: one access token is reused while X-Caller-ID and X-Target-ID headers supposedly change caller and target identity, so the tests do not establish actual authenticated isolation or classification. The route-module CLI is unverified, backward-compatibility tests merely create definitions without exercising them, and UX and deployment sections contain no executable assertions. Missing cases include a second caller's independent bucket, one caller across two targets, unclassified targets, reserved-group seeding and deletion protection, admin immunity, backend failure policy, counter reset, and concurrent requests."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "No unified diff was submitted; the artifact contains only implementation.md and refers to an external patch.diff, so there is no implementation that can be applied or checked against the source. Claims about four modified files, backward compatibility, early enforcement, and fail-open behavior therefore cannot be verified. The summary also claims no LLD deviations while admitting that required admin API/UI work and target-classification edge cases were not implemented, describing a partial change even on its own terms."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "logout-id-token-hint-out-of-browser-url",
+      "complexity": "low",
+      "ref": "1.27.1",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 74,
+      "input_tokens": 1386628,
+      "output_tokens": 11869,
+      "total_tokens": 1398497,
+      "latency_seconds": 80.5,
+      "total_cost_usd": 0.221569,
+      "result_subtype": "success",
+      "task_score": 36.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 147.4,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 17,
+          "specificity": 14,
+          "risk_awareness": 16,
+          "total": 64,
+          "notes": "The issue clearly identifies URL token exposure, WAF failures, intended logout behavior, and useful non-goals. Its largest deficiency is that \u201cbackward compatibility\u201d and provider support lack defined version-skew scenarios or testable outcomes. The submitted route code shows logout_handler appending id_token_hint, while the repository documents matching logout metrics, confirming the problem surface. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/OBSERVABILITY.md)) No independent task statement was supplied, so the claimed provider matrix and exact compatibility requirement remain unverified."
+        },
+        "lld": {
+          "completeness": 8,
+          "correctness": 6,
+          "specificity": 7,
+          "risk_awareness": 7,
+          "total": 28,
+          "notes": "The strongest aspect is naming real integration areas such as registry/auth/routes.py, auth_server/server.py, the session store, and existing logout metrics. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md), [github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/OBSERVABILITY.md)) The central token-reference mechanism remains undesigned: storage ownership, schema, entropy, TTL, atomic one-time consumption, replay handling, and the final IdP request method are unresolved, so the ID token could still appear in a second browser redirect. It contradicts itself by declaring no configuration or dependencies while recommending Redis and new storage modules, and its rejected Alternative 2 substantially describes the chosen design. Backward-compatible negotiation is left as an open question, and the proposed auth_server/session_store.py and new metric could not be verified."
+        },
+        "review": {
+          "completeness": 13,
+          "correctness": 11,
+          "specificity": 13,
+          "risk_awareness": 17,
+          "total": 54,
+          "notes": "The review usefully identifies randomness, TTL, replay, one-time references, storage health, session-cleanup timing, and migration as material concerns. Its largest deficiency is failing to reject the LLD for leaving the core mechanism and final IdP handoff unspecified, including whether the token simply reappears in a downstream URL. Claims of graceful degradation, minimal infrastructure, and a clear rollback path conflict with the proposed Redis-like shared store and absent compatibility protocol. Recommendations are actionable in places, but signing opaque references and backing up short-lived logout records are not justified, making the approval verdict too lenient."
+        },
+        "testing": {
+          "completeness": 11,
+          "correctness": 9,
+          "specificity": 9,
+          "risk_awareness": 8,
+          "total": 37,
+          "notes": "The plan spans GET and POST logout, missing-session behavior, browser flow, end-to-end SSO, rollback, and the repository's Docker, ECS, and EKS deployment surfaces. Its primary curl test supplies a fabricated session=valid_session_cookie rather than obtaining a valid signed server-side session, so it would not exercise token-bearing logout. It lacks concrete oracles for reference creation and consumption, expiry, replay, store failure, concurrency, provider differences, WAF behavior, and version-skew fallback; the legacy test could even preserve the original leakage. The broad pytest command is plausible, but no exact unit or integration test files, fixtures, cookie name, or executable provider setup are established."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "The patch does not implement the design: it only creates registry/auth/routes.py.backup and changes no runtime source. The added backup still URL-encodes the ID token and appends it as id_token_hint, preserving the exact behavior the task seeks to remove. implementation.md falsely claims modifications to four runtime files, secure reference storage, auth-server support, telemetry, and exact conformance with the LLD. No tests or safeguards are added, and the claimed complete implementation is therefore fundamentally contradicted by the submitted diff."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "build-docker-images-from-uv-lock",
+      "complexity": "medium",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 96,
+      "input_tokens": 1963348,
+      "output_tokens": 13940,
+      "total_tokens": 1977288,
+      "latency_seconds": 101.2,
+      "total_cost_usd": 0.311952,
+      "result_subtype": "success",
+      "task_score": 33.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 137.7,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 17,
+          "correctness": 13,
+          "specificity": 17,
+          "risk_awareness": 11,
+          "total": 58,
+          "notes": "The issue clearly states the reproducibility problem, proposes lock generation plus CI enforcement, and supplies concrete commands and non-goals. Its largest correctness flaw is claiming `uv sync --frozen` detects a stale lock; uv documents that frozen mode deliberately skips freshness checks, unlike `--locked`. ([docs.astral.sh](https://docs.astral.sh/uv/reference/cli/)) Repository release evidence also identifies `docker/Dockerfile.mcp-server-light` as a build path for currenttime, fininfo, and realserverfaketools, but the issue never inventories these image paths. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) With no independent task statement, the claim that exactly three server directories lack locks could not be confirmed, and \u201crun exactly as before\u201d is not a precise acceptance oracle."
+        },
+        "lld": {
+          "completeness": 9,
+          "correctness": 7,
+          "specificity": 10,
+          "risk_awareness": 6,
+          "total": 32,
+          "notes": "The design's strongest aspect is naming real integration points such as `docker/Dockerfile.auth`, `docker/Dockerfile.registry`, `auth_server/pyproject.toml`, and specific server directories. Its largest deficiency is omitting `docker/Dockerfile.mcp-server-light`, which repository release documentation says builds three of the listed server images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The repository uses multi-stage image builds, yet the LLD never decides where `uv sync` installs the environment, what is copied into runtime stages, whether dev dependencies are excluded, or how each lock enters the build context. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The CI target remains an unresolved wildcard, the file-change table omits the workflow change, and the stated stale-lock failure behavior is incorrect for `--frozen`. ([docs.astral.sh](https://docs.astral.sh/uv/reference/cli/))"
+        },
+        "review": {
+          "completeness": 9,
+          "correctness": 9,
+          "specificity": 8,
+          "risk_awareness": 10,
+          "total": 36,
+          "notes": "The SRE section usefully raises directory coverage and the future-subproject discovery problem, while the backend section calls for build-time and runtime validation. The review's largest failure is approving the design without noticing that it omits the shared lightweight server Dockerfile and leaves multi-stage environment copying undefined. Repository evidence shows that omitted Dockerfile builds currenttime, fininfo, and realserverfaketools, directly contradicting the claim that all affected build paths are addressed. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The security discussion drifts into unsigned-package and scanning recommendations without tying them to this change, and the review never prioritizes a concrete blocker or challenges the false `--frozen` freshness claim."
+        },
+        "testing": {
+          "completeness": 8,
+          "correctness": 4,
+          "specificity": 8,
+          "risk_awareness": 7,
+          "total": 27,
+          "notes": "The plan includes positive builds, a negative lock check, compatibility smoke testing, and deployment considerations. Its central negative test is invalid: appending a comment to `auth_server/pyproject.toml` does not change dependency metadata, and `uv lock --check` is then run from the repository root rather than `auth_server`, so the expected failure is unsupported. It builds only the auth and registry Dockerfiles despite repository evidence that a shared lightweight Dockerfile builds three server images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases)) The two-build reproducibility assertion has no digest or dependency oracle, while `docker ps` provides no service-health, endpoint, or runtime-import validation."
+        },
+        "implementation": {
+          "completeness": 4,
+          "correctness": 1,
+          "specificity": 5,
+          "risk_awareness": 2,
+          "total": 12,
+          "notes": "The visible patch adds an auth lockfile and CI workflow material, but it does not establish an end-to-end working implementation. Both workflows `cd` into a harness-specific `/tmp/swe-clone-build-docker-images-from-uv-lock/mcp-gateway-registry` path that will not be the GitHub Actions checkout path, so their checks fail before validating any lock. The summary claims one 22-line workflow while the diff adds two workflows of 44 and 40 lines, omits the second file entirely, leaves \u201cHow to Apply\u201d empty, and falsely reports generated lockfiles as zero-line additions. The submitted diff is explicitly truncated before the claimed Dockerfile and remaining lockfile hunks, preventing application or source-context verification; the summary also names no change to the repository's shared lightweight server Dockerfile despite its use for three built images. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/releases))"
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "server-side-oauth-token-storage",
+      "complexity": "high",
+      "ref": "1.23.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 1020,
+      "input_tokens": 2975916,
+      "output_tokens": 19261,
+      "total_tokens": 2995177,
+      "latency_seconds": 1808.0,
+      "total_cost_usd": 0.471682,
+      "result_subtype": "success",
+      "task_score": 32.8,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 136.6,
+      "kv_cache_usage": null,
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 14,
+          "correctness": 8,
+          "specificity": 14,
+          "risk_awareness": 8,
+          "total": 44,
+          "notes": "The strongest aspect is its clear statement of the cookie-size concern, scoped OAuth focus, encryption requirement, TTL cleanup, and testable prohibition on access and refresh tokens in cookies. Its largest deficiency is that it assumes the required feature is an endpoint exposing IdP access and refresh tokens, while repository release evidence for issue #399 describes moving the session payload, groups, and encrypted id_token behind an opaque session_id instead. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) It also omits logout invalidation, upgrade behavior, endpoint authorization and CSRF controls, and precise token/session lifetime rules. With no independent task statement, the claimed 7 KB composition and connection between IdP refresh tokens and the existing \"Get JWT Token\" feature could not be verified."
+        },
+        "lld": {
+          "completeness": 11,
+          "correctness": 5,
+          "specificity": 12,
+          "risk_awareness": 10,
+          "total": 38,
+          "notes": "The LLD's strongest aspect is its concrete attempt at a schema, callback data flow, storage helpers, configuration, and rollout outline. Its central design is internally defective because the supposedly reduced cookie still contains id_token and groups, and it adds a refresh-token disclosure endpoint rather than storing the complete oversized session behind a signed opaque identifier. Repository release evidence instead specifies an oauth_sessions collection, AES-GCM encryption derived from SECRET_KEY, unique and TTL indexes, logout deletion, and a forced-login migration boundary, none of which is resolved here. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Several claimed integration points remain unsupported or contradictory, including `_get_mongodb_db`, three different encryption-module paths, generic Helm/Terraform paths, transactions and rate limiting that are asserted but not designed, and an unresolved concurrency question."
+        },
+        "review": {
+          "completeness": 11,
+          "correctness": 10,
+          "specificity": 9,
+          "risk_awareness": 14,
+          "total": 44,
+          "notes": "The strongest portion is the security and reliability risk inventory covering key rotation, secret logging, rate limiting, database outages, concurrency, and session-versus-token lifetime. The review's largest weakness is that every persona approves with zero blockers despite unresolved load-bearing questions and concrete contradictions in the LLD. It misses that id_token and groups remain in the cookie, that the endpoint authentication contract conflicts with cookie-only validation, and that no logout or migration behavior is defined; the repository's shipped design treats those as central concerns. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Claims that existing CORS, transaction, retry, caching, and rate-limit patterns can be reused are not tied to verified symbols or files, while some recommendations such as backing up ephemeral tokens and planning sharding are poorly prioritized."
+        },
+        "testing": {
+          "completeness": 9,
+          "correctness": 5,
+          "specificity": 7,
+          "risk_awareness": 8,
+          "total": 29,
+          "notes": "The plan's strongest aspect is that it at least names valid-session, invalid-session, no-token-in-cookie, TTL, rollback, and concurrent-access scenarios. Its largest deficiency is that most cases are not executable: the callback uses fabricated credentials, cookies are placeholders, database inspection is unspecified, encrypted-cookie decoding is unexplained, and expected token values are not established. It also contradicts itself by switching between `OAUTH_STORE_TOKENS_IN_SESSION` and `OAUTH_TOKEN_STORAGE_ENABLED`, and its deployment paths do not match the repository's documented chart and `terraform/aws-ecs` surfaces. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Missing high-value cases include database failure, logout/replay, cross-user reference access, absent refresh tokens, expired records before MongoDB's asynchronous TTL deletion, key failure, and the upgrade incompatibility described by the repository."
+        },
+        "implementation": {
+          "completeness": 2,
+          "correctness": 0,
+          "specificity": 4,
+          "risk_awareness": 3,
+          "total": 9,
+          "notes": "The strongest aspect is the summary's honest admission that callback integration is unfinished, together with a partial document model and storage-helper sketch. The submitted unified diff is unusable: both new-file hunk counts are far smaller than their supplied contents, multiple lines lack a diff prefix, and no `server.py` hunk implements the callback, cookie, endpoint, configuration, indexes, or logout behavior. The utility imports `auth_server.utils.credential_encryption` even though the design identifies `registry/utils/credential_encryption.py`, and it depends on an unverified `_get_mongodb_db` symbol. Even as standalone code it creates no TTL or unique index, treats refresh tokens as mandatory, returns records without checking `expires_at`, silently collapses all failures to `None`, and provides no tests."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "idp-authenticated-embedding-endpoint",
+      "complexity": "high",
+      "ref": "1.28.0",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 142,
+      "input_tokens": 4240354,
+      "output_tokens": 27380,
+      "total_tokens": 4267734,
+      "latency_seconds": 203.5,
+      "total_cost_usd": 0.672056,
+      "result_subtype": "success",
+      "task_score": 28.2,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 134.5,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 18,
+          "correctness": 16,
+          "specificity": 17,
+          "risk_awareness": 16,
+          "total": 67,
+          "notes": "The issue clearly defines the short-lived-token failure, preserves static-key behavior, and excludes other OAuth flows. Its largest weakness is that criteria such as proper error handling and secure credential handling lack observable outcomes. It specifically identifies EMBEDDINGS_API_KEY, LiteLLM, refresh buffering, deployment surfaces, and the re-index caveat. With no independent task statement, related issue #1415 and the exact deployment requirements remain unverified."
+        },
+        "lld": {
+          "completeness": 12,
+          "correctness": 3,
+          "specificity": 14,
+          "risk_awareness": 9,
+          "total": 38,
+          "notes": "The design names concrete configuration fields, files, and a token-manager integration path. Its core pseudocode is nonfunctional: it uses async with on threading.Lock and sends the literal value [REDACTED] instead of the client secret to the token endpoint. It also permits HTTP despite later claims of HTTPS enforcement, omits complete settings-to-factory wiring, and leaves refresh-failure behavior unresolved. The claimed existing symbols and patterns in registry/embeddings/client.py and credentials-provider/token_refresher.py could not be verified from the supplied artifact evidence."
+        },
+        "review": {
+          "completeness": 5,
+          "correctness": 1,
+          "specificity": 4,
+          "risk_awareness": 2,
+          "total": 12,
+          "notes": "The review at least calls for compatibility, documentation, concurrency, and timeout testing. Its largest defect is declaring security and thread-safety resolved while missing the LLD's invalid lock usage and redacted credential request. It also claims HTTPS enforcement, retry handling, and deployment integration that the LLD does not provide. The reviewer-role sections are largely generic approvals and do not identify or prioritize the design's critical-path failures."
+        },
+        "testing": {
+          "completeness": 8,
+          "correctness": 3,
+          "specificity": 7,
+          "risk_awareness": 6,
+          "total": 24,
+          "notes": "The plan spans baseline, configuration, deployment, rollback, and nominal end-to-end scenarios. The curl tests use an unsupported /api/embeddings endpoint and do not observe the upstream Authorization header, so they cannot prove token injection or refresh. Test 4 claims to validate missing configuration but merely constructs a client with idp_token_manager=None and treats default acceptance as success. There are no concrete tests for expiry boundaries, concurrent single-flight refresh, malformed token responses, transient failures, or secret redaction."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "No unified patch.diff content was submitted, so there is no actual implementation to apply or inspect. The summary names three intended files and admits that required configuration validation was omitted, but a summary cannot establish code correctness. It also reports no deployment, documentation, or test changes despite those being acceptance criteria. Target context, symbols, API compatibility, and runtime behavior therefore cannot be verified."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "consistent-csrf-across-toggle-endpoints",
+      "complexity": "medium",
+      "ref": "v1.0.20",
+      "artifacts_produced": 6,
+      "artifacts_expected": 6,
+      "num_turns": 104,
+      "input_tokens": 1984803,
+      "output_tokens": 10836,
+      "total_tokens": 1995639,
+      "latency_seconds": 83.8,
+      "total_cost_usd": 0.313349,
+      "result_subtype": "success",
+      "task_score": 24.6,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 129.3,
+      "kv_cache_usage": null,
+      "agent_invocations": 1,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 11,
+          "correctness": 6,
+          "specificity": 9,
+          "risk_awareness": 8,
+          "total": 34,
+          "notes": "The issue clearly identifies the real user-visible symptom: CSRF validation blocks bearer-authenticated agent and skill toggles. However, the repository's v1.0.21 notes identify the fix as skipping CSRF for Bearer clients on toggle endpoints, while this issue instead centers the solution on adding CSRF to virtual-server toggles. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) The acceptance criteria never specify when CSRF must be enforced or bypassed, authentication precedence, or concrete expected responses. The assertion that virtual-server coverage is the cause of the agent/skill failure is unsupported, although the documented virtual-server toggle route itself exists."
+        },
+        "lld": {
+          "completeness": 7,
+          "correctness": 3,
+          "specificity": 10,
+          "risk_awareness": 4,
+          "total": 24,
+          "notes": "The design is concrete about `registry/api/virtual_server_routes.py`, the toggle signature, and the proposed dependency, and the repository documentation confirms that route and endpoint exist. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/design/virtual-mcp-server.md)) Its sole implementation step adds CSRF validation to the virtual-server endpoint, but the established fix required Bearer clients to skip CSRF and specifically addressed blocked agent/skill toggles. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) The M2M sequence still performs CSRF validation despite acknowledging that these clients lack the required cookie and token, leaving the load-bearing bypass and authentication decision undefined. The claimed line numbers, helper behavior, session handling, and compatibility were not substantiated, and rollout, error handling, and testing are largely dismissed."
+        },
+        "review": {
+          "completeness": 10,
+          "correctness": 7,
+          "specificity": 9,
+          "risk_awareness": 10,
+          "total": 36,
+          "notes": "The backend and security sections correctly raise the central question of whether `verify_csrf_token_flexible` blocks M2M clients without session cookies. The review nevertheless approves the design, declares no blocking findings, and even contradicts its own summary table, which records one security blocker. Repository release evidence shows that Bearer-token bypass was the essential fix, so leaving that question unanswered should have blocked approval. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) Frontend token behavior and the asserted absence of operational impact are recommendations or assumptions rather than repository-grounded findings."
+        },
+        "testing": {
+          "completeness": 9,
+          "correctness": 4,
+          "specificity": 9,
+          "risk_awareness": 7,
+          "total": 29,
+          "notes": "The plan provides concrete HTTP examples and includes missing-token and invalid-token negative cases. Its virtual-server curls provide only an `enabled` query parameter even though the LLD's own route signature requires a `ToggleVirtualServerRequest` body, so the expected 200 response is not supported. More importantly, it never concretely tests the required Bearer-only request without session cookie or CSRF token; instead, the examples mix Bearer and session authentication and even expect that combination to fail without CSRF. The repository identifies programmatic agent/skill toggles as the regression, while those flows receive only checklist assertions, and the token file path and test-directory conventions were not verified. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md))"
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "No unified diff was included in the submitted implementation artifact; only a summary referencing `./patch.diff` was supplied, so there is no code change to validate or apply. The described change adds CSRF to the virtual-server toggle, whereas the repository records the required fix as skipping CSRF for Bearer clients on toggle endpoints to unblock agent and skill operations. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/v1.0.21.md)) Consequently, the described implementation does not address the established failure and could extend CSRF blocking to another M2M path. Claims about the baseline commit, `+2 / -1` change, exact LLD compliance, and preserved M2M compatibility are unverifiable and oversell the absent patch."
+        }
+      },
+      "is_error": false,
+      "failed": false
+    },
+    {
+      "task": "cli-custom-egress-oauth-provider-flags",
+      "complexity": "low",
+      "ref": "1.28.0",
+      "artifacts_produced": 0,
+      "artifacts_expected": 6,
+      "num_turns": 187,
+      "input_tokens": 3519965,
+      "output_tokens": 15275,
+      "total_tokens": 3535240,
+      "latency_seconds": 213.5,
+      "total_cost_usd": 0.553275,
+      "result_subtype": "success",
+      "task_score": 0.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 38.2,
+      "kv_cache_usage": null,
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        },
+        "lld": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        },
+        "review": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        },
+        "testing": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        }
+      },
+      "is_error": false,
+      "failed": true
+    },
+    {
+      "task": "registration-admission-control-gate",
+      "complexity": "high",
+      "ref": "v1.0.19",
+      "artifacts_produced": 3,
+      "artifacts_expected": 6,
+      "num_turns": 250,
+      "input_tokens": 5220046,
+      "output_tokens": 32636,
+      "total_tokens": 5252682,
+      "latency_seconds": 244.6,
+      "total_cost_usd": 0.826666,
+      "result_subtype": "success",
+      "task_score": 0.0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0,
+      "prefix_cache_hit_rate": null,
+      "generation_tokens_per_sec": 136.0,
+      "kv_cache_usage": null,
+      "agent_invocations": 2,
+      "topped_up_artifacts": [],
+      "eval_scores": {
+        "github_issue": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        },
+        "lld": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        },
+        "review": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        },
+        "testing": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        },
+        "implementation": {
+          "completeness": 0,
+          "correctness": 0,
+          "specificity": 0,
+          "risk_awareness": 0,
+          "total": 0,
+          "notes": "Artifact not produced by the candidate run."
+        }
+      },
+      "is_error": false,
+      "failed": true
+    }
+  ],
+  "run_date": "2026-09-11"
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/eval.json
@@ -1,0 +1,64 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "scores": {
+    "github_issue": {
+      "completeness": 14,
+      "correctness": 8,
+      "specificity": 14,
+      "risk_awareness": 8,
+      "total": 44,
+      "notes": "The strongest aspect is its clear statement of the cookie-size concern, scoped OAuth focus, encryption requirement, TTL cleanup, and testable prohibition on access and refresh tokens in cookies. Its largest deficiency is that it assumes the required feature is an endpoint exposing IdP access and refresh tokens, while repository release evidence for issue #399 describes moving the session payload, groups, and encrypted id_token behind an opaque session_id instead. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) It also omits logout invalidation, upgrade behavior, endpoint authorization and CSRF controls, and precise token/session lifetime rules. With no independent task statement, the claimed 7 KB composition and connection between IdP refresh tokens and the existing \"Get JWT Token\" feature could not be verified."
+    },
+    "lld": {
+      "completeness": 11,
+      "correctness": 5,
+      "specificity": 12,
+      "risk_awareness": 10,
+      "total": 38,
+      "notes": "The LLD's strongest aspect is its concrete attempt at a schema, callback data flow, storage helpers, configuration, and rollout outline. Its central design is internally defective because the supposedly reduced cookie still contains id_token and groups, and it adds a refresh-token disclosure endpoint rather than storing the complete oversized session behind a signed opaque identifier. Repository release evidence instead specifies an oauth_sessions collection, AES-GCM encryption derived from SECRET_KEY, unique and TTL indexes, logout deletion, and a forced-login migration boundary, none of which is resolved here. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Several claimed integration points remain unsupported or contradictory, including `_get_mongodb_db`, three different encryption-module paths, generic Helm/Terraform paths, transactions and rate limiting that are asserted but not designed, and an unresolved concurrency question."
+    },
+    "review": {
+      "completeness": 11,
+      "correctness": 10,
+      "specificity": 9,
+      "risk_awareness": 14,
+      "total": 44,
+      "notes": "The strongest portion is the security and reliability risk inventory covering key rotation, secret logging, rate limiting, database outages, concurrency, and session-versus-token lifetime. The review's largest weakness is that every persona approves with zero blockers despite unresolved load-bearing questions and concrete contradictions in the LLD. It misses that id_token and groups remain in the cookie, that the endpoint authentication contract conflicts with cookie-only validation, and that no logout or migration behavior is defined; the repository's shipped design treats those as central concerns. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Claims that existing CORS, transaction, retry, caching, and rate-limit patterns can be reused are not tied to verified symbols or files, while some recommendations such as backing up ephemeral tokens and planning sharding are poorly prioritized."
+    },
+    "testing": {
+      "completeness": 9,
+      "correctness": 5,
+      "specificity": 7,
+      "risk_awareness": 8,
+      "total": 29,
+      "notes": "The plan's strongest aspect is that it at least names valid-session, invalid-session, no-token-in-cookie, TTL, rollback, and concurrent-access scenarios. Its largest deficiency is that most cases are not executable: the callback uses fabricated credentials, cookies are placeholders, database inspection is unspecified, encrypted-cookie decoding is unexplained, and expected token values are not established. It also contradicts itself by switching between `OAUTH_STORE_TOKENS_IN_SESSION` and `OAUTH_TOKEN_STORAGE_ENABLED`, and its deployment paths do not match the repository's documented chart and `terraform/aws-ecs` surfaces. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Missing high-value cases include database failure, logout/replay, cross-user reference access, absent refresh tokens, expired records before MongoDB's asynchronous TTL deletion, key failure, and the upgrade incompatibility described by the repository."
+    },
+    "implementation": {
+      "completeness": 2,
+      "correctness": 0,
+      "specificity": 4,
+      "risk_awareness": 3,
+      "total": 9,
+      "notes": "The strongest aspect is the summary's honest admission that callback integration is unfinished, together with a partial document model and storage-helper sketch. The submitted unified diff is unusable: both new-file hunk counts are far smaller than their supplied contents, multiple lines lack a diff prefix, and no `server.py` hunk implements the callback, cookie, endpoint, configuration, indexes, or logout behavior. The utility imports `auth_server.utils.credential_encryption` even though the design identifies `registry/utils/credential_encryption.py`, and it depends on an unverified `_get_mongodb_db` symbol. Even as standalone code it creates no TTL or unique index, treats refresh tokens as mandatory, returns records without checking `expires_at`, silently collapses all failures to `None`, and provides no tests."
+    }
+  },
+  "task_score": 32.8,
+  "verdict": "The submission offers a readable but repository-misaligned design and an unusable, non-integrated patch; its largest limitation is modeling a token-retrieval service instead of completing the server-side session-store behavior needed to fix the cookie problem.",
+  "judge": {
+    "model": "openai.gpt-5.6-sol",
+    "provider": "codex-exec",
+    "repo_grounded": true,
+    "evaluated_at": "2026-09-11T18:30:43.705222Z",
+    "repo_ref": "1.23.0",
+    "reasoning_effort": "high",
+    "token_usage": {
+      "input_tokens": 184474,
+      "cached_input_tokens": 97637,
+      "cache_write_input_tokens": 26920,
+      "output_tokens": 11435,
+      "reasoning_output_tokens": 9680
+    },
+    "duration_ms": 130906
+  }
+}

--- a/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
+++ b/benchmarks/swe-benchmark-data/qwen.qwen3-coder-30b-a3b-instruct/codex/swe3/mcp-gateway-registry-v2/server-side-oauth-token-storage/metrics.json
@@ -1,0 +1,178 @@
+{
+  "task": "server-side-oauth-token-storage",
+  "repo": "https://github.com/agentic-community/mcp-gateway-registry",
+  "ref": "1.23.0",
+  "complexity": "high",
+  "tags": [
+    "authentication",
+    "oauth",
+    "session",
+    "mongodb",
+    "encryption",
+    "auth-server",
+    "fixed-in-1.24.0"
+  ],
+  "model": "qwen.qwen3-coder-30b-a3b-instruct",
+  "model_slug": "qwen.qwen3-coder-30b-a3b-instruct",
+  "agent": "codex",
+  "skill": "swe3",
+  "provider": "endpoint",
+  "endpoint": "http://127.0.0.1:4002",
+  "aws_region": null,
+  "serving": {
+    "instance_type": "g6e.4xlarge",
+    "tensor_parallel_size": null,
+    "precision": null,
+    "context_window": null
+  },
+  "artifacts_produced": 6,
+  "artifacts_expected": 6,
+  "generation_tokens_per_sec": 136.6,
+  "token_accounting_warning": null,
+  "prompt_token_reconciliation": null,
+  "metrics": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2975916,
+    "output_tokens": 19261,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2995177,
+    "total_cost_usd": 0.471682,
+    "latency_seconds": 1808.0,
+    "num_turns": 1020,
+    "generation_tokens_per_sec": 136.6,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "input_tokens": 2975916,
+  "output_tokens": 19261,
+  "latency_seconds": 1808.0,
+  "num_turns": 1020,
+  "total_cost_usd": 0.471682,
+  "is_error": false,
+  "result_subtype": "success",
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "run_started_at": "2026-09-11T17:24:44.980264Z",
+  "run_ended_at": "2026-09-11T17:27:05.983818Z",
+  "metrics_that_matter": {
+    "note": "Headline metrics resolved to the best available source for each; see 'sources'. Values drawn from vllm_prometheus carry its single-tenant, server-wide caveat.",
+    "input_tokens": 2975916,
+    "output_tokens": 19261,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "total_tokens": 2995177,
+    "total_cost_usd": 0.471682,
+    "latency_seconds": 1808.0,
+    "num_turns": 1020,
+    "generation_tokens_per_sec": 136.6,
+    "prefix_cache_hit_rate": null,
+    "sources": {
+      "input_tokens": "codex_api.usage.input",
+      "output_tokens": "codex_api.usage.output",
+      "cache_read_tokens": "codex_api.usage.cache_read_input_tokens",
+      "cache_write_tokens": "codex_api.usage.cache_creation_input_tokens",
+      "total_tokens": "total tokens processed once each (issue #136): input + output, plus cache_read + cache_write ONLY when the cache is additive (not a partition of input). An agent with disjoint counts declares that instead of being detected (issue #183).",
+      "total_cost_usd": "codex_api.total_cost_usd (metered)",
+      "latency_seconds": "harness wall-clock (or codex_api.duration_ms)",
+      "num_turns": "codex_api.num_turns",
+      "generation_tokens_per_sec": "derived: output_tokens / latency_seconds",
+      "prefix_cache_hit_rate": "vllm_prometheus.derived.prefix_cache_hit_rate"
+    }
+  },
+  "vllm_prometheus": {
+    "available": false,
+    "source": "vllm_prometheus_window",
+    "note": "vLLM metrics were not reachable; run against a vLLM endpoint exposing /metrics to populate this block.",
+    "derived": {
+      "prefix_cache_hit_rate": null,
+      "prompt_tokens_cached_rate": null
+    },
+    "counters": {},
+    "histograms": {},
+    "gauges": {},
+    "gauges_sampled": {
+      "available": false,
+      "source": "vllm_prometheus_poll",
+      "note": "No vLLM gauges were sampled during the run; endpoint unreachable or not a vLLM server.",
+      "interval_seconds": 1.0,
+      "gauges": {}
+    }
+  },
+  "agent_invocations": 2,
+  "evaluation": {
+    "task": "server-side-oauth-token-storage",
+    "model": "qwen.qwen3-coder-30b-a3b-instruct",
+    "scores": {
+      "github_issue": {
+        "completeness": 14,
+        "correctness": 8,
+        "specificity": 14,
+        "risk_awareness": 8,
+        "total": 44,
+        "notes": "The strongest aspect is its clear statement of the cookie-size concern, scoped OAuth focus, encryption requirement, TTL cleanup, and testable prohibition on access and refresh tokens in cookies. Its largest deficiency is that it assumes the required feature is an endpoint exposing IdP access and refresh tokens, while repository release evidence for issue #399 describes moving the session payload, groups, and encrypted id_token behind an opaque session_id instead. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) It also omits logout invalidation, upgrade behavior, endpoint authorization and CSRF controls, and precise token/session lifetime rules. With no independent task statement, the claimed 7 KB composition and connection between IdP refresh tokens and the existing \"Get JWT Token\" feature could not be verified."
+      },
+      "lld": {
+        "completeness": 11,
+        "correctness": 5,
+        "specificity": 12,
+        "risk_awareness": 10,
+        "total": 38,
+        "notes": "The LLD's strongest aspect is its concrete attempt at a schema, callback data flow, storage helpers, configuration, and rollout outline. Its central design is internally defective because the supposedly reduced cookie still contains id_token and groups, and it adds a refresh-token disclosure endpoint rather than storing the complete oversized session behind a signed opaque identifier. Repository release evidence instead specifies an oauth_sessions collection, AES-GCM encryption derived from SECRET_KEY, unique and TTL indexes, logout deletion, and a forced-login migration boundary, none of which is resolved here. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Several claimed integration points remain unsupported or contradictory, including `_get_mongodb_db`, three different encryption-module paths, generic Helm/Terraform paths, transactions and rate limiting that are asserted but not designed, and an unresolved concurrency question."
+      },
+      "review": {
+        "completeness": 11,
+        "correctness": 10,
+        "specificity": 9,
+        "risk_awareness": 14,
+        "total": 44,
+        "notes": "The strongest portion is the security and reliability risk inventory covering key rotation, secret logging, rate limiting, database outages, concurrency, and session-versus-token lifetime. The review's largest weakness is that every persona approves with zero blockers despite unresolved load-bearing questions and concrete contradictions in the LLD. It misses that id_token and groups remain in the cookie, that the endpoint authentication contract conflicts with cookie-only validation, and that no logout or migration behavior is defined; the repository's shipped design treats those as central concerns. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Claims that existing CORS, transaction, retry, caching, and rate-limit patterns can be reused are not tied to verified symbols or files, while some recommendations such as backing up ephemeral tokens and planning sharding are poorly prioritized."
+      },
+      "testing": {
+        "completeness": 9,
+        "correctness": 5,
+        "specificity": 7,
+        "risk_awareness": 8,
+        "total": 29,
+        "notes": "The plan's strongest aspect is that it at least names valid-session, invalid-session, no-token-in-cookie, TTL, rollback, and concurrent-access scenarios. Its largest deficiency is that most cases are not executable: the callback uses fabricated credentials, cookies are placeholders, database inspection is unspecified, encrypted-cookie decoding is unexplained, and expected token values are not established. It also contradicts itself by switching between `OAUTH_STORE_TOKENS_IN_SESSION` and `OAUTH_TOKEN_STORAGE_ENABLED`, and its deployment paths do not match the repository's documented chart and `terraform/aws-ecs` surfaces. ([github.com](https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/1.24.1.md)) Missing high-value cases include database failure, logout/replay, cross-user reference access, absent refresh tokens, expired records before MongoDB's asynchronous TTL deletion, key failure, and the upgrade incompatibility described by the repository."
+      },
+      "implementation": {
+        "completeness": 2,
+        "correctness": 0,
+        "specificity": 4,
+        "risk_awareness": 3,
+        "total": 9,
+        "notes": "The strongest aspect is the summary's honest admission that callback integration is unfinished, together with a partial document model and storage-helper sketch. The submitted unified diff is unusable: both new-file hunk counts are far smaller than their supplied contents, multiple lines lack a diff prefix, and no `server.py` hunk implements the callback, cookie, endpoint, configuration, indexes, or logout behavior. The utility imports `auth_server.utils.credential_encryption` even though the design identifies `registry/utils/credential_encryption.py`, and it depends on an unverified `_get_mongodb_db` symbol. Even as standalone code it creates no TTL or unique index, treats refresh tokens as mandatory, returns records without checking `expires_at`, silently collapses all failures to `None`, and provides no tests."
+      }
+    },
+    "task_score": 32.8,
+    "verdict": "The submission offers a readable but repository-misaligned design and an unusable, non-integrated patch; its largest limitation is modeling a token-retrieval service instead of completing the server-side session-store behavior needed to fix the cookie problem.",
+    "judge": {
+      "model": "openai.gpt-5.6-sol",
+      "provider": "codex-exec",
+      "repo_grounded": true,
+      "evaluated_at": "2026-09-11T18:30:43.705222Z",
+      "repo_ref": "1.23.0",
+      "reasoning_effort": "high",
+      "token_usage": {
+        "input_tokens": 184474,
+        "cached_input_tokens": 97637,
+        "cache_write_input_tokens": 26920,
+        "output_tokens": 11435,
+        "reasoning_output_tokens": 9680
+      },
+      "duration_ms": 130906
+    }
+  }
+}

--- a/benchmarks/tests/test_bedrock_pricing.py
+++ b/benchmarks/tests/test_bedrock_pricing.py
@@ -49,10 +49,38 @@ class CostUsdTest(unittest.TestCase):
         self.assertLess(cached, fresh)
 
     def test_price_table_rows_are_complete(self) -> None:
+        # input and output are always required; a caching-incapable model
+        # carries no cache rate at all (see test_cached_tokens_against_...).
         for model, rates in PRICES.items():
-            for key in ("input", "output", "cache_read", "cache_write"):
+            for key in ("input", "output"):
                 self.assertIn(key, rates, f"{model} missing {key}")
-                self.assertGreaterEqual(rates[key], 0.0)
+            for key, rate in rates.items():
+                self.assertGreaterEqual(rate, 0.0, f"{model}.{key} is negative")
+
+    def test_version_suffix_and_instruct_alias_resolve(self) -> None:
+        # The Bedrock id, the LiteLLM alias the harness records, and the bare
+        # key are the same model. A miss here reads as a free run.
+        bare = cost_usd("qwen.qwen3-coder-30b-a3b", 1_000_000, 1_000_000)
+        self.assertAlmostEqual(bare, 0.1545 + 0.6180, places=6)
+        for spelling in (
+            "qwen.qwen3-coder-30b-a3b-v1:0",
+            "qwen.qwen3-coder-30b-a3b-instruct",
+            "us.qwen.qwen3-coder-30b-a3b-v1:0",
+        ):
+            self.assertEqual(cost_usd(spelling, 1_000_000, 1_000_000), bare)
+
+    def test_cached_tokens_against_an_uncached_model_returns_none(self) -> None:
+        # Bedrock refuses a cachePoint for Qwen, so a non-zero cached count is
+        # a measurement bug. Pricing it at 0 would understate the bill and look
+        # exactly like a genuinely cheap run.
+        priced = cost_usd("qwen.qwen3-coder-30b-a3b", 1000, 1000)
+        self.assertIsNotNone(priced)
+        self.assertIsNone(
+            cost_usd("qwen.qwen3-coder-30b-a3b", 1000, 1000, cache_read_tokens=500)
+        )
+        self.assertIsNone(
+            cost_usd("qwen.qwen3-coder-30b-a3b", 1000, 1000, cache_write_tokens=500)
+        )
 
     def test_prices_carry_an_as_of_date(self) -> None:
         # Rates move; an undated table cannot be audited against the source.


### PR DESCRIPTION
A codex run against `qwen.qwen3-coder-30b-a3b` on Bedrock recorded `total_cost_usd: null`, which plots as a free model on the cost/quality frontier. Two separate causes, both fixed here.

## The model had no price row

Added from the Bedrock pricing page, **Standard tier**: `$0.1545` per 1M input, `$0.6180` per 1M output. Other tiers for the same model, if a run ever needs one: Flex and Batch both `$0.0773 / $0.3090`, Priority `$0.2704 / $1.0815`.

`qwen.qwen3-coder-480b-a35b` is deliberately **absent**. Its cells on the pricing page render client-side (`{priceOf!bedrock/...}` placeholders) and did not resolve, so there is no number to cite. `pricing:GetProducts` is denied for this instance role, so the API could not confirm it either.

## A row alone would not have fixed it

`_rates` stripped only the `us.` / `global.` / `eu.` / `ap.` inference-profile prefixes. Neither spelling that actually reaches the module resolved:

- the Bedrock id carries a version suffix: `qwen.qwen3-coder-30b-a3b-v1:0`
- the harness records the LiteLLM alias as `--model`: `qwen.qwen3-coder-30b-a3b-instruct`

`_normalize` now strips the prefix, a `-vN:M` version suffix, and a trailing `-instruct`, so all three spellings resolve to one row.

## Qwen does not support prompt caching on Bedrock

Measured, not assumed. Identical Converse requests, same region, same `cachePoint` block, only the model changed:

| Model | Result |
|---|---|
| `qwen.qwen3-coder-30b-a3b-v1:0` | `AccessDeniedException: You invoked an unsupported model or your request did not allow prompt caching` |
| `us.anthropic.claude-haiku-4-5` | cold: `cacheWriteInputTokens: 5204`; warm: `cacheReadInputTokens: 5204` |

The pricing page also publishes no cache columns for the Qwen family. So the row carries no `cache_read` / `cache_write` rate, and `cost_usd` returns `None` when a caller reports cached tokens against a row that has none. Pricing them at zero would understate the bill and be indistinguishable from a genuinely cheap run.

## Result

The hello-world task that recorded `null` now prices at **$0.117154** from its 726,017 fresh input and 8,065 output tokens.

## Tests

`test_price_table_rows_are_complete` asserted all four rate keys on every row. That is no longer the contract, so re-pinning it would have been wrong: it now requires `input` and `output` and checks that whatever rates a row does carry are non-negative. Two added:

- all three spellings of the Qwen id price identically
- cached tokens against an uncached model return `None`, not a silent zero

`470 tests pass` (was 468). `ruff format` and `ruff check` clean, `bandit` clean.